### PR TITLE
feat: recurring jobs with solid_queue-compatible config

### DIFF
--- a/app/controllers/pgbus/recurring_tasks_controller.rb
+++ b/app/controllers/pgbus/recurring_tasks_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class RecurringTasksController < ApplicationController
+    def index
+      case params[:frame]
+      when "recurring_tasks"
+        @recurring_tasks = data_source.recurring_tasks
+        render_frame("pgbus/recurring_tasks/tasks_table")
+      else
+        @recurring_tasks = data_source.recurring_tasks
+      end
+    end
+
+    def show
+      @task = data_source.recurring_task(params[:id])
+      redirect_to pgbus.recurring_tasks_path, alert: "Task not found" unless @task
+    end
+
+    def toggle
+      if data_source.toggle_recurring_task(params[:id])
+        redirect_to pgbus.recurring_tasks_path, notice: "Task toggled"
+      else
+        redirect_to pgbus.recurring_tasks_path, alert: "Failed to toggle task"
+      end
+    end
+
+    def enqueue
+      if data_source.enqueue_recurring_task_now(params[:id])
+        redirect_to pgbus.recurring_tasks_path, notice: "Task enqueued"
+      else
+        redirect_to pgbus.recurring_tasks_path, alert: "Failed to enqueue task"
+      end
+    end
+  end
+end

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -68,6 +68,35 @@ module Pgbus
       Pgbus.configuration.web_refresh_interval
     end
 
+    def pgbus_time_ago_future(time)
+      return "—" unless time
+
+      time = Time.parse(time) if time.is_a?(String)
+      seconds = (time - Time.now).to_i
+
+      if seconds <= 0
+        "now"
+      elsif seconds < 60
+        "in #{seconds}s"
+      elsif seconds < 3600
+        "in #{seconds / 60}m"
+      elsif seconds < 86_400
+        "in #{seconds / 3600}h"
+      else
+        "in #{seconds / 86_400}d"
+      end
+    end
+
+    def pgbus_recurring_health_badge(task)
+      if task[:last_run_at].nil?
+        tag.span("Pending",
+                 class: "inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800")
+      else
+        tag.span("Active",
+                 class: "inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800")
+      end
+    end
+
     def pgbus_nav_link(label, path)
       active = request.path == path || (path != pgbus.root_path && request.path.start_with?(path))
       css = if active

--- a/app/models/pgbus/recurring_execution_record.rb
+++ b/app/models/pgbus/recurring_execution_record.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class RecurringExecutionRecord < ApplicationRecord
+    self.table_name = "pgbus_recurring_executions"
+
+    validates :task_key, presence: true
+    validates :run_at, presence: true
+
+    scope :for_task, ->(key) { where(task_key: key) }
+    scope :recent, ->(limit = 50) { order(run_at: :desc).limit(limit) }
+    scope :older_than, ->(time) { where("run_at < ?", time) }
+
+    # Record a recurring execution with deduplication.
+    # Uses the unique index on (task_key, run_at) to prevent duplicates.
+    # Yields to the caller to perform the actual enqueue.
+    def self.record(task_key, run_at)
+      transaction do
+        execution = create!(task_key: task_key, run_at: run_at)
+        yield execution if block_given?
+        execution
+      end
+    rescue ActiveRecord::RecordNotUnique
+      raise Pgbus::Recurring::AlreadyRecorded,
+            "Recurring task '#{task_key}' already recorded for #{run_at.iso8601}"
+    end
+
+    # Find the most recent execution for a task
+    def self.last_execution(task_key)
+      for_task(task_key).order(run_at: :desc).first
+    end
+  end
+end

--- a/app/models/pgbus/recurring_task_record.rb
+++ b/app/models/pgbus/recurring_task_record.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class RecurringTaskRecord < ApplicationRecord
+    self.table_name = "pgbus_recurring_tasks"
+
+    validates :key, presence: true, uniqueness: true
+    validates :schedule, presence: true
+
+    scope :static_tasks, -> { where(static: true) }
+    scope :enabled, -> { where(enabled: true) }
+    scope :disabled, -> { where(enabled: false) }
+
+    # Sync static tasks from configuration.
+    # Creates new tasks, updates existing ones, removes stale ones.
+    def self.sync_from_config!(tasks_hash)
+      transaction do
+        task_keys = tasks_hash.keys
+
+        # Upsert all configured tasks
+        tasks_hash.each do |key, options|
+          options = options.transform_keys(&:to_s)
+          record = find_or_initialize_by(key: key)
+          record.assign_attributes(
+            class_name: options["class"],
+            command: options["command"],
+            schedule: options["schedule"],
+            queue_name: options["queue"],
+            arguments: options["args"],
+            priority: options.fetch("priority", 0).to_i,
+            description: options["description"],
+            static: true
+          )
+          record.save!
+        end
+
+        # Remove static tasks no longer in config
+        static_tasks.where.not(key: task_keys).delete_all
+      end
+    end
+  end
+end

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -42,6 +42,7 @@
               <%= pgbus_nav_link "Dashboard", pgbus.root_path %>
               <%= pgbus_nav_link "Queues", pgbus.queues_path %>
               <%= pgbus_nav_link "Jobs", pgbus.jobs_path %>
+              <%= pgbus_nav_link "Recurring", pgbus.recurring_tasks_path %>
               <%= pgbus_nav_link "Processes", pgbus.processes_path %>
               <%= pgbus_nav_link "Events", pgbus.events_path %>
               <%= pgbus_nav_link "DLQ", pgbus.dead_letter_index_path %>

--- a/app/views/pgbus/dashboard/_stats_cards.html.erb
+++ b/app/views/pgbus/dashboard/_stats_cards.html.erb
@@ -1,5 +1,5 @@
 <turbo-frame id="dashboard-stats" data-auto-refresh src="<%= pgbus.root_path(frame: 'stats') %>">
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5 mb-8">
     <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
       <p class="text-sm font-medium text-gray-500">Queues</p>
       <p class="mt-1 text-3xl font-semibold text-gray-900"><%= @stats[:total_queues] %></p>
@@ -15,6 +15,14 @@
       <p class="text-sm font-medium text-gray-500">Processes</p>
       <p class="mt-1 text-3xl font-semibold <%= @stats[:active_processes] > 0 ? 'text-green-600' : 'text-gray-400' %>">
         <%= @stats[:active_processes] %>
+      </p>
+    </div>
+
+    <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
+      <p class="text-sm font-medium text-gray-500">Recurring</p>
+      <p class="mt-1 text-3xl font-semibold text-gray-900"><%= @stats[:recurring_count] %></p>
+      <p class="text-xs text-gray-400">
+        <%= link_to "View tasks", pgbus.recurring_tasks_path, class: "text-blue-500 hover:text-blue-700" %>
       </p>
     </div>
 

--- a/app/views/pgbus/recurring_tasks/_tasks_table.html.erb
+++ b/app/views/pgbus/recurring_tasks/_tasks_table.html.erb
@@ -1,0 +1,79 @@
+<turbo-frame id="recurring-tasks" data-auto-refresh src="<%= pgbus.recurring_tasks_path(frame: 'recurring_tasks') %>">
+  <div class="rounded-lg bg-white shadow ring-1 ring-gray-200">
+    <% if @recurring_tasks.empty? %>
+      <div class="p-8 text-center text-gray-500">
+        <p class="text-lg font-medium">No recurring tasks configured</p>
+        <p class="mt-1 text-sm">Add tasks to <code class="bg-gray-100 px-1.5 py-0.5 rounded text-xs">config/recurring.yml</code></p>
+      </div>
+    <% else %>
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Task</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Schedule</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Queue</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Last Run</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Next Run</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+          <% @recurring_tasks.each do |task| %>
+            <tr class="hover:bg-gray-50">
+              <td class="px-4 py-3">
+                <div>
+                  <%= link_to task[:key], pgbus.recurring_task_path(task[:id]),
+                      class: "text-sm font-medium text-blue-600 hover:text-blue-800" %>
+                </div>
+                <div class="text-xs text-gray-500"><%= task[:class_name] || task[:command]&.truncate(40) %></div>
+                <% if task[:description] %>
+                  <div class="text-xs text-gray-400 mt-0.5"><%= task[:description] %></div>
+                <% end %>
+              </td>
+              <td class="px-4 py-3">
+                <div class="text-sm text-gray-900"><%= task[:schedule] %></div>
+                <% if task[:human_schedule] && task[:human_schedule] != task[:schedule] %>
+                  <div class="text-xs text-gray-400"><%= task[:human_schedule] %></div>
+                <% end %>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-600">
+                <%= task[:queue_name] || "default" %>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-600">
+                <%= task[:last_run_at] ? pgbus_time_ago(task[:last_run_at]) : "Never" %>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-600">
+                <% if task[:enabled] && task[:next_run_at] %>
+                  <%= pgbus_time_ago_future(task[:next_run_at]) %>
+                <% else %>
+                  <span class="text-gray-400">—</span>
+                <% end %>
+              </td>
+              <td class="px-4 py-3">
+                <% if task[:enabled] %>
+                  <%= pgbus_recurring_health_badge(task) %>
+                <% else %>
+                  <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                    Disabled
+                  </span>
+                <% end %>
+              </td>
+              <td class="px-4 py-3 text-right space-x-1">
+                <%= button_to task[:enabled] ? "Disable" : "Enable",
+                    pgbus.toggle_recurring_task_path(task[:id]),
+                    class: "inline-flex items-center rounded px-2 py-1 text-xs font-medium " \
+                           "#{task[:enabled] ? 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200' : 'bg-green-100 text-green-700 hover:bg-green-200'}" %>
+                <% if task[:enabled] %>
+                  <%= button_to "Run Now",
+                      pgbus.enqueue_recurring_task_path(task[:id]),
+                      class: "inline-flex items-center rounded bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-200" %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</turbo-frame>

