### PR TITLE
refactor: remove Record suffix and add separate database support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ PostgreSQL-native job processing and event bus for Rails, built on PGMQ.
 4. **NO `Marshal.load`** — JSON serialization only
 5. **NO unsynchronized shared state** — use Mutex or Concurrent primitives
 6. **NO swallowing errors** — log via `Pgbus.logger`, track in `pgbus_failed_events`
+7. **NO `Record` suffix on model classes** — see Model Naming below
 
 ### Always Do
 1. **TDD**: Write tests BEFORE implementation
@@ -58,6 +59,48 @@ Layer 3: Event Bus       lib/pgbus/event_bus/ (publisher, subscriber, registry, 
 Layer 2: ActiveJob       lib/pgbus/active_job/ (adapter, executor)
 Layer 1: Client          lib/pgbus/client.rb (PGMQ wrapper)
 Layer 0: Config          lib/pgbus/configuration.rb, config_loader.rb
+```
+
+## Model Naming
+
+ActiveRecord models live in `app/models/pgbus/` and inherit from `Pgbus::BaseModel`.
+**Never use a `Record` suffix.** Resolve naming conflicts as follows:
+
+| Model Class | Table | Why not the obvious name |
+|---|---|---|
+| `Pgbus::BaseModel` | (abstract) | Avoids conflict with Rails `ApplicationRecord` |
+| `Pgbus::BatchEntry` | `pgbus_batches` | `Pgbus::Batch` is the batch API class |
+| `Pgbus::BlockedExecution` | `pgbus_blocked_executions` | — |
+| `Pgbus::ProcessEntry` | `pgbus_processes` | `Process` conflicts with Ruby's `Process` module |
+| `Pgbus::ProcessedEvent` | `pgbus_processed_events` | — |
+| `Pgbus::RecurringExecution` | `pgbus_recurring_executions` | — |
+| `Pgbus::RecurringTask` | `pgbus_recurring_tasks` | `Pgbus::Recurring::Task` is a different namespace |
+| `Pgbus::Semaphore` | `pgbus_semaphores` | `Pgbus::Concurrency::Semaphore` is a different namespace |
+
+When a model name collides with a service/module name, prefer `Entry` suffix or a descriptive alternative over `Record`.
+
+## Separate Database Support
+
+Pgbus supports running in the primary database or a dedicated database (like SolidQueue).
+
+**Configuration** (`config.connects_to`):
+- `nil` (default) — uses the primary Rails database
+- `{ database: { writing: :pgbus } }` — uses a separate database
+
+**Generator flags**:
+- `rails generate pgbus:install --database=pgbus` — migrations go to `db/pgbus_migrate/`
+- Without `--database` — migrations go to `db/migrate/` (default)
+
+**database.yml example**:
+```yaml
+production:
+  primary:
+    <<: *default
+    database: myapp_production
+  pgbus:
+    <<: *default
+    database: myapp_pgbus_production
+    migrations_paths: db/pgbus_migrate
 ```
 
 ## Key Design Decisions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,12 @@ Layer 0: Config          lib/pgbus/configuration.rb, config_loader.rb
 
 ## Model Naming
 
-ActiveRecord models live in `app/models/pgbus/` and inherit from `Pgbus::BaseModel`.
+ActiveRecord models live in `app/models/pgbus/` and inherit from `Pgbus::ApplicationRecord`.
 **Never use a `Record` suffix.** Resolve naming conflicts as follows:
 
 | Model Class | Table | Why not the obvious name |
 |---|---|---|
-| `Pgbus::BaseModel` | (abstract) | Avoids conflict with Rails `ApplicationRecord` |
+| `Pgbus::ApplicationRecord` | (abstract) | Standard Rails base model convention |
 | `Pgbus::BatchEntry` | `pgbus_batches` | `Pgbus::Batch` is the batch API class |
 | `Pgbus::BlockedExecution` | `pgbus_blocked_executions` | — |
 | `Pgbus::ProcessEntry` | `pgbus_processes` | `Process` conflicts with Ruby's `Process` module |
@@ -89,6 +89,8 @@ Pgbus supports running in the primary database or a dedicated database (like Sol
 
 **Generator flags**:
 - `rails generate pgbus:install --database=pgbus` — migrations go to `db/pgbus_migrate/`
+- `rails generate pgbus:add_recurring --database=pgbus` — recurring migrations also go to `db/pgbus_migrate/`
+- `rails generate pgbus:upgrade_pgmq --database=pgbus` — upgrade migrations also go to `db/pgbus_migrate/`
 - Without `--database` — migrations go to `db/migrate/` (default)
 
 **database.yml example**:

--- a/app/models/pgbus/application_record.rb
+++ b/app/models/pgbus/application_record.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class BaseModel < ActiveRecord::Base
+  class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true
   end
 end

--- a/app/models/pgbus/base_model.rb
+++ b/app/models/pgbus/base_model.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ApplicationRecord < ActiveRecord::Base
+  class BaseModel < ActiveRecord::Base
     self.abstract_class = true
   end
 end

--- a/app/models/pgbus/batch_entry.rb
+++ b/app/models/pgbus/batch_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class BatchRecord < ApplicationRecord
+  class BatchEntry < BaseModel
     self.table_name = "pgbus_batches"
 
     COUNTER_COLUMNS = %w[completed_jobs discarded_jobs].freeze

--- a/app/models/pgbus/batch_entry.rb
+++ b/app/models/pgbus/batch_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class BatchEntry < BaseModel
+  class BatchEntry < ApplicationRecord
     self.table_name = "pgbus_batches"
 
     COUNTER_COLUMNS = %w[completed_jobs discarded_jobs].freeze

--- a/app/models/pgbus/blocked_execution.rb
+++ b/app/models/pgbus/blocked_execution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class BlockedExecution < BaseModel
+  class BlockedExecution < ApplicationRecord
     self.table_name = "pgbus_blocked_executions"
 
     scope :for_key, ->(key) { where(concurrency_key: key) }

--- a/app/models/pgbus/blocked_execution.rb
+++ b/app/models/pgbus/blocked_execution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class BlockedExecutionRecord < ApplicationRecord
+  class BlockedExecution < BaseModel
     self.table_name = "pgbus_blocked_executions"
 
     scope :for_key, ->(key) { where(concurrency_key: key) }

--- a/app/models/pgbus/process_entry.rb
+++ b/app/models/pgbus/process_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ProcessEntry < BaseModel
+  class ProcessEntry < ApplicationRecord
     self.table_name = "pgbus_processes"
 
     scope :stale, ->(threshold) { where("last_heartbeat_at < ?", threshold) }

--- a/app/models/pgbus/process_entry.rb
+++ b/app/models/pgbus/process_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ProcessRecord < ApplicationRecord
+  class ProcessEntry < BaseModel
     self.table_name = "pgbus_processes"
 
     scope :stale, ->(threshold) { where("last_heartbeat_at < ?", threshold) }

--- a/app/models/pgbus/processed_event.rb
+++ b/app/models/pgbus/processed_event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ProcessedEvent < BaseModel
+  class ProcessedEvent < ApplicationRecord
     self.table_name = "pgbus_processed_events"
 
     scope :expired, ->(before) { where("processed_at < ?", before) }

--- a/app/models/pgbus/processed_event.rb
+++ b/app/models/pgbus/processed_event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ProcessedEventRecord < ApplicationRecord
+  class ProcessedEvent < BaseModel
     self.table_name = "pgbus_processed_events"
 
     scope :expired, ->(before) { where("processed_at < ?", before) }

--- a/app/models/pgbus/recurring_execution.rb
+++ b/app/models/pgbus/recurring_execution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class RecurringExecutionRecord < ApplicationRecord
+  class RecurringExecution < BaseModel
     self.table_name = "pgbus_recurring_executions"
 
     validates :task_key, presence: true

--- a/app/models/pgbus/recurring_execution.rb
+++ b/app/models/pgbus/recurring_execution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class RecurringExecution < BaseModel
+  class RecurringExecution < ApplicationRecord
     self.table_name = "pgbus_recurring_executions"
 
     validates :task_key, presence: true

--- a/app/models/pgbus/recurring_task.rb
+++ b/app/models/pgbus/recurring_task.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class RecurringTaskRecord < ApplicationRecord
+  class RecurringTask < BaseModel
     self.table_name = "pgbus_recurring_tasks"
 
     validates :key, presence: true, uniqueness: true

--- a/app/models/pgbus/recurring_task.rb
+++ b/app/models/pgbus/recurring_task.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class RecurringTask < BaseModel
+  class RecurringTask < ApplicationRecord
     self.table_name = "pgbus_recurring_tasks"
 
     validates :key, presence: true, uniqueness: true

--- a/app/models/pgbus/semaphore.rb
+++ b/app/models/pgbus/semaphore.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class Semaphore < BaseModel
+  class Semaphore < ApplicationRecord
     self.table_name = "pgbus_semaphores"
 
     scope :expired, ->(now = Time.current) { where("expires_at < ? OR value <= 0", now) }

--- a/app/models/pgbus/semaphore.rb
+++ b/app/models/pgbus/semaphore.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class SemaphoreRecord < ApplicationRecord
+  class Semaphore < BaseModel
     self.table_name = "pgbus_semaphores"
 
     scope :expired, ->(now = Time.current) { where("expires_at < ? OR value <= 0", now) }

--- a/lib/generators/pgbus/add_recurring_generator.rb
+++ b/lib/generators/pgbus/add_recurring_generator.rb
@@ -12,9 +12,19 @@ module Pgbus
 
       desc "Add recurring jobs tables to an existing Pgbus installation"
 
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
       def create_migration
-        migration_template "add_recurring_tables.rb.erb",
-                           "db/migrate/add_pgbus_recurring_tables.rb"
+        if separate_database?
+          migration_template "add_recurring_tables.rb.erb",
+                             "db/pgbus_migrate/add_pgbus_recurring_tables.rb"
+        else
+          migration_template "add_recurring_tables.rb.erb",
+                             "db/migrate/add_pgbus_recurring_tables.rb"
+        end
       end
 
       def create_recurring_config
@@ -26,7 +36,7 @@ module Pgbus
         say "Pgbus recurring jobs installed!", :green
         say ""
         say "Next steps:"
-        say "  1. Run: rails db:migrate"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
         say "  2. Edit config/recurring.yml to define your recurring tasks"
         say "  3. Restart pgbus: bin/pgbus start"
         say ""
@@ -36,6 +46,10 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/install_generator.rb
+++ b/lib/generators/pgbus/install_generator.rb
@@ -73,7 +73,7 @@ module Pgbus
         say db_config, :cyan
         say ""
         say "Then add to config/application.rb or an initializer:", :yellow
-        say "  Pgbus.configure { |c| c.connects_to = { database: { writing: :pgbus } } }", :cyan
+        say "  Pgbus.configure { |c| c.connects_to = { database: { writing: :#{database_name} } } }", :cyan
         say ""
       end
 

--- a/lib/generators/pgbus/install_generator.rb
+++ b/lib/generators/pgbus/install_generator.rb
@@ -18,8 +18,20 @@ module Pgbus
                    desc: "PGMQ install mode: auto (try extension, fallback embedded), " \
                          "extension (require ext), embedded (no ext)"
 
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus). " \
+                         "Migrations go to db/pgbus_migrate/ and schema to db/pgbus_schema.rb"
+
       def create_migration
-        migration_template "migration.rb.erb", "db/migrate/create_pgbus_tables.rb"
+        if separate_database?
+          migration_template "migration.rb.erb",
+                             "db/pgbus_migrate/create_pgbus_tables.rb"
+        else
+          migration_template "migration.rb.erb",
+                             "db/migrate/create_pgbus_tables.rb"
+        end
       end
 
       def create_config_file
@@ -41,6 +53,30 @@ module Pgbus
                          after: "class Application < Rails::Application\n"
       end
 
+      def configure_separate_database
+        return unless separate_database?
+
+        db_config = <<~YAML
+
+          # Pgbus separate database (added by pgbus:install --database=#{database_name})
+          # Uncomment and configure for your environment:
+          # #{database_name}:
+          #   primary:
+          #     <<: *default
+          #     database: #{Rails.application.class.module_parent_name.underscore}_#{database_name}_<%= Rails.env %>
+          #     migrations_paths: db/pgbus_migrate
+        YAML
+
+        say ""
+        say "Separate database mode enabled!", :yellow
+        say "Add the following to your config/database.yml:", :yellow
+        say db_config, :cyan
+        say ""
+        say "Then add to config/application.rb or an initializer:", :yellow
+        say "  Pgbus.configure { |c| c.connects_to = { database: { writing: :pgbus } } }", :cyan
+        say ""
+      end
+
       def display_post_install
         say ""
         say "Pgbus installed successfully!", :green
@@ -57,9 +93,16 @@ module Pgbus
           say "  The migration uses embedded SQL — no pgmq extension needed."
           say "  PGMQ #{Pgbus::PgmqSchema.latest_version} schema will be created directly."
         end
+
+        if separate_database?
+          say ""
+          say "Migrations path: db/pgbus_migrate/", :yellow
+          say "Schema dump: db/pgbus_schema.rb", :yellow
+        end
+
         say ""
         say "Next steps:"
-        say "  1. Run: rails db:migrate"
+        say "  1. Run: rails db:migrate#{":#{database_name}" if separate_database?}"
         say "  2. Edit config/pgbus.yml to configure workers"
         say "  3. Start processing: bin/pgbus start"
         say ""
@@ -73,6 +116,14 @@ module Pgbus
 
       def pgmq_schema_mode
         options[:pgmq_schema_mode]
+      end
+
+      def database_name
+        options[:database]
+      end
+
+      def separate_database?
+        database_name.present?
       end
     end
   end

--- a/lib/generators/pgbus/upgrade_pgmq_generator.rb
+++ b/lib/generators/pgbus/upgrade_pgmq_generator.rb
@@ -12,8 +12,19 @@ module Pgbus
 
       desc "Upgrade PGMQ schema to the latest vendored version"
 
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
       def create_migration
-        migration_template "upgrade_pgmq.rb.erb", "db/migrate/upgrade_pgmq_to_v#{target_version_slug}.rb"
+        if separate_database?
+          migration_template "upgrade_pgmq.rb.erb",
+                             "db/pgbus_migrate/upgrade_pgmq_to_v#{target_version_slug}.rb"
+        else
+          migration_template "upgrade_pgmq.rb.erb",
+                             "db/migrate/upgrade_pgmq_to_v#{target_version_slug}.rb"
+        end
       end
 
       def display_post_upgrade
@@ -22,8 +33,8 @@ module Pgbus
         say "  Target version: #{target_version}", :yellow
         say ""
         say "Next steps:"
-        say "  1. Review the migration in db/migrate/"
-        say "  2. Run: rails db:migrate"
+        say "  1. Review the migration in db/#{separate_database? ? "pgbus_migrate" : "migrate"}/"
+        say "  2. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
         say ""
       end
 
@@ -39,6 +50,10 @@ module Pgbus
 
       def target_version_slug
         target_version.tr(".", "_")
+      end
+
+      def separate_database?
+        options[:database].present?
       end
     end
   end

--- a/lib/pgbus/batch.rb
+++ b/lib/pgbus/batch.rb
@@ -41,18 +41,18 @@ module Pgbus
 
     # Find a batch record by ID. Returns a hash or nil.
     def self.find(batch_id)
-      BatchRecord.find_by(batch_id: batch_id)&.attributes
+      BatchEntry.find_by(batch_id: batch_id)&.attributes
     end
 
     # Delete finished batches older than the given threshold.
     def self.cleanup(older_than:)
-      BatchRecord.stale(before: older_than).delete_all
+      BatchEntry.stale(before: older_than).delete_all
     end
 
     private
 
     def create_record
-      BatchRecord.create!(
+      BatchEntry.create!(
         batch_id: batch_id,
         description: description,
         on_finish_class: on_finish&.name,
@@ -81,19 +81,19 @@ module Pgbus
     def update_total
       if @job_count.zero?
         # Finish empty batches immediately — no jobs to signal completion
-        BatchRecord.where(batch_id: batch_id).update_all(
+        BatchEntry.where(batch_id: batch_id).update_all(
           total_jobs: 0,
           status: "finished",
           finished_at: Time.current
         )
         fire_empty_batch_callbacks
       else
-        BatchRecord.where(batch_id: batch_id).update_all(total_jobs: @job_count, status: "processing")
+        BatchEntry.where(batch_id: batch_id).update_all(total_jobs: @job_count, status: "processing")
       end
     end
 
     def fire_empty_batch_callbacks
-      record = BatchRecord.find_by(batch_id: batch_id)
+      record = BatchEntry.find_by(batch_id: batch_id)
       return unless record
 
       properties = parse_properties(record.properties)
@@ -112,7 +112,7 @@ module Pgbus
       private
 
       def update_counter(batch_id, column)
-        result = BatchRecord.increment_counter!(batch_id, column)
+        result = BatchEntry.increment_counter!(batch_id, column)
         return nil unless result
 
         fire_callbacks(result[:record]) if result[:just_finished]

--- a/lib/pgbus/cli.rb
+++ b/lib/pgbus/cli.rb
@@ -33,8 +33,8 @@ module Pgbus
     end
 
     def show_status
-      processes = ProcessRecord.order(:kind, :created_at)
-                               .select(:kind, :hostname, :pid, :metadata, :last_heartbeat_at)
+      processes = ProcessEntry.order(:kind, :created_at)
+                              .select(:kind, :hostname, :pid, :metadata, :last_heartbeat_at)
 
       if processes.none?
         puts "No Pgbus processes running."

--- a/lib/pgbus/concurrency/blocked_execution.rb
+++ b/lib/pgbus/concurrency/blocked_execution.rb
@@ -28,7 +28,7 @@ module Pgbus
         # otherwise. This avoids losing a blocked row if enqueue fails.
         def promote_next(concurrency_key, client:, delay: 0)
           released = nil
-          ActiveRecord::Base.transaction do
+          Pgbus::BlockedExecution.transaction do
             released = release_next(concurrency_key)
             raise ActiveRecord::Rollback unless released
 

--- a/lib/pgbus/concurrency/blocked_execution.rb
+++ b/lib/pgbus/concurrency/blocked_execution.rb
@@ -8,7 +8,7 @@ module Pgbus
       class << self
         # Insert a blocked execution for a job that hit the concurrency limit.
         def insert(concurrency_key:, queue_name:, payload:, duration:, priority: 0)
-          BlockedExecutionRecord.create!(
+          Pgbus::BlockedExecution.create!(
             concurrency_key: concurrency_key,
             queue_name: queue_name,
             payload: JSON.generate(payload),
@@ -20,7 +20,7 @@ module Pgbus
         # Release the next blocked execution for a given concurrency key.
         # Returns the released row (queue_name, payload) or nil if none.
         def release_next(concurrency_key)
-          BlockedExecutionRecord.release_next!(concurrency_key)
+          Pgbus::BlockedExecution.release_next!(concurrency_key)
         end
 
         # Atomically promote the next blocked execution: delete the row and enqueue
@@ -45,12 +45,12 @@ module Pgbus
         # Delete blocked executions that have expired.
         # Returns the count of deleted rows.
         def expire_stale
-          BlockedExecutionRecord.expired(Time.now.utc).delete_all
+          Pgbus::BlockedExecution.expired(Time.now.utc).delete_all
         end
 
         # Count blocked executions for a given key. Useful for testing/monitoring.
         def count_for(concurrency_key)
-          BlockedExecutionRecord.where(concurrency_key: concurrency_key).count
+          Pgbus::BlockedExecution.where(concurrency_key: concurrency_key).count
         end
 
         private

--- a/lib/pgbus/concurrency/semaphore.rb
+++ b/lib/pgbus/concurrency/semaphore.rb
@@ -8,19 +8,19 @@ module Pgbus
         # Returns :acquired if a slot was available, :blocked if the limit is reached.
         def acquire(key, max_value, duration)
           expires_at = Time.now.utc + duration
-          SemaphoreRecord.acquire!(key, max_value, expires_at)
+          Pgbus::Semaphore.acquire!(key, max_value, expires_at)
         end
 
         # Release one slot in the semaphore. Called after a job completes.
         def release(key)
-          SemaphoreRecord.where(key: key).update_all("value = GREATEST(value - 1, 0)")
+          Pgbus::Semaphore.where(key: key).update_all("value = GREATEST(value - 1, 0)")
         end
 
         # Delete semaphores that have expired (safety net for crashed workers).
         # Returns an array of hashes with expired keys.
         # Uses DELETE ... RETURNING for atomicity (no race between pluck and delete).
         def expire_stale
-          result = SemaphoreRecord.connection.exec_query(
+          result = Pgbus::Semaphore.connection.exec_query(
             "DELETE FROM pgbus_semaphores WHERE expires_at < $1 RETURNING key",
             "Pgbus Semaphore Expire",
             [Time.now.utc]
@@ -30,7 +30,7 @@ module Pgbus
 
         # Check current value for a key. Useful for testing/monitoring.
         def current_value(key)
-          SemaphoreRecord.where(key: key).pick(:value)
+          Pgbus::Semaphore.where(key: key).pick(:value)
         end
       end
     end

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -42,7 +42,7 @@ module Pgbus
                   :skip_recurring, :recurring_execution_retention
 
     # Multi-database support (optional separate database for pgbus tables)
-    # Set to { writing: :pgbus, reading: :pgbus } to use a separate database.
+    # Set to { database: { writing: :pgbus, reading: :pgbus } } to use a separate database.
     # Requires a matching entry in config/database.yml under the "pgbus" key.
     attr_accessor :connects_to
 

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -41,6 +41,11 @@ module Pgbus
     attr_accessor :recurring_tasks, :recurring_schedule_interval, :recurring_tasks_file,
                   :skip_recurring, :recurring_execution_retention
 
+    # Multi-database support (optional separate database for pgbus tables)
+    # Set to { writing: :pgbus, reading: :pgbus } to use a separate database.
+    # Requires a matching entry in config/database.yml under the "pgbus" key.
+    attr_accessor :connects_to
+
     # Web dashboard
     attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source
 
@@ -82,6 +87,8 @@ module Pgbus
       @recurring_tasks_file = nil
       @skip_recurring = false
       @recurring_execution_retention = 7 * 24 * 3600 # 7 days
+
+      @connects_to = nil
 
       @web_auth = nil
       @web_refresh_interval = 5000

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -21,7 +21,7 @@ module Pgbus
 
     initializer "pgbus.db" do
       ActiveSupport.on_load(:active_record) do
-        Pgbus::BaseModel.connects_to(**Pgbus.configuration.connects_to) if Pgbus.configuration.connects_to
+        Pgbus::ApplicationRecord.connects_to(**Pgbus.configuration.connects_to) if Pgbus.configuration.connects_to
       end
     end
 

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -19,6 +19,12 @@ module Pgbus
       end
     end
 
+    initializer "pgbus.db" do
+      ActiveSupport.on_load(:active_record) do
+        Pgbus::BaseModel.connects_to(**Pgbus.configuration.connects_to) if Pgbus.configuration.connects_to
+      end
+    end
+
     initializer "pgbus.active_job" do
       ActiveSupport.on_load(:active_job) do
         include Pgbus::Concurrency

--- a/lib/pgbus/event_bus/handler.rb
+++ b/lib/pgbus/event_bus/handler.rb
@@ -52,11 +52,11 @@ module Pgbus
       end
 
       def already_processed?(event_id)
-        ProcessedEventRecord.exists?(event_id: event_id, handler_class: self.class.name)
+        ProcessedEvent.exists?(event_id: event_id, handler_class: self.class.name)
       end
 
       def mark_processed!(event_id)
-        ProcessedEventRecord.upsert(
+        ProcessedEvent.upsert(
           { event_id: event_id, handler_class: self.class.name, processed_at: Time.now.utc },
           unique_by: %i[event_id handler_class]
         )

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -91,7 +91,7 @@ module Pgbus
         ttl = config.idempotency_ttl
         return unless ttl&.positive?
 
-        deleted = ProcessedEventRecord.expired(Time.now.utc - ttl).delete_all
+        deleted = ProcessedEvent.expired(Time.now.utc - ttl).delete_all
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} expired processed events" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Idempotency cleanup failed: #{e.message}" }
@@ -99,7 +99,7 @@ module Pgbus
 
       def reap_stale_processes
         threshold = Heartbeat::ALIVE_THRESHOLD
-        deleted = ProcessRecord.stale(Time.now.utc - threshold).delete_all
+        deleted = ProcessEntry.stale(Time.now.utc - threshold).delete_all
         Pgbus.logger.info { "[Pgbus] Reaped #{deleted} stale processes" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Stale process reaping failed: #{e.message}" }
@@ -135,7 +135,7 @@ module Pgbus
         retention = config.recurring_execution_retention
         return unless retention&.positive?
 
-        deleted = RecurringExecutionRecord.older_than(Time.now.utc - retention).delete_all
+        deleted = RecurringExecution.older_than(Time.now.utc - retention).delete_all
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} old recurring executions" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Recurring execution cleanup failed: #{e.message}" }

--- a/lib/pgbus/process/heartbeat.rb
+++ b/lib/pgbus/process/heartbeat.rb
@@ -9,7 +9,7 @@ module Pgbus
       INTERVAL = 60 # seconds
       ALIVE_THRESHOLD = 300 # 5 minutes
 
-      attr_reader :process_record
+      attr_reader :process_entry
 
       def initialize(kind:, metadata: {})
         @kind = kind
@@ -31,7 +31,7 @@ module Pgbus
       def beat
         return unless @process_id
 
-        ProcessRecord.where(id: @process_id).update_all(last_heartbeat_at: Time.current)
+        ProcessEntry.where(id: @process_id).update_all(last_heartbeat_at: Time.current)
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Heartbeat failed: #{e.message}" }
       end
@@ -39,7 +39,7 @@ module Pgbus
       private
 
       def register_process
-        record = ProcessRecord.create!(
+        record = ProcessEntry.create!(
           kind: @kind,
           hostname: Socket.gethostname,
           pid: ::Process.pid,
@@ -54,7 +54,7 @@ module Pgbus
       def deregister_process
         return unless @process_id
 
-        ProcessRecord.where(id: @process_id).delete_all
+        ProcessEntry.where(id: @process_id).delete_all
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Process deregistration failed: #{e.message}" }
       end

--- a/lib/pgbus/recurring/schedule.rb
+++ b/lib/pgbus/recurring/schedule.rb
@@ -17,7 +17,7 @@ module Pgbus
       def enqueue_task(task, run_at:)
         queue = resolve_queue(task)
 
-        RecurringExecutionRecord.record(task.key, run_at) do
+        RecurringExecution.record(task.key, run_at) do
           payload = build_payload(task)
           headers = build_headers(task, run_at)
 

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -319,8 +319,8 @@ module Pgbus
 
       # Recurring tasks
       def recurring_tasks
-        records = RecurringTaskRecord.order(:key).to_a
-        last_runs = RecurringExecutionRecord
+        records = RecurringTask.order(:key).to_a
+        last_runs = RecurringExecution
                     .where(task_key: records.map(&:key))
                     .select("task_key, MAX(run_at) AS run_at")
                     .group(:task_key)
@@ -361,7 +361,7 @@ module Pgbus
       end
 
       def recurring_task(id)
-        record = RecurringTaskRecord.find_by(id: id)
+        record = RecurringTask.find_by(id: id)
         return nil unless record
 
         task = Recurring::Task.from_configuration(record.key,
@@ -373,7 +373,7 @@ module Pgbus
                                                   priority: record.priority,
                                                   description: record.description)
 
-        executions = RecurringExecutionRecord.for_task(record.key).recent(25).map do |exec|
+        executions = RecurringExecution.for_task(record.key).recent(25).map do |exec|
           { run_at: exec.run_at, created_at: exec.created_at }
         end
 
@@ -401,7 +401,7 @@ module Pgbus
       end
 
       def toggle_recurring_task(id)
-        record = RecurringTaskRecord.find_by(id: id)
+        record = RecurringTask.find_by(id: id)
         return false unless record
 
         record.update!(enabled: !record.enabled)
@@ -412,7 +412,7 @@ module Pgbus
       end
 
       def enqueue_recurring_task_now(id)
-        record = RecurringTaskRecord.find_by(id: id)
+        record = RecurringTask.find_by(id: id)
         return false unless record
 
         task = Recurring::Task.from_configuration(record.key,
@@ -432,7 +432,7 @@ module Pgbus
       end
 
       def recurring_tasks_count
-        RecurringTaskRecord.count
+        RecurringTask.count
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error counting recurring tasks: #{e.message}" }
         0

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -451,7 +451,7 @@ module Pgbus
       private
 
       def connection
-        ActiveRecord::Base.connection
+        Pgbus::ApplicationRecord.connection
       end
 
       # name is the full PGMQ queue name (already prefixed)

--- a/spec/pgbus/batch_spec.rb
+++ b/spec/pgbus/batch_spec.rb
@@ -4,9 +4,9 @@ require "spec_helper"
 require "active_job"
 
 RSpec.describe Pgbus::Batch do
-  let(:batch_record_double) do
+  let(:batch_entry_double) do
     double(
-      "BatchRecord",
+      "BatchEntry",
       id: 1,
       attributes: { "batch_id" => "abc" },
       on_finish_class: nil,
@@ -17,8 +17,8 @@ RSpec.describe Pgbus::Batch do
   end
 
   before do
-    allow(Pgbus::BatchRecord).to receive_message_chain(:where, :update_all).and_return(1) # rubocop:disable RSpec/MessageChain
-    allow(Pgbus::BatchRecord).to receive_messages(create!: batch_record_double, find_by: batch_record_double)
+    allow(Pgbus::BatchEntry).to receive_message_chain(:where, :update_all).and_return(1) # rubocop:disable RSpec/MessageChain
+    allow(Pgbus::BatchEntry).to receive_messages(create!: batch_entry_double, find_by: batch_entry_double)
   end
 
   describe "#initialize" do
@@ -45,7 +45,7 @@ RSpec.describe Pgbus::Batch do
       batch = described_class.new(description: "test")
       batch.enqueue {} # rubocop:disable Lint/EmptyBlock
 
-      expect(Pgbus::BatchRecord).to have_received(:create!).with(
+      expect(Pgbus::BatchEntry).to have_received(:create!).with(
         hash_including(batch_id: batch.batch_id, description: "test", status: "pending")
       )
     end
@@ -54,7 +54,7 @@ RSpec.describe Pgbus::Batch do
       batch = described_class.new
       batch.enqueue {} # rubocop:disable Lint/EmptyBlock
 
-      expect(Pgbus::BatchRecord).to have_received(:where).with(batch_id: batch.batch_id)
+      expect(Pgbus::BatchEntry).to have_received(:where).with(batch_id: batch.batch_id)
     end
 
     it "sets thread-local batch_id during block execution" do
@@ -83,18 +83,18 @@ RSpec.describe Pgbus::Batch do
         properties: "{}"
       }.merge(overrides)
 
-      record = double("BatchRecord", **attrs, presence: attrs[:properties])
+      record = double("BatchEntry", **attrs, presence: attrs[:properties])
       allow(record).to receive(:properties).and_return(attrs[:properties])
       { record: record, just_finished: overrides.fetch(:just_finished, false) }
     end
 
     it "increments completed_jobs counter" do
       result = build_batch_result
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(result)
+      allow(Pgbus::BatchEntry).to receive(:increment_counter!).and_return(result)
 
       described_class.job_completed("batch-123")
 
-      expect(Pgbus::BatchRecord).to have_received(:increment_counter!).with("batch-123", "completed_jobs")
+      expect(Pgbus::BatchEntry).to have_received(:increment_counter!).with("batch-123", "completed_jobs")
     end
 
     it "fires on_finish callback when batch finishes" do
@@ -103,7 +103,7 @@ RSpec.describe Pgbus::Batch do
         on_finish_class: "BatchCallbackJob", properties: '{"user_id":1}',
         just_finished: true
       )
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(result)
+      allow(Pgbus::BatchEntry).to receive(:increment_counter!).and_return(result)
 
       callback_job = class_double("BatchCallbackJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("BatchCallbackJob", callback_job)
@@ -119,7 +119,7 @@ RSpec.describe Pgbus::Batch do
         on_success_class: "SuccessJob",
         just_finished: true
       )
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(result)
+      allow(Pgbus::BatchEntry).to receive(:increment_counter!).and_return(result)
 
       callback_job = class_double("SuccessJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("SuccessJob", callback_job)
@@ -135,7 +135,7 @@ RSpec.describe Pgbus::Batch do
         on_discard_class: "DiscardJob",
         just_finished: true
       )
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(result)
+      allow(Pgbus::BatchEntry).to receive(:increment_counter!).and_return(result)
 
       callback_job = class_double("DiscardJob", perform_later: nil) # rubocop:disable RSpec/VerifiedDoubleReference
       stub_const("DiscardJob", callback_job)
@@ -146,7 +146,7 @@ RSpec.describe Pgbus::Batch do
     end
 
     it "returns nil when batch not found" do
-      allow(Pgbus::BatchRecord).to receive(:increment_counter!).and_return(nil)
+      allow(Pgbus::BatchEntry).to receive(:increment_counter!).and_return(nil)
 
       expect(described_class.job_completed("nonexistent")).to be_nil
     end
@@ -154,14 +154,14 @@ RSpec.describe Pgbus::Batch do
 
   describe ".find" do
     it "returns the batch record attributes" do
-      record = double("BatchRecord", attributes: { "batch_id" => "abc", "status" => "processing" })
-      allow(Pgbus::BatchRecord).to receive(:find_by).with(batch_id: "abc").and_return(record)
+      record = double("BatchEntry", attributes: { "batch_id" => "abc", "status" => "processing" })
+      allow(Pgbus::BatchEntry).to receive(:find_by).with(batch_id: "abc").and_return(record)
 
       expect(described_class.find("abc")).to eq({ "batch_id" => "abc", "status" => "processing" })
     end
 
     it "returns nil when not found" do
-      allow(Pgbus::BatchRecord).to receive(:find_by).and_return(nil)
+      allow(Pgbus::BatchEntry).to receive(:find_by).and_return(nil)
 
       expect(described_class.find("missing")).to be_nil
     end
@@ -170,7 +170,7 @@ RSpec.describe Pgbus::Batch do
   describe ".cleanup" do
     it "deletes finished batches older than threshold" do
       scope = double("scope", delete_all: 3)
-      allow(Pgbus::BatchRecord).to receive(:stale).and_return(scope)
+      allow(Pgbus::BatchEntry).to receive(:stale).and_return(scope)
 
       expect(described_class.cleanup(older_than: Time.now - 86_400)).to eq(3)
     end

--- a/spec/pgbus/cli_spec.rb
+++ b/spec/pgbus/cli_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe Pgbus::CLI do
 
   describe ".show_status" do
     it "prints processes table when processes exist" do
-      process = double("ProcessRecord",
+      process = double("ProcessEntry",
                        kind: "supervisor", hostname: "web-1", pid: "100",
                        last_heartbeat_at: "2026-01-01 00:00:00", metadata: "{}")
       scope = double("scope", none?: false, each: nil)
       allow(scope).to receive(:each).and_yield(process)
-      allow(Pgbus::ProcessRecord).to receive_message_chain(:order, :select).and_return(scope) # rubocop:disable RSpec/MessageChain
+      allow(Pgbus::ProcessEntry).to receive_message_chain(:order, :select).and_return(scope) # rubocop:disable RSpec/MessageChain
 
       output = capture_stdout { described_class.show_status }
 
@@ -47,7 +47,7 @@ RSpec.describe Pgbus::CLI do
 
     it "prints 'no processes' when result is empty" do
       scope = double("scope", none?: true)
-      allow(Pgbus::ProcessRecord).to receive_message_chain(:order, :select).and_return(scope) # rubocop:disable RSpec/MessageChain
+      allow(Pgbus::ProcessEntry).to receive_message_chain(:order, :select).and_return(scope) # rubocop:disable RSpec/MessageChain
 
       output = capture_stdout { described_class.show_status }
 

--- a/spec/pgbus/concurrency/blocked_execution_spec.rb
+++ b/spec/pgbus/concurrency/blocked_execution_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
     let(:mock_client) { build_mock_client }
 
     before do
-      allow(ActiveRecord::Base).to receive(:transaction).and_yield
+      allow(Pgbus::BlockedExecution).to receive(:transaction).and_yield
     end
 
     it "deletes the blocked row and enqueues atomically, returning true" do
@@ -66,7 +66,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
     end
 
     it "returns false and logs warning on error" do
-      allow(ActiveRecord::Base).to receive(:transaction).and_raise(StandardError, "db error")
+      allow(Pgbus::BlockedExecution).to receive(:transaction).and_raise(StandardError, "db error")
 
       promoted = described_class.promote_next("TestJob-42", client: mock_client)
 

--- a/spec/pgbus/concurrency/blocked_execution_spec.rb
+++ b/spec/pgbus/concurrency/blocked_execution_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe Pgbus::Concurrency::BlockedExecution do
   describe ".insert" do
     it "creates a blocked execution record" do
-      allow(Pgbus::BlockedExecutionRecord).to receive(:create!).and_return(double("record"))
+      allow(Pgbus::BlockedExecution).to receive(:create!).and_return(double("record"))
 
       described_class.insert(
         concurrency_key: "TestJob-42",
@@ -15,16 +15,16 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
         duration: 900
       )
 
-      expect(Pgbus::BlockedExecutionRecord).to have_received(:create!).with(
+      expect(Pgbus::BlockedExecution).to have_received(:create!).with(
         hash_including(concurrency_key: "TestJob-42", queue_name: "default", priority: 0)
       )
     end
   end
 
   describe ".release_next" do
-    it "delegates to BlockedExecutionRecord.release_next!" do
+    it "delegates to BlockedExecution.release_next!" do
       released = { queue_name: "default", payload: { "job_class" => "TestJob" } }
-      allow(Pgbus::BlockedExecutionRecord).to receive(:release_next!).with("TestJob-42").and_return(released)
+      allow(Pgbus::BlockedExecution).to receive(:release_next!).with("TestJob-42").and_return(released)
 
       result = described_class.release_next("TestJob-42")
 
@@ -32,7 +32,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
     end
 
     it "returns nil when no blocked executions exist" do
-      allow(Pgbus::BlockedExecutionRecord).to receive(:release_next!).and_return(nil)
+      allow(Pgbus::BlockedExecution).to receive(:release_next!).and_return(nil)
 
       expect(described_class.release_next("TestJob-42")).to be_nil
     end
@@ -47,7 +47,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
 
     it "deletes the blocked row and enqueues atomically, returning true" do
       released = { queue_name: "default", payload: { "job_class" => "TestJob" } }
-      allow(Pgbus::BlockedExecutionRecord).to receive(:release_next!).and_return(released)
+      allow(Pgbus::BlockedExecution).to receive(:release_next!).and_return(released)
       allow(mock_client).to receive(:send_message).and_return(42)
 
       promoted = described_class.promote_next("TestJob-42", client: mock_client)
@@ -57,7 +57,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
     end
 
     it "returns false when no blocked executions exist" do
-      allow(Pgbus::BlockedExecutionRecord).to receive(:release_next!).and_return(nil)
+      allow(Pgbus::BlockedExecution).to receive(:release_next!).and_return(nil)
 
       promoted = described_class.promote_next("TestJob-42", client: mock_client)
 
@@ -77,7 +77,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
   describe ".expire_stale" do
     it "deletes expired blocked executions" do
       scope = double("scope", delete_all: 2)
-      allow(Pgbus::BlockedExecutionRecord).to receive(:expired).and_return(scope)
+      allow(Pgbus::BlockedExecution).to receive(:expired).and_return(scope)
 
       count = described_class.expire_stale
 
@@ -88,7 +88,7 @@ RSpec.describe Pgbus::Concurrency::BlockedExecution do
   describe ".count_for" do
     it "returns the count of blocked executions for a key" do
       scope = double("scope", count: 5)
-      allow(Pgbus::BlockedExecutionRecord).to receive(:where).with(concurrency_key: "TestJob-42").and_return(scope)
+      allow(Pgbus::BlockedExecution).to receive(:where).with(concurrency_key: "TestJob-42").and_return(scope)
 
       expect(described_class.count_for("TestJob-42")).to eq(5)
     end

--- a/spec/pgbus/concurrency/semaphore_spec.rb
+++ b/spec/pgbus/concurrency/semaphore_spec.rb
@@ -5,14 +5,14 @@ require "spec_helper"
 RSpec.describe Pgbus::Concurrency::Semaphore do
   describe ".acquire" do
     it "returns :acquired when a slot is available" do
-      allow(Pgbus::SemaphoreRecord).to receive(:acquire!).and_return(:acquired)
+      allow(Pgbus::Semaphore).to receive(:acquire!).and_return(:acquired)
 
       expect(described_class.acquire("TestJob-42", 2, 900)).to eq(:acquired)
-      expect(Pgbus::SemaphoreRecord).to have_received(:acquire!).with("TestJob-42", 2, an_instance_of(Time))
+      expect(Pgbus::Semaphore).to have_received(:acquire!).with("TestJob-42", 2, an_instance_of(Time))
     end
 
     it "returns :blocked when limit is reached" do
-      allow(Pgbus::SemaphoreRecord).to receive(:acquire!).and_return(:blocked)
+      allow(Pgbus::Semaphore).to receive(:acquire!).and_return(:blocked)
 
       expect(described_class.acquire("TestJob-42", 1, 900)).to eq(:blocked)
     end
@@ -21,7 +21,7 @@ RSpec.describe Pgbus::Concurrency::Semaphore do
   describe ".release" do
     it "decrements the semaphore value" do
       scope = double("scope", update_all: 1)
-      allow(Pgbus::SemaphoreRecord).to receive(:where).with(key: "TestJob-42").and_return(scope)
+      allow(Pgbus::Semaphore).to receive(:where).with(key: "TestJob-42").and_return(scope)
 
       described_class.release("TestJob-42")
 
@@ -33,7 +33,7 @@ RSpec.describe Pgbus::Concurrency::Semaphore do
     it "deletes expired semaphores and returns their keys" do
       result = double("result", rows: [["old-key-1"], ["old-key-2"]])
       connection = double("connection")
-      allow(Pgbus::SemaphoreRecord).to receive(:connection).and_return(connection)
+      allow(Pgbus::Semaphore).to receive(:connection).and_return(connection)
       allow(connection).to receive(:exec_query).and_return(result)
 
       expired = described_class.expire_stale
@@ -44,13 +44,13 @@ RSpec.describe Pgbus::Concurrency::Semaphore do
 
   describe ".current_value" do
     it "returns the current value for a key" do
-      allow(Pgbus::SemaphoreRecord).to receive_message_chain(:where, :pick).and_return(3) # rubocop:disable RSpec/MessageChain
+      allow(Pgbus::Semaphore).to receive_message_chain(:where, :pick).and_return(3) # rubocop:disable RSpec/MessageChain
 
       expect(described_class.current_value("TestJob-42")).to eq(3)
     end
 
     it "returns nil when key does not exist" do
-      allow(Pgbus::SemaphoreRecord).to receive_message_chain(:where, :pick).and_return(nil) # rubocop:disable RSpec/MessageChain
+      allow(Pgbus::Semaphore).to receive_message_chain(:where, :pick).and_return(nil) # rubocop:disable RSpec/MessageChain
 
       expect(described_class.current_value("missing")).to be_nil
     end

--- a/spec/pgbus/event_bus/handler_spec.rb
+++ b/spec/pgbus/event_bus/handler_spec.rb
@@ -136,24 +136,24 @@ RSpec.describe Pgbus::EventBus::Handler do
     let(:handler) { handler_class.new }
 
     it "returns :handled when event has not been processed" do
-      allow(Pgbus::ProcessedEventRecord).to receive(:exists?).and_return(false)
-      allow(Pgbus::ProcessedEventRecord).to receive(:upsert)
+      allow(Pgbus::ProcessedEvent).to receive(:exists?).and_return(false)
+      allow(Pgbus::ProcessedEvent).to receive(:upsert)
 
       result = handler.process(message)
 
       expect(result).to eq(:handled)
-      expect(Pgbus::ProcessedEventRecord).to have_received(:exists?)
-      expect(Pgbus::ProcessedEventRecord).to have_received(:upsert)
+      expect(Pgbus::ProcessedEvent).to have_received(:exists?)
+      expect(Pgbus::ProcessedEvent).to have_received(:upsert)
     end
 
     it "returns :skipped when event was already processed" do
-      allow(Pgbus::ProcessedEventRecord).to receive(:exists?).and_return(true)
-      allow(Pgbus::ProcessedEventRecord).to receive(:upsert)
+      allow(Pgbus::ProcessedEvent).to receive(:exists?).and_return(true)
+      allow(Pgbus::ProcessedEvent).to receive(:upsert)
 
       result = handler.process(message)
 
       expect(result).to eq(:skipped)
-      expect(Pgbus::ProcessedEventRecord).not_to have_received(:upsert)
+      expect(Pgbus::ProcessedEvent).not_to have_received(:upsert)
     end
   end
 

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -51,28 +51,28 @@ RSpec.describe Pgbus::Process::Dispatcher do
   describe "#cleanup_processed_events (private)" do
     it "deletes expired processed events" do
       scope = double("scope", delete_all: 5)
-      allow(Pgbus::ProcessedEventRecord).to receive(:expired).and_return(scope)
+      allow(Pgbus::ProcessedEvent).to receive(:expired).and_return(scope)
 
       dispatcher.send(:cleanup_processed_events)
 
-      expect(Pgbus::ProcessedEventRecord).to have_received(:expired).with(an_instance_of(Time))
+      expect(Pgbus::ProcessedEvent).to have_received(:expired).with(an_instance_of(Time))
       expect(scope).to have_received(:delete_all)
     end
 
     it "returns early when idempotency_ttl is not set" do
       original_ttl = dispatcher.config.idempotency_ttl
       dispatcher.config.idempotency_ttl = nil
-      allow(Pgbus::ProcessedEventRecord).to receive(:expired)
+      allow(Pgbus::ProcessedEvent).to receive(:expired)
 
       dispatcher.send(:cleanup_processed_events)
 
-      expect(Pgbus::ProcessedEventRecord).not_to have_received(:expired)
+      expect(Pgbus::ProcessedEvent).not_to have_received(:expired)
     ensure
       dispatcher.config.idempotency_ttl = original_ttl
     end
 
     it "rescues StandardError and logs a warning" do
-      allow(Pgbus::ProcessedEventRecord).to receive(:expired).and_raise(StandardError, "db error")
+      allow(Pgbus::ProcessedEvent).to receive(:expired).and_raise(StandardError, "db error")
       expect { dispatcher.send(:cleanup_processed_events) }.not_to raise_error
     end
   end
@@ -80,16 +80,16 @@ RSpec.describe Pgbus::Process::Dispatcher do
   describe "#reap_stale_processes (private)" do
     it "deletes stale processes" do
       scope = double("scope", delete_all: 2)
-      allow(Pgbus::ProcessRecord).to receive(:stale).and_return(scope)
+      allow(Pgbus::ProcessEntry).to receive(:stale).and_return(scope)
 
       dispatcher.send(:reap_stale_processes)
 
-      expect(Pgbus::ProcessRecord).to have_received(:stale).with(an_instance_of(Time))
+      expect(Pgbus::ProcessEntry).to have_received(:stale).with(an_instance_of(Time))
       expect(scope).to have_received(:delete_all)
     end
 
     it "rescues StandardError and logs a warning" do
-      allow(Pgbus::ProcessRecord).to receive(:stale).and_raise(StandardError, "db error")
+      allow(Pgbus::ProcessEntry).to receive(:stale).and_raise(StandardError, "db error")
       expect { dispatcher.send(:reap_stale_processes) }.not_to raise_error
     end
   end
@@ -195,26 +195,26 @@ RSpec.describe Pgbus::Process::Dispatcher do
   describe "#cleanup_recurring_executions (private)" do
     it "deletes old recurring execution records" do
       relation = instance_double(ActiveRecord::Relation, delete_all: 5)
-      allow(Pgbus::RecurringExecutionRecord).to receive(:older_than).and_return(relation)
+      allow(Pgbus::RecurringExecution).to receive(:older_than).and_return(relation)
 
       dispatcher.send(:cleanup_recurring_executions)
 
-      expect(Pgbus::RecurringExecutionRecord).to have_received(:older_than).with(an_instance_of(Time))
+      expect(Pgbus::RecurringExecution).to have_received(:older_than).with(an_instance_of(Time))
       expect(relation).to have_received(:delete_all)
     end
 
     it "rescues errors gracefully" do
-      allow(Pgbus::RecurringExecutionRecord).to receive(:older_than).and_raise(StandardError, "db error")
+      allow(Pgbus::RecurringExecution).to receive(:older_than).and_raise(StandardError, "db error")
       expect { dispatcher.send(:cleanup_recurring_executions) }.not_to raise_error
     end
 
     it "skips when retention is not positive" do
       allow(Pgbus.configuration).to receive(:recurring_execution_retention).and_return(0)
-      allow(Pgbus::RecurringExecutionRecord).to receive(:older_than)
+      allow(Pgbus::RecurringExecution).to receive(:older_than)
 
       dispatcher.send(:cleanup_recurring_executions)
 
-      expect(Pgbus::RecurringExecutionRecord).not_to have_received(:older_than)
+      expect(Pgbus::RecurringExecution).not_to have_received(:older_than)
     end
   end
 

--- a/spec/pgbus/process/heartbeat_spec.rb
+++ b/spec/pgbus/process/heartbeat_spec.rb
@@ -6,7 +6,7 @@ require "socket"
 
 RSpec.describe Pgbus::Process::Heartbeat do
   let(:timer) { instance_double(Concurrent::TimerTask, execute: true, shutdown: true) }
-  let(:process_record) { double("ProcessRecord", id: 42) }
+  let(:process_record) { double("ProcessEntry", id: 42) }
   let(:heartbeat) { described_class.new(kind: "worker", metadata: { queues: %w[default] }) }
 
   before do
@@ -15,13 +15,13 @@ RSpec.describe Pgbus::Process::Heartbeat do
 
   describe "#start" do
     before do
-      allow(Pgbus::ProcessRecord).to receive(:create!).and_return(process_record)
+      allow(Pgbus::ProcessEntry).to receive(:create!).and_return(process_record)
     end
 
-    it "registers the process via ProcessRecord" do
+    it "registers the process via ProcessEntry" do
       heartbeat.start
 
-      expect(Pgbus::ProcessRecord).to have_received(:create!).with(
+      expect(Pgbus::ProcessEntry).to have_received(:create!).with(
         hash_including(kind: "worker", pid: Process.pid)
       )
     end
@@ -39,8 +39,8 @@ RSpec.describe Pgbus::Process::Heartbeat do
       let(:scope) { double("scope", update_all: 1) }
 
       before do
-        allow(Pgbus::ProcessRecord).to receive(:create!).and_return(process_record)
-        allow(Pgbus::ProcessRecord).to receive(:where).with(id: 42).and_return(scope)
+        allow(Pgbus::ProcessEntry).to receive(:create!).and_return(process_record)
+        allow(Pgbus::ProcessEntry).to receive(:where).with(id: 42).and_return(scope)
         heartbeat.start
       end
 
@@ -59,8 +59,8 @@ RSpec.describe Pgbus::Process::Heartbeat do
 
     context "when update raises an error" do
       before do
-        allow(Pgbus::ProcessRecord).to receive(:create!).and_return(process_record)
-        allow(Pgbus::ProcessRecord).to receive(:where).and_raise(StandardError, "connection lost")
+        allow(Pgbus::ProcessEntry).to receive(:create!).and_return(process_record)
+        allow(Pgbus::ProcessEntry).to receive(:where).and_raise(StandardError, "connection lost")
         heartbeat.start
       end
 
@@ -74,8 +74,8 @@ RSpec.describe Pgbus::Process::Heartbeat do
     let(:scope) { double("scope", delete_all: 1) }
 
     before do
-      allow(Pgbus::ProcessRecord).to receive(:create!).and_return(process_record)
-      allow(Pgbus::ProcessRecord).to receive(:where).with(id: 42).and_return(scope)
+      allow(Pgbus::ProcessEntry).to receive(:create!).and_return(process_record)
+      allow(Pgbus::ProcessEntry).to receive(:where).with(id: 42).and_return(scope)
       heartbeat.start
     end
 

--- a/spec/pgbus/recurring/recurring_execution_spec.rb
+++ b/spec/pgbus/recurring/recurring_execution_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Pgbus::RecurringExecutionRecord do
+RSpec.describe Pgbus::RecurringExecution do
   describe ".record" do
     it "creates a record and yields" do
       yielded = false

--- a/spec/pgbus/recurring/schedule_spec.rb
+++ b/spec/pgbus/recurring/schedule_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Pgbus::Recurring::Schedule do
 
     before do
       # Mock the RecurringExecution to allow recording
-      allow(Pgbus::RecurringExecutionRecord).to receive(:record).and_yield
+      allow(Pgbus::RecurringExecution).to receive(:record).and_yield
     end
 
     it "sends a message through the client" do
@@ -122,18 +122,18 @@ RSpec.describe Pgbus::Recurring::Schedule do
     end
 
     it "records the execution for deduplication" do
-      allow(Pgbus::RecurringExecutionRecord).to receive(:record)
+      allow(Pgbus::RecurringExecution).to receive(:record)
         .with("daily_cleanup", run_at)
         .and_yield
 
       schedule.enqueue_task(task, run_at: run_at)
 
-      expect(Pgbus::RecurringExecutionRecord).to have_received(:record)
+      expect(Pgbus::RecurringExecution).to have_received(:record)
         .with("daily_cleanup", run_at)
     end
 
     it "does not enqueue when execution already recorded" do
-      allow(Pgbus::RecurringExecutionRecord).to receive(:record)
+      allow(Pgbus::RecurringExecution).to receive(:record)
         .and_raise(Pgbus::Recurring::AlreadyRecorded)
 
       schedule.enqueue_task(task, run_at: run_at)

--- a/spec/pgbus/recurring/scheduler_spec.rb
+++ b/spec/pgbus/recurring/scheduler_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Pgbus::Recurring::Scheduler do
     it "enqueues due tasks" do
       scheduler = described_class.new(config: config)
 
-      allow(Pgbus::RecurringExecutionRecord).to receive(:record) do |_key, _time, &block|
+      allow(Pgbus::RecurringExecution).to receive(:record) do |_key, _time, &block|
         block&.call
       end
 
@@ -69,7 +69,7 @@ RSpec.describe Pgbus::Recurring::Scheduler do
 
     it "tracks last_run_at per task" do
       scheduler = described_class.new(config: config)
-      allow(Pgbus::RecurringExecutionRecord).to receive(:record) do |_key, _time, &block|
+      allow(Pgbus::RecurringExecution).to receive(:record) do |_key, _time, &block|
         block&.call
       end
 

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Pgbus::Web::DataSource do
   let(:mock_connection) { double("ActiveRecord::Connection") }
 
   before do
-    allow(ActiveRecord::Base).to receive(:connection).and_return(mock_connection)
+    allow(Pgbus::ApplicationRecord).to receive(:connection).and_return(mock_connection)
   end
 
   describe "#queues_with_metrics" do

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Pgbus::Web::DataSource do
 
   describe "#recurring_tasks" do
     it "returns formatted recurring tasks" do
-      mock_record = double("RecurringTaskRecord",
+      mock_record = double("RecurringTask",
                            id: 1, key: "daily_cleanup", class_name: "CleanupJob",
                            command: nil, schedule: "0 2 * * *", queue_name: "maintenance",
                            arguments: nil, priority: 0, description: "Cleanup",
@@ -116,11 +116,11 @@ RSpec.describe Pgbus::Web::DataSource do
                            created_at: Time.now, updated_at: Time.now)
 
       relation = double("relation", to_a: [mock_record])
-      allow(Pgbus::RecurringTaskRecord).to receive(:order).with(:key).and_return(relation)
+      allow(Pgbus::RecurringTask).to receive(:order).with(:key).and_return(relation)
 
       # Mock the aggregate query for last runs
       empty_scope = double("scope")
-      allow(Pgbus::RecurringExecutionRecord).to receive(:where).and_return(empty_scope)
+      allow(Pgbus::RecurringExecution).to receive(:where).and_return(empty_scope)
       allow(empty_scope).to receive_messages(select: empty_scope, group: empty_scope, index_by: {})
 
       result = data_source.recurring_tasks
@@ -131,7 +131,7 @@ RSpec.describe Pgbus::Web::DataSource do
     end
 
     it "returns empty array on error" do
-      allow(Pgbus::RecurringTaskRecord).to receive(:order).and_raise(StandardError)
+      allow(Pgbus::RecurringTask).to receive(:order).and_raise(StandardError)
 
       expect(data_source.recurring_tasks).to eq([])
     end
@@ -139,13 +139,13 @@ RSpec.describe Pgbus::Web::DataSource do
 
   describe "#recurring_tasks_count" do
     it "returns the count of recurring tasks" do
-      allow(Pgbus::RecurringTaskRecord).to receive(:count).and_return(5)
+      allow(Pgbus::RecurringTask).to receive(:count).and_return(5)
 
       expect(data_source.recurring_tasks_count).to eq(5)
     end
 
     it "returns 0 on error" do
-      allow(Pgbus::RecurringTaskRecord).to receive(:count).and_raise(StandardError)
+      allow(Pgbus::RecurringTask).to receive(:count).and_raise(StandardError)
 
       expect(data_source.recurring_tasks_count).to eq(0)
     end
@@ -153,15 +153,15 @@ RSpec.describe Pgbus::Web::DataSource do
 
   describe "#toggle_recurring_task" do
     it "toggles the enabled state" do
-      mock_record = double("RecurringTaskRecord", enabled: true)
-      allow(Pgbus::RecurringTaskRecord).to receive(:find_by).with(id: 1).and_return(mock_record)
+      mock_record = double("RecurringTask", enabled: true)
+      allow(Pgbus::RecurringTask).to receive(:find_by).with(id: 1).and_return(mock_record)
       allow(mock_record).to receive(:update!).with(enabled: false).and_return(true)
 
       expect(data_source.toggle_recurring_task(1)).to be true
     end
 
     it "returns false when task not found" do
-      allow(Pgbus::RecurringTaskRecord).to receive(:find_by).with(id: 99).and_return(nil)
+      allow(Pgbus::RecurringTask).to receive(:find_by).with(id: 99).and_return(nil)
 
       expect(data_source.toggle_recurring_task(99)).to be false
     end


### PR DESCRIPTION
## Summary
- Remove `Record` suffix from all ActiveRecord model classes for cleaner naming
- Add optional separate database support (`connects_to`, `--database` generator flag, `db/pgbus_migrate/` path)
- Document naming conventions and conflict resolution strategy in CLAUDE.md

### Model Naming Changes

| Before | After | Why |
|---|---|---|
| `ApplicationRecord` | `BaseModel` | Avoids Rails `ApplicationRecord` conflict |
| `BatchRecord` | `BatchEntry` | `Pgbus::Batch` is the batch API class |
| `BlockedExecutionRecord` | `BlockedExecution` | No conflict |
| `ProcessRecord` | `ProcessEntry` | Ruby's `Process` module conflict |
| `ProcessedEventRecord` | `ProcessedEvent` | No conflict |
| `RecurringExecutionRecord` | `RecurringExecution` | No conflict |
| `RecurringTaskRecord` | `RecurringTask` | Different namespace than `Pgbus::Recurring::Task` |
| `SemaphoreRecord` | `Semaphore` | Different namespace than `Pgbus::Concurrency::Semaphore` |

### Separate Database Support
- `Pgbus.configure { |c| c.connects_to = { database: { writing: :pgbus } } }` 
- `rails generate pgbus:install --database=pgbus` puts migrations in `db/pgbus_migrate/`
- Follows the same pattern as SolidQueue's `queue_schema.rb` / `queue_migrate/`

## Test plan
- [x] `bundle exec rspec --exclude-pattern "spec/system/**/*_spec.rb"` — 381 examples, 0 failures
- [x] `bundle exec rspec spec/system/` — 32 examples, 0 failures (run in isolation)
- [x] `bundle exec rubocop` — 131 files, no offenses
- [ ] Verify system specs order-dependency is pre-existing (confirmed: same 34 failures on main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring pgbus to use a separate database for its tables via `--database` option in generators and `config.connects_to` configuration.

* **Documentation**
  * Added comprehensive model naming guidelines and separate database configuration instructions.

* **Breaking Changes**
  * Renamed ActiveRecord model classes to remove "Record" suffix (e.g., `BatchRecord` → `BatchEntry`, `ProcessRecord` → `ProcessEntry`). Update any direct references to these classes in your application code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->