### PR TITLE
perf: benchmarks, allocation budgets, and instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,10 @@ group :test do
   gem "capybara-playwright-driver", require: false
   gem "puma"
   gem "sqlite3"
+
+  # Performance & memory profiling
+  gem "benchmark-ips", "~> 2.13"
+  gem "memory_profiler", "~> 1.1"
 end
 
 group :development, :test do

--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,32 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
+namespace :bench do
+  desc "Run serialization benchmarks"
+  task :serialization do
+    ruby "benchmarks/serialization_bench.rb"
+  end
+
+  desc "Run client operation benchmarks"
+  task :client do
+    ruby "benchmarks/client_bench.rb"
+  end
+
+  desc "Run executor benchmarks"
+  task :executor do
+    ruby "benchmarks/executor_bench.rb"
+  end
+
+  desc "Run detailed memory profiling"
+  task :memory do
+    ruby "benchmarks/memory_profile.rb"
+  end
+
+  desc "Run all benchmarks"
+  task all: %i[serialization client executor]
+end
+
+desc "Run all benchmarks"
+task bench: "bench:all"
+
 task default: %i[spec rubocop]

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "memory_profiler"
+require "json"
+require "securerandom"
+require "pgbus"
+
+# Suppress logging during benchmarks
+Pgbus.configure do |c|
+  c.logger = Logger.new(IO::NULL)
+  c.queue_prefix = "pgbus_bench"
+  c.default_queue = "default"
+end
+
+# Stub PGMQ to isolate Pgbus overhead from database I/O.
+# This measures the gem's own CPU and memory cost.
+module BenchStubs
+  def self.build_mock_pgmq
+    MockPgmq.new
+  end
+
+  def self.build_mock_client
+    pgmq = build_mock_pgmq
+    Pgbus::Client.allocate.tap do |client|
+      client.instance_variable_set(:@pgmq, pgmq)
+      client.instance_variable_set(:@config, Pgbus.configuration)
+      client.instance_variable_set(:@queues_created, Hash.new(true))
+      client.instance_variable_set(:@mutex, Mutex.new)
+    end
+  end
+
+  class MockPgmq
+    def create(...) = nil
+    def enable_notify_insert(...) = nil
+    def produce(...) = 1
+    def produce_batch(_, msgs, **) = (1..msgs.size).to_a
+    def read(...) = nil
+    def read_batch(*, **) = []
+    def read_with_poll(...) = []
+    def delete(...) = true # rubocop:disable Naming/PredicateMethod
+    def archive(...) = true # rubocop:disable Naming/PredicateMethod
+    def set_vt(...) = nil
+    def metrics(...) = nil
+    def metrics_all(...) = []
+    def list_queues(...) = []
+    def purge_queue(...) = nil
+    def bind_topic(...) = nil
+    def produce_topic(...) = nil
+    def close(...) = nil
+    def transaction(...) = yield(self)
+  end
+end
+
+# Sample payloads of varying sizes
+SMALL_PAYLOAD = { "job_class" => "SmallJob", "job_id" => SecureRandom.uuid,
+                  "queue_name" => "default", "arguments" => [1] }.freeze
+MEDIUM_PAYLOAD = SMALL_PAYLOAD.merge("arguments" => (1..100).to_a).freeze
+LARGE_PAYLOAD = SMALL_PAYLOAD.merge("arguments" => [{ "data" => "x" * 10_000 }]).freeze

--- a/benchmarks/client_bench.rb
+++ b/benchmarks/client_bench.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "bench_helper"
+
+puts "=" * 60
+puts "Pgbus Client Benchmarks (mocked PGMQ — measures gem overhead)"
+puts "=" * 60
+
+client = BenchStubs.build_mock_client
+
+puts "\n--- send_message throughput ---"
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("small payload") do
+    client.send_message("default", SMALL_PAYLOAD)
+  end
+
+  x.report("large payload") do
+    client.send_message("default", LARGE_PAYLOAD)
+  end
+
+  x.compare!
+end
+
+puts "\n--- send_batch throughput ---"
+batch_ten = Array.new(10) { SMALL_PAYLOAD }
+batch_hundred = Array.new(100) { SMALL_PAYLOAD }
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+  x.report("batch of 10") { client.send_batch("default", batch_ten) }
+  x.report("batch of 100") { client.send_batch("default", batch_hundred) }
+  x.compare!
+end
+
+puts "\n--- read_batch throughput ---"
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+  x.report("read_batch(5)") { client.read_batch("default", qty: 5) }
+  x.report("read_batch(25)") { client.read_batch("default", qty: 25) }
+  x.compare!
+end
+
+puts "\n--- Memory: send_message (1000 calls) ---"
+report = MemoryProfiler.report { 1000.times { client.send_message("default", SMALL_PAYLOAD) } }
+puts "Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+puts "Total retained:  #{report.total_retained_memsize} bytes (#{report.total_retained} objects)"
+puts "Per-call allocated: ~#{report.total_allocated_memsize / 1000} bytes (~#{report.total_allocated / 1000} objects)"
+
+puts "\n--- Memory: send_batch of 100 (100 calls) ---"
+report = MemoryProfiler.report { 100.times { client.send_batch("default", batch_hundred) } }
+puts "Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+puts "Total retained:  #{report.total_retained_memsize} bytes (#{report.total_retained} objects)"
+puts "Per-call allocated: ~#{report.total_allocated_memsize / 100} bytes (~#{report.total_allocated / 100} objects)"

