### PR TITLE
ci: add release workflow and Rake release task

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,173 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test before release
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby:
+          - "3.3"
+          - "3.4"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      gem_name: ${{ steps.build.outputs.gem_name }}
+      version: ${{ steps.build.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Verify tag matches gem version
+        run: |
+          GEM_VERSION=$(ruby -r ./lib/pgbus/version -e "puts Pgbus::VERSION")
+          TAG_VERSION="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          if [ "$GEM_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match gem version ($GEM_VERSION)"
+            exit 1
+          fi
+
+      - name: Build gem
+        id: build
+        run: |
+          gem build pgbus.gemspec --strict
+          GEM_NAME=$(ls pgbus-*.gem)
+          echo "gem_name=$GEM_NAME" >> "$GITHUB_OUTPUT"
+          TAG_VERSION="${{ github.event.release.tag_name }}"
+          echo "version=${TAG_VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify gem contents
+        run: |
+          GEM_NAME=$(ls pgbus-*.gem)
+          gem unpack "$GEM_NAME" --target /tmp/gem-verify
+
+          echo "=== File count ==="
+          find /tmp/gem-verify -type f | wc -l
+
+          echo "=== Checking for unwanted files ==="
+          UNWANTED=$(find /tmp/gem-verify \( -name ".git*" -o -name "*.gemspec" \) -print)
+          if [ -n "$UNWANTED" ]; then
+            echo "::error::Unwanted files found in gem:"
+            echo "$UNWANTED"
+            exit 1
+          fi
+
+          UNWANTED_DIRS=$(find /tmp/gem-verify -type d \( -name "spec" -o -name "test" \) -print)
+          if [ -n "$UNWANTED_DIRS" ]; then
+            echo "::error::Unwanted directories found in gem:"
+            echo "$UNWANTED_DIRS"
+            exit 1
+          fi
+
+          echo "No unwanted files found"
+
+      - name: Generate checksums
+        run: |
+          GEM_NAME=$(ls pgbus-*.gem)
+          sha256sum "$GEM_NAME" > "$GEM_NAME.sha256"
+          sha512sum "$GEM_NAME" > "$GEM_NAME.sha512"
+          echo "=== SHA256 ===" && cat "$GEM_NAME.sha256"
+          echo "=== SHA512 ===" && cat "$GEM_NAME.sha512"
+
+      - name: Upload gem artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: gem
+          path: |
+            pgbus-*.gem
+            pgbus-*.gem.sha256
+            pgbus-*.gem.sha512
+          if-no-files-found: error
+
+  publish-rubygems:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: rubygems
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: gem
+
+      - name: Verify checksums
+        run: |
+          sha256sum -c pgbus-*.gem.sha256
+          sha512sum -c pgbus-*.gem.sha512
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+
+      - name: Configure RubyGems trusted publishing credentials
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
+
+      - name: Push to RubyGems with Sigstore attestation
+        run: |
+          GEM_NAME=$(ls pgbus-*.gem)
+
+          gem exec sigstore-cli sign "$GEM_NAME" \
+            --bundle "$GEM_NAME.sigstore.json"
+
+          gem push "$GEM_NAME" --attestation "$GEM_NAME.sigstore.json"
+
+      - name: Upload Sigstore bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: sigstore
+          path: pgbus-*.gem.sigstore.json
+          if-no-files-found: error
+
+  upload-release-assets:
+    needs: [build, publish-rubygems]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: gem
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: sigstore
+
+      - name: Upload assets to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          GEM_NAME="${{ needs.build.outputs.gem_name }}"
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "$GEM_NAME" \
+            "$GEM_NAME.sha256" \
+            "$GEM_NAME.sha512" \
+            "$GEM_NAME.sigstore.json" \
+            --repo "${{ github.repository }}"

--- a/Rakefile
+++ b/Rakefile
@@ -39,4 +39,71 @@ end
 desc "Run all benchmarks"
 task bench: "bench:all"
 
+desc "Build gem and verify contents"
+task :build do
+  sh("gem build pgbus.gemspec --strict")
+  gem_file = Dir["pgbus-*.gem"].first
+  abort "Gem file not found after build" unless gem_file
+
+  sh("gem unpack #{gem_file} --target /tmp/gem-verify")
+  puts "\n=== Gem contents ==="
+  sh("find /tmp/gem-verify -type f | sort")
+  sh("rm -rf /tmp/gem-verify #{gem_file}")
+end
+
+desc "Release a new version (rake release[1.2.3] or rake release[pre])"
+task :release, [:version] do |_t, args|
+  require "pgbus/version"
+
+  new_version = args[:version]
+  abort "Usage: rake release[X.Y.Z] or rake release[pre]" unless new_version
+
+  current = Pgbus::VERSION
+  prerelease = new_version.match?(/alpha|beta|rc|pre/) || new_version == "pre"
+
+  if new_version == "pre"
+    new_version = current
+    prerelease = true
+  end
+
+  tag = "v#{new_version}"
+
+  puts "Current version: #{current}"
+  puts "New version:     #{new_version}"
+  puts "Tag:             #{tag}"
+  puts "Pre-release:     #{prerelease}"
+  puts ""
+
+  # Update version file if needed
+  version_file = "lib/pgbus/version.rb"
+  if new_version != current
+    content = File.read(version_file)
+    content.sub!(/VERSION = ".*"/, "VERSION = \"#{new_version}\"")
+    File.write(version_file, content)
+    puts "Updated #{version_file}"
+  end
+
+  # Verify gem builds cleanly
+  sh("gem build pgbus.gemspec --strict")
+  sh("rm -f pgbus-*.gem")
+
+  # Commit, push, and create release
+  if new_version != current
+    sh("git add #{version_file}")
+    sh("git commit -m 'chore: bump version to #{new_version}'")
+  end
+  sh("git push origin main")
+
+  pre_flag = prerelease ? "--prerelease" : ""
+  sh("gh release create #{tag} --generate-notes --target main #{pre_flag}".strip)
+
+  puts ""
+  puts "Release #{tag} created! CI will handle the rest:"
+  puts "  - Run tests"
+  puts "  - Build + verify gem"
+  puts "  - Sign with Sigstore"
+  puts "  - Publish to RubyGems"
+  puts "  - Upload assets to the release"
+end
+
 task default: %i[spec rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -58,6 +58,9 @@ task :release, [:version] do |_t, args|
   new_version = args[:version]
   abort "Usage: rake release[X.Y.Z] or rake release[pre]" unless new_version
 
+  dirty = `git status --porcelain`.strip
+  abort "Aborting: working directory is not clean.\n#{dirty}" unless dirty.empty?
+
   current = Pgbus::VERSION
   prerelease = new_version.match?(/alpha|beta|rc|pre/) || new_version == "pre"
 


### PR DESCRIPTION
## Summary

- **Release workflow** (`.github/workflows/release.yml`): Triggered on GitHub release publish → runs tests on Ruby 3.3+3.4 → builds gem → verifies contents/checksums → signs with Sigstore → publishes to RubyGems → uploads assets to the release
- **`rake release[X.Y.Z]`**: Bumps version in `lib/pgbus/version.rb`, verifies gem builds, commits, pushes to main, creates GitHub release (which triggers the workflow)
- **`rake build`**: Local gem build with content verification (no unwanted files)

Adapted from the sidekiq-unique-jobs release pipeline. Uses RubyGems trusted publishing (OIDC) — no API key secrets needed.

### Setup required after merge

1. Create a `rubygems` environment in GitHub repo settings (Settings → Environments)
2. Configure trusted publishing on rubygems.org for the `pgbus` gem (link to this repo's release workflow)

## Test plan

- [x] `bundle exec rubocop Rakefile` — 0 offenses
- [x] Workflow YAML validates
- [x] `bundle exec rspec` — 302 examples, 0 failures
- [ ] End-to-end: `rake release[0.1.0]` after rubygems environment is configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow: runs tests across Ruby versions, builds and validates gems, generates checksums, signs artifacts, and publishes to RubyGems with attestation; uploads release assets to GitHub Releases.
  * Added Rake tasks to build and verify gems and to create parameterized releases with version management, cleanup, and automated GitHub release creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->