--- a/app/views/pgbus/recurring_tasks/index.html.erb
+++ b/app/views/pgbus/recurring_tasks/index.html.erb
@@ -1,0 +1,6 @@
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold text-gray-900">Recurring Tasks</h1>
+  <span class="text-sm text-gray-500"><%= @recurring_tasks.size %> task(s) configured</span>
+</div>
+
+<%= render "pgbus/recurring_tasks/tasks_table" %>

--- a/app/views/pgbus/recurring_tasks/show.html.erb
+++ b/app/views/pgbus/recurring_tasks/show.html.erb
@@ -1,0 +1,122 @@
+<div class="mb-6">
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900"><%= @task[:key] %></h1>
+      <p class="mt-1 text-sm text-gray-500"><%= @task[:class_name] || @task[:command] %></p>
+    </div>
+    <div class="flex space-x-2">
+      <%= button_to @task[:enabled] ? "Disable" : "Enable",
+          pgbus.toggle_recurring_task_path(@task[:id]),
+          class: "inline-flex items-center rounded-md px-3 py-2 text-sm font-medium " \
+                 "#{@task[:enabled] ? 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200' : 'bg-green-100 text-green-700 hover:bg-green-200'}" %>
+      <% if @task[:enabled] %>
+        <%= button_to "Run Now",
+            pgbus.enqueue_recurring_task_path(@task[:id]),
+            class: "inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700" %>
+      <% end %>
+      <%= link_to "Back", pgbus.recurring_tasks_path,
+          class: "inline-flex items-center rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200" %>
+    </div>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+  <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
+    <p class="text-sm font-medium text-gray-500">Schedule</p>
+    <p class="mt-1 text-lg font-semibold text-gray-900"><%= @task[:schedule] %></p>
+    <% if @task[:human_schedule] && @task[:human_schedule] != @task[:schedule] %>
+      <p class="text-xs text-gray-400"><%= @task[:human_schedule] %></p>
+    <% end %>
+  </div>
+
+  <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
+    <p class="text-sm font-medium text-gray-500">Next Run</p>
+    <% if @task[:enabled] && @task[:next_run_at] %>
+      <p class="mt-1 text-lg font-semibold text-gray-900"><%= pgbus_time_ago_future(@task[:next_run_at]) %></p>
+      <p class="text-xs text-gray-400"><%= @task[:next_run_at]&.strftime("%Y-%m-%d %H:%M:%S %Z") %></p>
+    <% else %>
+      <p class="mt-1 text-lg font-semibold text-gray-400">—</p>
+    <% end %>
+  </div>
+
+  <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
+    <p class="text-sm font-medium text-gray-500">Status</p>
+    <p class="mt-1"><%= @task[:enabled] ? pgbus_recurring_health_badge(@task) : raw('<span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">Disabled</span>') %></p>
+  </div>
+</div>
+
+<div class="rounded-lg bg-white shadow ring-1 ring-gray-200 mb-8">
+  <div class="px-4 py-3 border-b border-gray-200">
+    <h2 class="text-lg font-medium text-gray-900">Configuration</h2>
+  </div>
+  <div class="p-4">
+    <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Job Class</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @task[:class_name] || "—" %></dd>
+      </div>
+      <% if @task[:command] %>
+        <div>
+          <dt class="text-sm font-medium text-gray-500">Command</dt>
+          <dd class="mt-1 text-sm text-gray-900 font-mono text-xs"><%= @task[:command] %></dd>
+        </div>
+      <% end %>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Queue</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @task[:queue_name] || "default" %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Priority</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @task[:priority] %></dd>
+      </div>
+      <% if @task[:arguments]&.any? %>
+        <div class="sm:col-span-2">
+          <dt class="text-sm font-medium text-gray-500">Arguments</dt>
+          <dd class="mt-1 text-sm text-gray-900 font-mono text-xs"><%= @task[:arguments].inspect %></dd>
+        </div>
+      <% end %>
+      <% if @task[:description] %>
+        <div class="sm:col-span-2">
+          <dt class="text-sm font-medium text-gray-500">Description</dt>
+          <dd class="mt-1 text-sm text-gray-900"><%= @task[:description] %></dd>
+        </div>
+      <% end %>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Source</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @task[:static] ? "Config file" : "Dynamic" %></dd>
+      </div>
+    </dl>
+  </div>
+</div>
+
+<div class="rounded-lg bg-white shadow ring-1 ring-gray-200">
+  <div class="px-4 py-3 border-b border-gray-200">
+    <h2 class="text-lg font-medium text-gray-900">Recent Executions</h2>
+  </div>
+  <% if @task[:executions]&.any? %>
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Scheduled For</th>
+          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Enqueued At</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200">
+        <% @task[:executions].each do |exec| %>
+          <tr class="hover:bg-gray-50">
+            <td class="px-4 py-3 text-sm text-gray-900">
+              <%= exec[:run_at]&.strftime("%Y-%m-%d %H:%M:%S %Z") %>
+            </td>
+            <td class="px-4 py-3 text-sm text-gray-600">
+              <%= exec[:created_at] ? pgbus_time_ago(exec[:created_at]) : "—" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="p-8 text-center text-gray-500">
+      <p>No executions recorded yet</p>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,13 @@ Pgbus::Engine.routes.draw do
     end
   end
 
+  resources :recurring_tasks, only: %i[index show] do
+    member do
+      post :toggle
+      post :enqueue
+    end
+  end
+
   resources :processes, only: [:index]
 
   resources :events, only: %i[index show] do

--- a/lib/generators/pgbus/add_recurring_generator.rb
+++ b/lib/generators/pgbus/add_recurring_generator.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class AddRecurringGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Add recurring jobs tables to an existing Pgbus installation"
+
+      def create_migration
+        migration_template "add_recurring_tables.rb.erb",
+                           "db/migrate/add_pgbus_recurring_tables.rb"
+      end
+
+      def create_recurring_config
+        template "recurring.yml.erb", "config/recurring.yml"
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus recurring jobs installed!", :green
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate"
+        say "  2. Edit config/recurring.yml to define your recurring tasks"
+        say "  3. Restart pgbus: bin/pgbus start"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/templates/add_recurring_tables.rb.erb
+++ b/lib/generators/pgbus/templates/add_recurring_tables.rb.erb
@@ -1,0 +1,31 @@
+class AddPgbusRecurringTables < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :pgbus_recurring_tasks do |t|
+      t.string :key, null: false
+      t.string :class_name
+      t.string :command, limit: 2048
+      t.string :schedule, null: false
+      t.text :arguments
+      t.string :queue_name
+      t.integer :priority, default: 0
+      t.boolean :static, null: false, default: true
+      t.boolean :enabled, null: false, default: true
+      t.text :description
+      t.timestamps
+    end
+
+    add_index :pgbus_recurring_tasks, :key,
+      unique: true, name: "idx_pgbus_recurring_tasks_key"
+
+    create_table :pgbus_recurring_executions do |t|
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :pgbus_recurring_executions, [:task_key, :run_at],
+      unique: true, name: "idx_pgbus_recurring_executions_dedup"
+    add_index :pgbus_recurring_executions, :run_at,
+      name: "idx_pgbus_recurring_executions_cleanup"
+  end
+end

--- a/lib/generators/pgbus/templates/migration.rb.erb
+++ b/lib/generators/pgbus/templates/migration.rb.erb
@@ -115,6 +115,36 @@ class CreatePgbusTables < ActiveRecord::Migration<%= migration_version %>
     add_index :pgbus_batches, :status,
       name: "idx_pgbus_batches_status"
 
+    # Recurring task definitions (synced from config/recurring.yml)
+    create_table :pgbus_recurring_tasks do |t|
+      t.string :key, null: false
+      t.string :class_name
+      t.string :command, limit: 2048
+      t.string :schedule, null: false
+      t.text :arguments
+      t.string :queue_name
+      t.integer :priority, default: 0
+      t.boolean :static, null: false, default: true
+      t.boolean :enabled, null: false, default: true
+      t.text :description
+      t.timestamps
+    end
+
+    add_index :pgbus_recurring_tasks, :key,
+      unique: true, name: "idx_pgbus_recurring_tasks_key"
+
+    # Recurring execution deduplication (prevents double-enqueue)
+    create_table :pgbus_recurring_executions do |t|
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :pgbus_recurring_executions, [:task_key, :run_at],
+      unique: true, name: "idx_pgbus_recurring_executions_dedup"
+    add_index :pgbus_recurring_executions, :run_at,
+      name: "idx_pgbus_recurring_executions_cleanup"
+
     # Create default queues via PGMQ
     execute "SELECT pgmq.create('pgbus_default')"
     execute "SELECT pgmq.create('pgbus_default_dlq')"
@@ -124,6 +154,8 @@ class CreatePgbusTables < ActiveRecord::Migration<%= migration_version %>
     execute "SELECT pgmq.drop_queue('pgbus_default_dlq')"
     execute "SELECT pgmq.drop_queue('pgbus_default')"
 
