### PR TITLE
fix: use correct DB connection with connects_to and stabilize test suite

### DIFF
--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -18,14 +18,31 @@ module Pgbus
         loader.inflector.inflect("pgbus" => "Pgbus", "cli" => "CLI", "dsl" => "DSL")
         loader.ignore("#{__dir__}/generators")
         loader.ignore("#{__dir__}/active_job")
-        # Register app/models for non-Rails usage (specs, standalone).
-        # When Rails is running, the Engine handles autoloading app/models.
-        unless defined?(Rails::Engine)
-          models_dir = File.expand_path("../app/models", __dir__)
-          loader.push_dir(models_dir) if File.directory?(models_dir)
-        end
         loader
       end
+    end
+
+    # Separate loader for app/models used only in non-Rails contexts (specs,
+    # standalone scripts). When the Engine boots, Rails' autoloader takes over
+    # app/models and this loader is torn down to avoid conflicts.
+    def models_loader
+      models_dir = File.expand_path("../app/models", __dir__)
+      return nil unless File.directory?(models_dir)
+
+      @models_loader ||= begin
+        loader = Zeitwerk::Loader.new
+        loader.tag = "pgbus-models"
+        loader.push_dir(models_dir)
+        loader.setup
+        loader
+      end
+    end
+
+    def teardown_models_loader!
+      return unless @models_loader
+
+      @models_loader.unregister
+      @models_loader = nil
     end
 
     def configuration
@@ -52,6 +69,10 @@ module Pgbus
   end
 
   loader.setup
+
+  # In non-Rails contexts, set up model autoloading via a separate loader.
+  # This is torn down by the Engine initializer when Rails boots.
+  models_loader unless defined?(Rails::Engine)
 end
 
 require "active_job/queue_adapters/pgbus_adapter" if defined?(ActiveJob)

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -137,7 +137,11 @@ module Pgbus
       elsif connection_params
         connection_params
       elsif defined?(ActiveRecord::Base)
-        -> { ActiveRecord::Base.connection.raw_connection }
+        if connects_to
+          -> { Pgbus::ApplicationRecord.connection.raw_connection }
+        else
+          -> { ActiveRecord::Base.connection.raw_connection }
+        end
       else
         raise ConfigurationError, "No database connection configured. " \
                                   "Set Pgbus.configuration.database_url, connection_params, or use with Rails."

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -6,6 +6,12 @@ module Pgbus
   class Engine < ::Rails::Engine
     isolate_namespace Pgbus
 
+    # When pgbus was loaded before Rails, a separate Zeitwerk loader manages
+    # app/models. Tear it down before Rails' autoloader claims the same paths.
+    initializer "pgbus.release_models_loader", before: :set_autoload_paths do
+      Pgbus.teardown_models_loader!
+    end
+
     initializer "pgbus.configure" do |app|
       config_path = app.root.join("config", "pgbus.yml")
       Pgbus::ConfigLoader.load(config_path) if config_path.exist?

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -107,7 +107,8 @@ module Pgbus
         dlq_suffix = config.dead_letter_queue_suffix
         prefix = "#{config.queue_prefix}_"
 
-        all_queues = ActiveRecord::Base.connection.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
+        conn = Pgbus.configuration.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
+        all_queues = conn.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
         resolved = all_queues
                    .reject { |q| q.end_with?(dlq_suffix) }
                    .map { |q| q.delete_prefix(prefix) }

--- a/lib/tasks/pgbus_pgmq.rake
+++ b/lib/tasks/pgbus_pgmq.rake
@@ -12,8 +12,10 @@ namespace :pgbus do
       latest = Pgbus::PgmqSchema.latest_version
       puts "Vendored version:  #{latest}"
 
