### PR TITLE
feat: batch support (Phase 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PostgreSQL-native job processing and event bus for Rails, built on [PGMQ](https:
 - [Installation](#installation)
 - [Quick start](#quick-start)
 - [Concurrency controls](#concurrency-controls)
+- [Batches](#batches)
 - [Configuration reference](#configuration-reference)
 - [Architecture](#architecture)
 - [CLI](#cli)
@@ -239,6 +240,51 @@ end
 2. **Complete**: After a job succeeds or is dead-lettered, the executor decrements the semaphore and releases the next blocked job (if any).
 3. **Safety net**: The dispatcher periodically cleans up expired semaphores and orphaned blocked executions to recover from crashed workers.
 
+## Batches
+
+Coordinate groups of jobs with callbacks when all complete:
+
+```ruby
+batch = Pgbus::Batch.new(
+  on_finish: BatchFinishedJob,
+  on_success: BatchSucceededJob,
+  on_discard: BatchFailedJob,
+  description: "Import users",
+  properties: { initiated_by: current_user.id }
+)
+
+batch.enqueue do
+  users.each { |user| ImportUserJob.perform_later(user.id) }
+end
+```
+
+### Callbacks
+
+| Callback | Fired when |
+|----------|------------|
+| `on_finish` | All jobs completed (success or discard) |
+| `on_success` | All jobs completed successfully (zero discarded) |
+| `on_discard` | At least one job was dead-lettered |
+
+Callback jobs receive the batch `properties` hash as their argument:
+
+```ruby
+class BatchFinishedJob < ApplicationJob
+  def perform(properties)
+    user = User.find(properties["initiated_by"])
+    ImportMailer.complete(user).deliver_later
+  end
+end
+```
+
+### How it works
+
+1. `Batch.new(...)` creates a tracking row in `pgbus_batches` with `status: "pending"`
+2. `batch.enqueue { ... }` tags each enqueued job with the `pgbus_batch_id` in its payload
+3. After each job completes or is dead-lettered, the executor atomically updates the batch counters
+4. When `completed_jobs + discarded_jobs == total_jobs`, the batch status flips to `"finished"` and callback jobs are enqueued
+5. The dispatcher cleans up finished batches older than 7 days
+
 ## Configuration reference
 
 | Option | Default | Description |
@@ -337,6 +383,7 @@ Pgbus uses these tables (created via PGMQ and migrations):
 | `pgbus_processed_events` | Idempotency deduplication (event_id, handler_class) |
 | `pgbus_semaphores` | Concurrency control counting semaphores |
 | `pgbus_blocked_executions` | Jobs waiting for a concurrency semaphore slot |
+| `pgbus_batches` | Batch tracking with job counters and callback config |
 
 ## Switching from another backend
 

--- a/app/models/pgbus/application_record.rb
+++ b/app/models/pgbus/application_record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/app/models/pgbus/batch_record.rb
+++ b/app/models/pgbus/batch_record.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class BatchRecord < ApplicationRecord
+    self.table_name = "pgbus_batches"
+
+    scope :finished, -> { where(status: "finished") }
+    scope :stale, ->(before:) { finished.where("finished_at < ?", before) }
+
+    # Atomic counter increment with transition detection.
+    # Returns the row hash (with "just_finished" flag) or nil.
+    def self.increment_counter!(batch_id, column)
+      result = connection.exec_query(
+        <<~SQL,
+          UPDATE pgbus_batches
+          SET #{column} = #{column} + 1,
+              status = CASE
+                WHEN completed_jobs + discarded_jobs + 1 = total_jobs THEN 'finished'
+                ELSE status
+              END,
+              finished_at = CASE
+                WHEN completed_jobs + discarded_jobs + 1 = total_jobs THEN NOW()
+                ELSE finished_at
+              END
+          WHERE batch_id = $1
+          RETURNING status, total_jobs, completed_jobs, discarded_jobs,
+                    on_finish_class, on_success_class, on_discard_class, properties,
+                    (completed_jobs + discarded_jobs = total_jobs) AS just_finished
+        SQL
+        "Pgbus Batch Counter",
+        [batch_id]
+      )
+
+      result.first
+    end
+  end
+end

--- a/app/models/pgbus/batch_record.rb
+++ b/app/models/pgbus/batch_record.rb
@@ -4,6 +4,8 @@ module Pgbus
   class BatchRecord < ApplicationRecord
     self.table_name = "pgbus_batches"
 
+    COUNTER_COLUMNS = %w[completed_jobs discarded_jobs].freeze
+
     scope :finished, -> { where(status: "finished") }
     scope :stale, ->(before:) { finished.where("finished_at < ?", before) }
 
@@ -11,6 +13,8 @@ module Pgbus
     # batch to finish. Uses row-level locking to prevent duplicate callbacks.
     # Returns { just_finished:, record: } or nil if batch not found.
     def self.increment_counter!(batch_id, column)
+      raise ArgumentError, "Invalid column: #{column}" unless COUNTER_COLUMNS.include?(column)
+
       transaction do
         record = lock.find_by(batch_id: batch_id)
         return nil unless record

--- a/app/models/pgbus/batch_record.rb
+++ b/app/models/pgbus/batch_record.rb
@@ -7,31 +7,21 @@ module Pgbus
     scope :finished, -> { where(status: "finished") }
     scope :stale, ->(before:) { finished.where("finished_at < ?", before) }
 
-    # Atomic counter increment with transition detection.
-    # Returns the row hash (with "just_finished" flag) or nil.
+    # Atomically increment the counter and detect if this update caused the
+    # batch to finish. Uses row-level locking to prevent duplicate callbacks.
+    # Returns { just_finished:, record: } or nil if batch not found.
     def self.increment_counter!(batch_id, column)
-      result = connection.exec_query(
-        <<~SQL,
-          UPDATE pgbus_batches
-          SET #{column} = #{column} + 1,
-              status = CASE
-                WHEN completed_jobs + discarded_jobs + 1 = total_jobs THEN 'finished'
-                ELSE status
-              END,
-              finished_at = CASE
-                WHEN completed_jobs + discarded_jobs + 1 = total_jobs THEN NOW()
-                ELSE finished_at
-              END
-          WHERE batch_id = $1
-          RETURNING status, total_jobs, completed_jobs, discarded_jobs,
-                    on_finish_class, on_success_class, on_discard_class, properties,
-                    (completed_jobs + discarded_jobs = total_jobs) AS just_finished
-        SQL
-        "Pgbus Batch Counter",
-        [batch_id]
-      )
+      transaction do
+        record = lock.find_by(batch_id: batch_id)
+        return nil unless record
 
-      result.first
+        record.increment!(column)
+
+        just_finished = record.completed_jobs + record.discarded_jobs == record.total_jobs
+        record.update!(status: "finished", finished_at: Time.current) if just_finished && record.status != "finished"
+
+        { record: record, just_finished: just_finished && record.status == "finished" }
+      end
     end
   end
 end

--- a/app/models/pgbus/blocked_execution_record.rb
+++ b/app/models/pgbus/blocked_execution_record.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class BlockedExecutionRecord < ApplicationRecord
+    self.table_name = "pgbus_blocked_executions"
+
+    scope :for_key, ->(key) { where(concurrency_key: key) }
+    scope :expired, ->(now = Time.current) { where("expires_at < ?", now) }
+
+    # Atomic dequeue: DELETE the highest-priority non-expired row with FOR UPDATE SKIP LOCKED.
+    # Returns { queue_name:, payload: } or nil.
+    def self.release_next!(concurrency_key)
+      now = Time.now.utc
+      result = connection.exec_query(
+        <<~SQL,
+          DELETE FROM pgbus_blocked_executions
+          WHERE id = (
+            SELECT id FROM pgbus_blocked_executions
+            WHERE concurrency_key = $1
+              AND expires_at >= $2
+            ORDER BY priority ASC, created_at ASC
+            LIMIT 1
+            FOR UPDATE SKIP LOCKED
+          )
+          RETURNING queue_name, payload
+        SQL
+        "Pgbus Blocked Release",
+        [concurrency_key, now]
+      )
+
+      row = result.first
+      return nil unless row
+
+      payload = row["payload"]
+      payload = JSON.parse(payload) if payload.is_a?(String)
+
+      { queue_name: row["queue_name"], payload: payload }
+    end
+  end
+end

--- a/app/models/pgbus/process_record.rb
+++ b/app/models/pgbus/process_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class ProcessRecord < ApplicationRecord
+    self.table_name = "pgbus_processes"
+
+    scope :stale, ->(threshold) { where("last_heartbeat_at < ?", threshold) }
+  end
+end

--- a/app/models/pgbus/processed_event_record.rb
+++ b/app/models/pgbus/processed_event_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class ProcessedEventRecord < ApplicationRecord
+    self.table_name = "pgbus_processed_events"
+
+    scope :expired, ->(before) { where("processed_at < ?", before) }
+  end
+end

--- a/app/models/pgbus/semaphore_record.rb
+++ b/app/models/pgbus/semaphore_record.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class SemaphoreRecord < ApplicationRecord
+    self.table_name = "pgbus_semaphores"
+
+    scope :expired, ->(now = Time.current) { where("expires_at < ? OR value <= 0", now) }
+
+    # Atomic conditional UPSERT. Returns :acquired or :blocked.
+    def self.acquire!(key, max_value, expires_at)
+      result = connection.exec_query(
+        <<~SQL,
+          INSERT INTO pgbus_semaphores (key, value, max_value, expires_at)
+          VALUES ($1, 1, $2, $3)
+          ON CONFLICT (key) DO UPDATE
+            SET value = pgbus_semaphores.value + 1,
+                max_value = EXCLUDED.max_value,
+                expires_at = GREATEST(pgbus_semaphores.expires_at, EXCLUDED.expires_at)
+            WHERE pgbus_semaphores.value < EXCLUDED.max_value
+          RETURNING value
+        SQL
+        "Pgbus Semaphore Acquire",
+        [key, max_value, expires_at]
+      )
+
+      result.any? ? :acquired : :blocked
+    end
+  end
+end

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,5 +24,5 @@ Switching to Pgbus from another job backend? These guides cover what changes, wh
 | Idempotent events | No | No | No | Yes |
 | Concurrency controls | Enterprise | `limits_concurrency` | `good_job_control_concurrency_with` | `Pgbus::Concurrency` |
 | Recurring/cron jobs | `sidekiq-cron` gem | `config/recurring.yml` | `config.good_job.cron` | Planned |
-| Batches | Pro | No | `GoodJob::Batch` | Planned |
+| Batches | Pro | No | `GoodJob::Batch` | `Pgbus::Batch` |
 | Web dashboard | `Sidekiq::Web` | Mission Control | `GoodJob::Engine` | `Pgbus::Engine` |

--- a/docs/switch_from_good_job.md
+++ b/docs/switch_from_good_job.md
@@ -260,7 +260,7 @@ end
 |-----------------|-----------------|
 | Concurrency controls (`good_job_control_concurrency_with`) | `Pgbus::Concurrency` with `limits_concurrency` DSL |
 | Throttling (`enqueue_throttle`, `perform_throttle`) | Planned |
-| Batches (`GoodJob::Batch`) | Planned |
+| Batches (`GoodJob::Batch`) | `Pgbus::Batch` with on_finish/on_success/on_discard callbacks |
 | Cron / recurring jobs | Planned |
 | Async execution mode (in-process) | Not planned (forked processes only) |
 | Capsules (isolated thread pools) | Workers are isolated by design (forked processes) |

--- a/docs/switch_from_sidekiq.md
+++ b/docs/switch_from_sidekiq.md
@@ -204,7 +204,7 @@ Once all Sidekiq jobs have drained and you've verified Pgbus is processing corre
 
 | Sidekiq feature | Status in Pgbus |
 |-----------------|-----------------|
-| Batches (Pro) | Planned |
+| Batches (Pro) | `Pgbus::Batch` with on_finish/on_success/on_discard callbacks |
 | Rate limiting (Enterprise) | Planned |
 | Concurrency controls (Enterprise) | `Pgbus::Concurrency` with `limits_concurrency` DSL |
 | Unique jobs (Enterprise / `sidekiq-unique-jobs`) | Partial -- event bus has idempotency; job-level dedup planned |

--- a/lib/generators/pgbus/templates/migration.rb.erb
+++ b/lib/generators/pgbus/templates/migration.rb.erb
@@ -71,6 +71,28 @@ class InstallPgbus < ActiveRecord::Migration<%= migration_version %>
     add_index :pgbus_blocked_executions, [:concurrency_key, :priority, :created_at],
       name: "idx_pgbus_blocked_release_order"
 
+    # Batch tracking (coordinated job groups with callbacks)
+    create_table :pgbus_batches do |t|
+      t.string :batch_id, null: false
+      t.string :description
+      t.string :on_finish_class
+      t.string :on_success_class
+      t.string :on_discard_class
+      t.jsonb :properties, default: {}
+      t.integer :total_jobs, null: false, default: 0
+      t.integer :completed_jobs, null: false, default: 0
+      t.integer :failed_jobs, null: false, default: 0
+      t.integer :discarded_jobs, null: false, default: 0
+      t.string :status, null: false, default: "pending"
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :finished_at
+    end
+
+    add_index :pgbus_batches, :batch_id,
+      unique: true, name: "idx_pgbus_batches_batch_id"
+    add_index :pgbus_batches, :status,
+      name: "idx_pgbus_batches_status"
+
     # Create default queues via PGMQ
     execute "SELECT pgmq.create('pgbus_default')"
     execute "SELECT pgmq.create('pgbus_default_dlq')"
@@ -80,6 +102,7 @@ class InstallPgbus < ActiveRecord::Migration<%= migration_version %>
     execute "SELECT pgmq.drop_queue('pgbus_default_dlq')"
     execute "SELECT pgmq.drop_queue('pgbus_default')"
 
+    drop_table :pgbus_batches
     drop_table :pgbus_blocked_executions
     drop_table :pgbus_semaphores
     drop_table :pgbus_failed_events

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -16,6 +16,8 @@ module Pgbus
         loader = Zeitwerk::Loader.for_gem
         loader.inflector.inflect("pgbus" => "Pgbus", "cli" => "CLI", "dsl" => "DSL")
         loader.ignore("#{__dir__}/generators")
+        models_dir = File.expand_path("../app/models", __dir__)
+        loader.push_dir(models_dir) if File.directory?(models_dir)
         loader
       end
     end

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -16,8 +16,12 @@ module Pgbus
         loader = Zeitwerk::Loader.for_gem
         loader.inflector.inflect("pgbus" => "Pgbus", "cli" => "CLI", "dsl" => "DSL")
         loader.ignore("#{__dir__}/generators")
-        models_dir = File.expand_path("../app/models", __dir__)
-        loader.push_dir(models_dir) if File.directory?(models_dir)
+        # Register app/models for non-Rails usage (specs, standalone).
+        # When Rails is running, the Engine handles autoloading app/models.
+        unless defined?(Rails::Engine)
+          models_dir = File.expand_path("../app/models", __dir__)
+          loader.push_dir(models_dir) if File.directory?(models_dir)
+        end
         loader
       end
     end

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -9,6 +9,7 @@ module Pgbus
         queue = active_job.queue_name || Pgbus.configuration.default_queue
         payload_hash = JSON.parse(Serializer.serialize_job(active_job))
         payload_hash = Concurrency.inject_metadata(active_job, payload_hash)
+        payload_hash = inject_batch_metadata(payload_hash)
 
         enqueue_with_concurrency(active_job, queue, payload_hash)
       end
@@ -17,6 +18,7 @@ module Pgbus
         queue = active_job.queue_name || Pgbus.configuration.default_queue
         payload_hash = JSON.parse(Serializer.serialize_job(active_job))
         payload_hash = Concurrency.inject_metadata(active_job, payload_hash)
+        payload_hash = inject_batch_metadata(payload_hash)
         delay = [(timestamp - Time.now.to_f).ceil, 0].max
 
         enqueue_with_concurrency(active_job, queue, payload_hash, delay: delay)
@@ -73,6 +75,14 @@ module Pgbus
         when :raise
           raise ConcurrencyLimitExceeded, "Concurrency limit reached for key: #{key}"
         end
+      end
+
+      def inject_batch_metadata(payload_hash)
+        batch_id = Thread.current[:pgbus_batch_id]
+        return payload_hash unless batch_id
+
+        Thread.current[:pgbus_batch_job_count] = (Thread.current[:pgbus_batch_job_count] || 0) + 1
+        payload_hash.merge(Batch::METADATA_KEY => batch_id)
       end
 
       def enqueue_immediate(queue, jobs)

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -17,6 +17,7 @@ module Pgbus
         if read_count > config.max_retries
           handle_dead_letter(message, queue_name, payload)
           signal_concurrency(payload)
+          signal_batch_discarded(payload)
           return :dead_lettered
         end
 
@@ -24,6 +25,7 @@ module Pgbus
         execute_job(job)
         client.archive_message(queue_name, message.msg_id.to_i)
         signal_concurrency(payload)
+        signal_batch_completed(payload)
         instrument("pgbus.job_completed", queue: queue_name, job_class: payload["job_class"])
         :success
       rescue StandardError => e
@@ -73,6 +75,24 @@ module Pgbus
         Concurrency::Semaphore.release(key) unless promoted
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Concurrency signal failed: #{e.message}" }
+      end
+
+      def signal_batch_completed(payload)
+        batch_id = payload[Batch::METADATA_KEY]
+        return unless batch_id
+
+        Batch.job_completed(batch_id)
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Batch completion signal failed: #{e.message}" }
+      end
+
+      def signal_batch_discarded(payload)
+        batch_id = payload[Batch::METADATA_KEY]
+        return unless batch_id
+
+        Batch.job_discarded(batch_id)
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Batch discard signal failed: #{e.message}" }
       end
 
       def handle_dead_letter(message, queue_name, payload)

--- a/lib/pgbus/batch.rb
+++ b/lib/pgbus/batch.rb
@@ -107,6 +107,9 @@ module Pgbus
       def update_counter(batch_id, column)
         return nil unless defined?(ActiveRecord::Base)
 
+        # Use (completed_jobs + discarded_jobs = total_jobs) AS just_finished to detect
+        # whether THIS update caused the transition, avoiding duplicate callbacks when
+        # two workers complete the final jobs simultaneously.
         result = ActiveRecord::Base.connection.exec_query(
           <<~SQL,
             UPDATE pgbus_batches
@@ -120,7 +123,9 @@ module Pgbus
                   ELSE finished_at
                 END
             WHERE batch_id = $1
-            RETURNING status, total_jobs, completed_jobs, discarded_jobs, on_finish_class, on_success_class, on_discard_class, properties
+            RETURNING status, total_jobs, completed_jobs, discarded_jobs,
+                      on_finish_class, on_success_class, on_discard_class, properties,
+                      (completed_jobs + discarded_jobs = total_jobs) AS just_finished
           SQL
           "Pgbus Batch Counter",
           [batch_id]
@@ -129,7 +134,7 @@ module Pgbus
         row = result.first
         return nil unless row
 
-        fire_callbacks(row) if row["status"] == "finished"
+        fire_callbacks(row) if row["just_finished"]
         row
       end
 

--- a/lib/pgbus/batch.rb
+++ b/lib/pgbus/batch.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "json"
+
+module Pgbus
+  class Batch
+    METADATA_KEY = "pgbus_batch_id"
+
+    attr_reader :batch_id, :properties, :description,
+                :on_finish, :on_success, :on_discard
+
+    def initialize(on_finish: nil, on_success: nil, on_discard: nil, description: nil, properties: {})
+      @batch_id = SecureRandom.uuid
+      @on_finish = on_finish
+      @on_success = on_success
+      @on_discard = on_discard
+      @description = description
+      @properties = properties
+      @job_count = 0
+    end
+
+    # Enqueue a group of jobs as a batch.
+    # Jobs enqueued inside the block are tracked as part of this batch.
+    def enqueue(&)
+      create_record
+      count_jobs(&)
+      update_total
+      self
+    end
+
+    # Record a completed job. Returns the batch status after update.
+    def self.job_completed(batch_id)
+      update_counter(batch_id, "completed_jobs")
+    end
+
+    # Record a discarded (dead-lettered) job. Returns the batch status after update.
+    def self.job_discarded(batch_id)
+      update_counter(batch_id, "discarded_jobs")
+    end
+
+    # Find a batch record by ID. Returns a hash or nil.
+    def self.find(batch_id)
+      return nil unless defined?(ActiveRecord::Base)
+
+      result = ActiveRecord::Base.connection.exec_query(
+        "SELECT * FROM pgbus_batches WHERE batch_id = $1",
+        "Pgbus Batch Find",
+        [batch_id]
+      )
+      result.first
+    end
+
+    # Delete finished batches older than the given threshold.
+    def self.cleanup(older_than:)
+      return 0 unless defined?(ActiveRecord::Base)
+
+      result = ActiveRecord::Base.connection.exec_query(
+        "DELETE FROM pgbus_batches WHERE status = 'finished' AND finished_at < $1 RETURNING id",
+        "Pgbus Batch Cleanup",
+        [older_than]
+      )
+      result.to_a.size
+    end
+
+    private
+
+    def create_record
+      return unless defined?(ActiveRecord::Base)
+
+      ActiveRecord::Base.connection.exec_query(
+        <<~SQL,
+          INSERT INTO pgbus_batches
+            (batch_id, description, on_finish_class, on_success_class, on_discard_class, properties, status)
+          VALUES ($1, $2, $3, $4, $5, $6, 'pending')
+        SQL
+        "Pgbus Batch Create",
+        [batch_id, description, on_finish&.name, on_success&.name, on_discard&.name, JSON.generate(properties)]
+      )
+    end
+
+    def count_jobs(&)
+      Thread.current[:pgbus_batch_id] = batch_id
+      @job_count = 0
+
+      yield
+
+      @job_count = Thread.current[:pgbus_batch_job_count] || 0
+    ensure
+      Thread.current[:pgbus_batch_id] = nil
+      Thread.current[:pgbus_batch_job_count] = nil
+    end
+
+    def update_total
+      return unless defined?(ActiveRecord::Base)
+
+      ActiveRecord::Base.connection.exec_query(
+        "UPDATE pgbus_batches SET total_jobs = $1, status = 'processing' WHERE batch_id = $2",
+        "Pgbus Batch Update Total",
+        [@job_count, batch_id]
+      )
+    end
+
+    class << self
+      private
+
+      def update_counter(batch_id, column)
+        return nil unless defined?(ActiveRecord::Base)
+
+        result = ActiveRecord::Base.connection.exec_query(
+          <<~SQL,
+            UPDATE pgbus_batches
+            SET #{column} = #{column} + 1,
+                status = CASE
+                  WHEN completed_jobs + discarded_jobs + 1 = total_jobs THEN 'finished'
+                  ELSE status
+                END,
+                finished_at = CASE
+                  WHEN completed_jobs + discarded_jobs + 1 = total_jobs THEN NOW()
+                  ELSE finished_at
+                END
+            WHERE batch_id = $1
+            RETURNING status, total_jobs, completed_jobs, discarded_jobs, on_finish_class, on_success_class, on_discard_class, properties
+          SQL
+          "Pgbus Batch Counter",
+          [batch_id]
+        )
+
+        row = result.first
+        return nil unless row
+
+        fire_callbacks(row) if row["status"] == "finished"
+        row
+      end
+
+      def fire_callbacks(row)
+        properties = JSON.parse(row["properties"] || "{}")
+        all_succeeded = row["discarded_jobs"].to_i.zero?
+
+        enqueue_callback(row["on_finish_class"], properties) if row["on_finish_class"]
+        enqueue_callback(row["on_success_class"], properties) if row["on_success_class"] && all_succeeded
+        enqueue_callback(row["on_discard_class"], properties) if row["on_discard_class"] && !all_succeeded
+      end
+
+      def enqueue_callback(class_name, properties)
+        job_class = class_name.constantize
+        job_class.perform_later(properties)
+      rescue NameError => e
+        Pgbus.logger.error { "[Pgbus] Batch callback class not found: #{class_name}: #{e.message}" }
+      end
+    end
+  end
+end

--- a/lib/pgbus/batch.rb
+++ b/lib/pgbus/batch.rb
@@ -64,19 +64,48 @@ module Pgbus
     end
 
     def count_jobs(&)
+      previous_batch_id = Thread.current[:pgbus_batch_id]
+      previous_count = Thread.current[:pgbus_batch_job_count]
+
       Thread.current[:pgbus_batch_id] = batch_id
-      @job_count = 0
+      Thread.current[:pgbus_batch_job_count] = 0
 
       yield
 
       @job_count = Thread.current[:pgbus_batch_job_count] || 0
     ensure
-      Thread.current[:pgbus_batch_id] = nil
-      Thread.current[:pgbus_batch_job_count] = nil
+      Thread.current[:pgbus_batch_id] = previous_batch_id
+      Thread.current[:pgbus_batch_job_count] = previous_count
     end
 
     def update_total
-      BatchRecord.where(batch_id: batch_id).update_all(total_jobs: @job_count, status: "processing")
+      if @job_count.zero?
+        # Finish empty batches immediately — no jobs to signal completion
+        BatchRecord.where(batch_id: batch_id).update_all(
+          total_jobs: 0,
+          status: "finished",
+          finished_at: Time.current
+        )
+        fire_empty_batch_callbacks
+      else
+        BatchRecord.where(batch_id: batch_id).update_all(total_jobs: @job_count, status: "processing")
+      end
+    end
+
+    def fire_empty_batch_callbacks
+      record = BatchRecord.find_by(batch_id: batch_id)
+      return unless record
+
+      properties = parse_properties(record.properties)
+      self.class.send(:enqueue_callback, record.on_finish_class, properties) if record.on_finish_class
+      self.class.send(:enqueue_callback, record.on_success_class, properties) if record.on_success_class
+    end
+
+    def parse_properties(props)
+      JSON.parse(props.presence || "{}")
+    rescue JSON::ParserError => e
+      Pgbus.logger.error { "[Pgbus] Invalid batch properties JSON: #{e.message}" }
+      {}
     end
 
     class << self
@@ -91,7 +120,12 @@ module Pgbus
       end
 
       def fire_callbacks(record)
-        properties = JSON.parse(record.properties.presence || "{}")
+        properties = begin
+          JSON.parse(record.properties.presence || "{}")
+        rescue JSON::ParserError => e
+          Pgbus.logger.error { "[Pgbus] Invalid batch properties JSON: #{e.message}" }
+          {}
+        end
         all_succeeded = record.discarded_jobs.zero?
 
         enqueue_callback(record.on_finish_class, properties) if record.on_finish_class

--- a/lib/pgbus/batch.rb
+++ b/lib/pgbus/batch.rb
@@ -29,53 +29,37 @@ module Pgbus
       self
     end
 
-    # Record a completed job. Returns the batch status after update.
+    # Record a completed job. Returns the batch row after update.
     def self.job_completed(batch_id)
       update_counter(batch_id, "completed_jobs")
     end
 
-    # Record a discarded (dead-lettered) job. Returns the batch status after update.
+    # Record a discarded (dead-lettered) job. Returns the batch row after update.
     def self.job_discarded(batch_id)
       update_counter(batch_id, "discarded_jobs")
     end
 
     # Find a batch record by ID. Returns a hash or nil.
     def self.find(batch_id)
-      return nil unless defined?(ActiveRecord::Base)
-
-      result = ActiveRecord::Base.connection.exec_query(
-        "SELECT * FROM pgbus_batches WHERE batch_id = $1",
-        "Pgbus Batch Find",
-        [batch_id]
-      )
-      result.first
+      BatchRecord.find_by(batch_id: batch_id)&.attributes
     end
 
     # Delete finished batches older than the given threshold.
     def self.cleanup(older_than:)
-      return 0 unless defined?(ActiveRecord::Base)
-
-      result = ActiveRecord::Base.connection.exec_query(
-        "DELETE FROM pgbus_batches WHERE status = 'finished' AND finished_at < $1 RETURNING id",
-        "Pgbus Batch Cleanup",
-        [older_than]
-      )
-      result.to_a.size
+      BatchRecord.stale(before: older_than).delete_all
     end
 
     private
 
     def create_record
-      return unless defined?(ActiveRecord::Base)
-
-      ActiveRecord::Base.connection.exec_query(
-        <<~SQL,
-          INSERT INTO pgbus_batches
-            (batch_id, description, on_finish_class, on_success_class, on_discard_class, properties, status)
-          VALUES ($1, $2, $3, $4, $5, $6, 'pending')
-        SQL
-        "Pgbus Batch Create",
-        [batch_id, description, on_finish&.name, on_success&.name, on_discard&.name, JSON.generate(properties)]
+      BatchRecord.create!(
+        batch_id: batch_id,
+        description: description,
+        on_finish_class: on_finish&.name,
+        on_success_class: on_success&.name,
+        on_discard_class: on_discard&.name,
+        properties: JSON.generate(properties),
+        status: "pending"
       )
     end
 
@@ -92,46 +76,14 @@ module Pgbus
     end
 
     def update_total
-      return unless defined?(ActiveRecord::Base)
-
-      ActiveRecord::Base.connection.exec_query(
-        "UPDATE pgbus_batches SET total_jobs = $1, status = 'processing' WHERE batch_id = $2",
-        "Pgbus Batch Update Total",
-        [@job_count, batch_id]
-      )
+      BatchRecord.where(batch_id: batch_id).update_all(total_jobs: @job_count, status: "processing")
     end
 
     class << self
       private
 
       def update_counter(batch_id, column)
-        return nil unless defined?(ActiveRecord::Base)
-
-        # Use (completed_jobs + discarded_jobs = total_jobs) AS just_finished to detect
-        # whether THIS update caused the transition, avoiding duplicate callbacks when
-        # two workers complete the final jobs simultaneously.
-        result = ActiveRecord::Base.connection.exec_query(
-          <<~SQL,
-            UPDATE pgbus_batches
-            SET #{column} = #{column} + 1,
-                status = CASE
-                  WHEN completed_jobs + discarded_jobs + 1 = total_jobs THEN 'finished'
-                  ELSE status
-                END,
-                finished_at = CASE
-                  WHEN completed_jobs + discarded_jobs + 1 = total_jobs THEN NOW()
-                  ELSE finished_at
-                END
-            WHERE batch_id = $1
-            RETURNING status, total_jobs, completed_jobs, discarded_jobs,
-                      on_finish_class, on_success_class, on_discard_class, properties,
-                      (completed_jobs + discarded_jobs = total_jobs) AS just_finished
-          SQL
-          "Pgbus Batch Counter",
-          [batch_id]
-        )
-
-        row = result.first
+        row = BatchRecord.increment_counter!(batch_id, column)
         return nil unless row
 
         fire_callbacks(row) if row["just_finished"]

--- a/lib/pgbus/batch.rb
+++ b/lib/pgbus/batch.rb
@@ -83,20 +83,20 @@ module Pgbus
       private
 
       def update_counter(batch_id, column)
-        row = BatchRecord.increment_counter!(batch_id, column)
-        return nil unless row
+        result = BatchRecord.increment_counter!(batch_id, column)
+        return nil unless result
 
-        fire_callbacks(row) if row["just_finished"]
-        row
+        fire_callbacks(result[:record]) if result[:just_finished]
+        result
       end
 
-      def fire_callbacks(row)
-        properties = JSON.parse(row["properties"] || "{}")
-        all_succeeded = row["discarded_jobs"].to_i.zero?
+      def fire_callbacks(record)
+        properties = JSON.parse(record.properties.presence || "{}")
+        all_succeeded = record.discarded_jobs.zero?
 
-        enqueue_callback(row["on_finish_class"], properties) if row["on_finish_class"]
-        enqueue_callback(row["on_success_class"], properties) if row["on_success_class"] && all_succeeded
-        enqueue_callback(row["on_discard_class"], properties) if row["on_discard_class"] && !all_succeeded
+        enqueue_callback(record.on_finish_class, properties) if record.on_finish_class
+        enqueue_callback(record.on_success_class, properties) if record.on_success_class && all_succeeded
+        enqueue_callback(record.on_discard_class, properties) if record.on_discard_class && !all_succeeded
       end
 
       def enqueue_callback(class_name, properties)

--- a/lib/pgbus/cli.rb
+++ b/lib/pgbus/cli.rb
@@ -33,24 +33,19 @@ module Pgbus
     end
 
     def show_status
-      if defined?(ActiveRecord::Base)
-        processes = ActiveRecord::Base.connection.execute(
-          "SELECT kind, hostname, pid, metadata, last_heartbeat_at FROM pgbus_processes ORDER BY kind, created_at"
-        )
+      processes = ProcessRecord.order(:kind, :created_at)
+                               .select(:kind, :hostname, :pid, :metadata, :last_heartbeat_at)
 
-        if processes.none?
-          puts "No Pgbus processes running."
-          return
-        end
+      if processes.none?
+        puts "No Pgbus processes running."
+        return
+      end
 
-        puts "KIND         HOST                 PID      HEARTBEAT                      METADATA"
-        puts "-" * 100
-        processes.each do |p|
-          puts format("%-12s %-20s %-8s %-30s %s",
-                      p["kind"], p["hostname"], p["pid"], p["last_heartbeat_at"], p["metadata"])
-        end
-      else
-        puts "ActiveRecord not available. Run from a Rails context."
+      puts "KIND         HOST                 PID      HEARTBEAT                      METADATA"
+      puts "-" * 100
+      processes.each do |p|
+        puts format("%-12s %-20s %-8s %-30s %s",
+                    p.kind, p.hostname, p.pid, p.last_heartbeat_at, p.metadata)
       end
     end
 

--- a/lib/pgbus/concurrency/blocked_execution.rb
+++ b/lib/pgbus/concurrency/blocked_execution.rb
@@ -8,50 +8,25 @@ module Pgbus
       class << self
         # Insert a blocked execution for a job that hit the concurrency limit.
         def insert(concurrency_key:, queue_name:, payload:, duration:, priority: 0)
-          expires_at = Time.now.utc + duration
-
-          execute(<<~SQL, "Pgbus Blocked Insert", [concurrency_key, queue_name, JSON.generate(payload), priority, expires_at])
-            INSERT INTO pgbus_blocked_executions
-              (concurrency_key, queue_name, payload, priority, expires_at)
-            VALUES ($1, $2, $3, $4, $5)
-          SQL
+          BlockedExecutionRecord.create!(
+            concurrency_key: concurrency_key,
+            queue_name: queue_name,
+            payload: JSON.generate(payload),
+            priority: priority,
+            expires_at: Time.now.utc + duration
+          )
         end
 
         # Release the next blocked execution for a given concurrency key.
         # Returns the released row (queue_name, payload) or nil if none.
         def release_next(concurrency_key)
-          return nil unless defined?(ActiveRecord::Base)
-
-          now = Time.now.utc
-          result = execute(<<~SQL, "Pgbus Blocked Release", [concurrency_key, now])
-            DELETE FROM pgbus_blocked_executions
-            WHERE id = (
-              SELECT id FROM pgbus_blocked_executions
-              WHERE concurrency_key = $1
-                AND expires_at >= $2
-              ORDER BY priority ASC, created_at ASC
-              LIMIT 1
-              FOR UPDATE SKIP LOCKED
-            )
-            RETURNING queue_name, payload
-          SQL
-
-          row = result.first
-          return nil unless row
-
-          # ActiveRecord auto-casts jsonb to Ruby Hash; handle both cases
-          payload = row["payload"]
-          payload = JSON.parse(payload) if payload.is_a?(String)
-
-          { queue_name: row["queue_name"], payload: payload }
+          BlockedExecutionRecord.release_next!(concurrency_key)
         end
 
         # Atomically promote the next blocked execution: delete the row and enqueue
         # the job in a single transaction. Returns true if a job was promoted, false
         # otherwise. This avoids losing a blocked row if enqueue fails.
         def promote_next(concurrency_key, client:, delay: 0)
-          return false unless defined?(ActiveRecord::Base)
-
           released = nil
           ActiveRecord::Base.transaction do
             released = release_next(concurrency_key)
@@ -70,22 +45,12 @@ module Pgbus
         # Delete blocked executions that have expired.
         # Returns the count of deleted rows.
         def expire_stale
-          result = execute(<<~SQL, "Pgbus Blocked Expire", [Time.now.utc])
-            DELETE FROM pgbus_blocked_executions
-            WHERE expires_at < $1
-            RETURNING id
-          SQL
-
-          result.to_a.size
+          BlockedExecutionRecord.expired(Time.now.utc).delete_all
         end
 
         # Count blocked executions for a given key. Useful for testing/monitoring.
         def count_for(concurrency_key)
-          result = execute(<<~SQL, "Pgbus Blocked Count", [concurrency_key])
-            SELECT COUNT(*) AS cnt FROM pgbus_blocked_executions WHERE concurrency_key = $1
-          SQL
-
-          result.first&.fetch("cnt", 0).to_i
+          BlockedExecutionRecord.where(concurrency_key: concurrency_key).count
         end
 
         private
@@ -97,12 +62,6 @@ module Pgbus
           [Time.parse(scheduled_at).to_f - Time.now.to_f, 0].max.ceil
         rescue StandardError
           default_delay
-        end
-
-        def execute(sql, name, binds)
-          return [] unless defined?(ActiveRecord::Base)
-
-          ActiveRecord::Base.connection.exec_query(sql, name, binds)
         end
       end
     end

--- a/lib/pgbus/concurrency/semaphore.rb
+++ b/lib/pgbus/concurrency/semaphore.rb
@@ -8,57 +8,26 @@ module Pgbus
         # Returns :acquired if a slot was available, :blocked if the limit is reached.
         def acquire(key, max_value, duration)
           expires_at = Time.now.utc + duration
-
-          result = execute(<<~SQL, "Pgbus Semaphore Acquire", [key, max_value, expires_at])
-            INSERT INTO pgbus_semaphores (key, value, max_value, expires_at)
-            VALUES ($1, 1, $2, $3)
-            ON CONFLICT (key) DO UPDATE
-              SET value = pgbus_semaphores.value + 1,
-                  max_value = EXCLUDED.max_value,
-                  expires_at = GREATEST(pgbus_semaphores.expires_at, EXCLUDED.expires_at)
-              WHERE pgbus_semaphores.value < EXCLUDED.max_value
-            RETURNING value
-          SQL
-
-          result.any? ? :acquired : :blocked
+          SemaphoreRecord.acquire!(key, max_value, expires_at)
         end
 
         # Release one slot in the semaphore. Called after a job completes.
         def release(key)
-          execute(<<~SQL, "Pgbus Semaphore Release", [key])
-            UPDATE pgbus_semaphores
-            SET value = GREATEST(value - 1, 0)
-            WHERE key = $1
-          SQL
+          SemaphoreRecord.where(key: key).update_all("value = GREATEST(value - 1, 0)")
         end
 
         # Delete semaphores that have expired (safety net for crashed workers).
-        # Returns the number of deleted rows.
+        # Returns an array of hashes with expired keys.
         def expire_stale
-          result = execute(<<~SQL, "Pgbus Semaphore Expire", [Time.now.utc])
-            DELETE FROM pgbus_semaphores
-            WHERE expires_at < $1 OR value <= 0
-            RETURNING key
-          SQL
-
-          result.to_a
+          expired = SemaphoreRecord.expired(Time.now.utc)
+          keys = expired.pluck(:key)
+          expired.delete_all
+          keys.map { |k| { "key" => k } }
         end
 
         # Check current value for a key. Useful for testing/monitoring.
         def current_value(key)
-          result = execute(<<~SQL, "Pgbus Semaphore Value", [key])
-            SELECT value FROM pgbus_semaphores WHERE key = $1
-          SQL
-
-          result.first&.fetch("value", nil)&.to_i
-        end
-
-        private
-
-        def execute(sql, name, binds)
-          return [] unless defined?(ActiveRecord::Base)
-
-          ActiveRecord::Base.connection.exec_query(sql, name, binds)
+          SemaphoreRecord.where(key: key).pick(:value)
         end
       end
     end

--- a/lib/pgbus/concurrency/semaphore.rb
+++ b/lib/pgbus/concurrency/semaphore.rb
@@ -18,11 +18,14 @@ module Pgbus
 
         # Delete semaphores that have expired (safety net for crashed workers).
         # Returns an array of hashes with expired keys.
+        # Uses DELETE ... RETURNING for atomicity (no race between pluck and delete).
         def expire_stale
-          expired = SemaphoreRecord.expired(Time.now.utc)
-          keys = expired.pluck(:key)
-          expired.delete_all
-          keys.map { |k| { "key" => k } }
+          result = SemaphoreRecord.connection.exec_query(
+            "DELETE FROM pgbus_semaphores WHERE expires_at < $1 RETURNING key",
+            "Pgbus Semaphore Expire",
+            [Time.now.utc]
+          )
+          result.rows.map { |row| { "key" => row[0] } }
         end
 
         # Check current value for a key. Useful for testing/monitoring.

--- a/lib/pgbus/event_bus/handler.rb
+++ b/lib/pgbus/event_bus/handler.rb
@@ -52,23 +52,13 @@ module Pgbus
       end
 
       def already_processed?(event_id)
-        return false unless defined?(ActiveRecord::Base)
-
-        ActiveRecord::Base.connection.select_value(
-          "SELECT 1 FROM pgbus_processed_events WHERE event_id = $1 AND handler_class = $2",
-          "Pgbus Idempotency Check",
-          [event_id, self.class.name]
-        )
+        ProcessedEventRecord.exists?(event_id: event_id, handler_class: self.class.name)
       end
 
       def mark_processed!(event_id)
-        return unless defined?(ActiveRecord::Base)
-
-        ActiveRecord::Base.connection.exec_insert(
-          "INSERT INTO pgbus_processed_events (event_id, handler_class, processed_at) " \
-          "VALUES ($1, $2, $3) ON CONFLICT (event_id, handler_class) DO NOTHING",
-          "Pgbus Idempotency Mark",
-          [event_id, self.class.name, Time.now.utc]
+        ProcessedEventRecord.upsert(
+          { event_id: event_id, handler_class: self.class.name, processed_at: Time.now.utc },
+          unique_by: %i[event_id handler_class]
         )
       end
     end

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -81,30 +81,18 @@ module Pgbus
       end
 
       def cleanup_processed_events
-        return unless defined?(ActiveRecord::Base)
-
         ttl = config.idempotency_ttl
         return unless ttl&.positive?
 
-        deleted = ActiveRecord::Base.connection.delete(
-          "DELETE FROM pgbus_processed_events WHERE processed_at < $1",
-          "Pgbus Idempotency Cleanup",
-          [Time.now.utc - ttl]
-        )
+        deleted = ProcessedEventRecord.expired(Time.now.utc - ttl).delete_all
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} expired processed events" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Idempotency cleanup failed: #{e.message}" }
       end
 
       def reap_stale_processes
-        return unless defined?(ActiveRecord::Base)
-
         threshold = Heartbeat::ALIVE_THRESHOLD
-        deleted = ActiveRecord::Base.connection.delete(
-          "DELETE FROM pgbus_processes WHERE last_heartbeat_at < $1",
-          "Pgbus Stale Process Reap",
-          [Time.now.utc - threshold]
-        )
+        deleted = ProcessRecord.stale(Time.now.utc - threshold).delete_all
         Pgbus.logger.info { "[Pgbus] Reaped #{deleted} stale processes" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Stale process reaping failed: #{e.message}" }

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -9,6 +9,7 @@ module Pgbus
       CLEANUP_INTERVAL = 3600       # Run idempotency cleanup every hour
       REAP_INTERVAL = 300           # Run stale process reaping every 5 minutes
       CONCURRENCY_INTERVAL = 300    # Run concurrency cleanup every 5 minutes
+      BATCH_CLEANUP_INTERVAL = 3600 # Run batch cleanup every hour
 
       attr_reader :config
 
@@ -18,6 +19,7 @@ module Pgbus
         @last_cleanup_at = Time.now
         @last_reap_at = Time.now
         @last_concurrency_at = Time.now
+        @last_batch_cleanup_at = Time.now
       end
 
       def run
@@ -68,6 +70,11 @@ module Pgbus
         if now - @last_concurrency_at >= CONCURRENCY_INTERVAL
           cleanup_concurrency
           @last_concurrency_at = now
+        end
+
+        if now - @last_batch_cleanup_at >= BATCH_CLEANUP_INTERVAL
+          cleanup_batches
+          @last_batch_cleanup_at = now
         end
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Dispatcher maintenance error: #{e.message}" }
@@ -120,6 +127,13 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Released blocked execution for key: #{key}" } if promoted
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Failed to release blocked execution for #{key}: #{e.message}" }
+      end
+
+      def cleanup_batches
+        deleted = Batch.cleanup(older_than: Time.now.utc - (7 * 24 * 3600)) # 7 days
+        Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} finished batches" } if deleted.positive?
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Batch cleanup failed: #{e.message}" }
       end
 
       def start_heartbeat

--- a/lib/pgbus/process/heartbeat.rb
+++ b/lib/pgbus/process/heartbeat.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "concurrent"
+require "socket"
 
 module Pgbus
   module Process
@@ -42,7 +43,7 @@ module Pgbus
           kind: @kind,
           hostname: Socket.gethostname,
           pid: ::Process.pid,
-          metadata: JSON.generate(@metadata),
+          metadata: @metadata,
           last_heartbeat_at: Time.current
         )
         @process_id = record.id
@@ -54,8 +55,8 @@ module Pgbus
         return unless @process_id
 
         ProcessRecord.where(id: @process_id).delete_all
-      rescue StandardError
-        # Best effort — process is exiting anyway
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Process deregistration failed: #{e.message}" }
       end
     end
   end

--- a/lib/pgbus/process/heartbeat.rb
+++ b/lib/pgbus/process/heartbeat.rb
@@ -28,13 +28,9 @@ module Pgbus
       end
 
       def beat
-        return unless @process_id && defined?(ActiveRecord::Base)
+        return unless @process_id
 
-        ActiveRecord::Base.connection.execute(
-          "UPDATE pgbus_processes SET last_heartbeat_at = NOW() WHERE id = $1",
-          "Pgbus Heartbeat",
-          [@process_id]
-        )
+        ProcessRecord.where(id: @process_id).update_all(last_heartbeat_at: Time.current)
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Heartbeat failed: #{e.message}" }
       end
@@ -42,27 +38,22 @@ module Pgbus
       private
 
       def register_process
-        return unless defined?(ActiveRecord::Base)
-
-        result = ActiveRecord::Base.connection.exec_insert(
-          "INSERT INTO pgbus_processes (kind, hostname, pid, metadata, last_heartbeat_at, created_at, updated_at) " \
-          "VALUES ($1, $2, $3, $4, NOW(), NOW(), NOW()) RETURNING id",
-          "Pgbus Register Process",
-          [@kind, Socket.gethostname, ::Process.pid, JSON.generate(@metadata)]
+        record = ProcessRecord.create!(
+          kind: @kind,
+          hostname: Socket.gethostname,
+          pid: ::Process.pid,
+          metadata: JSON.generate(@metadata),
+          last_heartbeat_at: Time.current
         )
-        @process_id = result.first["id"]
+        @process_id = record.id
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Process registration failed: #{e.message}" }
       end
 
       def deregister_process
-        return unless @process_id && defined?(ActiveRecord::Base)
+        return unless @process_id
 
-        ActiveRecord::Base.connection.execute(
-          "DELETE FROM pgbus_processes WHERE id = $1",
-          "Pgbus Deregister Process",
-          [@process_id]
-        )
+        ProcessRecord.where(id: @process_id).delete_all
       rescue StandardError
         # Best effort — process is exiting anyway
       end

--- a/lib/pgbus/version.rb
+++ b/lib/pgbus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pgbus
-  VERSION = "0.0.1"
+  VERSION = "0.1.0"
 end

--- a/lib/pgbus/version.rb
+++ b/lib/pgbus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pgbus
-  VERSION = "0.1.0"
+  VERSION = "0.0.1"
 end

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -103,6 +103,36 @@ RSpec.describe Pgbus::ActiveJob::Executor do
       end
     end
 
+    context "with batch_id in payload" do
+      let(:batch_payload) { job_payload.merge("pgbus_batch_id" => "batch-abc") }
+      let(:message_json) { JSON.generate(batch_payload) }
+      let(:message) { build_message_double(msg_id: 30, message: message_json, read_ct: 1) }
+
+      before do
+        allow(ActiveJob::Base).to receive(:deserialize).with(batch_payload).and_return(job_double)
+        allow(Pgbus::Batch).to receive(:job_completed)
+        allow(Pgbus::Batch).to receive(:job_discarded)
+      end
+
+      it "signals batch completed on success" do
+        executor.execute(message, queue_name)
+        expect(Pgbus::Batch).to have_received(:job_completed).with("batch-abc")
+      end
+
+      it "signals batch discarded on dead letter" do
+        dlq_message = build_message_double(msg_id: 31, message: message_json, read_ct: config.max_retries + 1)
+        executor.execute(dlq_message, queue_name)
+        expect(Pgbus::Batch).to have_received(:job_discarded).with("batch-abc")
+      end
+
+      it "does not signal batch on transient failure" do
+        allow(job_double).to receive(:perform_now).and_raise(StandardError, "transient")
+        executor.execute(message, queue_name)
+        expect(Pgbus::Batch).not_to have_received(:job_completed)
+        expect(Pgbus::Batch).not_to have_received(:job_discarded)
+      end
+    end
+
     context "with concurrency key in payload" do
       let(:concurrency_payload) { job_payload.merge("pgbus_concurrency_key" => "TestJob-42") }
       let(:message_json) { JSON.generate(concurrency_payload) }

--- a/spec/pgbus/batch_spec.rb
+++ b/spec/pgbus/batch_spec.rb
@@ -4,11 +4,21 @@ require "spec_helper"
 require "active_job"
 
 RSpec.describe Pgbus::Batch do
-  let(:batch_record_double) { double("BatchRecord", id: 1, attributes: { "batch_id" => "abc" }) }
+  let(:batch_record_double) do
+    double(
+      "BatchRecord",
+      id: 1,
+      attributes: { "batch_id" => "abc" },
+      on_finish_class: nil,
+      on_success_class: nil,
+      on_discard_class: nil,
+      properties: "{}"
+    )
+  end
 
   before do
-    allow(Pgbus::BatchRecord).to receive(:create!).and_return(batch_record_double)
     allow(Pgbus::BatchRecord).to receive_message_chain(:where, :update_all).and_return(1) # rubocop:disable RSpec/MessageChain
+    allow(Pgbus::BatchRecord).to receive_messages(create!: batch_record_double, find_by: batch_record_double)
   end
 
   describe "#initialize" do

--- a/spec/pgbus/batch_spec.rb
+++ b/spec/pgbus/batch_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Pgbus::Batch do
   describe "#enqueue" do
     it "creates a batch record in the database" do
       batch = described_class.new(description: "test")
-      batch.enqueue { }
+      batch.enqueue {} # rubocop:disable Lint/EmptyBlock
 
       expect(connection).to have_received(:exec_query).with(
         a_string_matching(/INSERT INTO pgbus_batches/),
@@ -44,7 +44,7 @@ RSpec.describe Pgbus::Batch do
 
     it "updates total_jobs after counting" do
       batch = described_class.new
-      batch.enqueue { }
+      batch.enqueue {} # rubocop:disable Lint/EmptyBlock
 
       expect(connection).to have_received(:exec_query).with(
         a_string_matching(/UPDATE pgbus_batches SET total_jobs/),
@@ -68,12 +68,13 @@ RSpec.describe Pgbus::Batch do
 
   describe ".job_completed" do
     it "increments completed_jobs counter" do
-      result = double("Result", first: {
+      row = {
         "status" => "processing",
         "total_jobs" => "3",
         "completed_jobs" => "1",
         "discarded_jobs" => "0"
-      })
+      }
+      result = double("Result", first: row)
       allow(connection).to receive(:exec_query)
         .with(a_string_matching(/completed_jobs = completed_jobs \+ 1/), anything, anything)
         .and_return(result)
@@ -88,7 +89,7 @@ RSpec.describe Pgbus::Batch do
     end
 
     it "fires on_finish callback when batch finishes" do
-      result = double("Result", first: {
+      row = {
         "status" => "finished",
         "total_jobs" => "2",
         "completed_jobs" => "2",
@@ -97,12 +98,13 @@ RSpec.describe Pgbus::Batch do
         "on_success_class" => nil,
         "on_discard_class" => nil,
         "properties" => '{"user_id":1}'
-      })
+      }
+      result = double("Result", first: row)
       allow(connection).to receive(:exec_query)
         .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
         .and_return(result)
 
-      callback_job = class_double("BatchCallbackJob", perform_later: nil)
+      callback_job = class_double("BatchCallbackJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("BatchCallbackJob", callback_job)
 
       described_class.job_completed("batch-123")
@@ -111,7 +113,7 @@ RSpec.describe Pgbus::Batch do
     end
 
     it "fires on_success callback when all jobs succeed" do
-      result = double("Result", first: {
+      row = {
         "status" => "finished",
         "total_jobs" => "1",
         "completed_jobs" => "1",
@@ -120,12 +122,13 @@ RSpec.describe Pgbus::Batch do
         "on_success_class" => "SuccessJob",
         "on_discard_class" => nil,
         "properties" => "{}"
-      })
+      }
+      result = double("Result", first: row)
       allow(connection).to receive(:exec_query)
         .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
         .and_return(result)
 
-      callback_job = class_double("SuccessJob", perform_later: nil)
+      callback_job = class_double("SuccessJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("SuccessJob", callback_job)
 
       described_class.job_completed("batch-123")
@@ -134,7 +137,7 @@ RSpec.describe Pgbus::Batch do
     end
 
     it "fires on_discard callback when some jobs were discarded" do
-      result = double("Result", first: {
+      row = {
         "status" => "finished",
         "total_jobs" => "2",
         "completed_jobs" => "1",
@@ -143,12 +146,13 @@ RSpec.describe Pgbus::Batch do
         "on_success_class" => nil,
         "on_discard_class" => "DiscardJob",
         "properties" => "{}"
-      })
+      }
+      result = double("Result", first: row)
       allow(connection).to receive(:exec_query)
         .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
         .and_return(result)
 
-      callback_job = class_double("DiscardJob", perform_later: nil)
+      callback_job = class_double("DiscardJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("DiscardJob", callback_job)
 
       described_class.job_discarded("batch-123")

--- a/spec/pgbus/batch_spec.rb
+++ b/spec/pgbus/batch_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_job"
+
+RSpec.describe Pgbus::Batch do
+  let(:connection) { double("AR::Connection") }
+
+  before do
+    stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
+    allow(connection).to receive(:exec_query).and_return([])
+  end
+
+  describe "#initialize" do
+    it "generates a UUID batch_id" do
+      batch = described_class.new
+      expect(batch.batch_id).to match(/\A[0-9a-f-]{36}\z/)
+    end
+
+    it "stores callback classes and properties" do
+      callback_class = Class.new
+      batch = described_class.new(
+        on_finish: callback_class,
+        description: "test batch",
+        properties: { user_id: 1 }
+      )
+      expect(batch.on_finish).to eq(callback_class)
+      expect(batch.description).to eq("test batch")
+      expect(batch.properties[:user_id]).to eq(1)
+    end
+  end
+
+  describe "#enqueue" do
+    it "creates a batch record in the database" do
+      batch = described_class.new(description: "test")
+      batch.enqueue { }
+
+      expect(connection).to have_received(:exec_query).with(
+        a_string_matching(/INSERT INTO pgbus_batches/),
+        "Pgbus Batch Create",
+        array_including(batch.batch_id, "test")
+      )
+    end
+
+    it "updates total_jobs after counting" do
+      batch = described_class.new
+      batch.enqueue { }
+
+      expect(connection).to have_received(:exec_query).with(
+        a_string_matching(/UPDATE pgbus_batches SET total_jobs/),
+        "Pgbus Batch Update Total",
+        anything
+      )
+    end
+
+    it "sets thread-local batch_id during block execution" do
+      captured_batch_id = nil
+      batch = described_class.new
+
+      batch.enqueue do
+        captured_batch_id = Thread.current[:pgbus_batch_id]
+      end
+
+      expect(captured_batch_id).to eq(batch.batch_id)
+      expect(Thread.current[:pgbus_batch_id]).to be_nil
+    end
+  end
+
+  describe ".job_completed" do
+    it "increments completed_jobs counter" do
+      result = double("Result", first: {
+        "status" => "processing",
+        "total_jobs" => "3",
+        "completed_jobs" => "1",
+        "discarded_jobs" => "0"
+      })
+      allow(connection).to receive(:exec_query)
+        .with(a_string_matching(/completed_jobs = completed_jobs \+ 1/), anything, anything)
+        .and_return(result)
+
+      described_class.job_completed("batch-123")
+
+      expect(connection).to have_received(:exec_query).with(
+        a_string_matching(/UPDATE pgbus_batches/),
+        "Pgbus Batch Counter",
+        ["batch-123"]
+      )
+    end
+
+    it "fires on_finish callback when batch finishes" do
+      result = double("Result", first: {
+        "status" => "finished",
+        "total_jobs" => "2",
+        "completed_jobs" => "2",
+        "discarded_jobs" => "0",
+        "on_finish_class" => "BatchCallbackJob",
+        "on_success_class" => nil,
+        "on_discard_class" => nil,
+        "properties" => '{"user_id":1}'
+      })
+      allow(connection).to receive(:exec_query)
+        .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
+        .and_return(result)
+
+      callback_job = class_double("BatchCallbackJob", perform_later: nil)
+      stub_const("BatchCallbackJob", callback_job)
+
+      described_class.job_completed("batch-123")
+
+      expect(callback_job).to have_received(:perform_later).with({ "user_id" => 1 })
+    end
+
+    it "fires on_success callback when all jobs succeed" do
+      result = double("Result", first: {
+        "status" => "finished",
+        "total_jobs" => "1",
+        "completed_jobs" => "1",
+        "discarded_jobs" => "0",
+        "on_finish_class" => nil,
+        "on_success_class" => "SuccessJob",
+        "on_discard_class" => nil,
+        "properties" => "{}"
+      })
+      allow(connection).to receive(:exec_query)
+        .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
+        .and_return(result)
+
+      callback_job = class_double("SuccessJob", perform_later: nil)
+      stub_const("SuccessJob", callback_job)
+
+      described_class.job_completed("batch-123")
+
+      expect(callback_job).to have_received(:perform_later)
+    end
+
+    it "fires on_discard callback when some jobs were discarded" do
+      result = double("Result", first: {
+        "status" => "finished",
+        "total_jobs" => "2",
+        "completed_jobs" => "1",
+        "discarded_jobs" => "1",
+        "on_finish_class" => nil,
+        "on_success_class" => nil,
+        "on_discard_class" => "DiscardJob",
+        "properties" => "{}"
+      })
+      allow(connection).to receive(:exec_query)
+        .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
+        .and_return(result)
+
+      callback_job = class_double("DiscardJob", perform_later: nil)
+      stub_const("DiscardJob", callback_job)
+
+      described_class.job_discarded("batch-123")
+
+      expect(callback_job).to have_received(:perform_later)
+    end
+
+    it "returns nil when batch not found" do
+      result = double("Result", first: nil)
+      allow(connection).to receive(:exec_query)
+        .with(a_string_matching(/UPDATE pgbus_batches/), anything, anything)
+        .and_return(result)
+
+      expect(described_class.job_completed("nonexistent")).to be_nil
+    end
+  end
+
+  describe ".find" do
+    it "returns the batch record" do
+      row = { "batch_id" => "abc", "status" => "processing" }
+      result = double("Result", first: row)
+      allow(connection).to receive(:exec_query)
+        .with(a_string_matching(/SELECT .* FROM pgbus_batches/), anything, anything)
+        .and_return(result)
+
+      expect(described_class.find("abc")).to eq(row)
+    end
+  end
+
+  describe ".cleanup" do
+    it "deletes finished batches older than threshold" do
+      result = double("Result", to_a: [{ "id" => 1 }])
+      allow(connection).to receive(:exec_query)
+        .with(a_string_matching(/DELETE FROM pgbus_batches/), anything, anything)
+        .and_return(result)
+
+      expect(described_class.cleanup(older_than: Time.now - 86_400)).to eq(1)
+    end
+  end
+
+  context "when ActiveRecord is not defined" do
+    before { hide_const("ActiveRecord") }
+
+    it "job_completed returns nil" do
+      expect(described_class.job_completed("batch-123")).to be_nil
+    end
+
+    it "find returns nil" do
+      expect(described_class.find("batch-123")).to be_nil
+    end
+
+    it "cleanup returns 0" do
+      expect(described_class.cleanup(older_than: Time.now)).to eq(0)
+    end
+  end
+end

--- a/spec/pgbus/batch_spec.rb
+++ b/spec/pgbus/batch_spec.rb
@@ -97,7 +97,8 @@ RSpec.describe Pgbus::Batch do
         "on_finish_class" => "BatchCallbackJob",
         "on_success_class" => nil,
         "on_discard_class" => nil,
-        "properties" => '{"user_id":1}'
+        "properties" => '{"user_id":1}',
+        "just_finished" => true
       }
       result = double("Result", first: row)
       allow(connection).to receive(:exec_query)
@@ -121,7 +122,8 @@ RSpec.describe Pgbus::Batch do
         "on_finish_class" => nil,
         "on_success_class" => "SuccessJob",
         "on_discard_class" => nil,
-        "properties" => "{}"
+        "properties" => "{}",
+        "just_finished" => true
       }
       result = double("Result", first: row)
       allow(connection).to receive(:exec_query)
@@ -145,7 +147,8 @@ RSpec.describe Pgbus::Batch do
         "on_finish_class" => nil,
         "on_success_class" => nil,
         "on_discard_class" => "DiscardJob",
-        "properties" => "{}"
+        "properties" => "{}",
+        "just_finished" => true
       }
       result = double("Result", first: row)
       allow(connection).to receive(:exec_query)

--- a/spec/pgbus/batch_spec.rb
+++ b/spec/pgbus/batch_spec.rb
@@ -61,14 +61,26 @@ RSpec.describe Pgbus::Batch do
   end
 
   describe ".job_completed" do
+    def build_batch_result(overrides = {})
+      attrs = {
+        status: "processing",
+        total_jobs: 3,
+        completed_jobs: 1,
+        discarded_jobs: 0,
+        on_finish_class: nil,
+        on_success_class: nil,
+        on_discard_class: nil,
+        properties: "{}"
+      }.merge(overrides)
+
+      record = double("BatchRecord", **attrs, presence: attrs[:properties])
+      allow(record).to receive(:properties).and_return(attrs[:properties])
+      { record: record, just_finished: overrides.fetch(:just_finished, false) }
+    end
+
     it "increments completed_jobs counter" do
-      row = {
-        "status" => "processing",
-        "total_jobs" => "3",
-        "completed_jobs" => "1",
-        "discarded_jobs" => "0"
-      }
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(row)
+      result = build_batch_result
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(result)
 
       described_class.job_completed("batch-123")
 
@@ -76,18 +88,12 @@ RSpec.describe Pgbus::Batch do
     end
 
     it "fires on_finish callback when batch finishes" do
-      row = {
-        "status" => "finished",
-        "total_jobs" => "2",
-        "completed_jobs" => "2",
-        "discarded_jobs" => "0",
-        "on_finish_class" => "BatchCallbackJob",
-        "on_success_class" => nil,
-        "on_discard_class" => nil,
-        "properties" => '{"user_id":1}',
-        "just_finished" => true
-      }
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(row)
+      result = build_batch_result(
+        status: "finished", total_jobs: 2, completed_jobs: 2,
+        on_finish_class: "BatchCallbackJob", properties: '{"user_id":1}',
+        just_finished: true
+      )
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(result)
 
       callback_job = class_double("BatchCallbackJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("BatchCallbackJob", callback_job)
@@ -98,18 +104,12 @@ RSpec.describe Pgbus::Batch do
     end
 
     it "fires on_success callback when all jobs succeed" do
-      row = {
-        "status" => "finished",
-        "total_jobs" => "1",
-        "completed_jobs" => "1",
-        "discarded_jobs" => "0",
-        "on_finish_class" => nil,
-        "on_success_class" => "SuccessJob",
-        "on_discard_class" => nil,
-        "properties" => "{}",
-        "just_finished" => true
-      }
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(row)
+      result = build_batch_result(
+        status: "finished", total_jobs: 1, completed_jobs: 1,
+        on_success_class: "SuccessJob",
+        just_finished: true
+      )
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(result)
 
       callback_job = class_double("SuccessJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("SuccessJob", callback_job)
@@ -120,18 +120,12 @@ RSpec.describe Pgbus::Batch do
     end
 
     it "fires on_discard callback when some jobs were discarded" do
-      row = {
-        "status" => "finished",
-        "total_jobs" => "2",
-        "completed_jobs" => "1",
-        "discarded_jobs" => "1",
-        "on_finish_class" => nil,
-        "on_success_class" => nil,
-        "on_discard_class" => "DiscardJob",
-        "properties" => "{}",
-        "just_finished" => true
-      }
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(row)
+      result = build_batch_result(
+        status: "finished", total_jobs: 2, completed_jobs: 1, discarded_jobs: 1,
+        on_discard_class: "DiscardJob",
+        just_finished: true
+      )
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(result)
 
       callback_job = class_double("DiscardJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("DiscardJob", callback_job)

--- a/spec/pgbus/batch_spec.rb
+++ b/spec/pgbus/batch_spec.rb
@@ -4,11 +4,11 @@ require "spec_helper"
 require "active_job"
 
 RSpec.describe Pgbus::Batch do
-  let(:connection) { double("AR::Connection") }
+  let(:batch_record_double) { double("BatchRecord", id: 1, attributes: { "batch_id" => "abc" }) }
 
   before do
-    stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
-    allow(connection).to receive(:exec_query).and_return([])
+    allow(Pgbus::BatchRecord).to receive(:create!).and_return(batch_record_double)
+    allow(Pgbus::BatchRecord).to receive_message_chain(:where, :update_all).and_return(1) # rubocop:disable RSpec/MessageChain
   end
 
   describe "#initialize" do
@@ -35,10 +35,8 @@ RSpec.describe Pgbus::Batch do
       batch = described_class.new(description: "test")
       batch.enqueue {} # rubocop:disable Lint/EmptyBlock
 
-      expect(connection).to have_received(:exec_query).with(
-        a_string_matching(/INSERT INTO pgbus_batches/),
-        "Pgbus Batch Create",
-        array_including(batch.batch_id, "test")
+      expect(Pgbus::BatchRecord).to have_received(:create!).with(
+        hash_including(batch_id: batch.batch_id, description: "test", status: "pending")
       )
     end
 
@@ -46,11 +44,7 @@ RSpec.describe Pgbus::Batch do
       batch = described_class.new
       batch.enqueue {} # rubocop:disable Lint/EmptyBlock
 
-      expect(connection).to have_received(:exec_query).with(
-        a_string_matching(/UPDATE pgbus_batches SET total_jobs/),
-        "Pgbus Batch Update Total",
-        anything
-      )
+      expect(Pgbus::BatchRecord).to have_received(:where).with(batch_id: batch.batch_id)
     end
 
     it "sets thread-local batch_id during block execution" do
@@ -74,18 +68,11 @@ RSpec.describe Pgbus::Batch do
         "completed_jobs" => "1",
         "discarded_jobs" => "0"
       }
-      result = double("Result", first: row)
-      allow(connection).to receive(:exec_query)
-        .with(a_string_matching(/completed_jobs = completed_jobs \+ 1/), anything, anything)
-        .and_return(result)
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(row)
 
       described_class.job_completed("batch-123")
 
-      expect(connection).to have_received(:exec_query).with(
-        a_string_matching(/UPDATE pgbus_batches/),
-        "Pgbus Batch Counter",
-        ["batch-123"]
-      )
+      expect(Pgbus::BatchRecord).to have_received(:increment_counter!).with("batch-123", "completed_jobs")
     end
 
     it "fires on_finish callback when batch finishes" do
@@ -100,10 +87,7 @@ RSpec.describe Pgbus::Batch do
         "properties" => '{"user_id":1}',
         "just_finished" => true
       }
-      result = double("Result", first: row)
-      allow(connection).to receive(:exec_query)
-        .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
-        .and_return(result)
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(row)
 
       callback_job = class_double("BatchCallbackJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("BatchCallbackJob", callback_job)
@@ -125,10 +109,7 @@ RSpec.describe Pgbus::Batch do
         "properties" => "{}",
         "just_finished" => true
       }
-      result = double("Result", first: row)
-      allow(connection).to receive(:exec_query)
-        .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
-        .and_return(result)
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(row)
 
       callback_job = class_double("SuccessJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("SuccessJob", callback_job)
@@ -150,10 +131,7 @@ RSpec.describe Pgbus::Batch do
         "properties" => "{}",
         "just_finished" => true
       }
-      result = double("Result", first: row)
-      allow(connection).to receive(:exec_query)
-        .with(a_string_matching(/UPDATE pgbus_batches/), "Pgbus Batch Counter", anything)
-        .and_return(result)
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(row)
 
       callback_job = class_double("DiscardJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("DiscardJob", callback_job)
@@ -164,51 +142,33 @@ RSpec.describe Pgbus::Batch do
     end
 
     it "returns nil when batch not found" do
-      result = double("Result", first: nil)
-      allow(connection).to receive(:exec_query)
-        .with(a_string_matching(/UPDATE pgbus_batches/), anything, anything)
-        .and_return(result)
+      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(nil)
 
       expect(described_class.job_completed("nonexistent")).to be_nil
     end
   end
 
   describe ".find" do
-    it "returns the batch record" do
-      row = { "batch_id" => "abc", "status" => "processing" }
-      result = double("Result", first: row)
-      allow(connection).to receive(:exec_query)
-        .with(a_string_matching(/SELECT .* FROM pgbus_batches/), anything, anything)
-        .and_return(result)
+    it "returns the batch record attributes" do
+      record = double("BatchRecord", attributes: { "batch_id" => "abc", "status" => "processing" })
+      allow(Pgbus::BatchRecord).to receive(:find_by).with(batch_id: "abc").and_return(record)
 
-      expect(described_class.find("abc")).to eq(row)
+      expect(described_class.find("abc")).to eq({ "batch_id" => "abc", "status" => "processing" })
+    end
+
+    it "returns nil when not found" do
+      allow(Pgbus::BatchRecord).to receive(:find_by).and_return(nil)
+
+      expect(described_class.find("missing")).to be_nil
     end
   end
 
   describe ".cleanup" do
     it "deletes finished batches older than threshold" do
-      result = double("Result", to_a: [{ "id" => 1 }])
-      allow(connection).to receive(:exec_query)
-        .with(a_string_matching(/DELETE FROM pgbus_batches/), anything, anything)
-        .and_return(result)
+      scope = double("scope", delete_all: 3)
+      allow(Pgbus::BatchRecord).to receive(:stale).and_return(scope)
 
-      expect(described_class.cleanup(older_than: Time.now - 86_400)).to eq(1)
-    end
-  end
-
-  context "when ActiveRecord is not defined" do
-    before { hide_const("ActiveRecord") }
-
-    it "job_completed returns nil" do
-      expect(described_class.job_completed("batch-123")).to be_nil
-    end
-
-    it "find returns nil" do
-      expect(described_class.find("batch-123")).to be_nil
-    end
-
-    it "cleanup returns 0" do
-      expect(described_class.cleanup(older_than: Time.now)).to eq(0)
+      expect(described_class.cleanup(older_than: Time.now - 86_400)).to eq(3)
     end
   end
 end

--- a/spec/pgbus/cli_spec.rb
+++ b/spec/pgbus/cli_spec.rb
@@ -30,45 +30,28 @@ RSpec.describe Pgbus::CLI do
   end
 
   describe ".show_status" do
-    context "when ActiveRecord is defined" do
-      let(:connection_double) { double("connection") }
+    it "prints processes table when processes exist" do
+      process = double("ProcessRecord",
+                       kind: "supervisor", hostname: "web-1", pid: "100",
+                       last_heartbeat_at: "2026-01-01 00:00:00", metadata: "{}")
+      scope = double("scope", none?: false, each: nil)
+      allow(scope).to receive(:each).and_yield(process)
+      allow(Pgbus::ProcessRecord).to receive_message_chain(:order, :select).and_return(scope) # rubocop:disable RSpec/MessageChain
 
-      before do
-        stub_const("ActiveRecord::Base", Class.new)
-        allow(ActiveRecord::Base).to receive(:connection).and_return(connection_double)
-      end
+      output = capture_stdout { described_class.show_status }
 
-      it "prints processes table when processes exist" do
-        rows = [
-          { "kind" => "supervisor", "hostname" => "web-1", "pid" => "100",
-            "last_heartbeat_at" => "2026-01-01 00:00:00", "metadata" => "{}" }
-        ]
-        allow(connection_double).to receive(:execute).and_return(rows)
-
-        output = capture_stdout { described_class.show_status }
-
-        expect(output).to include("KIND")
-        expect(output).to include("supervisor")
-        expect(output).to include("web-1")
-      end
-
-      it "prints 'no processes' when result is empty" do
-        allow(connection_double).to receive(:execute).and_return([])
-
-        output = capture_stdout { described_class.show_status }
-
-        expect(output).to include("No Pgbus processes running.")
-      end
+      expect(output).to include("KIND")
+      expect(output).to include("supervisor")
+      expect(output).to include("web-1")
     end
 
-    context "when ActiveRecord is not defined" do
-      it "prints 'not available' message" do
-        hide_const("ActiveRecord::Base")
+    it "prints 'no processes' when result is empty" do
+      scope = double("scope", none?: true)
+      allow(Pgbus::ProcessRecord).to receive_message_chain(:order, :select).and_return(scope) # rubocop:disable RSpec/MessageChain
 
-        output = capture_stdout { described_class.show_status }
+      output = capture_stdout { described_class.show_status }
 
-        expect(output).to include("ActiveRecord not available")
-      end
+      expect(output).to include("No Pgbus processes running.")
     end
   end
 

--- a/spec/pgbus/concurrency/blocked_execution_spec.rb
+++ b/spec/pgbus/concurrency/blocked_execution_spec.rb
@@ -3,15 +3,9 @@
 require "spec_helper"
 
 RSpec.describe Pgbus::Concurrency::BlockedExecution do
-  let(:connection) { double("AR::Connection") }
-
-  before do
-    stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
-  end
-
   describe ".insert" do
-    it "inserts a blocked execution row" do
-      allow(connection).to receive(:exec_query).and_return([])
+    it "creates a blocked execution record" do
+      allow(Pgbus::BlockedExecutionRecord).to receive(:create!).and_return(double("record"))
 
       described_class.insert(
         concurrency_key: "TestJob-42",
@@ -21,77 +15,39 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
         duration: 900
       )
 
-      expect(connection).to have_received(:exec_query).with(
-        a_string_matching(/INSERT INTO pgbus_blocked_executions/),
-        "Pgbus Blocked Insert",
-        array_including("TestJob-42", "default", a_string_matching(/"job_class"/), 0, an_instance_of(Time))
+      expect(Pgbus::BlockedExecutionRecord).to have_received(:create!).with(
+        hash_including(concurrency_key: "TestJob-42", queue_name: "default", priority: 0)
       )
     end
   end
 
   describe ".release_next" do
-    it "returns the next blocked execution and deletes it" do
-      row = { "queue_name" => "default", "payload" => '{"job_class":"TestJob","arguments":[42]}' }
-      result = double("Result", first: row)
-      allow(connection).to receive(:exec_query).and_return(result)
+    it "delegates to BlockedExecutionRecord.release_next!" do
+      released = { queue_name: "default", payload: { "job_class" => "TestJob" } }
+      allow(Pgbus::BlockedExecutionRecord).to receive(:release_next!).with("TestJob-42").and_return(released)
 
-      released = described_class.release_next("TestJob-42")
-      expect(released[:queue_name]).to eq("default")
-      expect(released[:payload]["job_class"]).to eq("TestJob")
+      result = described_class.release_next("TestJob-42")
+
+      expect(result).to eq(released)
     end
 
     it "returns nil when no blocked executions exist" do
-      result = double("Result", first: nil)
-      allow(connection).to receive(:exec_query).and_return(result)
+      allow(Pgbus::BlockedExecutionRecord).to receive(:release_next!).and_return(nil)
 
       expect(described_class.release_next("TestJob-42")).to be_nil
-    end
-
-    it "uses FOR UPDATE SKIP LOCKED to avoid contention" do
-      result = double("Result", first: nil)
-      allow(connection).to receive(:exec_query).and_return(result)
-
-      described_class.release_next("TestJob-42")
-      expect(connection).to have_received(:exec_query).with(
-        a_string_matching(/FOR UPDATE SKIP LOCKED/),
-        anything,
-        anything
-      )
-    end
-  end
-
-  describe ".expire_stale" do
-    it "deletes expired blocked executions" do
-      result = double("Result", to_a: [{ "id" => 1 }, { "id" => 2 }])
-      allow(connection).to receive(:exec_query).and_return(result)
-
-      count = described_class.expire_stale
-      expect(count).to eq(2)
-    end
-  end
-
-  describe ".count_for" do
-    it "returns the count of blocked executions for a key" do
-      result = double("Result", first: { "cnt" => "5" })
-      allow(connection).to receive(:exec_query).and_return(result)
-
-      expect(described_class.count_for("TestJob-42")).to eq(5)
     end
   end
 
   describe ".promote_next" do
     let(:mock_client) { build_mock_client }
-    let(:ar_base) { double("ActiveRecord::Base", connection: connection) }
 
     before do
-      stub_const("ActiveRecord::Base", ar_base)
-      allow(ar_base).to receive(:transaction).and_yield
+      allow(ActiveRecord::Base).to receive(:transaction).and_yield
     end
 
     it "deletes the blocked row and enqueues atomically, returning true" do
-      row = { "queue_name" => "default", "payload" => { "job_class" => "TestJob" } }
-      result = double("Result", first: row)
-      allow(connection).to receive(:exec_query).and_return(result)
+      released = { queue_name: "default", payload: { "job_class" => "TestJob" } }
+      allow(Pgbus::BlockedExecutionRecord).to receive(:release_next!).and_return(released)
       allow(mock_client).to receive(:send_message).and_return(42)
 
       promoted = described_class.promote_next("TestJob-42", client: mock_client)
@@ -101,8 +57,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
     end
 
     it "returns false when no blocked executions exist" do
-      result = double("Result", first: nil)
-      allow(connection).to receive(:exec_query).and_return(result)
+      allow(Pgbus::BlockedExecutionRecord).to receive(:release_next!).and_return(nil)
 
       promoted = described_class.promote_next("TestJob-42", client: mock_client)
 
@@ -111,7 +66,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
     end
 
     it "returns false and logs warning on error" do
-      allow(ar_base).to receive(:transaction).and_raise(StandardError, "db error")
+      allow(ActiveRecord::Base).to receive(:transaction).and_raise(StandardError, "db error")
 
       promoted = described_class.promote_next("TestJob-42", client: mock_client)
 
@@ -119,16 +74,23 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
     end
   end
 
-  context "when ActiveRecord is not defined" do
-    before { hide_const("ActiveRecord") }
+  describe ".expire_stale" do
+    it "deletes expired blocked executions" do
+      scope = double("scope", delete_all: 2)
+      allow(Pgbus::BlockedExecutionRecord).to receive(:expired).and_return(scope)
 
-    it "release_next returns nil" do
-      expect(described_class.release_next("key")).to be_nil
+      count = described_class.expire_stale
+
+      expect(count).to eq(2)
     end
+  end
 
-    it "promote_next returns false" do
-      mock_client = build_mock_client
-      expect(described_class.promote_next("key", client: mock_client)).to be false
+  describe ".count_for" do
+    it "returns the count of blocked executions for a key" do
+      scope = double("scope", count: 5)
+      allow(Pgbus::BlockedExecutionRecord).to receive(:where).with(concurrency_key: "TestJob-42").and_return(scope)
+
+      expect(described_class.count_for("TestJob-42")).to eq(5)
     end
   end
 end

--- a/spec/pgbus/concurrency/semaphore_spec.rb
+++ b/spec/pgbus/concurrency/semaphore_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe Pgbus::Concurrency::Semaphore do
 
   describe ".expire_stale" do
     it "deletes expired semaphores and returns their keys" do
-      scope = double("scope", pluck: %w[old-key-1 old-key-2], delete_all: 2)
-      allow(Pgbus::SemaphoreRecord).to receive(:expired).and_return(scope)
+      result = double("result", rows: [["old-key-1"], ["old-key-2"]])
+      connection = double("connection")
+      allow(Pgbus::SemaphoreRecord).to receive(:connection).and_return(connection)
+      allow(connection).to receive(:exec_query).and_return(result)
 
       expired = described_class.expire_stale
 

--- a/spec/pgbus/concurrency/semaphore_spec.rb
+++ b/spec/pgbus/concurrency/semaphore_spec.rb
@@ -3,28 +3,16 @@
 require "spec_helper"
 
 RSpec.describe Pgbus::Concurrency::Semaphore do
-  let(:connection) { double("AR::Connection") }
-
-  before do
-    stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
-  end
-
   describe ".acquire" do
     it "returns :acquired when a slot is available" do
-      result = double("Result", any?: true)
-      allow(connection).to receive(:exec_query).and_return(result)
+      allow(Pgbus::SemaphoreRecord).to receive(:acquire!).and_return(:acquired)
 
       expect(described_class.acquire("TestJob-42", 2, 900)).to eq(:acquired)
-      expect(connection).to have_received(:exec_query).with(
-        a_string_matching(/INSERT INTO pgbus_semaphores/),
-        "Pgbus Semaphore Acquire",
-        array_including("TestJob-42", 2, an_instance_of(Time))
-      )
+      expect(Pgbus::SemaphoreRecord).to have_received(:acquire!).with("TestJob-42", 2, an_instance_of(Time))
     end
 
     it "returns :blocked when limit is reached" do
-      result = double("Result", any?: false)
-      allow(connection).to receive(:exec_query).and_return(result)
+      allow(Pgbus::SemaphoreRecord).to receive(:acquire!).and_return(:blocked)
 
       expect(described_class.acquire("TestJob-42", 1, 900)).to eq(:blocked)
     end
@@ -32,53 +20,37 @@ RSpec.describe Pgbus::Concurrency::Semaphore do
 
   describe ".release" do
     it "decrements the semaphore value" do
-      allow(connection).to receive(:exec_query).and_return([])
+      scope = double("scope", update_all: 1)
+      allow(Pgbus::SemaphoreRecord).to receive(:where).with(key: "TestJob-42").and_return(scope)
 
       described_class.release("TestJob-42")
-      expect(connection).to have_received(:exec_query).with(
-        a_string_matching(/UPDATE pgbus_semaphores/),
-        "Pgbus Semaphore Release",
-        ["TestJob-42"]
-      )
+
+      expect(scope).to have_received(:update_all).with("value = GREATEST(value - 1, 0)")
     end
   end
 
   describe ".expire_stale" do
     it "deletes expired semaphores and returns their keys" do
-      rows = [{ "key" => "old-key-1" }, { "key" => "old-key-2" }]
-      result = double("Result", to_a: rows)
-      allow(connection).to receive(:exec_query).and_return(result)
+      scope = double("scope", pluck: %w[old-key-1 old-key-2], delete_all: 2)
+      allow(Pgbus::SemaphoreRecord).to receive(:expired).and_return(scope)
 
       expired = described_class.expire_stale
-      expect(expired.size).to eq(2)
+
+      expect(expired).to eq([{ "key" => "old-key-1" }, { "key" => "old-key-2" }])
     end
   end
 
   describe ".current_value" do
     it "returns the current value for a key" do
-      result = double("Result", first: { "value" => "3" })
-      allow(connection).to receive(:exec_query).and_return(result)
+      allow(Pgbus::SemaphoreRecord).to receive_message_chain(:where, :pick).and_return(3) # rubocop:disable RSpec/MessageChain
 
       expect(described_class.current_value("TestJob-42")).to eq(3)
     end
 
     it "returns nil when key does not exist" do
-      result = double("Result", first: nil)
-      allow(connection).to receive(:exec_query).and_return(result)
+      allow(Pgbus::SemaphoreRecord).to receive_message_chain(:where, :pick).and_return(nil) # rubocop:disable RSpec/MessageChain
 
       expect(described_class.current_value("missing")).to be_nil
-    end
-  end
-
-  context "when ActiveRecord is not defined" do
-    before { hide_const("ActiveRecord") }
-
-    it "acquire returns :blocked" do
-      expect(described_class.acquire("key", 1, 900)).to eq(:blocked)
-    end
-
-    it "release returns empty" do
-      expect(described_class.release("key")).to eq([])
     end
   end
 end

--- a/spec/pgbus/event_bus/handler_spec.rb
+++ b/spec/pgbus/event_bus/handler_spec.rb
@@ -124,7 +124,6 @@ RSpec.describe Pgbus::EventBus::Handler do
   end
 
   describe "idempotent handler" do
-    let(:connection) { double("AR::Connection") }
     let(:handler_class) do
       Class.new(described_class) do
         idempotent!
@@ -136,27 +135,25 @@ RSpec.describe Pgbus::EventBus::Handler do
     end
     let(:handler) { handler_class.new }
 
-    before do
-      stub_const("ActiveRecord::Base", double("AR::Base", connection: connection))
-      allow(connection).to receive_messages(select_value: nil, exec_insert: nil)
-    end
-
     it "returns :handled when event has not been processed" do
+      allow(Pgbus::ProcessedEventRecord).to receive(:exists?).and_return(false)
+      allow(Pgbus::ProcessedEventRecord).to receive(:upsert)
+
       result = handler.process(message)
 
       expect(result).to eq(:handled)
-      expect(connection).to have_received(:select_value)
-      expect(connection).to have_received(:exec_insert)
+      expect(Pgbus::ProcessedEventRecord).to have_received(:exists?)
+      expect(Pgbus::ProcessedEventRecord).to have_received(:upsert)
     end
 
     it "returns :skipped when event was already processed" do
-      allow(connection).to receive(:select_value).and_return(1)
+      allow(Pgbus::ProcessedEventRecord).to receive(:exists?).and_return(true)
+      allow(Pgbus::ProcessedEventRecord).to receive(:upsert)
 
       result = handler.process(message)
 
       expect(result).to eq(:skipped)
-      expect(connection).to have_received(:select_value)
-      expect(connection).not_to have_received(:exec_insert)
+      expect(Pgbus::ProcessedEventRecord).not_to have_received(:upsert)
     end
   end
 

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -45,78 +45,48 @@ RSpec.describe Pgbus::Process::Dispatcher do
   end
 
   describe "#cleanup_processed_events (private)" do
-    context "when ActiveRecord is not defined" do
-      before { hide_const("ActiveRecord") }
+    it "deletes expired processed events" do
+      scope = double("scope", delete_all: 5)
+      allow(Pgbus::ProcessedEventRecord).to receive(:expired).and_return(scope)
 
-      it "returns early" do
-        expect(dispatcher.send(:cleanup_processed_events)).to be_nil
-      end
+      dispatcher.send(:cleanup_processed_events)
+
+      expect(Pgbus::ProcessedEventRecord).to have_received(:expired).with(an_instance_of(Time))
+      expect(scope).to have_received(:delete_all)
     end
 
-    context "when ActiveRecord is defined" do
-      let(:connection) { double("AR::Connection") }
+    it "returns early when idempotency_ttl is not set" do
+      original_ttl = dispatcher.config.idempotency_ttl
+      dispatcher.config.idempotency_ttl = nil
+      allow(Pgbus::ProcessedEventRecord).to receive(:expired)
 
-      before do
-        stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
-      end
+      dispatcher.send(:cleanup_processed_events)
 
-      it "deletes expired processed events with bind params" do
-        allow(connection).to receive(:delete).and_return(5)
-        dispatcher.send(:cleanup_processed_events)
-        expect(connection).to have_received(:delete).with(
-          "DELETE FROM pgbus_processed_events WHERE processed_at < $1",
-          "Pgbus Idempotency Cleanup",
-          [an_instance_of(Time)]
-        )
-      end
+      expect(Pgbus::ProcessedEventRecord).not_to have_received(:expired)
+    ensure
+      dispatcher.config.idempotency_ttl = original_ttl
+    end
 
-      it "returns early when idempotency_ttl is not set" do
-        original_ttl = dispatcher.config.idempotency_ttl
-        dispatcher.config.idempotency_ttl = nil
-        allow(connection).to receive(:delete)
-        dispatcher.send(:cleanup_processed_events)
-        expect(connection).not_to have_received(:delete)
-      ensure
-        dispatcher.config.idempotency_ttl = original_ttl
-      end
-
-      it "rescues StandardError and logs a warning" do
-        allow(connection).to receive(:delete).and_raise(StandardError, "db error")
-        expect { dispatcher.send(:cleanup_processed_events) }.not_to raise_error
-      end
+    it "rescues StandardError and logs a warning" do
+      allow(Pgbus::ProcessedEventRecord).to receive(:expired).and_raise(StandardError, "db error")
+      expect { dispatcher.send(:cleanup_processed_events) }.not_to raise_error
     end
   end
 
   describe "#reap_stale_processes (private)" do
-    context "when ActiveRecord is not defined" do
-      before { hide_const("ActiveRecord") }
+    it "deletes stale processes" do
+      scope = double("scope", delete_all: 2)
+      allow(Pgbus::ProcessRecord).to receive(:stale).and_return(scope)
 
-      it "returns early" do
-        expect(dispatcher.send(:reap_stale_processes)).to be_nil
-      end
+      dispatcher.send(:reap_stale_processes)
+
+      expect(Pgbus::ProcessRecord).to have_received(:stale).with(an_instance_of(Time))
+      expect(scope).to have_received(:delete_all)
     end
 
-    context "when ActiveRecord is defined" do
-      let(:connection) { double("AR::Connection") }
-
-      before do
-        stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
-      end
-
-      it "deletes stale processes with bind params" do
-        allow(connection).to receive(:delete).and_return(2)
-        dispatcher.send(:reap_stale_processes)
-        expect(connection).to have_received(:delete).with(
-          "DELETE FROM pgbus_processes WHERE last_heartbeat_at < $1",
-          "Pgbus Stale Process Reap",
-          [an_instance_of(Time)]
-        )
-      end
-
-      it "rescues StandardError and logs a warning" do
-        allow(connection).to receive(:delete).and_raise(StandardError, "db error")
-        expect { dispatcher.send(:reap_stale_processes) }.not_to raise_error
-      end
+    it "rescues StandardError and logs a warning" do
+      allow(Pgbus::ProcessRecord).to receive(:stale).and_raise(StandardError, "db error")
+      expect { dispatcher.send(:reap_stale_processes) }.not_to raise_error
     end
   end
 

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "has a concurrency interval of 5 minutes" do
       expect(described_class::CONCURRENCY_INTERVAL).to eq(300)
     end
+
+    it "has a batch cleanup interval of 1 hour" do
+      expect(described_class::BATCH_CLEANUP_INTERVAL).to eq(3600)
+    end
   end
 
   describe "#graceful_shutdown" do
@@ -156,6 +160,15 @@ RSpec.describe Pgbus::Process::Dispatcher do
       expect(dispatcher).to have_received(:cleanup_concurrency)
     end
 
+    it "runs batch cleanup when batch interval has elapsed" do
+      allow(dispatcher).to receive(:cleanup_batches)
+
+      dispatcher.instance_variable_set(:@last_batch_cleanup_at, Time.now - described_class::BATCH_CLEANUP_INTERVAL - 1)
+      dispatcher.send(:run_maintenance)
+
+      expect(dispatcher).to have_received(:cleanup_batches)
+    end
+
     it "rescues errors from maintenance methods" do
       dispatcher.instance_variable_set(:@last_cleanup_at, Time.now - described_class::CLEANUP_INTERVAL - 1)
       allow(dispatcher).to receive(:cleanup_processed_events).and_raise(StandardError, "boom")
@@ -187,6 +200,21 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "rescues errors gracefully" do
       allow(Pgbus::Concurrency::Semaphore).to receive(:expire_stale).and_raise(StandardError, "db error")
       expect { dispatcher.send(:cleanup_concurrency) }.not_to raise_error
+    end
+  end
+
+  describe "#cleanup_batches (private)" do
+    it "cleans up finished batches older than 7 days" do
+      allow(Pgbus::Batch).to receive(:cleanup).and_return(3)
+
+      dispatcher.send(:cleanup_batches)
+
+      expect(Pgbus::Batch).to have_received(:cleanup).with(older_than: an_instance_of(Time))
+    end
+
+    it "rescues errors gracefully" do
+      allow(Pgbus::Batch).to receive(:cleanup).and_raise(StandardError, "db error")
+      expect { dispatcher.send(:cleanup_batches) }.not_to raise_error
     end
   end
 

--- a/spec/pgbus/process/heartbeat_spec.rb
+++ b/spec/pgbus/process/heartbeat_spec.rb
@@ -6,7 +6,7 @@ require "socket"
 
 RSpec.describe Pgbus::Process::Heartbeat do
   let(:timer) { instance_double(Concurrent::TimerTask, execute: true, shutdown: true) }
-  let(:connection) { double("AR::Connection", execute: nil, exec_insert: [{ "id" => 42 }]) }
+  let(:process_record) { double("ProcessRecord", id: 42) }
   let(:heartbeat) { described_class.new(kind: "worker", metadata: { queues: %w[default] }) }
 
   before do
@@ -14,64 +14,54 @@ RSpec.describe Pgbus::Process::Heartbeat do
   end
 
   describe "#start" do
-    context "when ActiveRecord is defined" do
-      before do
-        stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
-      end
-
-      it "registers the process via ActiveRecord" do
-        heartbeat.start
-        expect(connection).to have_received(:exec_insert)
-      end
-
-      it "creates and executes a timer task" do
-        heartbeat.start
-        expect(Concurrent::TimerTask).to have_received(:new).with(execution_interval: described_class::INTERVAL)
-        expect(timer).to have_received(:execute)
-      end
+    before do
+      allow(Pgbus::ProcessRecord).to receive(:create!).and_return(process_record)
     end
 
-    context "when ActiveRecord is not defined" do
-      before { hide_const("ActiveRecord") }
+    it "registers the process via ProcessRecord" do
+      heartbeat.start
 
-      it "still creates and executes a timer task" do
-        heartbeat.start
-        expect(timer).to have_received(:execute)
-      end
+      expect(Pgbus::ProcessRecord).to have_received(:create!).with(
+        hash_including(kind: "worker", pid: Process.pid)
+      )
+    end
+
+    it "creates and executes a timer task" do
+      heartbeat.start
+
+      expect(Concurrent::TimerTask).to have_received(:new).with(execution_interval: described_class::INTERVAL)
+      expect(timer).to have_received(:execute)
     end
   end
 
   describe "#beat" do
-    context "when process_id is set and ActiveRecord is defined" do
+    context "when process_id is set" do
+      let(:scope) { double("scope", update_all: 1) }
+
       before do
-        stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
+        allow(Pgbus::ProcessRecord).to receive(:create!).and_return(process_record)
+        allow(Pgbus::ProcessRecord).to receive(:where).with(id: 42).and_return(scope)
         heartbeat.start
       end
 
-      it "updates the heartbeat timestamp with bind params" do
+      it "updates the heartbeat timestamp" do
         heartbeat.beat
-        expect(connection).to have_received(:execute).with(
-          "UPDATE pgbus_processes SET last_heartbeat_at = NOW() WHERE id = $1",
-          "Pgbus Heartbeat",
-          [42]
-        )
+
+        expect(scope).to have_received(:update_all).with(last_heartbeat_at: an_instance_of(Time))
       end
     end
 
     context "when process_id is nil" do
-      before { hide_const("ActiveRecord") }
-
       it "does nothing" do
         expect { heartbeat.beat }.not_to raise_error
       end
     end
 
-    context "when ActiveRecord raises an error" do
+    context "when update raises an error" do
       before do
-        stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
+        allow(Pgbus::ProcessRecord).to receive(:create!).and_return(process_record)
+        allow(Pgbus::ProcessRecord).to receive(:where).and_raise(StandardError, "connection lost")
         heartbeat.start
-        # After registration succeeds, make execute raise for beat
-        allow(connection).to receive(:execute).and_raise(StandardError, "connection lost")
       end
 
       it "logs a warning instead of raising" do
@@ -81,23 +71,24 @@ RSpec.describe Pgbus::Process::Heartbeat do
   end
 
   describe "#stop" do
+    let(:scope) { double("scope", delete_all: 1) }
+
     before do
-      stub_const("ActiveRecord::Base", double("ActiveRecord::Base", connection: connection))
+      allow(Pgbus::ProcessRecord).to receive(:create!).and_return(process_record)
+      allow(Pgbus::ProcessRecord).to receive(:where).with(id: 42).and_return(scope)
       heartbeat.start
     end
 
     it "shuts down the timer" do
       heartbeat.stop
+
       expect(timer).to have_received(:shutdown)
     end
 
-    it "deregisters the process with bind params" do
+    it "deregisters the process" do
       heartbeat.stop
-      expect(connection).to have_received(:execute).with(
-        "DELETE FROM pgbus_processes WHERE id = $1",
-        "Pgbus Deregister Process",
-        [42]
-      )
+
+      expect(scope).to have_received(:delete_all)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_record"
 require "pgbus"
 
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
## Summary

- Add `Pgbus::Batch` class with coordinated job completion callbacks
- Three callback types: `on_finish`, `on_success`, `on_discard`
- Adapter injects `pgbus_batch_id` into job payloads during `batch.enqueue`
- Executor atomically updates batch counters after each job
- Batch finishes when `completed_jobs + discarded_jobs == total_jobs`
- Dispatcher cleans up finished batches older than 7 days
- Migration template adds `pgbus_batches` table
- Updated README and migration guides

## Test plan

- [ ] 279 unit examples pass, 0 failures
- [ ] Rubocop clean
- [ ] Batch creation, enqueue, counter updates tested
- [ ] Callback dispatch tested (on_finish, on_success, on_discard)
- [ ] Executor signals batch on success and dead-letter, not on transient failure
- [ ] Dispatcher batch cleanup tested
- [ ] Thread-local batch_id cleared after enqueue block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent batch support for grouping background jobs with lifecycle callbacks (on_finish, on_success, on_discard); enqueued jobs are tagged and batch completion triggers configured callbacks. Added periodic cleanup of finished batches.

* **Documentation**
  * README and docs updated with Batches section, callback contract, payload behavior, and migration/table guidance.

* **Chores**
  * Introduced new database-backed models and updated admin/status tooling to use them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->