### PR TITLE
feat: concurrency controls (Phase 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ PostgreSQL-native job processing and event bus for Rails, built on [PGMQ](https:
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Quick start](#quick-start)
+- [Concurrency controls](#concurrency-controls)
 - [Configuration reference](#configuration-reference)
 - [Architecture](#architecture)
 - [CLI](#cli)
@@ -196,6 +197,48 @@ Pgbus.configure do |config|
 end
 ```
 
+## Concurrency controls
+
+Limit how many jobs with the same key can run concurrently:
+
+```ruby
+class ProcessOrderJob < ApplicationJob
+  include Pgbus::Concurrency
+
+  limits_concurrency to: 1,
+                     key: ->(order_id) { "ProcessOrder-#{order_id}" },
+                     duration: 15.minutes,
+                     on_conflict: :block
+
+  def perform(order_id)
+    # Only one job per order_id runs at a time
+  end
+end
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `to:` | (required) | Maximum concurrent jobs for the same key |
+| `key:` | Job class name | Proc receiving job arguments, returns a string key |
+| `duration:` | `15.minutes` | Safety expiry for the semaphore (crashed worker recovery) |
+| `on_conflict:` | `:block` | What to do when the limit is reached |
+
+### Conflict strategies
+
+| Strategy | Behavior |
+|----------|----------|
+| `:block` | Hold the job in a blocked queue. It is automatically released when a slot opens or the semaphore expires. |
+| `:discard` | Silently drop the job. |
+| `:raise` | Raise `Pgbus::ConcurrencyLimitExceeded` so the caller can handle it. |
+
+### How it works
+
+1. **Enqueue**: The adapter checks a semaphore table for the concurrency key. If under the limit, it increments the counter and sends the job to PGMQ. If at the limit, it applies the `on_conflict` strategy.
+2. **Complete**: After a job succeeds or is dead-lettered, the executor decrements the semaphore and releases the next blocked job (if any).
+3. **Safety net**: The dispatcher periodically cleans up expired semaphores and orphaned blocked executions to recover from crashed workers.
+
 ## Configuration reference
 
 | Option | Default | Description |
@@ -292,6 +335,8 @@ Pgbus uses these tables (created via PGMQ and migrations):
 | `pgbus_processes` | Heartbeat tracking for workers/dispatcher/consumers |
 | `pgbus_failed_events` | Failed event dispatch records |
 | `pgbus_processed_events` | Idempotency deduplication (event_id, handler_class) |
+| `pgbus_semaphores` | Concurrency control counting semaphores |
+| `pgbus_blocked_executions` | Jobs waiting for a concurrency semaphore slot |
 
 ## Switching from another backend
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Switching to Pgbus from another job backend? These guides cover what changes, wh
 | Worker recycling | No | No | No | Yes |
 | Event bus | No | No | No | Yes |
 | Idempotent events | No | No | No | Yes |
-| Concurrency controls | Enterprise | `limits_concurrency` | `good_job_control_concurrency_with` | Planned |
+| Concurrency controls | Enterprise | `limits_concurrency` | `good_job_control_concurrency_with` | `Pgbus::Concurrency` |
 | Recurring/cron jobs | `sidekiq-cron` gem | `config/recurring.yml` | `config.good_job.cron` | Planned |
 | Batches | Pro | No | `GoodJob::Batch` | Planned |
 | Web dashboard | `Sidekiq::Web` | Mission Control | `GoodJob::Engine` | `Pgbus::Engine` |

--- a/docs/switch_from_good_job.md
+++ b/docs/switch_from_good_job.md
@@ -127,10 +127,17 @@ class ProcessOrderJob < ApplicationJob
 end
 ```
 
-> Pgbus plans to add concurrency controls. For now, use row-level locking for mutual exclusion:
+> Pgbus supports concurrency controls via `Pgbus::Concurrency`:
 > ```ruby
-> def perform(order)
->   order.with_lock { process(order) }  # SELECT ... FOR UPDATE
+> class ProcessOrderJob < ApplicationJob
+>   include Pgbus::Concurrency
+>   limits_concurrency to: 1,
+>                      key: -> { "ProcessOrder-#{arguments.first.id}" },
+>                      duration: 15.minutes,
+>                      on_conflict: :block
+>   def perform(order)
+>     # ...
+>   end
 > end
 > ```
 
@@ -251,7 +258,7 @@ end
 
 | GoodJob feature | Status in Pgbus |
 |-----------------|-----------------|
-| Concurrency controls (`good_job_control_concurrency_with`) | Planned |
+| Concurrency controls (`good_job_control_concurrency_with`) | `Pgbus::Concurrency` with `limits_concurrency` DSL |
 | Throttling (`enqueue_throttle`, `perform_throttle`) | Planned |
 | Batches (`GoodJob::Batch`) | Planned |
 | Cron / recurring jobs | Planned |

--- a/docs/switch_from_sidekiq.md
+++ b/docs/switch_from_sidekiq.md
@@ -206,6 +206,7 @@ Once all Sidekiq jobs have drained and you've verified Pgbus is processing corre
 |-----------------|-----------------|
 | Batches (Pro) | Planned |
 | Rate limiting (Enterprise) | Planned |
+| Concurrency controls (Enterprise) | `Pgbus::Concurrency` with `limits_concurrency` DSL |
 | Unique jobs (Enterprise / `sidekiq-unique-jobs`) | Partial -- event bus has idempotency; job-level dedup planned |
 | Cron / recurring jobs (`sidekiq-cron`) | Planned |
 | Real-time metrics (Sidekiq Web) | Pgbus dashboard covers queue depth, failures, processes |

--- a/docs/switch_from_solid_queue.md
+++ b/docs/switch_from_solid_queue.md
@@ -119,7 +119,19 @@ class ProcessOrderJob < ApplicationJob
 end
 ```
 
-> Pgbus plans to add concurrency controls. In the meantime, use PostgreSQL advisory locks (`with_advisory_lock` gem) for critical sections that need mutual exclusion.
+> Pgbus supports concurrency controls via `Pgbus::Concurrency`:
+> ```ruby
+> class ProcessOrderJob < ApplicationJob
+>   include Pgbus::Concurrency
+>   limits_concurrency to: 1,
+>                      key: ->(order) { order.account_id },
+>                      duration: 15.minutes,
+>                      on_conflict: :block
+>   def perform(order)
+>     # ...
+>   end
+> end
+> ```
 
 ## Step 5: Migrate recurring tasks
 
@@ -213,7 +225,7 @@ end
 
 | SolidQueue feature | Status in Pgbus |
 |--------------------|-----------------|
-| `limits_concurrency` | Planned |
+| `limits_concurrency` | `Pgbus::Concurrency` with `limits_concurrency` DSL |
 | `config/recurring.yml` | Planned |
 | Queue pausing (`SolidQueue::Queue.pause`) | Planned |
 | Separate queue database | Not planned (PGMQ lives in your primary DB) |

--- a/lib/generators/pgbus/templates/migration.rb.erb
+++ b/lib/generators/pgbus/templates/migration.rb.erb
@@ -44,6 +44,33 @@ class InstallPgbus < ActiveRecord::Migration<%= migration_version %>
     add_index :pgbus_failed_events, :queue_name, name: "idx_pgbus_failed_events_queue"
     add_index :pgbus_failed_events, :failed_at, name: "idx_pgbus_failed_events_time"
 
+    # Concurrency semaphores (counting locks for job concurrency limits)
+    create_table :pgbus_semaphores do |t|
+      t.string :key, null: false
+      t.integer :value, null: false, default: 0
+      t.integer :max_value, null: false, default: 1
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :pgbus_semaphores, :key,
+      unique: true, name: "idx_pgbus_semaphores_key"
+    add_index :pgbus_semaphores, :expires_at,
+      name: "idx_pgbus_semaphores_expired"
+
+    # Blocked executions (jobs waiting for a concurrency semaphore)
+    create_table :pgbus_blocked_executions do |t|
+      t.string :concurrency_key, null: false
+      t.string :queue_name, null: false
+      t.jsonb :payload, null: false
+      t.integer :priority, null: false, default: 0
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :pgbus_blocked_executions, [:concurrency_key, :priority, :created_at],
+      name: "idx_pgbus_blocked_release_order"
+
     # Create default queues via PGMQ
     execute "SELECT pgmq.create('pgbus_default')"
     execute "SELECT pgmq.create('pgbus_default_dlq')"
@@ -53,6 +80,8 @@ class InstallPgbus < ActiveRecord::Migration<%= migration_version %>
     execute "SELECT pgmq.drop_queue('pgbus_default_dlq')"
     execute "SELECT pgmq.drop_queue('pgbus_default')"
 
+    drop_table :pgbus_blocked_executions
+    drop_table :pgbus_semaphores
     drop_table :pgbus_failed_events
     drop_table :pgbus_processes
     drop_table :pgbus_processed_events

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -8,6 +8,7 @@ module Pgbus
   class SerializationError < Error; end
   class QueueNotFoundError < Error; end
   class DeadLetterError < Error; end
+  class ConcurrencyLimitExceeded < Error; end
 
   class << self
     def loader

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -7,19 +7,19 @@ module Pgbus
     class Adapter
       def enqueue(active_job)
         queue = active_job.queue_name || Pgbus.configuration.default_queue
-        payload = Serializer.serialize_job(active_job)
-        msg_id = Pgbus.client.send_message(queue, JSON.parse(payload))
-        active_job.provider_job_id = msg_id
-        active_job
+        payload_hash = JSON.parse(Serializer.serialize_job(active_job))
+        payload_hash = Concurrency.inject_metadata(active_job, payload_hash)
+
+        enqueue_with_concurrency(active_job, queue, payload_hash)
       end
 
       def enqueue_at(active_job, timestamp)
         queue = active_job.queue_name || Pgbus.configuration.default_queue
-        payload = Serializer.serialize_job(active_job)
+        payload_hash = JSON.parse(Serializer.serialize_job(active_job))
+        payload_hash = Concurrency.inject_metadata(active_job, payload_hash)
         delay = [(timestamp - Time.now.to_f).ceil, 0].max
-        msg_id = Pgbus.client.send_message(queue, JSON.parse(payload), delay: delay)
-        active_job.provider_job_id = msg_id
-        active_job
+
+        enqueue_with_concurrency(active_job, queue, payload_hash, delay: delay)
       end
 
       def enqueue_all(active_jobs)
@@ -32,6 +32,48 @@ module Pgbus
       end
 
       private
+
+      def enqueue_with_concurrency(active_job, queue, payload_hash, delay: 0)
+        key = Concurrency.extract_key(payload_hash)
+        concurrency = concurrency_config(active_job)
+
+        if key && concurrency
+          result = Concurrency::Semaphore.acquire(key, concurrency[:limit], concurrency[:duration])
+
+          if result == :acquired
+            msg_id = Pgbus.client.send_message(queue, payload_hash, delay: delay)
+            active_job.provider_job_id = msg_id
+          else
+            handle_conflict(concurrency, active_job, key, queue, payload_hash)
+          end
+        else
+          msg_id = Pgbus.client.send_message(queue, payload_hash, delay: delay)
+          active_job.provider_job_id = msg_id
+        end
+
+        active_job
+      end
+
+      def concurrency_config(active_job)
+        active_job.class.respond_to?(:pgbus_concurrency) && active_job.class.pgbus_concurrency
+      end
+
+      def handle_conflict(concurrency, active_job, key, queue, payload_hash)
+        case concurrency[:on_conflict]
+        when :block
+          Concurrency::BlockedExecution.insert(
+            concurrency_key: key,
+            queue_name: queue,
+            payload: payload_hash,
+            priority: active_job.try(:priority) || 0,
+            duration: concurrency[:duration]
+          )
+        when :discard
+          Pgbus.logger.info { "[Pgbus] Discarding job #{active_job.class.name}: concurrency limit for #{key}" }
+        when :raise
+          raise ConcurrencyLimitExceeded, "Concurrency limit reached for key: #{key}"
+        end
+      end
 
       def enqueue_immediate(queue, jobs)
         return if jobs.empty?

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -65,14 +65,28 @@ module Pgbus
         key = Concurrency.extract_key(payload)
         return unless key
 
-        Concurrency::Semaphore.release(key)
-
+        # Atomic permit handoff: try to promote a blocked job first.
+        # If promoted, the slot stays occupied (no release needed).
+        # Only release the semaphore if there's nothing to promote.
         released = Concurrency::BlockedExecution.release_next(key)
-        return unless released
 
-        client.send_message(released[:queue_name], released[:payload])
+        if released
+          delay = remaining_delay(released[:payload])
+          client.send_message(released[:queue_name], released[:payload], delay: delay)
+        else
+          Concurrency::Semaphore.release(key)
+        end
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Concurrency signal failed: #{e.message}" }
+      end
+
+      def remaining_delay(payload)
+        scheduled_at = payload["scheduled_at"]
+        return 0 unless scheduled_at
+
+        [Time.parse(scheduled_at).to_f - Time.now.to_f, 0].max.ceil
+      rescue StandardError
+        0
       end
 
       def handle_dead_letter(message, queue_name, payload)

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -66,27 +66,13 @@ module Pgbus
         return unless key
 
         # Atomic permit handoff: try to promote a blocked job first.
+        # promote_next wraps delete + enqueue in a transaction so neither is lost.
         # If promoted, the slot stays occupied (no release needed).
         # Only release the semaphore if there's nothing to promote.
-        released = Concurrency::BlockedExecution.release_next(key)
-
-        if released
-          delay = remaining_delay(released[:payload])
-          client.send_message(released[:queue_name], released[:payload], delay: delay)
-        else
-          Concurrency::Semaphore.release(key)
-        end
+        promoted = Concurrency::BlockedExecution.promote_next(key, client: client)
+        Concurrency::Semaphore.release(key) unless promoted
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Concurrency signal failed: #{e.message}" }
-      end
-
-      def remaining_delay(payload)
-        scheduled_at = payload["scheduled_at"]
-        return 0 unless scheduled_at
-
-        [Time.parse(scheduled_at).to_f - Time.now.to_f, 0].max.ceil
-      rescue StandardError
-        0
       end
 
       def handle_dead_letter(message, queue_name, payload)

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -16,17 +16,21 @@ module Pgbus
 
         if read_count > config.max_retries
           handle_dead_letter(message, queue_name, payload)
+          signal_concurrency(payload)
           return :dead_lettered
         end
 
         job = ::ActiveJob::Base.deserialize(payload)
         execute_job(job)
         client.archive_message(queue_name, message.msg_id.to_i)
+        signal_concurrency(payload)
         instrument("pgbus.job_completed", queue: queue_name, job_class: payload["job_class"])
         :success
       rescue StandardError => e
         handle_failure(message, queue_name, e)
         instrument("pgbus.job_failed", queue: queue_name, job_class: payload&.dig("job_class"), error: e.class.name)
+        # Don't signal concurrency on transient failure — the job will be retried.
+        # Semaphore is released only on success or dead-lettering.
         :failed
       end
 
@@ -55,6 +59,20 @@ module Pgbus
         ActiveSupport::Notifications.instrument(event_name, payload)
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus] Notification failure #{event_name}: #{e.class}: #{e.message}" }
+      end
+
+      def signal_concurrency(payload)
+        key = Concurrency.extract_key(payload)
+        return unless key
+
+        Concurrency::Semaphore.release(key)
+
+        released = Concurrency::BlockedExecution.release_next(key)
+        return unless released
+
+        client.send_message(released[:queue_name], released[:payload])
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Concurrency signal failed: #{e.message}" }
       end
 
       def handle_dead_letter(message, queue_name, payload)

--- a/lib/pgbus/concurrency.rb
+++ b/lib/pgbus/concurrency.rb
@@ -22,6 +22,8 @@ module Pgbus
       def limits_concurrency(to:, key: nil, duration: 15 * 60, on_conflict: :block) # rubocop:disable Naming/MethodParameterName
         raise ArgumentError, "to: must be a positive integer" unless to.is_a?(Integer) && to.positive?
         raise ArgumentError, "on_conflict must be :block, :discard, or :raise" unless %i[block discard raise].include?(on_conflict)
+        raise ArgumentError, "duration must be a positive number" unless duration.is_a?(Numeric) && duration.positive?
+        raise ArgumentError, "key must be callable (Proc or lambda)" if key && !key.respond_to?(:call)
 
         @pgbus_concurrency = {
           limit: to,

--- a/lib/pgbus/concurrency.rb
+++ b/lib/pgbus/concurrency.rb
@@ -30,7 +30,7 @@ module Pgbus
           key: key || ->(*) { name },
           duration: duration,
           on_conflict: on_conflict
-        }
+        }.freeze
       end
 
       def pgbus_concurrency
@@ -47,7 +47,13 @@ module Pgbus
         config = active_job.class.pgbus_concurrency
         return nil unless config
 
-        config[:key].call(*active_job.arguments)
+        args = active_job.arguments
+        last = args.last
+        if last.is_a?(Hash) && last.each_key.all?(Symbol)
+          config[:key].call(*args[...-1], **last)
+        else
+          config[:key].call(*args)
+        end
       end
 
       # Inject the resolved concurrency key into the job's serialized payload.

--- a/lib/pgbus/concurrency.rb
+++ b/lib/pgbus/concurrency.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Pgbus
+  module Concurrency
+    extend ActiveSupport::Concern
+
+    METADATA_KEY = "pgbus_concurrency_key"
+
+    class_methods do
+      # Limit concurrent execution of jobs with the same key.
+      #
+      #   limits_concurrency to: 1, key: ->(order) { "ProcessOrder-#{order.id}" }
+      #   limits_concurrency to: 3, key: ->(user_id) { "ImportUser-#{user_id}" }, on_conflict: :discard
+      #
+      # Options:
+      #   to:          Maximum concurrent jobs for the same key (required)
+      #   key:         Proc receiving job arguments, returns a string key. Default: job class name.
+      #   duration:    Safety expiry for semaphore (default: 15 minutes)
+      #   on_conflict: What to do when limit is reached — :block, :discard, or :raise (default: :block)
+      def limits_concurrency(to:, key: nil, duration: 15 * 60, on_conflict: :block) # rubocop:disable Naming/MethodParameterName
+        raise ArgumentError, "to: must be a positive integer" unless to.is_a?(Integer) && to.positive?
+        raise ArgumentError, "on_conflict must be :block, :discard, or :raise" unless %i[block discard raise].include?(on_conflict)
+
+        @pgbus_concurrency = {
+          limit: to,
+          key: key || ->(*) { name },
+          duration: duration,
+          on_conflict: on_conflict
+        }
+      end
+
+      def pgbus_concurrency
+        @pgbus_concurrency
+      end
+    end
+
+    class << self
+      # Resolve the concurrency key for a given job instance.
+      # Returns nil if the job class has no concurrency config.
+      def resolve_key(active_job)
+        return nil unless active_job.class.respond_to?(:pgbus_concurrency)
+
+        config = active_job.class.pgbus_concurrency
+        return nil unless config
+
+        config[:key].call(*active_job.arguments)
+      end
+
+      # Inject the resolved concurrency key into the job's serialized payload.
+      def inject_metadata(active_job, payload_hash)
+        key = resolve_key(active_job)
+        return payload_hash unless key
+
+        payload_hash.merge(METADATA_KEY => key)
+      end
+
+      # Extract the concurrency key from a deserialized payload.
+      def extract_key(payload)
+        payload[METADATA_KEY]
+      end
+    end
+  end
+end

--- a/lib/pgbus/concurrency/blocked_execution.rb
+++ b/lib/pgbus/concurrency/blocked_execution.rb
@@ -46,6 +46,27 @@ module Pgbus
           { queue_name: row["queue_name"], payload: payload }
         end
 
+        # Atomically promote the next blocked execution: delete the row and enqueue
+        # the job in a single transaction. Returns true if a job was promoted, false
+        # otherwise. This avoids losing a blocked row if enqueue fails.
+        def promote_next(concurrency_key, client:, delay: 0)
+          return false unless defined?(ActiveRecord::Base)
+
+          released = nil
+          ActiveRecord::Base.transaction do
+            released = release_next(concurrency_key)
+            raise ActiveRecord::Rollback unless released
+
+            actual_delay = resolve_delay(released[:payload], delay)
+            client.send_message(released[:queue_name], released[:payload], delay: actual_delay)
+          end
+
+          !!released
+        rescue StandardError => e
+          Pgbus.logger.warn { "[Pgbus] Promote blocked execution failed for #{concurrency_key}: #{e.message}" }
+          false
+        end
+
         # Delete blocked executions that have expired.
         # Returns the count of deleted rows.
         def expire_stale
@@ -68,6 +89,15 @@ module Pgbus
         end
 
         private
+
+        def resolve_delay(payload, default_delay)
+          scheduled_at = payload["scheduled_at"]
+          return default_delay unless scheduled_at
+
+          [Time.parse(scheduled_at).to_f - Time.now.to_f, 0].max.ceil
+        rescue StandardError
+          default_delay
+        end
 
         def execute(sql, name, binds)
           return [] unless defined?(ActiveRecord::Base)

--- a/lib/pgbus/concurrency/blocked_execution.rb
+++ b/lib/pgbus/concurrency/blocked_execution.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Pgbus
+  module Concurrency
+    module BlockedExecution
+      class << self
+        # Insert a blocked execution for a job that hit the concurrency limit.
+        def insert(concurrency_key:, queue_name:, payload:, duration:, priority: 0)
+          expires_at = Time.now.utc + duration
+
+          execute(<<~SQL, "Pgbus Blocked Insert", [concurrency_key, queue_name, JSON.generate(payload), priority, expires_at])
+            INSERT INTO pgbus_blocked_executions
+              (concurrency_key, queue_name, payload, priority, expires_at)
+            VALUES ($1, $2, $3, $4, $5)
+          SQL
+        end
+
+        # Release the next blocked execution for a given concurrency key.
+        # Returns the released row (queue_name, payload) or nil if none.
+        def release_next(concurrency_key)
+          return nil unless defined?(ActiveRecord::Base)
+
+          result = execute(<<~SQL, "Pgbus Blocked Release", [concurrency_key])
+            DELETE FROM pgbus_blocked_executions
+            WHERE id = (
+              SELECT id FROM pgbus_blocked_executions
+              WHERE concurrency_key = $1
+              ORDER BY priority ASC, created_at ASC
+              LIMIT 1
+              FOR UPDATE SKIP LOCKED
+            )
+            RETURNING queue_name, payload
+          SQL
+
+          row = result.first
+          return nil unless row
+
+          { queue_name: row["queue_name"], payload: JSON.parse(row["payload"]) }
+        end
+
+        # Delete blocked executions that have expired.
+        # Returns the count of deleted rows.
+        def expire_stale
+          result = execute(<<~SQL, "Pgbus Blocked Expire", [Time.now.utc])
+            DELETE FROM pgbus_blocked_executions
+            WHERE expires_at < $1
+            RETURNING id
+          SQL
+
+          result.to_a.size
+        end
+
+        # Count blocked executions for a given key. Useful for testing/monitoring.
+        def count_for(concurrency_key)
+          result = execute(<<~SQL, "Pgbus Blocked Count", [concurrency_key])
+            SELECT COUNT(*) AS cnt FROM pgbus_blocked_executions WHERE concurrency_key = $1
+          SQL
+
+          result.first&.fetch("cnt", 0).to_i
+        end
+
+        private
+
+        def execute(sql, name, binds)
+          return [] unless defined?(ActiveRecord::Base)
+
+          ActiveRecord::Base.connection.exec_query(sql, name, binds)
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/concurrency/blocked_execution.rb
+++ b/lib/pgbus/concurrency/blocked_execution.rb
@@ -22,11 +22,13 @@ module Pgbus
         def release_next(concurrency_key)
           return nil unless defined?(ActiveRecord::Base)
 
-          result = execute(<<~SQL, "Pgbus Blocked Release", [concurrency_key])
+          now = Time.now.utc
+          result = execute(<<~SQL, "Pgbus Blocked Release", [concurrency_key, now])
             DELETE FROM pgbus_blocked_executions
             WHERE id = (
               SELECT id FROM pgbus_blocked_executions
               WHERE concurrency_key = $1
+                AND expires_at >= $2
               ORDER BY priority ASC, created_at ASC
               LIMIT 1
               FOR UPDATE SKIP LOCKED
@@ -37,7 +39,11 @@ module Pgbus
           row = result.first
           return nil unless row
 
-          { queue_name: row["queue_name"], payload: JSON.parse(row["payload"]) }
+          # ActiveRecord auto-casts jsonb to Ruby Hash; handle both cases
+          payload = row["payload"]
+          payload = JSON.parse(payload) if payload.is_a?(String)
+
+          { queue_name: row["queue_name"], payload: payload }
         end
 
         # Delete blocked executions that have expired.

--- a/lib/pgbus/concurrency/semaphore.rb
+++ b/lib/pgbus/concurrency/semaphore.rb
@@ -16,7 +16,7 @@ module Pgbus
               SET value = pgbus_semaphores.value + 1,
                   max_value = EXCLUDED.max_value,
                   expires_at = GREATEST(pgbus_semaphores.expires_at, EXCLUDED.expires_at)
-              WHERE pgbus_semaphores.value < pgbus_semaphores.max_value
+              WHERE pgbus_semaphores.value < EXCLUDED.max_value
             RETURNING value
           SQL
 

--- a/lib/pgbus/concurrency/semaphore.rb
+++ b/lib/pgbus/concurrency/semaphore.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Concurrency
+    module Semaphore
+      class << self
+        # Attempt to acquire a slot in the semaphore for the given key.
+        # Returns :acquired if a slot was available, :blocked if the limit is reached.
+        def acquire(key, max_value, duration)
+          expires_at = Time.now.utc + duration
+
+          result = execute(<<~SQL, "Pgbus Semaphore Acquire", [key, max_value, expires_at])
+            INSERT INTO pgbus_semaphores (key, value, max_value, expires_at)
+            VALUES ($1, 1, $2, $3)
+            ON CONFLICT (key) DO UPDATE
+              SET value = pgbus_semaphores.value + 1,
+                  max_value = EXCLUDED.max_value,
+                  expires_at = GREATEST(pgbus_semaphores.expires_at, EXCLUDED.expires_at)
+              WHERE pgbus_semaphores.value < pgbus_semaphores.max_value
+            RETURNING value
+          SQL
+
+          result.any? ? :acquired : :blocked
+        end
+
+        # Release one slot in the semaphore. Called after a job completes.
+        def release(key)
+          execute(<<~SQL, "Pgbus Semaphore Release", [key])
+            UPDATE pgbus_semaphores
+            SET value = GREATEST(value - 1, 0)
+            WHERE key = $1
+          SQL
+        end
+
+        # Delete semaphores that have expired (safety net for crashed workers).
+        # Returns the number of deleted rows.
+        def expire_stale
+          result = execute(<<~SQL, "Pgbus Semaphore Expire", [Time.now.utc])
+            DELETE FROM pgbus_semaphores
+            WHERE expires_at < $1 OR value <= 0
+            RETURNING key
+          SQL
+
+          result.to_a
+        end
+
+        # Check current value for a key. Useful for testing/monitoring.
+        def current_value(key)
+          result = execute(<<~SQL, "Pgbus Semaphore Value", [key])
+            SELECT value FROM pgbus_semaphores WHERE key = $1
+          SQL
+
+          result.first&.fetch("value", nil)&.to_i
+        end
+
+        private
+
+        def execute(sql, name, binds)
+          return [] unless defined?(ActiveRecord::Base)
+
+          ActiveRecord::Base.connection.exec_query(sql, name, binds)
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -116,23 +116,10 @@ module Pgbus
       end
 
       def release_blocked_for_key(key)
-        released = Concurrency::BlockedExecution.release_next(key)
-        return unless released
-
-        delay = remaining_delay(released[:payload])
-        Pgbus.client.send_message(released[:queue_name], released[:payload], delay: delay)
-        Pgbus.logger.debug { "[Pgbus] Released blocked execution for key: #{key}" }
+        promoted = Concurrency::BlockedExecution.promote_next(key, client: Pgbus.client)
+        Pgbus.logger.debug { "[Pgbus] Released blocked execution for key: #{key}" } if promoted
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Failed to release blocked execution for #{key}: #{e.message}" }
-      end
-
-      def remaining_delay(payload)
-        scheduled_at = payload["scheduled_at"]
-        return 0 unless scheduled_at
-
-        [Time.parse(scheduled_at).to_f - Time.now.to_f, 0].max.ceil
-      rescue StandardError
-        0
       end
 
       def start_heartbeat

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -8,6 +8,7 @@ module Pgbus
       # Maintenance runs on coarser intervals than the main loop
       CLEANUP_INTERVAL = 3600       # Run idempotency cleanup every hour
       REAP_INTERVAL = 300           # Run stale process reaping every 5 minutes
+      CONCURRENCY_INTERVAL = 300    # Run concurrency cleanup every 5 minutes
 
       attr_reader :config
 
@@ -16,6 +17,7 @@ module Pgbus
         @shutting_down = false
         @last_cleanup_at = Time.now
         @last_reap_at = Time.now
+        @last_concurrency_at = Time.now
       end
 
       def run
@@ -62,6 +64,11 @@ module Pgbus
           reap_stale_processes
           @last_reap_at = now
         end
+
+        if now - @last_concurrency_at >= CONCURRENCY_INTERVAL
+          cleanup_concurrency
+          @last_concurrency_at = now
+        end
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Dispatcher maintenance error: #{e.message}" }
       end
@@ -94,6 +101,28 @@ module Pgbus
         Pgbus.logger.info { "[Pgbus] Reaped #{deleted} stale processes" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Stale process reaping failed: #{e.message}" }
+      end
+
+      def cleanup_concurrency
+        expired_keys = Concurrency::Semaphore.expire_stale
+        expired_keys.each do |row|
+          release_blocked_for_key(row["key"])
+        end
+
+        orphaned = Concurrency::BlockedExecution.expire_stale
+        Pgbus.logger.debug { "[Pgbus] Expired #{orphaned} orphaned blocked executions" } if orphaned.positive?
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Concurrency cleanup failed: #{e.message}" }
+      end
+
+      def release_blocked_for_key(key)
+        released = Concurrency::BlockedExecution.release_next(key)
+        return unless released
+
+        Pgbus.client.send_message(released[:queue_name], released[:payload])
+        Pgbus.logger.debug { "[Pgbus] Released blocked execution for key: #{key}" }
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Failed to release blocked execution for #{key}: #{e.message}" }
       end
 
       def start_heartbeat

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -119,10 +119,20 @@ module Pgbus
         released = Concurrency::BlockedExecution.release_next(key)
         return unless released
 
-        Pgbus.client.send_message(released[:queue_name], released[:payload])
+        delay = remaining_delay(released[:payload])
+        Pgbus.client.send_message(released[:queue_name], released[:payload], delay: delay)
         Pgbus.logger.debug { "[Pgbus] Released blocked execution for key: #{key}" }
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Failed to release blocked execution for #{key}: #{e.message}" }
+      end
+
+      def remaining_delay(payload)
+        scheduled_at = payload["scheduled_at"]
+        return 0 unless scheduled_at
+
+        [Time.parse(scheduled_at).to_f - Time.now.to_f, 0].max.ceil
+      rescue StandardError
+        0
       end
 
       def start_heartbeat

--- a/spec/pgbus/active_job/adapter_spec.rb
+++ b/spec/pgbus/active_job/adapter_spec.rb
@@ -69,17 +69,22 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
   end
 
   describe "#enqueue with concurrency" do
+    let(:concurrency_config) do
+      { limit: 1, duration: 900, on_conflict: :block, key: ->(*) { "TestJob-42" } }
+    end
+    let(:job_class_double) do
+      double("JobClass", pgbus_concurrency: concurrency_config, name: "TestJob").tap do |klass|
+        allow(klass).to receive(:respond_to?).and_return(false)
+        allow(klass).to receive(:respond_to?).with(:pgbus_concurrency).and_return(true)
+      end
+    end
     let(:concurrency_payload) do
       JSON.parse(serialized_json).merge("pgbus_concurrency_key" => "TestJob-42")
     end
 
     before do
-      allow(Pgbus::Concurrency).to receive(:inject_metadata).and_return(concurrency_payload)
-      allow(Pgbus::Concurrency).to receive(:extract_key).and_return("TestJob-42")
-      allow(job).to receive_message_chain(:class, :respond_to?).with(:pgbus_concurrency).and_return(true)
-      allow(job).to receive_message_chain(:class, :pgbus_concurrency).and_return(
-        { limit: 1, duration: 900, on_conflict: :block, key: ->(*) { "TestJob-42" } }
-      )
+      allow(Pgbus::Concurrency).to receive_messages(inject_metadata: concurrency_payload, extract_key: "TestJob-42")
+      allow(job).to receive(:class).and_return(job_class_double)
     end
 
     it "acquires semaphore and enqueues when under limit" do
@@ -111,10 +116,9 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
     end
 
     it "discards when at concurrency limit with on_conflict: :discard" do
-      allow(job).to receive_message_chain(:class, :pgbus_concurrency).and_return(
-        { limit: 1, duration: 900, on_conflict: :discard, key: ->(*) { "TestJob-42" } }
+      allow(job_class_double).to receive(:pgbus_concurrency).and_return(
+        concurrency_config.merge(on_conflict: :discard)
       )
-      allow(job).to receive_message_chain(:class, :name).and_return("TestJob")
       allow(Pgbus::Concurrency::Semaphore).to receive(:acquire).and_return(:blocked)
 
       adapter.enqueue(job)
@@ -123,8 +127,8 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
     end
 
     it "raises when at concurrency limit with on_conflict: :raise" do
-      allow(job).to receive_message_chain(:class, :pgbus_concurrency).and_return(
-        { limit: 1, duration: 900, on_conflict: :raise, key: ->(*) { "TestJob-42" } }
+      allow(job_class_double).to receive(:pgbus_concurrency).and_return(
+        concurrency_config.merge(on_conflict: :raise)
       )
       allow(Pgbus::Concurrency::Semaphore).to receive(:acquire).and_return(:blocked)
 

--- a/spec/pgbus/active_job/adapter_spec.rb
+++ b/spec/pgbus/active_job/adapter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
       result = adapter.enqueue(job)
 
       expect(Pgbus::Serializer).to have_received(:serialize_job).with(job)
-      expect(mock_client).to have_received(:send_message).with("default", JSON.parse(serialized_json))
+      expect(mock_client).to have_received(:send_message).with("default", JSON.parse(serialized_json), delay: 0)
       expect(job).to have_received(:provider_job_id=).with(42)
       expect(result).to eq(job)
     end
@@ -39,7 +39,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
 
         adapter.enqueue(job)
 
-        expect(mock_client).to have_received(:send_message).with("default", anything)
+        expect(mock_client).to have_received(:send_message).with("default", anything, delay: 0)
       end
     end
   end
@@ -65,6 +65,70 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
 
         expect(mock_client).to have_received(:send_message).with("default", JSON.parse(serialized_json), delay: 0)
       end
+    end
+  end
+
+  describe "#enqueue with concurrency" do
+    let(:concurrency_payload) do
+      JSON.parse(serialized_json).merge("pgbus_concurrency_key" => "TestJob-42")
+    end
+
+    before do
+      allow(Pgbus::Concurrency).to receive(:inject_metadata).and_return(concurrency_payload)
+      allow(Pgbus::Concurrency).to receive(:extract_key).and_return("TestJob-42")
+      allow(job).to receive_message_chain(:class, :respond_to?).with(:pgbus_concurrency).and_return(true)
+      allow(job).to receive_message_chain(:class, :pgbus_concurrency).and_return(
+        { limit: 1, duration: 900, on_conflict: :block, key: ->(*) { "TestJob-42" } }
+      )
+    end
+
+    it "acquires semaphore and enqueues when under limit" do
+      allow(Pgbus::Concurrency::Semaphore).to receive(:acquire).and_return(:acquired)
+      allow(mock_client).to receive(:send_message).and_return(42)
+
+      adapter.enqueue(job)
+
+      expect(Pgbus::Concurrency::Semaphore).to have_received(:acquire).with("TestJob-42", 1, 900)
+      expect(mock_client).to have_received(:send_message)
+      expect(job).to have_received(:provider_job_id=).with(42)
+    end
+
+    it "blocks when at concurrency limit with on_conflict: :block" do
+      allow(Pgbus::Concurrency::Semaphore).to receive(:acquire).and_return(:blocked)
+      allow(Pgbus::Concurrency::BlockedExecution).to receive(:insert)
+      allow(job).to receive(:try).with(:priority).and_return(0)
+
+      adapter.enqueue(job)
+
+      expect(Pgbus::Concurrency::BlockedExecution).to have_received(:insert).with(
+        concurrency_key: "TestJob-42",
+        queue_name: "default",
+        payload: concurrency_payload,
+        priority: 0,
+        duration: 900
+      )
+      expect(mock_client).not_to have_received(:send_message)
+    end
+
+    it "discards when at concurrency limit with on_conflict: :discard" do
+      allow(job).to receive_message_chain(:class, :pgbus_concurrency).and_return(
+        { limit: 1, duration: 900, on_conflict: :discard, key: ->(*) { "TestJob-42" } }
+      )
+      allow(job).to receive_message_chain(:class, :name).and_return("TestJob")
+      allow(Pgbus::Concurrency::Semaphore).to receive(:acquire).and_return(:blocked)
+
+      adapter.enqueue(job)
+
+      expect(mock_client).not_to have_received(:send_message)
+    end
+
+    it "raises when at concurrency limit with on_conflict: :raise" do
+      allow(job).to receive_message_chain(:class, :pgbus_concurrency).and_return(
+        { limit: 1, duration: 900, on_conflict: :raise, key: ->(*) { "TestJob-42" } }
+      )
+      allow(Pgbus::Concurrency::Semaphore).to receive(:acquire).and_return(:blocked)
+
+      expect { adapter.enqueue(job) }.to raise_error(Pgbus::ConcurrencyLimitExceeded, /TestJob-42/)
     end
   end
 

--- a/spec/pgbus/active_job/adapter_spec.rb
+++ b/spec/pgbus/active_job/adapter_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
       adapter.enqueue(job)
 
       expect(Pgbus::Concurrency::Semaphore).to have_received(:acquire).with("TestJob-42", 1, 900)
-      expect(mock_client).to have_received(:send_message)
+      expect(mock_client).to have_received(:send_message).with("default", concurrency_payload, delay: 0)
       expect(job).to have_received(:provider_job_id=).with(42)
     end
 

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -112,23 +112,22 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         allow(Pgbus::Concurrency).to receive(:extract_key).and_call_original
         allow(ActiveJob::Base).to receive(:deserialize).with(concurrency_payload).and_return(job_double)
         allow(Pgbus::Concurrency::Semaphore).to receive(:release)
-        allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(nil)
+        allow(Pgbus::Concurrency::BlockedExecution).to receive(:promote_next).and_return(false)
       end
 
       it "releases semaphore when no blocked jobs to promote" do
         executor.execute(message, queue_name)
 
-        expect(Pgbus::Concurrency::BlockedExecution).to have_received(:release_next).with("TestJob-42")
+        expect(Pgbus::Concurrency::BlockedExecution).to have_received(:promote_next).with("TestJob-42", client: mock_client)
         expect(Pgbus::Concurrency::Semaphore).to have_received(:release).with("TestJob-42")
       end
 
-      it "promotes blocked job without releasing semaphore (atomic handoff)" do
-        released = { queue_name: "default", payload: { "job_class" => "OtherJob" } }
-        allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(released)
+      it "skips semaphore release when promote_next succeeds (atomic handoff)" do
+        allow(Pgbus::Concurrency::BlockedExecution).to receive(:promote_next).and_return(true)
 
         executor.execute(message, queue_name)
 
-        expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "OtherJob" }, delay: 0)
+        expect(Pgbus::Concurrency::BlockedExecution).to have_received(:promote_next).with("TestJob-42", client: mock_client)
         expect(Pgbus::Concurrency::Semaphore).not_to have_received(:release)
       end
 
@@ -146,7 +145,7 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         executor.execute(message, queue_name)
 
         expect(Pgbus::Concurrency::Semaphore).not_to have_received(:release)
-        expect(Pgbus::Concurrency::BlockedExecution).not_to have_received(:release_next)
+        expect(Pgbus::Concurrency::BlockedExecution).not_to have_received(:promote_next)
       end
     end
   end

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -20,9 +20,6 @@ RSpec.describe Pgbus::ActiveJob::Executor do
   before do
     allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
     allow(ActiveJob::Base).to receive(:deserialize).with(job_payload).and_return(job_double)
-  end
-
-  before do
     # By default, no concurrency key in payloads
     allow(Pgbus::Concurrency).to receive(:extract_key).and_return(nil)
   end
@@ -118,14 +115,24 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(nil)
       end
 
-      it "signals semaphore on success" do
+      it "releases semaphore when no blocked jobs to promote" do
         executor.execute(message, queue_name)
 
-        expect(Pgbus::Concurrency::Semaphore).to have_received(:release).with("TestJob-42")
         expect(Pgbus::Concurrency::BlockedExecution).to have_received(:release_next).with("TestJob-42")
+        expect(Pgbus::Concurrency::Semaphore).to have_received(:release).with("TestJob-42")
       end
 
-      it "signals semaphore on dead letter" do
+      it "promotes blocked job without releasing semaphore (atomic handoff)" do
+        released = { queue_name: "default", payload: { "job_class" => "OtherJob" } }
+        allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(released)
+
+        executor.execute(message, queue_name)
+
+        expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "OtherJob" }, delay: 0)
+        expect(Pgbus::Concurrency::Semaphore).not_to have_received(:release)
+      end
+
+      it "releases semaphore on dead letter when no blocked jobs" do
         dlq_message = build_message_double(msg_id: 21, message: message_json, read_ct: config.max_retries + 1)
 
         executor.execute(dlq_message, queue_name)
@@ -133,21 +140,13 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         expect(Pgbus::Concurrency::Semaphore).to have_received(:release).with("TestJob-42")
       end
 
-      it "does not signal semaphore on transient failure" do
+      it "does not signal concurrency on transient failure" do
         allow(job_double).to receive(:perform_now).and_raise(StandardError, "transient")
 
         executor.execute(message, queue_name)
 
         expect(Pgbus::Concurrency::Semaphore).not_to have_received(:release)
-      end
-
-      it "enqueues blocked execution when released" do
-        released = { queue_name: "default", payload: { "job_class" => "OtherJob" } }
-        allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(released)
-
-        executor.execute(message, queue_name)
-
-        expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "OtherJob" })
+        expect(Pgbus::Concurrency::BlockedExecution).not_to have_received(:release_next)
       end
     end
   end

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 require "json"
-require "active_job/base"
+require "active_job"
 
 RSpec.describe Pgbus::ActiveJob::Executor do
   subject(:executor) { described_class.new(client: mock_client, config: config) }
@@ -20,6 +20,11 @@ RSpec.describe Pgbus::ActiveJob::Executor do
   before do
     allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
     allow(ActiveJob::Base).to receive(:deserialize).with(job_payload).and_return(job_double)
+  end
+
+  before do
+    # By default, no concurrency key in payloads
+    allow(Pgbus::Concurrency).to receive(:extract_key).and_return(nil)
   end
 
   describe "#execute" do
@@ -98,6 +103,51 @@ RSpec.describe Pgbus::ActiveJob::Executor do
 
         expect(mock_client).to have_received(:archive_message).with(queue_name, 11)
         expect(result).to eq(:success)
+      end
+    end
+
+    context "with concurrency key in payload" do
+      let(:concurrency_payload) { job_payload.merge("pgbus_concurrency_key" => "TestJob-42") }
+      let(:message_json) { JSON.generate(concurrency_payload) }
+      let(:message) { build_message_double(msg_id: 20, message: message_json, read_ct: 1) }
+
+      before do
+        allow(Pgbus::Concurrency).to receive(:extract_key).and_call_original
+        allow(ActiveJob::Base).to receive(:deserialize).with(concurrency_payload).and_return(job_double)
+        allow(Pgbus::Concurrency::Semaphore).to receive(:release)
+        allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(nil)
+      end
+
+      it "signals semaphore on success" do
+        executor.execute(message, queue_name)
+
+        expect(Pgbus::Concurrency::Semaphore).to have_received(:release).with("TestJob-42")
+        expect(Pgbus::Concurrency::BlockedExecution).to have_received(:release_next).with("TestJob-42")
+      end
+
+      it "signals semaphore on dead letter" do
+        dlq_message = build_message_double(msg_id: 21, message: message_json, read_ct: config.max_retries + 1)
+
+        executor.execute(dlq_message, queue_name)
+
+        expect(Pgbus::Concurrency::Semaphore).to have_received(:release).with("TestJob-42")
+      end
+
+      it "does not signal semaphore on transient failure" do
+        allow(job_double).to receive(:perform_now).and_raise(StandardError, "transient")
+
+        executor.execute(message, queue_name)
+
+        expect(Pgbus::Concurrency::Semaphore).not_to have_received(:release)
+      end
+
+      it "enqueues blocked execution when released" do
+        released = { queue_name: "default", payload: { "job_class" => "OtherJob" } }
+        allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(released)
+
+        executor.execute(message, queue_name)
+
+        expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "OtherJob" })
       end
     end
   end

