### PR TITLE
ci: test against Ruby 3.3, 3.4, and 4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
+      fail-fast: false
       matrix:
         ruby:
-          - '3.4.2'
+          - "3.3"
+          - "3.4"
+          - "4.0"
 
     steps:
       - uses: actions/checkout@v6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   NewCops: enable
   SuggestExtensions: false
 

--- a/lib/pgbus/event.rb
+++ b/lib/pgbus/event.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 module Pgbus
   class Event
     attr_reader :event_id, :payload, :published_at, :routing_key, :headers

--- a/pgbus.gemspec
+++ b/pgbus.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/mhenrixon/pgbus"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mhenrixon/pgbus"


### PR DESCRIPTION
## Summary

- Add CI matrix for Ruby 3.3, 3.4, and 4.0 with `fail-fast: false`
- Bump `required_ruby_version` to `>= 3.3.0` (pgmq-ruby requires 3.3+)
- Update RuboCop `TargetRubyVersion` to 3.3

## Test plan

- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rspec` — 31 examples, 0 failures
- [ ] CI: verify all three Ruby versions pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum required Ruby version to 3.3.0.
  * CI expanded to validate Ruby 3.3, 3.4, and 4.0 and no longer cancels remaining runs on a single failure.
  * Tooling configuration aligned to the newer Ruby target (3.3).
  * Improved event timestamp handling and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->