+    drop_table :pgbus_recurring_executions
+    drop_table :pgbus_recurring_tasks
     drop_table :pgbus_batches
     drop_table :pgbus_blocked_executions
     drop_table :pgbus_semaphores

--- a/lib/generators/pgbus/templates/recurring.yml.erb
+++ b/lib/generators/pgbus/templates/recurring.yml.erb
@@ -1,0 +1,40 @@
+# Pgbus Recurring Tasks Configuration
+#
+# Compatible with Solid Queue's recurring.yml format for easy migration.
+# Supports environment-scoped or flat configuration.
+#
+# Format:
+#   task_key:
+#     class: JobClassName      # ActiveJob class to run (or use command:)
+#     schedule: "0 * * * *"    # Cron expression or natural language
+#     queue: default           # Optional: queue name (default: pgbus default queue)
+#     args: [arg1, arg2]       # Optional: job arguments
+#     priority: 0              # Optional: numeric priority
+#     description: "text"      # Optional: human-readable description
+#
+# Schedule examples:
+#   "0 2 * * *"           → Every day at 2:00 AM
+#   "*/5 * * * *"         → Every 5 minutes
+#   "every hour"          → Every hour at :00
+#   "every day at 2am"    → Daily at 2:00 AM
+#   "@daily"              → Daily at midnight
+#   "0 9 * * mon-fri"     → Weekdays at 9:00 AM
+#
+# Command-based tasks (no job class needed):
+#   cleanup_old_records:
+#     command: "OldRecord.where('created_at < ?', 30.days.ago).delete_all"
+#     schedule: every day at 3am
+#
+# Examples:
+#
+# production:
+#   periodic_cleanup:
+#     class: CleanupJob
+#     queue: maintenance
+#     args: [1000, { batch_size: 500 }]
+#     schedule: every hour
+#
+#   daily_report:
+#     class: DailyReportJob
+#     schedule: "0 8 * * mon-fri"
+#     description: Generate daily business report

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -37,6 +37,10 @@ module Pgbus
     # Event consumers
     attr_accessor :event_consumers
 
+    # Recurring jobs
+    attr_accessor :recurring_tasks, :recurring_schedule_interval, :recurring_tasks_file,
+                  :skip_recurring, :recurring_execution_retention
+
     # Web dashboard
     attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source
 
@@ -72,6 +76,12 @@ module Pgbus
       @pgmq_schema_mode = :auto
 
       @event_consumers = nil
+
+      @recurring_tasks = nil
+      @recurring_schedule_interval = 1.0
+      @recurring_tasks_file = nil
+      @skip_recurring = false
+      @recurring_execution_retention = 7 * 24 * 3600 # 7 days
 
       @web_auth = nil
       @web_refresh_interval = 5000

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -11,6 +11,14 @@ module Pgbus
       Pgbus::ConfigLoader.load(config_path) if config_path.exist?
     end
 
+    initializer "pgbus.recurring" do |app|
+      recurring_path = app.root.join("config", "recurring.yml")
+      if recurring_path.exist? && !Pgbus.configuration.recurring_tasks
+        Pgbus.configuration.recurring_tasks = Pgbus::Recurring::ConfigLoader.load(recurring_path)
+        Pgbus.configuration.recurring_tasks_file ||= recurring_path.to_s
+      end
+    end
+
     initializer "pgbus.active_job" do
       ActiveSupport.on_load(:active_job) do
         include Pgbus::Concurrency

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -6,10 +6,11 @@ module Pgbus
       include SignalHandler
 
       # Maintenance runs on coarser intervals than the main loop
-      CLEANUP_INTERVAL = 3600       # Run idempotency cleanup every hour
-      REAP_INTERVAL = 300           # Run stale process reaping every 5 minutes
-      CONCURRENCY_INTERVAL = 300    # Run concurrency cleanup every 5 minutes
-      BATCH_CLEANUP_INTERVAL = 3600 # Run batch cleanup every hour
+      CLEANUP_INTERVAL = 3600               # Run idempotency cleanup every hour
+      REAP_INTERVAL = 300                   # Run stale process reaping every 5 minutes
+      CONCURRENCY_INTERVAL = 300            # Run concurrency cleanup every 5 minutes
+      BATCH_CLEANUP_INTERVAL = 3600         # Run batch cleanup every hour
+      RECURRING_CLEANUP_INTERVAL = 3600     # Run recurring execution cleanup every hour
 
       attr_reader :config
 
@@ -20,6 +21,7 @@ module Pgbus
         @last_reap_at = Time.now
         @last_concurrency_at = Time.now
         @last_batch_cleanup_at = Time.now
+        @last_recurring_cleanup_at = Time.now
       end
 
       def run
@@ -76,6 +78,11 @@ module Pgbus
           cleanup_batches
           @last_batch_cleanup_at = now
         end
+
+        if now - @last_recurring_cleanup_at >= RECURRING_CLEANUP_INTERVAL
+          cleanup_recurring_executions
+          @last_recurring_cleanup_at = now
+        end
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Dispatcher maintenance error: #{e.message}" }
       end
@@ -122,6 +129,16 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} finished batches" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Batch cleanup failed: #{e.message}" }
+      end
+
+      def cleanup_recurring_executions
+        retention = config.recurring_execution_retention
+        return unless retention&.positive?
+
+        deleted = RecurringExecutionRecord.older_than(Time.now.utc - retention).delete_all
+        Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} old recurring executions" } if deleted.positive?
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Recurring execution cleanup failed: #{e.message}" }
       end
 
       def start_heartbeat

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -50,6 +50,9 @@ module Pgbus
         # Boot dispatcher
         fork_dispatcher
 
+        # Boot recurring scheduler if configured
+        boot_scheduler
+
         # Boot event consumers if configured
         boot_consumers
       end
@@ -81,6 +84,50 @@ module Pgbus
 
         @forks[pid] = { type: :dispatcher }
         Pgbus.logger.info { "[Pgbus] Forked dispatcher pid=#{pid}" }
+      end
+
+      def boot_scheduler
+        return if config.skip_recurring
+        return unless recurring_tasks_configured?
+
+        fork_scheduler
+      end
+
+      def fork_scheduler
+        pid = fork do
+          restore_signals
+          setup_child_signals
+          load_rails_app
+          load_recurring_config
+          scheduler = Recurring::Scheduler.new(config: config)
+          scheduler.run
+        end
+
+        @forks[pid] = { type: :scheduler }
+        Pgbus.logger.info { "[Pgbus] Forked scheduler pid=#{pid}" }
+      end
+
+      def recurring_tasks_configured?
+        return true if config.recurring_tasks&.any?
+        return true if config.recurring_tasks_file && File.exist?(config.recurring_tasks_file.to_s)
+
+        # Check default location
+        if defined?(Rails)
+          default_path = Rails.root.join("config", "recurring.yml")
+          return File.exist?(default_path.to_s)
+        end
+
+        false
+      end
+
+      def load_recurring_config
+        return if config.recurring_tasks&.any?
+
+        path = config.recurring_tasks_file
+        path ||= defined?(Rails) ? Rails.root.join("config", "recurring.yml") : nil
+        return unless path && File.exist?(path.to_s)
+
+        config.recurring_tasks = Recurring::ConfigLoader.load(path)
       end
 
       def boot_consumers
@@ -144,6 +191,8 @@ module Pgbus
           fork_worker(info[:config])
         when :dispatcher
           fork_dispatcher
+        when :scheduler
+          fork_scheduler
         when :consumer
           fork_consumer(info[:config])
         end

--- a/lib/pgbus/recurring/already_recorded.rb
+++ b/lib/pgbus/recurring/already_recorded.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Recurring
+    class AlreadyRecorded < Pgbus::Error; end
+  end
+end

--- a/lib/pgbus/recurring/command_job.rb
+++ b/lib/pgbus/recurring/command_job.rb
@@ -8,8 +8,6 @@ module Pgbus
     # NOTE: Only use this with trusted commands from config/recurring.yml.
     # Never expose this to user input.
     class CommandJob < ::ActiveJob::Base
-      queue_as :pgbus_recurring
-
       def perform(command)
         eval(command) # rubocop:disable Security/Eval
       end

--- a/lib/pgbus/recurring/command_job.rb
+++ b/lib/pgbus/recurring/command_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Recurring
+    # Job class for command-based recurring tasks.
+    # Executes a Ruby command string, similar to solid_queue's RecurringJob.
+    #
+    # NOTE: Only use this with trusted commands from config/recurring.yml.
+    # Never expose this to user input.
+    class CommandJob < ::ActiveJob::Base
+      queue_as :pgbus_recurring
+
+      def perform(command)
+        eval(command) # rubocop:disable Security/Eval
+      end
+    end
+  end
+end