--- a/spec/pgbus/concurrency/blocked_execution_spec.rb
+++ b/spec/pgbus/concurrency/blocked_execution_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Concurrency::BlockedExecution do
+  let(:connection) { double("AR::Connection") }
+
+  before do
+    stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
+  end
+
+  describe ".insert" do
+    it "inserts a blocked execution row" do
+      allow(connection).to receive(:exec_query).and_return([])
+
+      described_class.insert(
+        concurrency_key: "TestJob-42",
+        queue_name: "default",
+        payload: { "job_class" => "TestJob", "arguments" => [42] },
+        priority: 0,
+        duration: 900
+      )
+
+      expect(connection).to have_received(:exec_query).with(
+        a_string_matching(/INSERT INTO pgbus_blocked_executions/),
+        "Pgbus Blocked Insert",
+        array_including("TestJob-42", "default", a_string_matching(/"job_class"/), 0, an_instance_of(Time))
+      )
+    end
+  end
+
+  describe ".release_next" do
+    it "returns the next blocked execution and deletes it" do
+      row = { "queue_name" => "default", "payload" => '{"job_class":"TestJob","arguments":[42]}' }
+      result = double("Result", first: row)
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      released = described_class.release_next("TestJob-42")
+      expect(released[:queue_name]).to eq("default")
+      expect(released[:payload]["job_class"]).to eq("TestJob")
+    end
+
+    it "returns nil when no blocked executions exist" do
+      result = double("Result", first: nil)
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      expect(described_class.release_next("TestJob-42")).to be_nil
+    end
+
+    it "uses FOR UPDATE SKIP LOCKED to avoid contention" do
+      result = double("Result", first: nil)
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      described_class.release_next("TestJob-42")
+      expect(connection).to have_received(:exec_query).with(
+        a_string_matching(/FOR UPDATE SKIP LOCKED/),
+        anything,
+        anything
+      )
+    end
+  end
+
+  describe ".expire_stale" do
+    it "deletes expired blocked executions" do
+      result = double("Result", to_a: [{ "id" => 1 }, { "id" => 2 }])
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      count = described_class.expire_stale
+      expect(count).to eq(2)
+    end
+  end
+
+  describe ".count_for" do
+    it "returns the count of blocked executions for a key" do
+      result = double("Result", first: { "cnt" => "5" })
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      expect(described_class.count_for("TestJob-42")).to eq(5)
+    end
+  end
+
+  context "when ActiveRecord is not defined" do
+    before { hide_const("ActiveRecord") }
+
+    it "release_next returns nil" do
+      expect(described_class.release_next("key")).to be_nil
+    end
+  end
+end