--- a/benchmarks/executor_bench.rb
+++ b/benchmarks/executor_bench.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "bench_helper"
+require "active_job"
+
+puts "=" * 60
+puts "Pgbus Executor Benchmarks (mocked PGMQ — measures gem overhead)"
+puts "=" * 60
+
+# Minimal ActiveJob for benchmarking
+class BenchJob < ActiveJob::Base
+  self.queue_adapter = :inline
+
+  def perform(*)
+    # no-op
+  end
+end
+
+client = BenchStubs.build_mock_client
+executor = Pgbus::ActiveJob::Executor.new(client: client, config: Pgbus.configuration)
+
+# Build a realistic message
+job = BenchJob.new(42)
+job_payload = job.serialize
+message_json = JSON.generate(job_payload)
+
+mock_message = Struct.new(:msg_id, :message, :read_ct, :headers)
+msg = mock_message.new(1, message_json, 1, nil)
+
+puts "\n--- Executor#execute throughput ---"
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("execute (small job)") do
+    executor.execute(msg, "default")
+  end
+
+  x.compare!
+end
+
+puts "\n--- Memory: execute (1000 jobs) ---"
+report = MemoryProfiler.report { 1000.times { executor.execute(msg, "default") } }
+puts "Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+puts "Total retained:  #{report.total_retained_memsize} bytes (#{report.total_retained} objects)"
+puts "Per-job allocated: ~#{report.total_allocated_memsize / 1000} bytes (~#{report.total_allocated / 1000} objects)"
+puts "Per-job retained:  ~#{report.total_retained_memsize / 1000} bytes (~#{report.total_retained / 1000} objects)"
+
+puts "\n--- Top allocations by gem ---"
+report.pretty_print(to_file: "/dev/stdout", scale_bytes: true, detailed_report: false)

--- a/benchmarks/memory_profile.rb
+++ b/benchmarks/memory_profile.rb
@@ -67,11 +67,15 @@ if report.total_retained.zero?
 else
   puts "\nWARNING: #{report.total_retained} retained objects (#{report.total_retained_memsize} bytes)"
   puts "Retained by gem:"
+  report.retained_objects_by_gem.each do |stat|
+    puts "  #{stat[:data]}: #{stat[:count]} objects"
+  end
+  puts "\nRetained memory by gem:"
   report.retained_memory_by_gem.each do |stat|
-    puts "  #{stat[:data]}: #{stat[:count]} objects, #{stat[:memory]} bytes"
+    puts "  #{stat[:data]}: #{stat[:count]} bytes"
   end
   puts "\nRetained by location:"
-  report.retained_memory_by_location.first(10).each do |stat|
-    puts "  #{stat[:data]}: #{stat[:count]} objects, #{stat[:memory]} bytes"
+  report.retained_objects_by_location.first(10).each do |stat|
+    puts "  #{stat[:data]}: #{stat[:count]} objects"
   end
 end