--- a/lib/pgbus/recurring/config_loader.rb
+++ b/lib/pgbus/recurring/config_loader.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "yaml"
+require "erb"
+
+module Pgbus
+  module Recurring
+    module ConfigLoader
+      module_function
+
+      def load(path, env: nil)
+        return {} unless path && File.exist?(path.to_s)
+
+        env ||= detect_env
+        raw = File.read(path)
+        parsed = YAML.safe_load(ERB.new(raw).result, permitted_classes: [Symbol], aliases: true)
+        return {} unless parsed.is_a?(Hash)
+
+        # If the parsed hash has an environment key, use that subtree
+        parsed.key?(env) ? parsed.fetch(env, {}) : parsed
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus] Failed to load recurring config from #{path}: #{e.message}" }
+        {}
+      end
+
+      def detect_env
+        if defined?(Rails)
+          Rails.env.to_s
+        else
+          ENV.fetch("PGBUS_ENV", "development")
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/recurring/schedule.rb
+++ b/lib/pgbus/recurring/schedule.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Recurring
+    class Schedule
+      attr_reader :tasks
+
+      def initialize(config: Pgbus.configuration)
+        @config = config
+        @tasks = load_tasks
+      end
+
+      def due_tasks(time = Time.now)
+        tasks.select { |task| task_due?(task, time) }
+      end
+
+      def enqueue_task(task, run_at:)
+        queue = resolve_queue(task)
+
+        RecurringExecutionRecord.record(task.key, run_at) do
+          payload = build_payload(task)
+          headers = build_headers(task, run_at)
+
+          Pgbus.client.ensure_queue(queue)
+          Pgbus.client.send_message(queue, payload, headers: headers)
+
+          Pgbus.logger.info do
+            "[Pgbus] Enqueued recurring task #{task.key} (#{task.class_name || task.command}) " \
+              "for run_at=#{run_at.iso8601}"
+          end
+        end
+      rescue AlreadyRecorded
+        Pgbus.logger.debug { "[Pgbus] Recurring task #{task.key} already enqueued for #{run_at.iso8601}" }
+      end
+
+      def build_payload(task)
+        if task.command
+          {
+            "job_class" => "Pgbus::Recurring::CommandJob",
+            "arguments" => [task.command],
+            "queue_name" => task.queue_name || @config.default_queue,
+            "priority" => nil
+          }
+        else
+          {
+            "job_class" => task.class_name,
+            "arguments" => task.arguments,
+            "queue_name" => task.queue_name || @config.default_queue,
+            "priority" => task.priority.zero? ? nil : task.priority
+          }
+        end
+      end
+
+      private
+
+      def load_tasks
+        raw = @config.recurring_tasks || {}
+        raw.filter_map do |key, options|
+          options = options.transform_keys(&:to_s).transform_keys(&:to_sym) if options.is_a?(Hash)
+          task = Task.from_configuration(key, **(options || {}))
+          if task.valid?
+            task
+          else
+            Pgbus.logger.warn { "[Pgbus] Skipping invalid recurring task '#{key}': #{task.errors.join(", ")}" }
+            nil
+          end
+        end
+      end
+
+      def task_due?(task, time)
+        # A task is due when its most recent cron occurrence (previous_time)
+        # falls within the current tick window. We also check match? to
+        # handle the exact-boundary case where time == cron time.
+        cron = task.parsed_schedule
+        return false unless cron
+
+        # Check if `time` itself matches the cron (exact boundary hit)
+        return true if cron.match?(time)
+
+        # Check if the previous occurrence was recent enough that we should
+        # still fire it (handles the case where we tick slightly after the
+        # cron time). The window is the scheduler interval.
+        prev = task.previous_time(time)
+        return false unless prev
+
+        (time - prev) <= @config.recurring_schedule_interval
+      end
+
+      def resolve_queue(task)
+        @config.queue_name(task.queue_name || @config.default_queue)
+      end
+
+      def build_headers(task, run_at)
+        {
+          "pgbus.recurring_key" => task.key,
+          "pgbus.recurring_run_at" => run_at.iso8601,
+          "pgbus.recurring_schedule" => task.schedule
+        }
+      end
+    end
+  end
+end

--- a/lib/pgbus/recurring/scheduler.rb
+++ b/lib/pgbus/recurring/scheduler.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Recurring
+    class Scheduler
+      include Process::SignalHandler
+
+      attr_reader :schedule, :config
+
+      def initialize(config: Pgbus.configuration)
+        @config = config
+        @schedule = Schedule.new(config: config)
+        @shutting_down = false
+        @last_runs = {}
+      end
+
+      def run
+        setup_signals
+        start_heartbeat
+
+        Pgbus.logger.info do
+          "[Pgbus] Scheduler started: #{schedule.tasks.size} recurring tasks, " \
+            "interval=#{config.recurring_schedule_interval}s"
+        end
+
+        loop do
+          break if @shutting_down
+
+          process_signals
+          break if @shutting_down
+
+          tick(Time.now)
+          break if @shutting_down
+
+          interruptible_sleep(config.recurring_schedule_interval)
+        end
+
+        shutdown
+      end
+
+      def tick(now)
+        schedule.due_tasks(now).each do |task|
+          run_at = task.previous_time(now)
+          next unless run_at
+
+          schedule.enqueue_task(task, run_at: run_at)
+          @last_runs[task.key] = now
+        rescue StandardError => e
+          Pgbus.logger.error do
+            "[Pgbus] Error scheduling recurring task #{task.key}: #{e.class}: #{e.message}"
+          end
+        end
+      end
+
+      def last_run_at(key)
+        @last_runs[key]
+      end
+
+      def task_statuses
+        schedule.tasks.map do |task|
+          {
+            key: task.key,
+            class_name: task.class_name,
+            command: task.command,
+            schedule: task.schedule,
+            human_schedule: task.human_schedule,
+            queue_name: task.queue_name,
+            arguments: task.arguments,
+            priority: task.priority,
+            description: task.description,
+            next_run_at: task.next_time,
+            last_run_at: @last_runs[task.key]
+          }
+        end
+      end
+
+      def graceful_shutdown
+        @shutting_down = true
+      end
+
+      def immediate_shutdown
+        @shutting_down = true
+      end
+
+      private
+
+      def start_heartbeat
+        @heartbeat = Process::Heartbeat.new(
+          kind: "scheduler",
+          metadata: { pid: ::Process.pid, tasks: schedule.tasks.size }
+        )
+        @heartbeat.start
+      end
+
+      def shutdown
+        @heartbeat&.stop
+        restore_signals
+        Pgbus.logger.info { "[Pgbus] Scheduler stopped" }
+      end
+    end
+  end
+end

--- a/lib/pgbus/recurring/task.rb
+++ b/lib/pgbus/recurring/task.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "fugit"
+
+module Pgbus
+  module Recurring
+    class Task
+      attr_reader :key, :class_name, :command, :schedule, :queue_name,
+                  :arguments, :priority, :description
+
+      def self.from_configuration(key, **options)
+        options = options.transform_keys(&:to_sym)
+        new(
+          key: key,
+          class_name: options[:class],
+          command: options[:command],
+          schedule: options[:schedule],
+          queue_name: options[:queue],
+          arguments: Array(options[:args]),
+          priority: options.fetch(:priority, 0).to_i,
+          description: options[:description]
+        )
+      end
+
+      def initialize(key:, class_name: nil, command: nil, schedule: nil,
+                     queue_name: nil, arguments: [], priority: 0, description: nil)
+        @key = key
+        @class_name = class_name
+        @command = command
+        @schedule = schedule
+        @queue_name = queue_name
+        @arguments = arguments || []
+        @priority = priority || 0
+        @description = description
+        @errors = []
+      end
+
+      def valid?
+        @errors = []
+        validate!
+        @errors.empty?
+      end
+
+      def errors
+        valid? unless defined?(@validated)
+        @errors
+      end
+
+      def parsed_schedule
+        @parsed_schedule ||= parse_schedule
+      end
+
+      def next_time(from = Time.now)
+        parsed_schedule&.next_time(from)&.to_t
+      end
+
+      def previous_time(from = Time.now)
+        parsed_schedule&.previous_time(from)&.to_t
+      end
+
+      def human_schedule
+        return nil unless parsed_schedule
+
+        parsed_schedule.to_cron_s
+      end
+
+      def job_class
+        class_name&.safe_constantize
+      end
+
+      def to_h
+        {
+          key: key,
+          class_name: class_name,
+          command: command,
+          schedule: schedule,
+          queue_name: queue_name,
+          arguments: arguments,
+          priority: priority,
+          description: description
+        }
+      end
+
+      private
+
+      def validate!
+        @validated = true
+
+        if schedule.nil? || schedule.to_s.strip.empty?
+          @errors << "Schedule is required"
+          return
+        end
+
+        @errors << "Either class or command is required" if class_name.nil? && command.nil?
+
+        return if parsed_schedule.is_a?(Fugit::Cron)
+
+        @errors << "Schedule '#{schedule}' is not a valid cron expression"
+      end
+
+      def parse_schedule
+        return nil if schedule.nil? || schedule.to_s.strip.empty?
+
+        parsed = Fugit.parse(schedule.to_s, multi: :fail)
+        parsed.is_a?(Fugit::Cron) ? parsed : nil
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/lib/pgbus/recurring/task.rb
+++ b/lib/pgbus/recurring/task.rb
@@ -91,7 +91,7 @@ module Pgbus
           return
         end
 
-        @errors << "Either class or command is required" if class_name.nil? && command.nil?
+        @errors << "Either class or command is required" if class_name.to_s.strip.empty? && command.to_s.strip.empty?
 
         return if parsed_schedule.is_a?(Fugit::Cron)
 

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -23,7 +23,8 @@ module Pgbus
           total_visible: total_visible,
           active_processes: processes.count,
           failed_count: failed_events_count,
-          dlq_depth: dlq_depth
+          dlq_depth: dlq_depth,
+          recurring_count: recurring_tasks_count
         }
       end
 