--- a/spec/pgbus/concurrency/blocked_execution_spec.rb
+++ b/spec/pgbus/concurrency/blocked_execution_spec.rb
@@ -79,11 +79,56 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
     end
   end
 
+  describe ".promote_next" do
+    let(:mock_client) { build_mock_client }
+    let(:ar_base) { double("ActiveRecord::Base", connection: connection) }
+
+    before do
+      stub_const("ActiveRecord::Base", ar_base)
+      allow(ar_base).to receive(:transaction).and_yield
+    end
+
+    it "deletes the blocked row and enqueues atomically, returning true" do
+      row = { "queue_name" => "default", "payload" => { "job_class" => "TestJob" } }
+      result = double("Result", first: row)
+      allow(connection).to receive(:exec_query).and_return(result)
+      allow(mock_client).to receive(:send_message).and_return(42)
+
+      promoted = described_class.promote_next("TestJob-42", client: mock_client)
+
+      expect(promoted).to be true
+      expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "TestJob" }, delay: 0)
+    end
+
+    it "returns false when no blocked executions exist" do
+      result = double("Result", first: nil)
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      promoted = described_class.promote_next("TestJob-42", client: mock_client)
+
+      expect(promoted).to be false
+      expect(mock_client).not_to have_received(:send_message)
+    end
+
+    it "returns false and logs warning on error" do
+      allow(ar_base).to receive(:transaction).and_raise(StandardError, "db error")
+
+      promoted = described_class.promote_next("TestJob-42", client: mock_client)
+
+      expect(promoted).to be false
+    end
+  end
+
   context "when ActiveRecord is not defined" do
     before { hide_const("ActiveRecord") }
 
     it "release_next returns nil" do
       expect(described_class.release_next("key")).to be_nil