-      if ActiveRecord::Base.connection.table_exists?("pgbus_pgmq_schema_versions")
-        row = ActiveRecord::Base.connection.select_one(
+      conn = Pgbus.configuration.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
+
+      if conn.table_exists?("pgbus_pgmq_schema_versions")
+        row = conn.select_one(
           "SELECT version, install_method, installed_at FROM pgbus_pgmq_schema_versions ORDER BY installed_at DESC LIMIT 1"
         )
         if row
@@ -32,7 +34,7 @@ namespace :pgbus do
         end
       else
         # Check if pgmq schema exists at all
-        schema_exists = ActiveRecord::Base.connection.select_value(
+        schema_exists = conn.select_value(
           "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgmq'"
         )
         if schema_exists

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -9,6 +9,9 @@ require "action_view/railtie"
 
 Bundler.require(*Rails.groups)
 require "pgbus"
+# Ensure the engine is loaded even if pgbus was required before Rails
+# (e.g. when unit specs using spec_helper run before system specs).
+require "pgbus/engine"
 
 module Dummy
   class Application < Rails::Application

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -85,5 +85,38 @@ RSpec.describe Pgbus::Configuration do
       hide_const("ActiveRecord::Base") if defined?(ActiveRecord::Base)
       expect { config.connection_options }.to raise_error(Pgbus::ConfigurationError)
     end
+
+    context "with connects_to configured" do
+      let(:raw_connection) { double("raw_connection") }
+      let(:ar_connection) { double("ar_connection", raw_connection: raw_connection) }
+
+      before do
+        config.connects_to = { database: { writing: :pgbus } }
+        stub_const("Pgbus::ApplicationRecord", Class.new)
+        allow(Pgbus::ApplicationRecord).to receive(:connection).and_return(ar_connection)
+      end
+
+      it "returns a lambda that uses Pgbus::ApplicationRecord connection" do
+        result = config.connection_options
+        expect(result).to be_a(Proc)
+        expect(result.call).to eq(raw_connection)
+      end
+    end
+
+    context "without connects_to" do
+      let(:raw_connection) { double("raw_connection") }
+      let(:ar_connection) { double("ar_connection", raw_connection: raw_connection) }
+
+      before do
+        stub_const("ActiveRecord::Base", Class.new)
+        allow(ActiveRecord::Base).to receive(:connection).and_return(ar_connection)
+      end
+
+      it "returns a lambda that uses ActiveRecord::Base connection" do
+        result = config.connection_options
+        expect(result).to be_a(Proc)
+        expect(result.call).to eq(raw_connection)
+      end
+    end
   end
 end

--- a/spec/pgbus/recurring/task_spec.rb
+++ b/spec/pgbus/recurring/task_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Pgbus::Recurring::Task do
                                                 schedule: "0 12 * * *")
 
       from = Time.utc(2026, 1, 1, 0, 0, 0)
-      next_time = task.next_time(from)
+      next_time = task.next_time(from).utc
       expect(next_time.hour).to eq(12)
       expect(next_time.day).to eq(1)
     end


### PR DESCRIPTION
## Summary

- **PGMQ schema not found with separate database**: When `connects_to` is configured, `Pgbus::Client`, rake tasks, and the worker used `ActiveRecord::Base.connection` (primary DB) instead of `Pgbus::ApplicationRecord.connection` (pgbus DB) where the PGMQ schema lives. This caused persistent "schema pgmq does not exist" errors in cosmos after migrations.
- **33 flaky system spec failures**: When unit specs load pgbus before Rails, the engine never loaded and the gem's Zeitwerk loader conflicted with Rails' autoloader over `app/models`. Fixed by using a separate teardown-able models loader and ensuring the engine loads during Rails initialization.
- **Flaky recurring task time test**: `next_time.hour` compared local-timezone hour instead of UTC when Rails was loaded.

## Test plan

- [x] `bundle exec rspec --seed 519` — previously 33 failures, now 0
- [x] `bundle exec rspec --seed 42` — 0 failures
- [x] `bundle exec rspec --seed 99999` — 0 failures
- [x] `bundle exec rspec --seed 12345` — 0 failures
- [x] `bundle exec rubocop` — no offenses
- [ ] Verify in cosmos that PGMQ operations work after migration with `connects_to` configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for Rails multi-database configurations via `connects_to` setup.
  * Improved model autoloading for non-Rails contexts.

* **Bug Fixes**
  * Fixed database connection routing to respect configured database connections in worker processes and rake tasks.

* **Tests**
  * Added test coverage for multi-database configuration handling.
  * Fixed time zone handling in recurring task tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->