@@ -316,6 +317,120 @@ module Pgbus
         false
       end
 
+      # Recurring tasks
+      def recurring_tasks
+        RecurringTaskRecord.order(:key).map do |record|
+          last_exec = RecurringExecutionRecord.last_execution(record.key)
+          task = Recurring::Task.from_configuration(record.key,
+                                                    class: record.class_name,
+                                                    command: record.command,
+                                                    schedule: record.schedule,
+                                                    queue: record.queue_name,
+                                                    args: parse_arguments(record.arguments),
+                                                    priority: record.priority,
+                                                    description: record.description)
+
+          {
+            id: record.id,
+            key: record.key,
+            class_name: record.class_name,
+            command: record.command,
+            schedule: record.schedule,
+            human_schedule: task.human_schedule,
+            queue_name: record.queue_name,
+            priority: record.priority,
+            description: record.description,
+            enabled: record.enabled,
+            static: record.static,
+            next_run_at: task.next_time,
+            last_run_at: last_exec&.run_at,
+            created_at: record.created_at,
+            updated_at: record.updated_at
+          }
+        end
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus::Web] Error fetching recurring tasks: #{e.class}: #{e.message}" }
+        []
+      end
+
+      def recurring_task(id)
+        record = RecurringTaskRecord.find_by(id: id)
+        return nil unless record
+
+        task = Recurring::Task.from_configuration(record.key,
+                                                  class: record.class_name,
+                                                  command: record.command,
+                                                  schedule: record.schedule,
+                                                  queue: record.queue_name,
+                                                  args: parse_arguments(record.arguments),
+                                                  priority: record.priority,
+                                                  description: record.description)
+
+        executions = RecurringExecutionRecord.for_task(record.key).recent(25).map do |exec|
+          { run_at: exec.run_at, created_at: exec.created_at }
+        end
+
+        {
+          id: record.id,
+          key: record.key,
+          class_name: record.class_name,
+          command: record.command,
+          schedule: record.schedule,
+          human_schedule: task.human_schedule,
+          queue_name: record.queue_name,
+          arguments: parse_arguments(record.arguments),
+          priority: record.priority,
+          description: record.description,
+          enabled: record.enabled,
+          static: record.static,
+          next_run_at: task.next_time,
+          executions: executions,
+          created_at: record.created_at,
+          updated_at: record.updated_at
+        }
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus::Web] Error fetching recurring task #{id}: #{e.class}: #{e.message}" }
+        nil
+      end
+
+      def toggle_recurring_task(id)
+        record = RecurringTaskRecord.find_by(id: id)
+        return false unless record
+
+        record.update!(enabled: !record.enabled)
+        true
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus::Web] Error toggling recurring task #{id}: #{e.message}" }
+        false
+      end
+
+      def enqueue_recurring_task_now(id)
+        record = RecurringTaskRecord.find_by(id: id)
+        return false unless record
+
+        task = Recurring::Task.from_configuration(record.key,
+                                                  class: record.class_name,
+                                                  command: record.command,
+                                                  schedule: record.schedule,
+                                                  queue: record.queue_name,
+                                                  args: parse_arguments(record.arguments),
+                                                  priority: record.priority)
+
+        schedule = Recurring::Schedule.new(config: Pgbus.configuration)
+        schedule.enqueue_task(task, run_at: Time.now.utc)
+        true
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus::Web] Error enqueuing recurring task #{id}: #{e.message}" }
+        false
+      end
+
+      def recurring_tasks_count
+        RecurringTaskRecord.count
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error counting recurring tasks: #{e.message}" }
+        0
+      end
+
       # Subscriber registry
       def registered_subscribers
         EventBus::Registry.instance.subscribers.map do |s|
@@ -431,6 +546,17 @@ module Pgbus
 
       def sanitize_name(name)
         name.gsub(/[^a-zA-Z0-9_]/, "")
+      end
+
+      def parse_arguments(args)
+        case args
+        when Array then args
+        when String then JSON.parse(args)
+        when NilClass then []
+        else Array(args)
+        end
+      rescue JSON::ParserError
+        []
       end
     end
   end

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -319,8 +319,15 @@ module Pgbus
 
       # Recurring tasks
       def recurring_tasks