+    end
+
+    it "promote_next returns false" do
+      mock_client = build_mock_client
+      expect(described_class.promote_next("key", client: mock_client)).to be false
     end
   end
 end

--- a/spec/pgbus/concurrency/semaphore_spec.rb
+++ b/spec/pgbus/concurrency/semaphore_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Concurrency::Semaphore do
+  let(:connection) { double("AR::Connection") }
+
+  before do
+    stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
+  end
+
+  describe ".acquire" do
+    it "returns :acquired when a slot is available" do
+      result = double("Result", any?: true)
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      expect(described_class.acquire("TestJob-42", 2, 900)).to eq(:acquired)
+      expect(connection).to have_received(:exec_query).with(
+        a_string_matching(/INSERT INTO pgbus_semaphores/),
+        "Pgbus Semaphore Acquire",
+        array_including("TestJob-42", 2, an_instance_of(Time))
+      )
+    end
+
+    it "returns :blocked when limit is reached" do
+      result = double("Result", any?: false)
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      expect(described_class.acquire("TestJob-42", 1, 900)).to eq(:blocked)
+    end
+  end
+
+  describe ".release" do
+    it "decrements the semaphore value" do
+      allow(connection).to receive(:exec_query).and_return([])
+
+      described_class.release("TestJob-42")
+      expect(connection).to have_received(:exec_query).with(
+        a_string_matching(/UPDATE pgbus_semaphores/),
+        "Pgbus Semaphore Release",
+        ["TestJob-42"]
+      )
+    end
+  end
+
+  describe ".expire_stale" do
+    it "deletes expired semaphores and returns their keys" do
+      rows = [{ "key" => "old-key-1" }, { "key" => "old-key-2" }]
+      result = double("Result", to_a: rows)
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      expired = described_class.expire_stale
+      expect(expired.size).to eq(2)
+    end
+  end
+
+  describe ".current_value" do
+    it "returns the current value for a key" do
+      result = double("Result", first: { "value" => "3" })
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      expect(described_class.current_value("TestJob-42")).to eq(3)
+    end
+
+    it "returns nil when key does not exist" do
+      result = double("Result", first: nil)
+      allow(connection).to receive(:exec_query).and_return(result)
+
+      expect(described_class.current_value("missing")).to be_nil
+    end
+  end
+
+  context "when ActiveRecord is not defined" do
+    before { hide_const("ActiveRecord") }
+
+    it "acquire returns :blocked" do
+      expect(described_class.acquire("key", 1, 900)).to eq(:blocked)
+    end
+
+    it "release returns empty" do
+      expect(described_class.release("key")).to eq([])
+    end
+  end
+end