--- a/benchmarks/memory_profile.rb
+++ b/benchmarks/memory_profile.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "bench_helper"
+require "active_job"
+
+puts "=" * 60
+puts "Pgbus Memory Profile — Detailed Allocation Analysis"
+puts "=" * 60
+
+# Minimal ActiveJob for profiling
+class ProfileJob < ActiveJob::Base
+  self.queue_adapter = :inline
+
+  def perform(*)
+    # no-op
+  end
+end
+
+client = BenchStubs.build_mock_client
+executor = Pgbus::ActiveJob::Executor.new(client: client, config: Pgbus.configuration)
+
+job = ProfileJob.new("hello", 42, { nested: true })
+job_payload = job.serialize
+message_json = JSON.generate(job_payload)
+
+mock_message = Struct.new(:msg_id, :message, :read_ct, :headers)
+msg = mock_message.new(1, message_json, 1, nil)
+
+# --- Profile individual operations ---
+
+puts "\n=== Client#send_message ==="
+report = MemoryProfiler.report(top: 10) { 500.times { client.send_message("default", SMALL_PAYLOAD) } }
+report.pretty_print(scale_bytes: true, detailed_report: false)
+
+puts "\n=== Client#send_batch (100 items) ==="
+batch = Array.new(100) { SMALL_PAYLOAD }
+report = MemoryProfiler.report(top: 10) { 100.times { client.send_batch("default", batch) } }
+report.pretty_print(scale_bytes: true, detailed_report: false)
+
+puts "\n=== Executor#execute ==="
+report = MemoryProfiler.report(top: 10) { 500.times { executor.execute(msg, "default") } }
+report.pretty_print(scale_bytes: true, detailed_report: false)
+
+puts "\n=== JSON.generate (isolation check) ==="
+report = MemoryProfiler.report(top: 10) { 500.times { JSON.generate(SMALL_PAYLOAD) } }
+report.pretty_print(scale_bytes: true, detailed_report: false)
+
+puts "\n=== JSON.parse (isolation check) ==="
+json_str = JSON.generate(SMALL_PAYLOAD)
+report = MemoryProfiler.report(top: 10) { 500.times { JSON.parse(json_str) } }
+report.pretty_print(scale_bytes: true, detailed_report: false)
+
+# --- Retained object detection (leak check) ---
+puts "\n#{"=" * 60}"
+puts "Retained Object Detection (potential leaks)"
+puts "=" * 60
+
+report = MemoryProfiler.report(top: 20) do
+  1000.times do
+    client.send_message("default", SMALL_PAYLOAD)
+    executor.execute(msg, "default")
+  end
+end
+
+if report.total_retained.zero?
+  puts "\nNo retained objects detected — no leaks."
+else
+  puts "\nWARNING: #{report.total_retained} retained objects (#{report.total_retained_memsize} bytes)"
+  puts "Retained by gem:"
+  report.retained_memory_by_gem.each do |stat|
+    puts "  #{stat[:data]}: #{stat[:count]} objects, #{stat[:memory]} bytes"
+  end
+  puts "\nRetained by location:"
+  report.retained_memory_by_location.first(10).each do |stat|
+    puts "  #{stat[:data]}: #{stat[:count]} objects, #{stat[:memory]} bytes"
+  end
+end

--- a/benchmarks/serialization_bench.rb
+++ b/benchmarks/serialization_bench.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "bench_helper"
+
+puts "=" * 60
+puts "Pgbus Serialization Benchmarks"
+puts "=" * 60
+
+small_json = JSON.generate(SMALL_PAYLOAD)
+medium_json = JSON.generate(MEDIUM_PAYLOAD)
+large_json = JSON.generate(LARGE_PAYLOAD)
+
+puts "\n--- JSON.generate throughput ---"
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+  x.report("small payload (#{small_json.bytesize}B)") { JSON.generate(SMALL_PAYLOAD) }
+  x.report("medium payload (#{medium_json.bytesize}B)") { JSON.generate(MEDIUM_PAYLOAD) }
+  x.report("large payload (#{large_json.bytesize}B)") { JSON.generate(LARGE_PAYLOAD) }
+  x.compare!
+end
+
+puts "\n--- JSON.parse throughput ---"
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+  x.report("small payload") { JSON.parse(small_json) }
+  x.report("medium payload") { JSON.parse(medium_json) }
+  x.report("large payload") { JSON.parse(large_json) }
+  x.compare!
+end
+
+puts "\n--- Memory: serialize small payload ---"
+report = MemoryProfiler.report { 1000.times { JSON.generate(SMALL_PAYLOAD) } }
+puts "Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+puts "Total retained:  #{report.total_retained_memsize} bytes (#{report.total_retained} objects)"
+
+puts "\n--- Memory: serialize large payload ---"
+report = MemoryProfiler.report { 1000.times { JSON.generate(LARGE_PAYLOAD) } }
+puts "Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+puts "Total retained:  #{report.total_retained_memsize} bytes (#{report.total_retained} objects)"

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -21,12 +21,17 @@ module Pgbus
           return :dead_lettered
         end
 