-        RecurringTaskRecord.order(:key).map do |record|
-          last_exec = RecurringExecutionRecord.last_execution(record.key)
+        records = RecurringTaskRecord.order(:key).to_a
+        last_runs = RecurringExecutionRecord
+                    .where(task_key: records.map(&:key))
+                    .select("task_key, MAX(run_at) AS run_at")
+                    .group(:task_key)
+                    .index_by(&:task_key)
+
+        records.map do |record|
+          last_exec = last_runs[record.key]
           task = Recurring::Task.from_configuration(record.key,
                                                     class: record.class_name,
                                                     command: record.command,
@@ -555,7 +562,8 @@ module Pgbus
         when NilClass then []
         else Array(args)
         end
-      rescue JSON::ParserError
+      rescue JSON::ParserError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Invalid recurring task arguments JSON: #{e.message}" }
         []
       end
     end

--- a/pgbus.gemspec
+++ b/pgbus.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "concurrent-ruby", "~> 1.2"
+  spec.add_dependency "fugit", "~> 1.11"
   spec.add_dependency "pgmq-ruby", "~> 0.5"
   spec.add_dependency "railties", ">= 7.1", "< 9.0"
   spec.add_dependency "zeitwerk", "~> 2.6"

--- a/pgbus.gemspec
+++ b/pgbus.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "concurrent-ruby", "~> 1.2"
-  spec.add_dependency "fugit", "~> 1.11"
+  spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
   spec.add_dependency "pgmq-ruby", "~> 0.5"
   spec.add_dependency "railties", ">= 7.1", "< 9.0"
   spec.add_dependency "zeitwerk", "~> 2.6"

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe Pgbus::Configuration do
       expect(config.max_memory_mb).to be_nil
       expect(config.max_worker_lifetime).to be_nil
     end
+
+    it "has default recurring schedule interval" do
+      expect(config.recurring_schedule_interval).to eq(1.0)
+    end
+
+    it "has no recurring tasks by default" do
+      expect(config.recurring_tasks).to be_nil
+    end
+
+    it "does not skip recurring by default" do
+      expect(config.skip_recurring).to be false
+    end
+
+    it "has default recurring execution retention of 7 days" do
+      expect(config.recurring_execution_retention).to eq(7 * 24 * 3600)
+    end
   end
 
   describe "#queue_name" do

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "has a batch cleanup interval of 1 hour" do
       expect(described_class::BATCH_CLEANUP_INTERVAL).to eq(3600)
     end
+
+    it "has a recurring cleanup interval of 1 hour" do
+      expect(described_class::RECURRING_CLEANUP_INTERVAL).to eq(3600)
+    end
   end
 
   describe "#graceful_shutdown" do
@@ -185,6 +189,32 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "rescues errors gracefully" do
       allow(Pgbus::Batch).to receive(:cleanup).and_raise(StandardError, "db error")
       expect { dispatcher.send(:cleanup_batches) }.not_to raise_error
+    end
+  end
+
+  describe "#cleanup_recurring_executions (private)" do
+    it "deletes old recurring execution records" do
+      relation = instance_double(ActiveRecord::Relation, delete_all: 5)
+      allow(Pgbus::RecurringExecutionRecord).to receive(:older_than).and_return(relation)
+
+      dispatcher.send(:cleanup_recurring_executions)
+
+      expect(Pgbus::RecurringExecutionRecord).to have_received(:older_than).with(an_instance_of(Time))
+      expect(relation).to have_received(:delete_all)
+    end
+
+    it "rescues errors gracefully" do
+      allow(Pgbus::RecurringExecutionRecord).to receive(:older_than).and_raise(StandardError, "db error")
+      expect { dispatcher.send(:cleanup_recurring_executions) }.not_to raise_error
+    end
+
+    it "skips when retention is not positive" do
+      allow(Pgbus.configuration).to receive(:recurring_execution_retention).and_return(0)
+      allow(Pgbus::RecurringExecutionRecord).to receive(:older_than)
+
+      dispatcher.send(:cleanup_recurring_executions)
+
+      expect(Pgbus::RecurringExecutionRecord).not_to have_received(:older_than)
     end
   end
 

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -116,5 +116,29 @@ RSpec.describe Pgbus::Process::Supervisor do
       expect(supervisor.instance_variable_get(:@forks)).to have_key(5001)
       expect(supervisor.instance_variable_get(:@forks)[5001][:type]).to eq(:consumer)
     end
+
+    it "routes :scheduler to fork_scheduler" do
+      info = { type: :scheduler }
+      supervisor.send(:restart_child, info)
+
+      expect(supervisor.instance_variable_get(:@forks)).to have_key(5001)
+      expect(supervisor.instance_variable_get(:@forks)[5001][:type]).to eq(:scheduler)
+    end
+  end
+
+  describe "recurring_tasks_configured? (private)" do
+    let(:supervisor) { described_class.new }
+
+    it "returns true when recurring_tasks are set in config" do
+      config.recurring_tasks = { "task1" => { "class" => "MyJob", "schedule" => "0 * * * *" } }
+      expect(supervisor.send(:recurring_tasks_configured?)).to be true
+      config.recurring_tasks = nil
+    end
+
+    it "returns false when nothing is configured" do
+      config.recurring_tasks = nil
+      config.recurring_tasks_file = nil
+      expect(supervisor.send(:recurring_tasks_configured?)).to be false
+    end
   end
 end

--- a/spec/pgbus/recurring/command_job_spec.rb
+++ b/spec/pgbus/recurring/command_job_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_job"
+
+RSpec.describe Pgbus::Recurring::CommandJob do
+  it "inherits from ActiveJob::Base" do
+    expect(described_class.ancestors).to include(ActiveJob::Base)
+  end
+
+  it "has pgbus_recurring as the default queue" do
+    job = described_class.new("1 + 1")
+    expect(job.queue_name).to eq("pgbus_recurring")
+  end
+end

--- a/spec/pgbus/recurring/command_job_spec.rb
+++ b/spec/pgbus/recurring/command_job_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Pgbus::Recurring::CommandJob do
     expect(described_class.ancestors).to include(ActiveJob::Base)
   end
 
-  it "has pgbus_recurring as the default queue" do
+  it "uses the default ActiveJob queue (no hardcoded queue)" do
     job = described_class.new("1 + 1")
-    expect(job.queue_name).to eq("pgbus_recurring")
+    expect(job.queue_name).to eq("default")
   end
 end

--- a/spec/pgbus/recurring/config_loader_spec.rb
+++ b/spec/pgbus/recurring/config_loader_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tempfile"
+
+RSpec.describe Pgbus::Recurring::ConfigLoader do
+  describe ".load" do
+    it "loads recurring tasks from a YAML file" do
+      yaml_content = <<~YAML
+        daily_cleanup:
+          class: CleanupJob
+          schedule: "0 2 * * *"
+          queue: maintenance
+        hourly_sync:
+          class: SyncJob
+          schedule: "0 * * * *"
+      YAML
+
+      file = Tempfile.new(["recurring", ".yml"])
+      file.write(yaml_content)
+      file.rewind
+
+      tasks = described_class.load(file.path)
+
+      expect(tasks).to be_a(Hash)
+      expect(tasks.size).to eq(2)
+      expect(tasks["daily_cleanup"]["class"]).to eq("CleanupJob")
+      expect(tasks["hourly_sync"]["schedule"]).to eq("0 * * * *")
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    it "loads environment-scoped config" do
+      yaml_content = <<~YAML
+        production:
+          prod_task:
+            class: ProdJob
+            schedule: "0 2 * * *"
+        development:
+          dev_task:
+            class: DevJob
+            schedule: "* * * * *"
+      YAML
+
+      file = Tempfile.new(["recurring", ".yml"])
+      file.write(yaml_content)
+      file.rewind
+
+      tasks = described_class.load(file.path, env: "production")
+
+      expect(tasks.size).to eq(1)
+      expect(tasks.keys).to eq(["prod_task"])
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    it "falls back to full config when environment key not found" do
+      yaml_content = <<~YAML
+        daily_cleanup:
+          class: CleanupJob
+          schedule: "0 2 * * *"
+      YAML
+
+      file = Tempfile.new(["recurring", ".yml"])
+      file.write(yaml_content)
+      file.rewind
+
+      tasks = described_class.load(file.path, env: "staging")
+
+      expect(tasks.size).to eq(1)
+      expect(tasks.keys).to eq(["daily_cleanup"])
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    it "processes ERB in the YAML file" do
+      yaml_content = <<~YAML
+        cleanup:
+          class: CleanupJob
+          schedule: "<%= '0 2 * * *' %>"
+      YAML
+
+      file = Tempfile.new(["recurring", ".yml"])
+      file.write(yaml_content)
+      file.rewind
+
+      tasks = described_class.load(file.path)
+
+      expect(tasks["cleanup"]["schedule"]).to eq("0 2 * * *")
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    it "returns empty hash for empty file" do
+      file = Tempfile.new(["recurring", ".yml"])
+      file.write("")
+      file.rewind
+
+      tasks = described_class.load(file.path)
+      expect(tasks).to eq({})
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    it "returns empty hash when file doesn't exist" do
+      tasks = described_class.load("/nonexistent/recurring.yml")
+      expect(tasks).to eq({})
+    end
+  end
+end

--- a/spec/pgbus/recurring/execution_record_spec.rb
+++ b/spec/pgbus/recurring/execution_record_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::RecurringExecutionRecord do
+  describe ".record" do
+    it "creates a record and yields" do
+      yielded = false
+      mock_record = double("execution", task_key: "test", run_at: Time.now)
+
+      allow(described_class).to receive(:transaction).and_yield
+      allow(described_class).to receive(:create!).and_return(mock_record)
+
+      described_class.record("test", Time.now) { yielded = true }
+
+      expect(yielded).to be true
+    end
+
+    it "raises AlreadyRecorded on duplicate" do
+      allow(described_class).to receive(:transaction).and_yield
+      allow(described_class).to receive(:create!)
+        .and_raise(ActiveRecord::RecordNotUnique)
+
+      expect do
+        described_class.record("test", Time.now)
+      end.to raise_error(Pgbus::Recurring::AlreadyRecorded)
+    end
+  end
+
+  describe ".last_execution" do
+    it "delegates to for_task scope" do
+      relation = double("relation")
+      ordered = double("ordered")
+
+      allow(described_class).to receive(:for_task).with("my_task").and_return(relation)
+      allow(relation).to receive(:order).with(run_at: :desc).and_return(ordered)
+      allow(ordered).to receive(:first).and_return(nil)
+
+      result = described_class.last_execution("my_task")
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/pgbus/recurring/schedule_spec.rb
+++ b/spec/pgbus/recurring/schedule_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Recurring::Schedule do
+  let(:config) { Pgbus::Configuration.new }
+  let(:mock_client) { instance_double(Pgbus::Client) }
+
+  before do
+    allow(Pgbus).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:ensure_queue)
+    allow(mock_client).to receive(:send_message)
+    config.recurring_tasks = {
+      "daily_cleanup" => {
+        "class" => "CleanupJob",
+        "schedule" => "0 2 * * *",
+        "queue" => "maintenance"
+      },
+      "hourly_sync" => {
+        "class" => "SyncJob",
+        "schedule" => "0 * * * *"
+      }
+    }
+  end
+
+  describe "#initialize" do
+    it "loads tasks from configuration" do
+      schedule = described_class.new(config: config)
+      expect(schedule.tasks.size).to eq(2)
+      expect(schedule.tasks.map(&:key)).to contain_exactly("daily_cleanup", "hourly_sync")
+    end
+
+    it "filters out invalid tasks with logging" do
+      config.recurring_tasks = {
+        "valid" => { "class" => "MyJob", "schedule" => "0 * * * *" },
+        "invalid" => { "class" => "MyJob", "schedule" => nil }
+      }
+
+      schedule = described_class.new(config: config)
+      expect(schedule.tasks.size).to eq(1)
+      expect(schedule.tasks.first.key).to eq("valid")
+    end
+
+    it "handles empty recurring tasks" do
+      config.recurring_tasks = {}
+      schedule = described_class.new(config: config)
+      expect(schedule.tasks).to be_empty
+    end
+
+    it "handles nil recurring tasks" do
+      config.recurring_tasks = nil
+      schedule = described_class.new(config: config)
+      expect(schedule.tasks).to be_empty
+    end
+  end
+
+  describe "#due_tasks" do
+    it "returns tasks whose next_time is at or before the given time" do
+      schedule = described_class.new(config: config)
+
+      # Both tasks should have some next_time
+      due = schedule.due_tasks(Time.now + 7200) # 2 hours from now
+      expect(due).to be_an(Array)
+    end
+
+    it "returns empty array when no tasks are due" do
+      # Use a once-a-year schedule so we can easily find a non-matching time
+      config.recurring_tasks = {
+        "yearly" => {
+          "class" => "YearlyJob",
+          "schedule" => "0 0 1 1 *" # Jan 1st midnight only
+        }
+      }
+      schedule = described_class.new(config: config)
+
+      # June 15 at noon — nowhere near Jan 1 midnight
+      due = schedule.due_tasks(Time.utc(2026, 6, 15, 12, 30, 0))
+      expect(due).to be_empty
+    end
+  end
+
+  describe "#enqueue_task" do
+    let(:schedule) { described_class.new(config: config) }
+    let(:task) { schedule.tasks.first }
+    let(:run_at) { Time.utc(2026, 3, 31, 2, 0, 0) }
+
+    before do
+      # Mock the RecurringExecution to allow recording
+      allow(Pgbus::RecurringExecutionRecord).to receive(:record).and_yield
+    end
+
+    it "sends a message through the client" do
+      schedule.enqueue_task(task, run_at: run_at)
+
+      expect(mock_client).to have_received(:send_message).with(
+        anything,
+        hash_including("job_class" => "CleanupJob"),
+        headers: hash_including("pgbus.recurring_key" => "daily_cleanup")
+      )
+    end
+
+    it "uses the task's configured queue" do
+      schedule.enqueue_task(task, run_at: run_at)
+
+      expect(mock_client).to have_received(:send_message).with(
+        "pgbus_maintenance",
+        anything,
+        headers: anything
+      )
+    end
+
+    it "uses default queue when task has no queue" do
+      task_no_queue = schedule.tasks.find { |t| t.key == "hourly_sync" }
+
+      schedule.enqueue_task(task_no_queue, run_at: run_at)
+
+      expect(mock_client).to have_received(:send_message).with(
+        "pgbus_default",
+        anything,
+        headers: anything
+      )
+    end
+
+    it "records the execution for deduplication" do
+      allow(Pgbus::RecurringExecutionRecord).to receive(:record)
+        .with("daily_cleanup", run_at)
+        .and_yield
+
+      schedule.enqueue_task(task, run_at: run_at)
+
+      expect(Pgbus::RecurringExecutionRecord).to have_received(:record)
+        .with("daily_cleanup", run_at)
+    end
+
+    it "does not enqueue when execution already recorded" do
+      allow(Pgbus::RecurringExecutionRecord).to receive(:record)
+        .and_raise(Pgbus::Recurring::AlreadyRecorded)
+
+      schedule.enqueue_task(task, run_at: run_at)
+
+      expect(mock_client).not_to have_received(:send_message)
+    end
+  end
+
+  describe "#build_payload" do
+    let(:schedule) { described_class.new(config: config) }
+
+    it "builds a serialized job payload for class-based tasks" do
+      task = schedule.tasks.find { |t| t.key == "daily_cleanup" }
+      payload = schedule.build_payload(task)
+
+      expect(payload["job_class"]).to eq("CleanupJob")
+      expect(payload["arguments"]).to eq([])
+      expect(payload["queue_name"]).to eq("maintenance")
+      expect(payload["priority"]).to be_nil
+    end
+
+    it "builds a command payload for command-based tasks" do
+      config.recurring_tasks = {
+        "cleanup_cmd" => {
+          "command" => "OldRecord.cleanup!",
+          "schedule" => "0 3 * * *"
+        }
+      }
+      schedule_with_cmd = described_class.new(config: config)
+      task = schedule_with_cmd.tasks.first
+      payload = schedule_with_cmd.build_payload(task)
+
+      expect(payload["job_class"]).to eq("Pgbus::Recurring::CommandJob")
+      expect(payload["arguments"]).to eq(["OldRecord.cleanup!"])
+    end
+  end
+end