--- a/spec/pgbus/concurrency_spec.rb
+++ b/spec/pgbus/concurrency_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Pgbus::Concurrency do
       expect do
         Class.new(ActiveJob::Base) do
           include Pgbus::Concurrency
+
           limits_concurrency to: 0, key: -> { "x" }
         end
       end.to raise_error(ArgumentError, /positive integer/)
@@ -48,14 +49,36 @@ RSpec.describe Pgbus::Concurrency do
       expect do
         Class.new(ActiveJob::Base) do
           include Pgbus::Concurrency
+
           limits_concurrency to: 1, on_conflict: :unknown
         end
       end.to raise_error(ArgumentError, /on_conflict/)
     end
 
+    it "validates duration is a positive number" do
+      expect do
+        Class.new(ActiveJob::Base) do
+          include Pgbus::Concurrency
+
+          limits_concurrency to: 1, duration: -5
+        end
+      end.to raise_error(ArgumentError, /duration/)
+    end
+
+    it "validates key is callable" do
+      expect do
+        Class.new(ActiveJob::Base) do
+          include Pgbus::Concurrency
+
+          limits_concurrency to: 1, key: "not_callable"
+        end
+      end.to raise_error(ArgumentError, /callable/)
+    end
+
     it "defaults key to class name" do
       job_class = Class.new(ActiveJob::Base) do
         include Pgbus::Concurrency
