### PR TITLE
fix: raise SchemaNotReady when PGMQ schema is missing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run unit tests
-        run: bundle exec rspec
+        run: bundle exec rspec spec/pgbus/
 
   system_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,22 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: RuboCop
+        run: bundle exec rubocop
+
+  test:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
@@ -31,8 +46,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run unit tests and rubocop
-        run: bundle exec rake
+      - name: Run unit tests
+        run: bundle exec rspec
 
   system_test:
     runs-on: ubuntu-latest

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -9,6 +9,7 @@ module Pgbus
   class QueueNotFoundError < Error; end
   class DeadLetterError < Error; end
   class ConcurrencyLimitExceeded < Error; end
+  class SchemaNotReady < Error; end
 
   class << self
     def loader

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -54,6 +54,9 @@ module Pgbus
         end
 
         active_job
+      rescue Pgbus::SchemaNotReady => e
+        Pgbus.logger.error { "[Pgbus] #{e.message}" }
+        raise
       end
 
       def concurrency_config(active_job)

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -99,6 +99,9 @@ module Pgbus
         end
 
         jobs.zip(msg_ids).each { |job, id| job.provider_job_id = id }
+      rescue Pgbus::SchemaNotReady => e
+        Pgbus.logger.error { "[Pgbus] #{e.message}" }
+        raise
       end
 
       def enqueue_after_transaction_commit?

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -36,6 +36,9 @@ module Pgbus
         @pgmq.enable_notify_insert(full_name, throttle_interval_ms: config.notify_throttle_ms) if config.listen_notify
         true
       end
+    rescue PGMQ::Errors::ConnectionError => e
+      raise Pgbus::SchemaNotReady,
+        "PGMQ schema is not available (#{e.message}). Run `rails db:migrate` for the pgbus database."
     end
 
     def ensure_dead_letter_queue(name)

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -38,7 +38,7 @@ module Pgbus
       end
     rescue PGMQ::Errors::ConnectionError => e
       raise Pgbus::SchemaNotReady,
-        "PGMQ schema is not available (#{e.message}). Run `rails db:migrate` for the pgbus database."
+            "PGMQ schema is not available (#{e.message}). Run `rails db:migrate` for the pgbus database."
     end
 
     def ensure_dead_letter_queue(name)

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -59,6 +59,19 @@ RSpec.describe Pgbus::Client do
       expect(mock_pgmq).to have_received(:create).with("pgbus_test_jobs").once
       expect(mock_pgmq).to have_received(:create).with("pgbus_test_events").once
     end
+
+    it "raises SchemaNotReady when PGMQ schema is missing" do
+      # PGMQ is lazy-loaded by the client, so define the error class if not yet available
+      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+
+      allow(mock_pgmq).to receive(:create).and_raise(
+        PGMQ::Errors::ConnectionError.new('Database connection error: ERROR:  relation "pgmq.meta" does not exist')
+      )
+
+      expect { client.ensure_queue("jobs") }.to raise_error(
+        Pgbus::SchemaNotReady, /PGMQ schema is not available/
+      )
+    end
   end
 
   describe "#ensure_dead_letter_queue" do

--- a/spec/pgbus/process/heartbeat_spec.rb
+++ b/spec/pgbus/process/heartbeat_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe Pgbus::Process::Heartbeat do
       it "updates the heartbeat timestamp" do
         heartbeat.beat
 
-        expect(scope).to have_received(:update_all).with(last_heartbeat_at: an_instance_of(Time))
+        expect(scope).to have_received(:update_all) do |args|
+          expect(args[:last_heartbeat_at]).to be_a(Time)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
- Adds `Pgbus::SchemaNotReady` error class for when the PGMQ schema hasn't been migrated
- `Client#ensure_queue` now rescues `PGMQ::Errors::ConnectionError` and re-raises as `SchemaNotReady` with an actionable message ("Run `rails db:migrate` for the pgbus database")
- ActiveJob adapter logs the error before re-raising, so it's visible in application logs
- Aligns with graceful degradation already present in worker (wildcard resolution) and web dashboard (queue metrics)

## Context
In production, if the pgbus migration hasn't run, `ensure_queue` queries `pgmq.meta` which doesn't exist. The raw `PGMQ::Errors::ConnectionError` with a SQL fragment was confusing and unhelpful. Now callers get a clear `Pgbus::SchemaNotReady` they can rescue if needed.

## Test plan
- [x] New spec: `Client#ensure_queue raises SchemaNotReady when PGMQ schema is missing`
- [x] All 389 unit/integration specs pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and logging when the database schema is unavailable, with clearer error messages and guidance to remediate.

* **Tests**
  * Added coverage for schema-unavailable scenarios and refined a heartbeat test to more directly validate timestamp updates.

* **Chores**
  * CI workflow restructured to run lint and test as separate jobs for clearer pipeline visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->