-        job = ::ActiveJob::Base.deserialize(payload)
-        execute_job(job)
-        client.archive_message(queue_name, message.msg_id.to_i)
-        signal_concurrency(payload)
-        signal_batch_completed(payload)
-        instrument("pgbus.job_completed", queue: queue_name, job_class: payload["job_class"])
+        job_class = payload["job_class"]
+
+        Instrumentation.instrument("pgbus.executor.execute", queue: queue_name, job_class: job_class) do
+          job = ::ActiveJob::Base.deserialize(payload)
+          execute_job(job)
+          client.archive_message(queue_name, message.msg_id.to_i)
+          signal_concurrency(payload)
+          signal_batch_completed(payload)
+        end
+
+        instrument("pgbus.job_completed", queue: queue_name, job_class: job_class)
         :success
       rescue StandardError => e
         handle_failure(message, queue_name, e)

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -42,25 +42,33 @@ module Pgbus
     def send_message(queue_name, payload, headers: nil, delay: 0)
       full_name = config.queue_name(queue_name)
       ensure_queue(queue_name)
-      @pgmq.produce(full_name, serialize(payload), headers: headers && serialize(headers), delay: delay)
+      Instrumentation.instrument("pgbus.client.send_message", queue: full_name) do
+        @pgmq.produce(full_name, serialize(payload), headers: headers && serialize(headers), delay: delay)
+      end
     end
 
     def send_batch(queue_name, payloads, headers: nil, delay: 0)
       full_name = config.queue_name(queue_name)
       ensure_queue(queue_name)
-      serialized = payloads.map { |p| serialize(p) }
-      serialized_headers = headers&.map { |h| serialize(h) }
-      @pgmq.produce_batch(full_name, serialized, headers: serialized_headers, delay: delay)
+      Instrumentation.instrument("pgbus.client.send_batch", queue: full_name, size: payloads.size) do
+        serialized = payloads.map { |p| serialize(p) }
+        serialized_headers = headers&.map { |h| serialize(h) }
+        @pgmq.produce_batch(full_name, serialized, headers: serialized_headers, delay: delay)
+      end
     end
 
     def read_message(queue_name, vt: nil)
       full_name = config.queue_name(queue_name)
-      @pgmq.read(full_name, vt: vt || config.visibility_timeout)
+      Instrumentation.instrument("pgbus.client.read_message", queue: full_name) do
+        @pgmq.read(full_name, vt: vt || config.visibility_timeout)
+      end
     end
 
     def read_batch(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
-      @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty)
+      Instrumentation.instrument("pgbus.client.read_batch", queue: full_name, qty: qty) do
+        @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty)
+      end
     end
 
     def read_with_poll(queue_name, qty:, vt: nil, max_poll_seconds: 5, poll_interval_ms: 100)

--- a/lib/pgbus/instrumentation.rb
+++ b/lib/pgbus/instrumentation.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Pgbus
+  # Lightweight instrumentation via ActiveSupport::Notifications.
+  #
+  # All events are prefixed with "pgbus." and carry timing information
+  # automatically when used with the block form of AS::Notifications.instrument.
+  #
+  # Events emitted:
+  #   pgbus.client.send_message   — single message enqueue
+  #   pgbus.client.send_batch     — batch enqueue
+  #   pgbus.client.read_batch     — batch dequeue
+  #   pgbus.client.read_message   — single message dequeue
+  #   pgbus.executor.execute      — full job execution (deserialize + perform + archive)
+  #   pgbus.serializer.serialize  — job/event serialization
+  #   pgbus.serializer.deserialize — job/event deserialization
+  #
+  module Instrumentation
+    module_function
+
+    def instrument(event, payload = {}, &block)
+      if defined?(ActiveSupport::Notifications)
+        ActiveSupport::Notifications.instrument(event, payload, &block)
+      elsif block
+        yield payload
+      end
+    end
+  end
+end

--- a/lib/pgbus/serializer.rb
+++ b/lib/pgbus/serializer.rb
@@ -7,15 +7,19 @@ module Pgbus
     module_function
 
     def serialize_job(active_job)
-      data = active_job.serialize
-      # GlobalID is handled by ActiveJob's serialize — it converts AR objects
-      # to GlobalID URIs automatically. We just JSON-encode the result.
-      JSON.generate(data)
+      Instrumentation.instrument("pgbus.serializer.serialize", kind: :job) do
+        data = active_job.serialize
+        # GlobalID is handled by ActiveJob's serialize — it converts AR objects
+        # to GlobalID URIs automatically. We just JSON-encode the result.
+        JSON.generate(data)
+      end
     end
 
     def deserialize_job(json_string)
-      data = JSON.parse(json_string)
-      ActiveJob::Base.deserialize(data)
+      Instrumentation.instrument("pgbus.serializer.deserialize", kind: :job) do
+        data = JSON.parse(json_string)
+        ActiveJob::Base.deserialize(data)
+      end
     end
 
     def serialize_event(event)