+
         limits_concurrency to: 1
 
         def perform; end

--- a/spec/pgbus/concurrency_spec.rb
+++ b/spec/pgbus/concurrency_spec.rb
@@ -95,6 +95,22 @@ RSpec.describe Pgbus::Concurrency do
       expect(described_class.resolve_key(job)).to eq("TestJob-42")
     end
 
+    it "forwards keyword arguments to the key lambda" do
+      kw_job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Concurrency
+
+        self.queue_adapter = :test
+
+        limits_concurrency to: 1,
+                           key: ->(user_id:) { "KWJob-#{user_id}" }
+
+        def perform(user_id:); end
+      end
+
+      job = kw_job_class.new(user_id: 99)
+      expect(described_class.resolve_key(job)).to eq("KWJob-99")
+    end
+
     it "returns nil for jobs without concurrency" do
       job = no_concurrency_job_class.new
       expect(described_class.resolve_key(job)).to be_nil

--- a/spec/pgbus/concurrency_spec.rb
+++ b/spec/pgbus/concurrency_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_job"
+
+RSpec.describe Pgbus::Concurrency do
+  let(:test_job_class) do
+    Class.new(ActiveJob::Base) do
+      include Pgbus::Concurrency
+
+      self.queue_adapter = :test
+
+      limits_concurrency to: 2,
+                         key: ->(user_id) { "TestJob-#{user_id}" },
+                         duration: 900,
+                         on_conflict: :discard
+
+      def perform(user_id); end
+    end
+  end
+
+  let(:no_concurrency_job_class) do
+    Class.new(ActiveJob::Base) do
+      self.queue_adapter = :test
+      def perform; end
+    end
+  end
+
+  describe ".limits_concurrency" do
+    it "stores concurrency config on the class" do
+      config = test_job_class.pgbus_concurrency
+      expect(config[:limit]).to eq(2)
+      expect(config[:duration]).to eq(900)
+      expect(config[:on_conflict]).to eq(:discard)
+      expect(config[:key]).to be_a(Proc)
+    end
+
+    it "validates to: is a positive integer" do
+      expect do
+        Class.new(ActiveJob::Base) do
+          include Pgbus::Concurrency
+          limits_concurrency to: 0, key: -> { "x" }
+        end
+      end.to raise_error(ArgumentError, /positive integer/)
+    end
+
+    it "validates on_conflict is a known strategy" do
+      expect do
+        Class.new(ActiveJob::Base) do
+          include Pgbus::Concurrency
+          limits_concurrency to: 1, on_conflict: :unknown
+        end
+      end.to raise_error(ArgumentError, /on_conflict/)
+    end
+
+    it "defaults key to class name" do
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Concurrency
+        limits_concurrency to: 1
+
+        def perform; end
+      end
+
+      config = job_class.pgbus_concurrency
+      expect(config[:key].call).to eq(job_class.name)
+    end
+  end
+
+  describe ".resolve_key" do
+    it "resolves the concurrency key from job arguments" do
+      job = test_job_class.new(42)
+      expect(described_class.resolve_key(job)).to eq("TestJob-42")
+    end
+
+    it "returns nil for jobs without concurrency" do
+      job = no_concurrency_job_class.new
+      expect(described_class.resolve_key(job)).to be_nil
+    end
+  end
+
+  describe ".inject_metadata" do
+    it "adds concurrency key to payload hash" do
+      job = test_job_class.new(42)
+      payload = { "job_class" => "TestJob", "arguments" => [42] }
+      result = described_class.inject_metadata(job, payload)
+      expect(result["pgbus_concurrency_key"]).to eq("TestJob-42")
+    end
+
+    it "returns original payload for jobs without concurrency" do
+      job = no_concurrency_job_class.new
+      payload = { "job_class" => "NoConcurrency" }
+      result = described_class.inject_metadata(job, payload)
+      expect(result).not_to have_key("pgbus_concurrency_key")
+    end
+  end
+
+  describe ".extract_key" do
+    it "extracts the concurrency key from a payload" do
+      payload = { "pgbus_concurrency_key" => "TestJob-42" }
+      expect(described_class.extract_key(payload)).to eq("TestJob-42")
+    end
+
+    it "returns nil when no concurrency key present" do
+      expect(described_class.extract_key({})).to be_nil
+    end
+  end
+end

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -164,25 +164,24 @@ RSpec.describe Pgbus::Process::Dispatcher do
   end
 
   describe "#cleanup_concurrency (private)" do