--- a/spec/pgbus/recurring/scheduler_spec.rb
+++ b/spec/pgbus/recurring/scheduler_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Recurring::Scheduler do
+  let(:config) { Pgbus::Configuration.new }
+  let(:mock_client) { instance_double(Pgbus::Client) }
+
+  before do
+    allow(Pgbus).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:ensure_queue)
+    allow(mock_client).to receive(:send_message)
+    config.recurring_tasks = {
+      "every_minute" => {
+        "class" => "MinuteJob",
+        "schedule" => "* * * * *"
+      }
+    }
+  end
+
+  describe "#initialize" do
+    it "creates a scheduler with a schedule" do
+      scheduler = described_class.new(config: config)
+      expect(scheduler.schedule).to be_a(Pgbus::Recurring::Schedule)
+      expect(scheduler.schedule.tasks.size).to eq(1)
+    end
+  end
+
+  describe "#tick" do
+    it "enqueues due tasks" do
+      scheduler = described_class.new(config: config)
+
+      allow(Pgbus::RecurringExecutionRecord).to receive(:record) do |_key, _time, &block|
+        block&.call
+      end
+
+      # Use a time that's exactly on a minute boundary — the task is "every minute",
+      # and cron.match? returns true at any :00 second boundary
+      now = Time.utc(2026, 3, 31, 12, 1, 0)
+      scheduler.tick(now)
+
+      expect(mock_client).to have_received(:send_message).at_least(:once)
+    end
+
+    it "does not enqueue tasks that are not due" do
+      config.recurring_tasks = {
+        "future_task" => {
+          "class" => "FutureJob",
+          "schedule" => "0 0 1 1 *" # Jan 1st only
+        }
+      }
+      scheduler = described_class.new(config: config)
+
+      # Use a time that's not Jan 1st midnight — task won't be due
+      scheduler.tick(Time.utc(2026, 6, 15, 12, 0, 30))
+
+      expect(mock_client).not_to have_received(:send_message)
+    end
+
+    it "handles errors during enqueue gracefully" do
+      scheduler = described_class.new(config: config)
+
+      allow(scheduler.schedule).to receive(:due_tasks).and_return(scheduler.schedule.tasks)
+      allow(scheduler.schedule).to receive(:enqueue_task).and_raise(StandardError, "DB connection lost")
+
+      # Should not raise
+      expect { scheduler.tick(Time.utc(2026, 3, 31, 12, 1, 0)) }.not_to raise_error
+    end
+
+    it "tracks last_run_at per task" do
+      scheduler = described_class.new(config: config)
+      allow(Pgbus::RecurringExecutionRecord).to receive(:record) do |_key, _time, &block|
+        block&.call
+      end
+
+      now = Time.utc(2026, 3, 31, 12, 1, 0)
+      scheduler.tick(now)
+
+      expect(scheduler.last_run_at("every_minute")).not_to be_nil
+    end
+  end
+
+  describe "#task_statuses" do
+    it "returns status information for all tasks" do
+      scheduler = described_class.new(config: config)
+
+      statuses = scheduler.task_statuses
+      expect(statuses).to be_an(Array)
+      expect(statuses.size).to eq(1)
+
+      status = statuses.first
+      expect(status[:key]).to eq("every_minute")
+      expect(status[:class_name]).to eq("MinuteJob")
+      expect(status[:schedule]).to eq("* * * * *")
+      expect(status[:next_run_at]).to be_a(Time)
+      expect(status[:last_run_at]).to be_nil
+    end
+  end
+end

--- a/spec/pgbus/recurring/task_spec.rb
+++ b/spec/pgbus/recurring/task_spec.rb
@@ -100,6 +100,16 @@ RSpec.describe Pgbus::Recurring::Task do
       expect(task.errors).to include(/class.*command/i)
     end
 
+    it "is invalid with blank class and command" do
+      task = described_class.from_configuration("t1",
+                                                class: "  ",
+                                                command: "",
+                                                schedule: "0 * * * *")
+
+      expect(task).not_to be_valid
+      expect(task.errors).to include(/class.*command/i)
+    end
+
     it "is invalid with unparseable schedule" do
       task = described_class.from_configuration("t1",
                                                 class: "MyJob",

--- a/spec/pgbus/recurring/task_spec.rb
+++ b/spec/pgbus/recurring/task_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fugit"
+
+RSpec.describe Pgbus::Recurring::Task do
+  describe ".from_configuration" do
+    it "creates a task from YAML-style config" do
+      task = described_class.from_configuration("daily_cleanup",
+                                                class: "CleanupJob",
+                                                schedule: "0 2 * * *",
+                                                queue: "maintenance",
+                                                args: [1000],
+                                                priority: 5,
+                                                description: "Daily cleanup task")
+
+      expect(task.key).to eq("daily_cleanup")
+      expect(task.class_name).to eq("CleanupJob")
+      expect(task.schedule).to eq("0 2 * * *")
+      expect(task.queue_name).to eq("maintenance")
+      expect(task.arguments).to eq([1000])
+      expect(task.priority).to eq(5)
+      expect(task.description).to eq("Daily cleanup task")
+    end
+
+    it "accepts string keys for config hash" do
+      task = described_class.from_configuration("sync",
+                                                "class" => "SyncJob",
+                                                "schedule" => "every hour")
+
+      expect(task.class_name).to eq("SyncJob")
+      expect(task.schedule).to eq("every hour")
+    end
+
+    it "defaults queue_name to nil when not specified" do
+      task = described_class.from_configuration("task1",
+                                                class: "MyJob",
+                                                schedule: "every hour")
+
+      expect(task.queue_name).to be_nil
+    end
+
+    it "defaults arguments to empty array" do
+      task = described_class.from_configuration("task1",
+                                                class: "MyJob",
+                                                schedule: "every hour")
+
+      expect(task.arguments).to eq([])
+    end
+
+    it "defaults priority to 0" do
+      task = described_class.from_configuration("task1",
+                                                class: "MyJob",
+                                                schedule: "every hour")
+
+      expect(task.priority).to eq(0)
+    end
+
+    it "supports command-based tasks" do
+      task = described_class.from_configuration("cleanup_cmd",
+                                                command: "OldRecord.where('created_at < ?', 30.days.ago).delete_all",
+                                                schedule: "0 3 * * *")
+
+      expect(task.command).to eq("OldRecord.where('created_at < ?', 30.days.ago).delete_all")
+      expect(task.class_name).to be_nil
+    end
+  end
+
+  describe "#valid?" do
+    it "is valid with class and schedule" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "0 * * * *")
+
+      expect(task).to be_valid
+    end
+
+    it "is valid with command and schedule" do
+      task = described_class.from_configuration("t1",
+                                                command: "puts 'hello'",
+                                                schedule: "0 * * * *")
+
+      expect(task).to be_valid
+    end
+
+    it "is invalid without schedule" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: nil)
+
+      expect(task).not_to be_valid
+      expect(task.errors).to include(/schedule/i)
+    end
+
+    it "is invalid without class or command" do
+      task = described_class.from_configuration("t1",
+                                                schedule: "0 * * * *")
+
+      expect(task).not_to be_valid
+      expect(task.errors).to include(/class.*command/i)
+    end
+
+    it "is invalid with unparseable schedule" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "not a valid cron")
+
+      expect(task).not_to be_valid
+      expect(task.errors).to include(/schedule/i)
+    end
+
+    it "rejects duration-style schedules (every 1.minute)" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "every 1.minute")
+
+      expect(task).not_to be_valid
+    end
+  end
+
+  describe "#parsed_schedule" do
+    it "returns a Fugit::Cron for standard cron" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "0 2 * * *")
+
+      expect(task.parsed_schedule).to be_a(Fugit::Cron)
+    end
+
+    it "parses natural language schedules" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "every day at 2am")
+
+      expect(task.parsed_schedule).to be_a(Fugit::Cron)
+    end
+
+    it "returns nil for invalid schedules" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "garbage")
+
+      expect(task.parsed_schedule).to be_nil
+    end
+  end
+
+  describe "#next_time" do
+    it "returns the next occurrence from now" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "0 * * * *")
+
+      next_time = task.next_time
+      expect(next_time).to be > Time.now
+      expect(next_time.min).to eq(0)
+    end
+
+    it "returns next occurrence from a given time" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "0 12 * * *")
+
+      from = Time.utc(2026, 1, 1, 0, 0, 0)
+      next_time = task.next_time(from)
+      expect(next_time.hour).to eq(12)
+      expect(next_time.day).to eq(1)
+    end
+  end
+
+  describe "#previous_time" do
+    it "returns the previous occurrence" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "0 * * * *")
+
+      prev_time = task.previous_time
+      expect(prev_time).to be < Time.now
+      expect(prev_time.min).to eq(0)
+    end
+  end
+
+  describe "#human_schedule" do
+    it "returns a human-readable schedule description" do
+      task = described_class.from_configuration("t1",
+                                                class: "MyJob",
+                                                schedule: "0 2 * * *")
+
+      expect(task.human_schedule).to be_a(String)
+      expect(task.human_schedule).not_to be_empty
+    end
+  end
+
+  describe "#job_class" do
+    it "constantizes the class_name" do
+      stub_const("CleanupJob", Class.new)
+      task = described_class.from_configuration("t1",
+                                                class: "CleanupJob",
+                                                schedule: "0 * * * *")
+
+      expect(task.job_class).to eq(CleanupJob)
+    end
+
+    it "returns nil for unknown class" do
+      task = described_class.from_configuration("t1",
+                                                class: "NonExistentJob",
+                                                schedule: "0 * * * *")
+
+      expect(task.job_class).to be_nil
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation" do
+      task = described_class.from_configuration("daily",
+                                                class: "CleanupJob",
+                                                schedule: "0 2 * * *",
+                                                queue: "maintenance",
+                                                args: [100],
+                                                priority: 3,
+                                                description: "Daily cleanup")
+
+      h = task.to_h
+      expect(h[:key]).to eq("daily")
+      expect(h[:class_name]).to eq("CleanupJob")
+      expect(h[:schedule]).to eq("0 2 * * *")
+      expect(h[:queue_name]).to eq("maintenance")
+      expect(h[:arguments]).to eq([100])
+      expect(h[:priority]).to eq(3)
+      expect(h[:description]).to eq("Daily cleanup")
+    end
+  end
+end

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -105,4 +105,62 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(result.first[:handler_class]).to eq("MyHandler")
     end
   end