--- a/spec/pgbus/allocation_budget_spec.rb
+++ b/spec/pgbus/allocation_budget_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "memory_profiler"
+
+RSpec.describe Pgbus::Client do
+  include PgmqDoubles
+
+  let(:mock_pgmq) { build_mock_pgmq }
+  let(:client) do
+    described_class.allocate.tap do |c|
+      c.instance_variable_set(:@pgmq, mock_pgmq)
+      c.instance_variable_set(:@config, Pgbus.configuration)
+      c.instance_variable_set(:@queues_created, Hash.new(true))
+      c.instance_variable_set(:@mutex, Mutex.new)
+    end
+  end
+
+  let(:small_payload) do
+    { "job_class" => "TestJob", "job_id" => "abc-123", "queue_name" => "default", "arguments" => [1] }
+  end
+
+  def count_allocations(&block)
+    report = MemoryProfiler.report(&block)
+    report.total_allocated
+  end
+
+  describe "#send_message" do
+    it "allocates fewer than 50 objects per call" do
+      5.times { client.send_message("default", small_payload) }
+
+      allocs = count_allocations { client.send_message("default", small_payload) }
+
+      expect(allocs).to be < 50
+    end
+  end
+
+  describe "#send_batch" do
+    let(:batch) { Array.new(10) { small_payload } }
+
+    it "allocates fewer than 25 objects per item in a batch of 10" do
+      5.times { client.send_batch("default", batch) }
+
+      allocs = count_allocations { client.send_batch("default", batch) }
+      per_item = allocs / 10.0
+
+      expect(per_item).to be < 25
+    end
+  end
+
+  describe "#read_batch" do
+    it "allocates fewer than 30 objects per call" do
+      5.times { client.read_batch("default", qty: 5) }
+
+      allocs = count_allocations { client.read_batch("default", qty: 5) }
+
+      expect(allocs).to be < 30
+    end
+  end
+
+  describe "JSON serialization round-trip" do
+    it "allocates fewer than 20 objects for generate + parse" do
+      json = JSON.generate(small_payload)
+      5.times { JSON.parse(json) }
+
+      allocs = count_allocations do
+        s = JSON.generate(small_payload)
+        JSON.parse(s)
+      end
+
+      expect(allocs).to be < 20
+    end
+  end
+
+  describe "no retained objects (leak detection)" do
+    let(:plain_pgmq) do
+      Class.new do
+        def create(...) = nil
+        def enable_notify_insert(...) = nil
+        def produce(...) = 1
+        def read(...) = nil
+        def read_batch(*, **) = []
+        def delete(...) = true
+        def archive(...) = true
+        def set_vt(...) = nil
+        def close(...) = nil
+        def transaction(...) = yield(self)
+      end.new
+    end
+
+    let(:plain_client) do
+      described_class.allocate.tap do |c|
+        c.instance_variable_set(:@pgmq, plain_pgmq)
+        c.instance_variable_set(:@config, Pgbus.configuration)
+        c.instance_variable_set(:@queues_created, Hash.new(true))
+        c.instance_variable_set(:@mutex, Mutex.new)
+      end
+    end
+
+    it "retains zero objects across 100 send_message cycles" do
+      10.times { plain_client.send_message("default", small_payload) }
+
+      report = MemoryProfiler.report do
+        100.times { plain_client.send_message("default", small_payload) }
+      end
+
+      expect(report.total_retained).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Instrumentation**: `ActiveSupport::Notifications` events on Client (`send_message`, `send_batch`, `read_message`, `read_batch`), Executor (`execute`), and Serializer (`serialize`, `deserialize`) for runtime observability
- **Benchmark suite**: `benchmark-ips` + `memory_profiler` scripts measuring throughput and memory for serialization, client ops, and executor cycles — PGMQ mocked to isolate gem overhead
- **Allocation budget specs**: CI guardrails that fail if object allocations spike above thresholds or if any objects are retained (leak detection)
- **Rake tasks**: `rake bench`, `rake bench:serialization`, `rake bench:client`, `rake bench:executor`, `rake bench:memory`

## Test plan

- [x] All 275 existing specs pass (no regressions from instrumentation changes)
- [x] 5 new allocation budget specs pass
- [x] Rubocop clean on all changed files
- [ ] Run `bundle exec rake bench` to verify benchmark scripts execute end-to-end
- [ ] Run `bundle exec rake bench:memory` to baseline current allocation profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime instrumentation to key client, executor, and serializer operations for performance monitoring.

* **Tests**
  * Added memory allocation budget tests and leak-detection specs.

* **Chores**
  * Added benchmarking scripts and Rake tasks to run performance/memory benchmarks.
  * Added profiling dependencies for benchmarking and memory analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->