-    it "expires stale semaphores and releases blocked executions" do
+    it "expires stale semaphores and promotes blocked executions" do
       allow(Pgbus::Concurrency::Semaphore).to receive(:expire_stale).and_return([{ "key" => "TestJob-42" }])
-      allow(Pgbus::Concurrency::BlockedExecution).to receive_messages(expire_stale: 0, release_next: nil)
+      allow(Pgbus::Concurrency::BlockedExecution).to receive_messages(expire_stale: 0, promote_next: false)
 
       dispatcher.send(:cleanup_concurrency)
 
       expect(Pgbus::Concurrency::Semaphore).to have_received(:expire_stale)
-      expect(Pgbus::Concurrency::BlockedExecution).to have_received(:release_next).with("TestJob-42")
+      expect(Pgbus::Concurrency::BlockedExecution).to have_received(:promote_next).with("TestJob-42", client: mock_client)
       expect(Pgbus::Concurrency::BlockedExecution).to have_received(:expire_stale)
     end
 
-    it "enqueues released blocked executions" do
-      released = { queue_name: "default", payload: { "job_class" => "TestJob" } }
+    it "promotes blocked executions atomically" do
       allow(Pgbus::Concurrency::Semaphore).to receive(:expire_stale).and_return([{ "key" => "TestJob-42" }])