+
+  describe "#recurring_tasks" do
+    it "returns formatted recurring tasks" do
+      mock_record = double("RecurringTaskRecord",
+                           id: 1, key: "daily_cleanup", class_name: "CleanupJob",
+                           command: nil, schedule: "0 2 * * *", queue_name: "maintenance",
+                           arguments: nil, priority: 0, description: "Cleanup",
+                           enabled: true, static: true,
+                           created_at: Time.now, updated_at: Time.now)
+
+      allow(Pgbus::RecurringTaskRecord).to receive(:order).with(:key)
+                                                          .and_return([mock_record])
+      allow(Pgbus::RecurringExecutionRecord).to receive(:last_execution)
+        .with("daily_cleanup").and_return(nil)
+
+      result = data_source.recurring_tasks
+      expect(result.size).to eq(1)
+      expect(result.first[:key]).to eq("daily_cleanup")
+      expect(result.first[:class_name]).to eq("CleanupJob")
+      expect(result.first[:enabled]).to be true
+    end
+
+    it "returns empty array on error" do
+      allow(Pgbus::RecurringTaskRecord).to receive(:order).and_raise(StandardError)
+
+      expect(data_source.recurring_tasks).to eq([])
+    end
+  end
+
+  describe "#recurring_tasks_count" do
+    it "returns the count of recurring tasks" do
+      allow(Pgbus::RecurringTaskRecord).to receive(:count).and_return(5)
+
+      expect(data_source.recurring_tasks_count).to eq(5)
+    end
+
+    it "returns 0 on error" do
+      allow(Pgbus::RecurringTaskRecord).to receive(:count).and_raise(StandardError)
+
+      expect(data_source.recurring_tasks_count).to eq(0)
+    end
+  end
+
+  describe "#toggle_recurring_task" do
+    it "toggles the enabled state" do
+      mock_record = double("RecurringTaskRecord", enabled: true)
+      allow(Pgbus::RecurringTaskRecord).to receive(:find_by).with(id: 1).and_return(mock_record)
+      allow(mock_record).to receive(:update!).with(enabled: false).and_return(true)
+
+      expect(data_source.toggle_recurring_task(1)).to be true
+    end
+
+    it "returns false when task not found" do
+      allow(Pgbus::RecurringTaskRecord).to receive(:find_by).with(id: 99).and_return(nil)
+
+      expect(data_source.toggle_recurring_task(99)).to be false
+    end
+  end
 end

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -115,10 +115,13 @@ RSpec.describe Pgbus::Web::DataSource do
                            enabled: true, static: true,
                            created_at: Time.now, updated_at: Time.now)
 
-      allow(Pgbus::RecurringTaskRecord).to receive(:order).with(:key)
-                                                          .and_return([mock_record])
-      allow(Pgbus::RecurringExecutionRecord).to receive(:last_execution)
-        .with("daily_cleanup").and_return(nil)
+      relation = double("relation", to_a: [mock_record])
+      allow(Pgbus::RecurringTaskRecord).to receive(:order).with(:key).and_return(relation)
+
+      # Mock the aggregate query for last runs
+      empty_scope = double("scope")
+      allow(Pgbus::RecurringExecutionRecord).to receive(:where).and_return(empty_scope)
+      allow(empty_scope).to receive_messages(select: empty_scope, group: empty_scope, index_by: {})
 
       result = data_source.recurring_tasks
       expect(result.size).to eq(1)


### PR DESCRIPTION
## Summary
- Add recurring job scheduling using `config/recurring.yml` (same format as solid_queue for easy migration)
- Dedicated scheduler process in the supervisor tree with heartbeat monitoring
- Database-backed deduplication via unique `(task_key, run_at)` constraint — exactly-once scheduling
- Full dashboard with task list, enable/disable toggle, "Run Now" button, and execution history
- Uses fugit for cron expression parsing (standard cron, natural language, timezone support)

## Key Design Decisions
- **Solid Queue compatible config**: Same YAML keys (`class`, `command`, `schedule`, `queue`, `args`, `priority`, `description`), same env-scoped config, same ERB support — drop-in migration from `Recurring::WhateverJob`
- **Database dedup over leader election**: Multiple schedulers can run safely; unique constraint prevents double-enqueue (same approach as solid_queue/GoodJob)
- **Separate scheduler process**: Forked by supervisor, automatically restarted on crash, includes heartbeat registration
- **Dispatcher cleanup**: Old recurring execution records pruned automatically (configurable retention, default 7 days)
- **Enable/disable without deploy**: Toggle tasks via dashboard without redeploying config

## New Files
| File | Purpose |
|------|---------|
| `lib/pgbus/recurring/task.rb` | Task POJO — validates cron, computes next/previous time |
| `lib/pgbus/recurring/schedule.rb` | Determines due tasks, enqueues with dedup |
| `lib/pgbus/recurring/scheduler.rb` | Process with signal handling, heartbeat, tick loop |
| `lib/pgbus/recurring/config_loader.rb` | Loads recurring.yml with ERB + env scoping |
| `lib/pgbus/recurring/command_job.rb` | ActiveJob for `command:` tasks |
| `app/models/pgbus/recurring_task_record.rb` | Persisted task definitions |
| `app/models/pgbus/recurring_execution_record.rb` | Dedup via unique index |
| `app/controllers/pgbus/recurring_tasks_controller.rb` | Dashboard controller |
| `app/views/pgbus/recurring_tasks/` | Index + show views with Turbo Frames |
| `lib/generators/pgbus/add_recurring_generator.rb` | Upgrade migration for existing installs |

## Test plan
- [x] `bundle exec rspec` — 380 examples, 0 failures
- [x] `bundle exec rubocop` — 131 files, 0 offenses
- [ ] Create `config/recurring.yml` with a test task, verify it schedules on `bin/pgbus start`
- [ ] Verify dashboard shows recurring tasks with correct next_run/last_run
- [ ] Test enable/disable toggle and "Run Now" from dashboard
- [ ] Test migration on existing pgbus installation (`rails generate pgbus:add_recurring`)
- [ ] Verify dedup: start two schedulers, confirm no double-enqueue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added recurring tasks management system with web interface for scheduling and monitoring background jobs
  * Added "Recurring" navigation menu item and dashboard statistics card
  * Introduced YAML-based configuration for defining recurring tasks with cron schedule support
  * New generator to set up recurring tasks infrastructure and required database tables
  * Ability to enable/disable, view details, and manually run recurring tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->