-      allow(Pgbus::Concurrency::BlockedExecution).to receive_messages(expire_stale: 0, release_next: released)
+      allow(Pgbus::Concurrency::BlockedExecution).to receive_messages(expire_stale: 0, promote_next: true)
 
       dispatcher.send(:cleanup_concurrency)
 
-      expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "TestJob" }, delay: 0)
+      expect(Pgbus::Concurrency::BlockedExecution).to have_received(:promote_next).with("TestJob-42", client: mock_client)
     end
 
     it "rescues errors gracefully" do

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "has a reap interval of 5 minutes" do
       expect(described_class::REAP_INTERVAL).to eq(300)
     end
+
+    it "has a concurrency interval of 5 minutes" do
+      expect(described_class::CONCURRENCY_INTERVAL).to eq(300)
+    end
   end
 
   describe "#graceful_shutdown" do
@@ -143,10 +147,49 @@ RSpec.describe Pgbus::Process::Dispatcher do
       expect(dispatcher).to have_received(:reap_stale_processes)
     end
 
+    it "runs concurrency cleanup when concurrency interval has elapsed" do
+      allow(dispatcher).to receive(:cleanup_concurrency)
+
+      dispatcher.instance_variable_set(:@last_concurrency_at, Time.now - described_class::CONCURRENCY_INTERVAL - 1)
+      dispatcher.send(:run_maintenance)
+
+      expect(dispatcher).to have_received(:cleanup_concurrency)
+    end
+
     it "rescues errors from maintenance methods" do
       dispatcher.instance_variable_set(:@last_cleanup_at, Time.now - described_class::CLEANUP_INTERVAL - 1)
       allow(dispatcher).to receive(:cleanup_processed_events).and_raise(StandardError, "boom")
       expect { dispatcher.send(:run_maintenance) }.not_to raise_error
+    end
+  end
+
+  describe "#cleanup_concurrency (private)" do
+    it "expires stale semaphores and releases blocked executions" do
+      allow(Pgbus::Concurrency::Semaphore).to receive(:expire_stale).and_return([{ "key" => "TestJob-42" }])
+      allow(Pgbus::Concurrency::BlockedExecution).to receive(:expire_stale).and_return(0)
+      allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(nil)
+
+      dispatcher.send(:cleanup_concurrency)
+
+      expect(Pgbus::Concurrency::Semaphore).to have_received(:expire_stale)
+      expect(Pgbus::Concurrency::BlockedExecution).to have_received(:release_next).with("TestJob-42")
+      expect(Pgbus::Concurrency::BlockedExecution).to have_received(:expire_stale)
+    end
+
+    it "enqueues released blocked executions" do
+      released = { queue_name: "default", payload: { "job_class" => "TestJob" } }
+      allow(Pgbus::Concurrency::Semaphore).to receive(:expire_stale).and_return([{ "key" => "TestJob-42" }])
+      allow(Pgbus::Concurrency::BlockedExecution).to receive(:expire_stale).and_return(0)
+      allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(released)
+
+      dispatcher.send(:cleanup_concurrency)
+
+      expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "TestJob" })
+    end
+
+    it "rescues errors gracefully" do
+      allow(Pgbus::Concurrency::Semaphore).to receive(:expire_stale).and_raise(StandardError, "db error")
+      expect { dispatcher.send(:cleanup_concurrency) }.not_to raise_error
     end
   end
 

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -166,8 +166,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
   describe "#cleanup_concurrency (private)" do
     it "expires stale semaphores and releases blocked executions" do
       allow(Pgbus::Concurrency::Semaphore).to receive(:expire_stale).and_return([{ "key" => "TestJob-42" }])
-      allow(Pgbus::Concurrency::BlockedExecution).to receive(:expire_stale).and_return(0)
-      allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(nil)
+      allow(Pgbus::Concurrency::BlockedExecution).to receive_messages(expire_stale: 0, release_next: nil)
 
       dispatcher.send(:cleanup_concurrency)
 
@@ -179,12 +178,11 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "enqueues released blocked executions" do
       released = { queue_name: "default", payload: { "job_class" => "TestJob" } }
       allow(Pgbus::Concurrency::Semaphore).to receive(:expire_stale).and_return([{ "key" => "TestJob-42" }])
-      allow(Pgbus::Concurrency::BlockedExecution).to receive(:expire_stale).and_return(0)
-      allow(Pgbus::Concurrency::BlockedExecution).to receive(:release_next).and_return(released)
+      allow(Pgbus::Concurrency::BlockedExecution).to receive_messages(expire_stale: 0, release_next: released)
 
       dispatcher.send(:cleanup_concurrency)
 
-      expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "TestJob" })
+      expect(mock_client).to have_received(:send_message).with("default", { "job_class" => "TestJob" }, delay: 0)
     end
 
     it "rescues errors gracefully" do


### PR DESCRIPTION
## Summary

- Add `Pgbus::Concurrency` ActiveJob mixin with `limits_concurrency` DSL
- Semaphore-based concurrency limiting (inspired by SolidQueue's approach)
- Three conflict strategies: `:block`, `:discard`, `:raise`
- Adapter checks semaphore before enqueuing, executor signals on completion
- Dispatcher cleans up expired semaphores and orphaned blocked executions
- Migration template adds `pgbus_semaphores` and `pgbus_blocked_executions` tables
- Updated README with concurrency docs, updated migration guides

## Test plan

- [ ] 257 unit examples pass, 0 failures
- [ ] Rubocop clean
- [ ] Concurrency mixin DSL validates arguments
- [ ] Semaphore acquire/release/expire tested
- [ ] BlockedExecution insert/release_next/expire tested
- [ ] Adapter tests cover all three on_conflict strategies
- [ ] Executor signals semaphore on success and dead-letter, not on transient failure
- [ ] Dispatcher maintenance tests cover concurrency cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added concurrency controls via Pgbus::Concurrency with a limits_concurrency DSL to limit concurrent job runs per key
  * Supports conflict strategies: :block (queue for later), :discard (skip), and :raise (error)
  * Executor now releases or promotes blocked jobs when slots free; background maintenance expires semaphores and enqueues waiting jobs
  * Added ConcurrencyLimitExceeded error type

* **Database**
  * New tables to track semaphores and blocked executions

* **Documentation**
  * Docs and migration/upgrade guides updated with usage examples and comparisons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->