### PR TITLE
feat: LavinMQ-inspired improvements — prefetch, circuit breaker, priority queues, archive compaction, outbox

### DIFF
--- a/app/controllers/pgbus/outbox_controller.rb
+++ b/app/controllers/pgbus/outbox_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class OutboxController < ApplicationController
+    def index
+      @stats = data_source.outbox_stats
+      @entries = data_source.outbox_entries(page: page_param, per_page: per_page)
+    end
+  end
+end

--- a/app/controllers/pgbus/queues_controller.rb
+++ b/app/controllers/pgbus/queues_controller.rb
@@ -17,5 +17,15 @@ module Pgbus
       data_source.purge_queue(params[:name])
       redirect_to queue_path(name: params[:name]), notice: "Queue purged."
     end
+
+    def pause
+      data_source.pause_queue(params[:name], reason: params[:reason])
+      redirect_to queue_path(name: params[:name]), notice: "Queue paused."
+    end
+
+    def resume
+      data_source.resume_queue(params[:name])
+      redirect_to queue_path(name: params[:name]), notice: "Queue resumed."
+    end
   end
 end

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -45,6 +45,12 @@ module Pgbus
       end
     end
 
+    def pgbus_paused_badge(paused)
+      return unless paused
+
+      tag.span("Paused", class: "inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800")
+    end
+
     def pgbus_parse_message(message)
       return {} unless message
 

--- a/app/models/pgbus/outbox_entry.rb
+++ b/app/models/pgbus/outbox_entry.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class OutboxEntry < ApplicationRecord
+    self.table_name = "pgbus_outbox_entries"
+
+    scope :unpublished, -> { where(published_at: nil) }
+    scope :published_before, ->(time) { where(published_at: ...time) }
+  end
+end

--- a/app/models/pgbus/outbox_entry.rb
+++ b/app/models/pgbus/outbox_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class OutboxEntry < ApplicationRecord
+  class OutboxEntry < Pgbus::ApplicationRecord
     self.table_name = "pgbus_outbox_entries"
 
     scope :unpublished, -> { where(published_at: nil) }

--- a/app/models/pgbus/queue_state.rb
+++ b/app/models/pgbus/queue_state.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class QueueState < ApplicationRecord
+    self.table_name = "pgbus_queue_states"
+
+    scope :paused, -> { where(paused: true) }
+
+    def self.paused?(queue_name)
+      where(queue_name: queue_name, paused: true).exists?
+    end
+
+    def self.pause!(queue_name, reason: nil)
+      record = find_or_initialize_by(queue_name: queue_name)
+      record.update!(paused: true, paused_reason: reason, paused_at: Time.current)
+      record
+    end
+
+    def self.resume!(queue_name)
+      record = find_by(queue_name: queue_name)
+      return unless record
+
+      record.update!(
+        paused: false,
+        paused_reason: nil,
+        paused_at: nil,
+        circuit_breaker_trip_count: 0,
+        circuit_breaker_resume_at: nil
+      )
+      record
+    end
+  end
+end

--- a/app/models/pgbus/queue_state.rb
+++ b/app/models/pgbus/queue_state.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class QueueState < ApplicationRecord
+  class QueueState < Pgbus::ApplicationRecord
     self.table_name = "pgbus_queue_states"
 
     scope :paused, -> { where(paused: true) }
@@ -12,7 +12,7 @@ module Pgbus
 
     def self.pause!(queue_name, reason: nil)
       record = find_or_initialize_by(queue_name: queue_name)
-      record.update!(paused: true, paused_reason: reason, paused_at: Time.current)
+      record.update!(paused: true, paused_reason: reason, paused_at: Time.current, circuit_breaker_resume_at: nil)
       record
     end
 

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -46,6 +46,7 @@
               <%= pgbus_nav_link "Processes", pgbus.processes_path %>
               <%= pgbus_nav_link "Events", pgbus.events_path %>
               <%= pgbus_nav_link "DLQ", pgbus.dead_letter_index_path %>
+              <%= pgbus_nav_link "Outbox", pgbus.outbox_index_path %>
             </div>
           </div>
         </div>

--- a/app/views/pgbus/dashboard/_stats_cards.html.erb
+++ b/app/views/pgbus/dashboard/_stats_cards.html.erb
@@ -1,5 +1,5 @@
 <turbo-frame id="dashboard-stats" data-auto-refresh src="<%= pgbus.root_path(frame: 'stats') %>">
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5 mb-8">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-6 mb-8">
     <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
       <p class="text-sm font-medium text-gray-500">Queues</p>
       <p class="mt-1 text-3xl font-semibold text-gray-900"><%= @stats[:total_queues] %></p>
@@ -31,6 +31,12 @@
       <p class="mt-1 text-3xl font-semibold <%= (@stats[:failed_count] + @stats[:dlq_depth]) > 0 ? 'text-red-600' : 'text-gray-900' %>">
         <%= @stats[:failed_count] %> / <%= @stats[:dlq_depth] %>
       </p>
+    </div>
+
+    <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
+      <p class="text-sm font-medium text-gray-500">Throughput</p>
+      <p class="mt-1 text-3xl font-semibold text-gray-900"><%= @stats[:throughput_rate] %></p>
+      <p class="text-xs text-gray-400">msgs/s</p>
     </div>
   </div>
 </turbo-frame>

--- a/app/views/pgbus/outbox/index.html.erb
+++ b/app/views/pgbus/outbox/index.html.erb
@@ -1,0 +1,55 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-bold text-gray-900">Outbox</h1>
+  <p class="mt-1 text-sm text-gray-500">Transactional outbox entries pending publication to PGMQ</p>
+</div>
+
+<div class="mb-6 grid grid-cols-3 gap-4">
+  <div class="rounded-lg bg-white p-4 shadow ring-1 ring-gray-200">
+    <dt class="text-xs font-medium uppercase text-gray-500">Unpublished</dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900"><%= pgbus_number(@stats[:unpublished]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white p-4 shadow ring-1 ring-gray-200">
+    <dt class="text-xs font-medium uppercase text-gray-500">Total</dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900"><%= pgbus_number(@stats[:total]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white p-4 shadow ring-1 ring-gray-200">
+    <dt class="text-xs font-medium uppercase text-gray-500">Oldest Unpublished</dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900"><%= @stats[:oldest_unpublished_age] ? "#{@stats[:oldest_unpublished_age]}s" : "—" %></dd>
+  </div>
+</div>
+
+<div class="overflow-hidden rounded-lg bg-white shadow ring-1 ring-gray-200">
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
+      <tr>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">ID</th>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Queue / Topic</th>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Payload</th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Priority</th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Status</th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Created</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100">
+      <% @entries.each do |entry| %>
+        <tr class="hover:bg-gray-50">
+          <td class="px-4 py-3 text-sm font-mono text-gray-700"><%= entry.id %></td>
+          <td class="px-4 py-3 text-sm text-gray-700"><%= entry.routing_key || entry.queue_name %></td>
+          <td class="px-4 py-3 text-sm text-gray-500 max-w-xs truncate"><%= pgbus_json_preview(entry.payload) %></td>
+          <td class="px-4 py-3 text-sm text-right text-gray-500"><%= entry.priority %></td>
+          <td class="px-4 py-3 text-sm text-right">
+            <% if entry.published_at %>
+              <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">Published</span>
+            <% else %>
+              <span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">Pending</span>
+            <% end %>
+          </td>
+          <td class="px-4 py-3 text-sm text-right text-gray-500"><%= pgbus_time_ago(entry.created_at) %></td>
+        </tr>
+      <% end %>
+      <% if @entries.empty? %>
+        <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400">No outbox entries</td></tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/pgbus/queues/_queues_list.html.erb
+++ b/app/views/pgbus/queues/_queues_list.html.erb
@@ -18,13 +18,27 @@
             <td class="px-4 py-3 text-sm">
               <%= link_to q[:name], pgbus.queue_path(name: q[:name]), class: "font-medium text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
               <%= pgbus_queue_badge(q[:name]) %>
+              <% if q[:paused] %>
+                <span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">Paused</span>
+              <% end %>
             </td>
             <td class="px-4 py-3 text-sm text-right font-mono text-gray-700"><%= pgbus_number(q[:queue_length]) %></td>
             <td class="px-4 py-3 text-sm text-right font-mono text-gray-700"><%= pgbus_number(q[:queue_visible_length]) %></td>
             <td class="px-4 py-3 text-sm text-right text-gray-500"><%= q[:oldest_msg_age_sec] || "—" %></td>
             <td class="px-4 py-3 text-sm text-right text-gray-500"><%= q[:newest_msg_age_sec] || "—" %></td>
             <td class="px-4 py-3 text-sm text-right text-gray-500"><%= pgbus_number(q[:total_messages]) %></td>
-            <td class="px-4 py-3 text-sm text-right">
+            <td class="px-4 py-3 text-sm text-right space-x-2">
+              <% if q[:paused] %>
+                <%= button_to "Resume", pgbus.resume_queue_path(name: q[:name]),
+                      method: :post,
+                      class: "text-xs text-green-600 hover:text-green-800 font-medium",
+                      data: { turbo_frame: "_top" } %>
+              <% else %>
+                <%= button_to "Pause", pgbus.pause_queue_path(name: q[:name]),
+                      method: :post,
+                      class: "text-xs text-yellow-600 hover:text-yellow-800 font-medium",
+                      data: { turbo_confirm: "Pause processing for #{q[:name]}?", turbo_frame: "_top" } %>
+              <% end %>
               <%= button_to "Purge", pgbus.purge_queue_path(name: q[:name]),
                     method: :post,
                     class: "text-xs text-red-600 hover:text-red-800 font-medium",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Pgbus::Engine.routes.draw do
   resources :queues, only: %i[index show], param: :name do
     member do
       post :purge
+      post :pause
+      post :resume
     end
   end
 
@@ -45,6 +47,8 @@ Pgbus::Engine.routes.draw do
       post :discard_all
     end
   end
+
+  resources :outbox, only: [:index], controller: "outbox"
 
   namespace :api do
     get :stats, to: "stats#show"

--- a/lib/generators/pgbus/add_outbox_generator.rb
+++ b/lib/generators/pgbus/add_outbox_generator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class AddOutboxGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Add outbox table for transactional event publishing"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
+      def create_migration
+        if separate_database?
+          migration_template "add_outbox.rb.erb",
+                             "db/pgbus_migrate/add_pgbus_outbox.rb"
+        else
+          migration_template "add_outbox.rb.erb",
+                             "db/migrate/add_pgbus_outbox.rb"
+        end
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus outbox installed!", :green
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
+        say "  2. Enable in config: config.outbox_enabled = true"
+        say "  3. Restart pgbus: bin/pgbus start"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/add_queue_states_generator.rb
+++ b/lib/generators/pgbus/add_queue_states_generator.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class AddQueueStatesGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Add queue states table for pause/resume and circuit breaker support"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
+      def create_migration
+        if separate_database?
+          migration_template "add_queue_states.rb.erb",
+                             "db/pgbus_migrate/add_pgbus_queue_states.rb"
+        else
+          migration_template "add_queue_states.rb.erb",
+                             "db/migrate/add_pgbus_queue_states.rb"
+        end
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus queue states table installed!", :green
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
+        say "  2. Restart pgbus: bin/pgbus start"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/templates/add_outbox.rb.erb
+++ b/lib/generators/pgbus/templates/add_outbox.rb.erb
@@ -1,0 +1,20 @@
+class AddPgbusOutbox < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :pgbus_outbox_entries do |t|
+      t.string :queue_name
+      t.string :routing_key
+      t.jsonb :payload, null: false
+      t.jsonb :headers
+      t.integer :priority, default: 0
+      t.integer :delay, default: 0
+      t.datetime :published_at
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :pgbus_outbox_entries, :published_at,
+      where: "published_at IS NULL",
+      name: "idx_pgbus_outbox_unpublished"
+    add_index :pgbus_outbox_entries, :created_at,
+      name: "idx_pgbus_outbox_cleanup"
+  end
+end

--- a/lib/generators/pgbus/templates/add_outbox.rb.erb
+++ b/lib/generators/pgbus/templates/add_outbox.rb.erb
@@ -11,10 +11,15 @@ class AddPgbusOutbox < ActiveRecord::Migration<%= migration_version %>
       t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
     end
 
+    add_check_constraint :pgbus_outbox_entries,
+      "(queue_name IS NOT NULL) <> (routing_key IS NOT NULL)",
+      name: "chk_pgbus_outbox_destination"
+
     add_index :pgbus_outbox_entries, :published_at,
       where: "published_at IS NULL",
       name: "idx_pgbus_outbox_unpublished"
-    add_index :pgbus_outbox_entries, :created_at,
+    add_index :pgbus_outbox_entries, :published_at,
+      where: "published_at IS NOT NULL",
       name: "idx_pgbus_outbox_cleanup"
   end
 end

--- a/lib/generators/pgbus/templates/add_queue_states.rb.erb
+++ b/lib/generators/pgbus/templates/add_queue_states.rb.erb
@@ -1,0 +1,16 @@
+class AddPgbusQueueStates < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :pgbus_queue_states do |t|
+      t.string :queue_name, null: false
+      t.boolean :paused, null: false, default: false
+      t.string :paused_reason
+      t.datetime :paused_at
+      t.integer :circuit_breaker_trip_count, default: 0
+      t.datetime :circuit_breaker_resume_at
+      t.timestamps
+    end
+
+    add_index :pgbus_queue_states, :queue_name,
+      unique: true, name: "idx_pgbus_queue_states_queue_name"
+  end
+end

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -63,11 +63,11 @@ module Pgbus
       @configuration = nil
     end
 
-    # Reinitialize the PGMQ client with a fresh connection.
-    # Must be called after fork to avoid inheriting the parent's
-    # PG::Connection which is in undefined state post-fork.
+    # Discard the inherited PGMQ client after fork.
+    # Do NOT call close — the parent's @pgmq_mutex is in undefined
+    # state post-fork and attempting to acquire it can deadlock.
+    # The next call to Pgbus.client will lazily create a fresh one.
     def reset_client!
-      @client&.close
       @client = nil
     end
 

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -63,6 +63,14 @@ module Pgbus
       @configuration = nil
     end
 
+    # Reinitialize the PGMQ client with a fresh connection.
+    # Must be called after fork to avoid inheriting the parent's
+    # PG::Connection which is in undefined state post-fork.
+    def reset_client!
+      @client&.close
+      @client = nil
+    end
+
     def logger
       configuration.logger
     end

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -47,7 +47,7 @@ module Pgbus
             msg_id = Pgbus.client.send_message(queue, payload_hash, delay: delay, priority: priority)
             active_job.provider_job_id = msg_id
           else
-            handle_conflict(concurrency, active_job, key, queue, payload_hash)
+            handle_conflict(concurrency, active_job, key, queue, payload_hash, priority: priority)
           end
         else
           msg_id = Pgbus.client.send_message(queue, payload_hash, delay: delay, priority: priority)
@@ -64,14 +64,14 @@ module Pgbus
         active_job.class.respond_to?(:pgbus_concurrency) && active_job.class.pgbus_concurrency
       end
 
-      def handle_conflict(concurrency, active_job, key, queue, payload_hash)
+      def handle_conflict(concurrency, active_job, key, queue, payload_hash, priority: nil)
         case concurrency[:on_conflict]
         when :block
           Concurrency::BlockedExecution.insert(
             concurrency_key: key,
             queue_name: queue,
             payload: payload_hash,
-            priority: active_job.try(:priority) || 0,
+            priority: priority || Pgbus.configuration.default_priority,
             duration: concurrency[:duration]
           )
         when :discard

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -38,18 +38,19 @@ module Pgbus
       def enqueue_with_concurrency(active_job, queue, payload_hash, delay: 0)
         key = Concurrency.extract_key(payload_hash)
         concurrency = concurrency_config(active_job)
+        priority = active_job.try(:priority)
 
         if key && concurrency
           result = Concurrency::Semaphore.acquire(key, concurrency[:limit], concurrency[:duration])
 
           if result == :acquired
-            msg_id = Pgbus.client.send_message(queue, payload_hash, delay: delay)
+            msg_id = Pgbus.client.send_message(queue, payload_hash, delay: delay, priority: priority)
             active_job.provider_job_id = msg_id
           else
             handle_conflict(concurrency, active_job, key, queue, payload_hash)
           end
         else
-          msg_id = Pgbus.client.send_message(queue, payload_hash, delay: delay)
+          msg_id = Pgbus.client.send_message(queue, payload_hash, delay: delay, priority: priority)
           active_job.provider_job_id = msg_id
         end
 

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -10,12 +10,12 @@ module Pgbus
         @config = config
       end
 
-      def execute(message, queue_name)
+      def execute(message, queue_name, source_queue: nil)
         payload = JSON.parse(message.message)
         read_count = message.read_ct.to_i
 
         if read_count > config.max_retries
-          handle_dead_letter(message, queue_name, payload)
+          handle_dead_letter(message, queue_name, payload, source_queue: source_queue)
           signal_concurrency(payload)
           signal_batch_discarded(payload)
           return :dead_lettered
@@ -28,7 +28,7 @@ module Pgbus
         Instrumentation.instrument("pgbus.executor.execute", queue: queue_name, job_class: job_class) do
           job = ::ActiveJob::Base.deserialize(payload)
           execute_job(job)
-          client.archive_message(queue_name, message.msg_id.to_i)
+          archive_from(queue_name, message.msg_id.to_i, source_queue: source_queue)
           job_succeeded = true
         end
 
@@ -109,12 +109,29 @@ module Pgbus
         Pgbus.logger.warn { "[Pgbus] Batch discard signal failed: #{e.message}" }
       end
 
-      def handle_dead_letter(message, queue_name, payload)
+      def archive_from(queue_name, msg_id, source_queue: nil)
+        if source_queue
+          client.archive_from_queue(source_queue, msg_id)
+        else
+          client.archive_message(queue_name, msg_id)
+        end
+      end
+
+      def handle_dead_letter(message, queue_name, payload, source_queue: nil)
         Pgbus.logger.warn do
           job_class = payload["job_class"] || "unknown"
           "[Pgbus] Moving job #{job_class} to dead letter queue after #{message.read_ct} attempts"
         end
-        client.move_to_dead_letter(queue_name, message)
+        if source_queue
+          client.ensure_dead_letter_queue(queue_name)
+          dlq_name = config.dead_letter_queue_name(queue_name)
+          client.pgmq.transaction do |txn|
+            txn.produce(dlq_name, message.message, headers: message.headers)
+            txn.delete(source_queue, message.msg_id.to_i)
+          end
+        else
+          client.move_to_dead_letter(queue_name, message)
+        end
       end
     end
   end

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -125,7 +125,7 @@ module Pgbus
         if source_queue
           client.ensure_dead_letter_queue(queue_name)
           dlq_name = config.dead_letter_queue_name(queue_name)
-          client.pgmq.transaction do |txn|
+          client.transaction do |txn|
             txn.produce(dlq_name, message.message, headers: message.headers)
             txn.delete(source_queue, message.msg_id.to_i)
           end

--- a/lib/pgbus/circuit_breaker.rb
+++ b/lib/pgbus/circuit_breaker.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Pgbus
+  class CircuitBreaker
+    attr_reader :config
+
+    def initialize(config: Pgbus.configuration)
+      @config = config
+      @failure_counts = Concurrent::Map.new
+      @pause_cache = Concurrent::Map.new
+      @pause_cache_ttl = 30 # seconds
+    end
+
+    def record_success(queue_name)
+      @failure_counts.delete(queue_name)
+    end
+
+    def record_failure(queue_name)
+      return unless config.circuit_breaker_enabled
+
+      count = @failure_counts.compute(queue_name) { |val| (val || 0) + 1 }
+
+      return unless count >= config.circuit_breaker_threshold
+
+      trip!(queue_name, count)
+    end
+
+    def paused?(queue_name)
+      cached = @pause_cache[queue_name]
+      return cached[:paused] if cached && (Time.now - cached[:checked_at]) < @pause_cache_ttl
+
+      paused = check_paused(queue_name)
+      @pause_cache[queue_name] = { paused: paused, checked_at: Time.now }
+      paused
+    end
+
+    def pause!(queue_name, reason: nil)
+      QueueState.pause!(queue_name, reason: reason)
+      invalidate_cache(queue_name)
+    end
+
+    def resume!(queue_name)
+      QueueState.resume!(queue_name)
+      @failure_counts.delete(queue_name)
+      invalidate_cache(queue_name)
+    end
+
+    def invalidate_cache(queue_name = nil)
+      if queue_name
+        @pause_cache.delete(queue_name)
+      else
+        @pause_cache.clear
+      end
+    end
+
+    private
+
+    def trip!(queue_name, failure_count)
+      trip_count = current_trip_count(queue_name) + 1
+      backoff = calculate_backoff(trip_count)
+      resume_at = Time.current + backoff
+
+      Pgbus.logger.warn do
+        "[Pgbus] Circuit breaker tripped for #{queue_name}: #{failure_count} consecutive failures, " \
+          "backoff #{backoff}s (trip ##{trip_count})"
+      end
+
+      QueueState.find_or_initialize_by(queue_name: queue_name).update!(
+        paused: true,
+        paused_reason: "circuit_breaker: #{failure_count} consecutive failures",
+        paused_at: Time.current,
+        circuit_breaker_trip_count: trip_count,
+        circuit_breaker_resume_at: resume_at
+      )
+
+      @failure_counts.delete(queue_name)
+      invalidate_cache(queue_name)
+    rescue StandardError => e
+      Pgbus.logger.error { "[Pgbus] Circuit breaker trip failed for #{queue_name}: #{e.message}" }
+    end
+
+    def check_paused(queue_name)
+      state = QueueState.find_by(queue_name: queue_name)
+      return false unless state&.paused?
+
+      # Auto-resume if circuit breaker backoff has expired
+      if state.circuit_breaker_resume_at && Time.current >= state.circuit_breaker_resume_at
+        state.update!(paused: false, paused_reason: nil, paused_at: nil, circuit_breaker_resume_at: nil)
+        Pgbus.logger.info { "[Pgbus] Circuit breaker auto-resumed #{queue_name}" }
+        return false
+      end
+
+      true
+    rescue StandardError => e
+      Pgbus.logger.warn { "[Pgbus] Circuit breaker pause check failed for #{queue_name}: #{e.message}" }
+      false
+    end
+
+    def current_trip_count(queue_name)
+      QueueState.find_by(queue_name: queue_name)&.circuit_breaker_trip_count || 0
+    rescue StandardError
+      0
+    end
+
+    def calculate_backoff(trip_count)
+      backoff = config.circuit_breaker_base_backoff * (2**(trip_count - 1))
+      [backoff, config.circuit_breaker_max_backoff].min
+    end
+  end
+end

--- a/lib/pgbus/circuit_breaker.rb
+++ b/lib/pgbus/circuit_breaker.rb
@@ -87,7 +87,7 @@ module Pgbus
 
       # Auto-resume if circuit breaker backoff has expired
       if state.circuit_breaker_resume_at && Time.current >= state.circuit_breaker_resume_at
-        state.update!(paused: false, paused_reason: nil, paused_at: nil, circuit_breaker_resume_at: nil)
+        QueueState.resume!(queue_name)
         Pgbus.logger.info { "[Pgbus] Circuit breaker auto-resumed #{queue_name}" }
         return false
       end

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -19,11 +19,18 @@ module Pgbus
         require "pgmq"
       end
       @config = config
+      # Force pool_size=1. PG::Connection (libpq) is not thread-safe.
+      # When using the Rails lambda path (-> { AR::Base.connection.raw_connection }),
+      # the pool would return the same underlying PG::Connection that ActiveRecord
+      # also uses, causing concurrent access corruption (segfaults, result.ntuples
+      # NoMethodError). A single-connection pool combined with @pgmq_mutex ensures
+      # all PGMQ operations are serialized.
       @pgmq = PGMQ::Client.new(
         config.connection_options,
-        pool_size: config.pool_size,
+        pool_size: 1,
         pool_timeout: config.pool_timeout
       )
+      @pgmq_mutex = Mutex.new
       @queues_created = Concurrent::Map.new
     end
 
@@ -43,7 +50,7 @@ module Pgbus
       return if @queues_created[dlq_name]
 
       @queues_created.compute_if_absent(dlq_name) do
-        @pgmq.create(dlq_name)
+        synchronized { @pgmq.create(dlq_name) }
         true
       end
     end
@@ -52,31 +59,31 @@ module Pgbus
       target = resolve_target_queue(queue_name, priority)
       ensure_queue(queue_name)
       Instrumentation.instrument("pgbus.client.send_message", queue: target) do
-        @pgmq.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay)
+        synchronized { @pgmq.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay) }
       end
     end
 
     def send_batch(queue_name, payloads, headers: nil, delay: 0)
       full_name = config.queue_name(queue_name)
       ensure_queue(queue_name)
+      serialized = payloads.map { |p| serialize(p) }
+      serialized_headers = headers&.map { |h| serialize(h) }
       Instrumentation.instrument("pgbus.client.send_batch", queue: full_name, size: payloads.size) do
-        serialized = payloads.map { |p| serialize(p) }
-        serialized_headers = headers&.map { |h| serialize(h) }
-        @pgmq.produce_batch(full_name, serialized, headers: serialized_headers, delay: delay)
+        synchronized { @pgmq.produce_batch(full_name, serialized, headers: serialized_headers, delay: delay) }
       end
     end
 
     def read_message(queue_name, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_message", queue: full_name) do
-        @pgmq.read(full_name, vt: vt || config.visibility_timeout)
+        synchronized { @pgmq.read(full_name, vt: vt || config.visibility_timeout) }
       end
     end
 
     def read_batch(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_batch", queue: full_name, qty: qty) do
-        @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty)
+        synchronized { @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty) }
       end
     end
 
@@ -92,7 +99,7 @@ module Pgbus
         break if remaining <= 0
 
         msgs = Instrumentation.instrument("pgbus.client.read_batch", queue: pq_name, qty: remaining) do
-          @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining)
+          synchronized { @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining) }
         end || []
 
         msgs.each { |m| results << [pq_name, m] }
@@ -104,44 +111,46 @@ module Pgbus
 
     def read_with_poll(queue_name, qty:, vt: nil, max_poll_seconds: 5, poll_interval_ms: 100)
       full_name = config.queue_name(queue_name)
-      @pgmq.read_with_poll(
-        full_name,
-        vt: vt || config.visibility_timeout,
-        qty: qty,
-        max_poll_seconds: max_poll_seconds,
-        poll_interval_ms: poll_interval_ms
-      )
+      synchronized do
+        @pgmq.read_with_poll(
+          full_name,
+          vt: vt || config.visibility_timeout,
+          qty: qty,
+          max_poll_seconds: max_poll_seconds,
+          poll_interval_ms: poll_interval_ms
+        )
+      end
     end
 
     def delete_message(queue_name, msg_id)
       full_name = config.queue_name(queue_name)
-      @pgmq.delete(full_name, msg_id)
+      synchronized { @pgmq.delete(full_name, msg_id) }
     end
 
     def archive_message(queue_name, msg_id)
       full_name = config.queue_name(queue_name)
-      @pgmq.archive(full_name, msg_id)
+      synchronized { @pgmq.archive(full_name, msg_id) }
     end
 
     def archive_from_queue(full_queue_name, msg_id)
-      @pgmq.archive(full_queue_name, msg_id)
+      synchronized { @pgmq.archive(full_queue_name, msg_id) }
     end
 
     def extend_visibility(queue_name, msg_id, vt:)
       full_name = config.queue_name(queue_name)
-      @pgmq.set_vt(full_name, msg_id, vt: vt)
+      synchronized { @pgmq.set_vt(full_name, msg_id, vt: vt) }
     end
 
     def set_visibility_timeout(queue_name, msg_id, vt:)
-      @pgmq.set_vt(queue_name, msg_id, vt: vt)
+      synchronized { @pgmq.set_vt(queue_name, msg_id, vt: vt) }
     end
 
     def delete_from_queue(queue_name, msg_id)
-      @pgmq.delete(queue_name, msg_id)
+      synchronized { @pgmq.delete(queue_name, msg_id) }
     end
 
-    def transaction(&)
-      @pgmq.transaction(&)
+    def transaction(&block)
+      synchronized { @pgmq.transaction(&block) }
     end
 
     def move_to_dead_letter(queue_name, message)
@@ -149,26 +158,30 @@ module Pgbus
       dlq_name = config.dead_letter_queue_name(queue_name)
       full_queue = config.queue_name(queue_name)
 
-      @pgmq.transaction do |txn|
-        txn.produce(dlq_name, message.message, headers: message.headers)
-        txn.delete(full_queue, message.msg_id.to_i)
+      synchronized do
+        @pgmq.transaction do |txn|
+          txn.produce(dlq_name, message.message, headers: message.headers)
+          txn.delete(full_queue, message.msg_id.to_i)
+        end
       end
     end
 
     def metrics(queue_name = nil)
-      if queue_name
-        @pgmq.metrics(config.queue_name(queue_name))
-      else
-        @pgmq.metrics_all
+      synchronized do
+        if queue_name
+          @pgmq.metrics(config.queue_name(queue_name))
+        else
+          @pgmq.metrics_all
+        end
       end
     end
 
     def list_queues
-      @pgmq.list_queues
+      synchronized { @pgmq.list_queues }
     end
 
     def purge_queue(queue_name)
-      @pgmq.purge_queue(config.queue_name(queue_name))
+      synchronized { @pgmq.purge_queue(config.queue_name(queue_name)) }
     end
 
     def purge_archive(queue_name, older_than:, batch_size: 1000)
@@ -176,12 +189,12 @@ module Pgbus
       sanitized = full_name.gsub(/[^a-zA-Z0-9_]/, "")
       total = 0
 
+      sql = "DELETE FROM pgmq.a_#{sanitized} " \
+            "WHERE ctid = ANY(ARRAY(SELECT ctid FROM pgmq.a_#{sanitized} WHERE enqueued_at < $1 LIMIT $2))"
+
       loop do
-        deleted = @pgmq.pool.with do |conn|
-          conn.exec_params(
-            "DELETE FROM pgmq.a_#{sanitized} WHERE ctid = ANY(ARRAY(SELECT ctid FROM pgmq.a_#{sanitized} WHERE enqueued_at < $1 LIMIT $2))",
-            [older_than, batch_size]
-          ).cmd_tuples
+        deleted = synchronized do
+          @pgmq.pool.with { |conn| conn.exec_params(sql, [older_than, batch_size]).cmd_tuples }
         end
         total += deleted
         break if deleted < batch_size
@@ -194,20 +207,22 @@ module Pgbus
     def bind_topic(pattern, queue_name)
       full_name = config.queue_name(queue_name)
       ensure_queue(queue_name)
-      @pgmq.bind_topic(pattern, full_name)
+      synchronized { @pgmq.bind_topic(pattern, full_name) }
     end
 
     def publish_to_topic(routing_key, payload, headers: nil, delay: 0)
-      @pgmq.produce_topic(
-        routing_key,
-        serialize(payload),
-        headers: headers && serialize(headers),
-        delay: delay
-      )
+      synchronized do
+        @pgmq.produce_topic(
+          routing_key,
+          serialize(payload),
+          headers: headers && serialize(headers),
+          delay: delay
+        )
+      end
     end
 
     def close
-      @pgmq.close
+      synchronized { @pgmq.close }
     end
 
     private
@@ -216,8 +231,10 @@ module Pgbus
       return if @queues_created[full_name]
 
       @queues_created.compute_if_absent(full_name) do
-        @pgmq.create(full_name)
-        @pgmq.enable_notify_insert(full_name, throttle_interval_ms: config.notify_throttle_ms) if config.listen_notify
+        synchronized do
+          @pgmq.create(full_name)
+          @pgmq.enable_notify_insert(full_name, throttle_interval_ms: config.notify_throttle_ms) if config.listen_notify
+        end
         true
       end
     end
@@ -235,6 +252,13 @@ module Pgbus
       else
         config.queue_name(queue_name)
       end
+    end
+
+    # Serialize all PGMQ operations through a single mutex.
+    # PG::Connection is not thread-safe — concurrent access from worker
+    # threads causes segfaults and result corruption.
+    def synchronized(&)
+      @pgmq_mutex.synchronize(&)
     end
 
     def serialize(data)

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -90,7 +90,7 @@ module Pgbus
     # Read from priority sub-queues, highest priority (p0) first.
     # Returns [priority_queue_name, messages] pairs.
     def read_batch_prioritized(queue_name, qty:, vt: nil)
-      return read_batch(queue_name, qty: qty, vt: vt)&.map { |m| [config.queue_name(queue_name), m] } unless priority_enabled?
+      return (read_batch(queue_name, qty: qty, vt: vt) || []).map { |m| [config.queue_name(queue_name), m] } unless priority_enabled?
 
       remaining = qty
       results = []

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -28,13 +28,10 @@ module Pgbus
     end
 
     def ensure_queue(name)
-      full_name = config.queue_name(name)
-      return if @queues_created[full_name]
-
-      @queues_created.compute_if_absent(full_name) do
-        @pgmq.create(full_name)
-        @pgmq.enable_notify_insert(full_name, throttle_interval_ms: config.notify_throttle_ms) if config.listen_notify
-        true
+      if priority_enabled?
+        config.priority_queue_names(name).each { |pq| ensure_single_queue(pq) }
+      else
+        ensure_single_queue(config.queue_name(name))
       end
     rescue PGMQ::Errors::ConnectionError => e
       raise Pgbus::SchemaNotReady,
@@ -51,11 +48,11 @@ module Pgbus
       end
     end
 
-    def send_message(queue_name, payload, headers: nil, delay: 0)
-      full_name = config.queue_name(queue_name)
+    def send_message(queue_name, payload, headers: nil, delay: 0, priority: nil)
+      target = resolve_target_queue(queue_name, priority)
       ensure_queue(queue_name)
-      Instrumentation.instrument("pgbus.client.send_message", queue: full_name) do
-        @pgmq.produce(full_name, serialize(payload), headers: headers && serialize(headers), delay: delay)
+      Instrumentation.instrument("pgbus.client.send_message", queue: target) do
+        @pgmq.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay)
       end
     end
 
@@ -83,6 +80,28 @@ module Pgbus
       end
     end
 
+    # Read from priority sub-queues, highest priority (p0) first.
+    # Returns [priority_queue_name, messages] pairs.
+    def read_batch_prioritized(queue_name, qty:, vt: nil)
+      return read_batch(queue_name, qty: qty, vt: vt)&.map { |m| [config.queue_name(queue_name), m] } unless priority_enabled?
+
+      remaining = qty
+      results = []
+
+      config.priority_queue_names(queue_name).each do |pq_name|
+        break if remaining <= 0
+
+        msgs = Instrumentation.instrument("pgbus.client.read_batch", queue: pq_name, qty: remaining) do
+          @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining)
+        end || []
+
+        msgs.each { |m| results << [pq_name, m] }
+        remaining -= msgs.size
+      end
+
+      results
+    end
+
     def read_with_poll(queue_name, qty:, vt: nil, max_poll_seconds: 5, poll_interval_ms: 100)
       full_name = config.queue_name(queue_name)
       @pgmq.read_with_poll(
@@ -102,6 +121,10 @@ module Pgbus
     def archive_message(queue_name, msg_id)
       full_name = config.queue_name(queue_name)
       @pgmq.archive(full_name, msg_id)
+    end
+
+    def archive_from_queue(full_queue_name, msg_id)
+      @pgmq.archive(full_queue_name, msg_id)
     end
 
     def extend_visibility(queue_name, msg_id, vt:)
@@ -148,6 +171,25 @@ module Pgbus
       @pgmq.purge_queue(config.queue_name(queue_name))
     end
 
+    def purge_archive(queue_name, older_than:, batch_size: 1000)
+      full_name = config.queue_name(queue_name)
+      sanitized = full_name.gsub(/[^a-zA-Z0-9_]/, "")
+      total = 0
+
+      loop do
+        deleted = @pgmq.pool.with do |conn|
+          conn.exec_params(
+            "DELETE FROM pgmq.a_#{sanitized} WHERE ctid = ANY(ARRAY(SELECT ctid FROM pgmq.a_#{sanitized} WHERE enqueued_at < $1 LIMIT $2))",
+            [older_than, batch_size]
+          ).cmd_tuples
+        end
+        total += deleted
+        break if deleted < batch_size
+      end
+
+      total
+    end
+
     # Topic routing
     def bind_topic(pattern, queue_name)
       full_name = config.queue_name(queue_name)
@@ -169,6 +211,31 @@ module Pgbus
     end
 
     private
+
+    def ensure_single_queue(full_name)
+      return if @queues_created[full_name]
+
+      @queues_created.compute_if_absent(full_name) do
+        @pgmq.create(full_name)
+        @pgmq.enable_notify_insert(full_name, throttle_interval_ms: config.notify_throttle_ms) if config.listen_notify
+        true
+      end
+    end
+
+    def priority_enabled?
+      config.priority_levels && config.priority_levels > 1
+    end
+
+    def resolve_target_queue(queue_name, priority)
+      if priority_enabled? && priority
+        clamped = priority.clamp(0, config.priority_levels - 1)
+        config.priority_queue_name(queue_name, clamped)
+      elsif priority_enabled?
+        config.priority_queue_name(queue_name, config.default_priority.clamp(0, config.priority_levels - 1))
+      else
+        config.queue_name(queue_name)
+      end
+    end
 
     def serialize(data)
       case data

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -11,7 +11,7 @@ module Pgbus
     attr_accessor :default_queue, :queue_prefix
 
     # Worker settings
-    attr_accessor :workers, :polling_interval, :visibility_timeout
+    attr_accessor :workers, :polling_interval, :visibility_timeout, :prefetch_limit
 
     # Worker recycling
     attr_accessor :max_jobs_per_worker, :max_memory_mb, :max_worker_lifetime
@@ -19,8 +19,21 @@ module Pgbus
     # Dispatcher settings
     attr_accessor :dispatch_interval
 
+    # Circuit breaker
+    attr_accessor :circuit_breaker_enabled, :circuit_breaker_threshold,
+                  :circuit_breaker_base_backoff, :circuit_breaker_max_backoff
+
     # Dead letter queue
     attr_accessor :max_retries, :dead_letter_queue_suffix
+
+    # Priority queues
+    attr_accessor :priority_levels, :default_priority
+
+    # Archive compaction
+    attr_accessor :archive_retention, :archive_compaction_interval, :archive_compaction_batch_size
+
+    # Transactional outbox
+    attr_accessor :outbox_enabled, :outbox_poll_interval, :outbox_batch_size, :outbox_retention
 
     # Event bus
     attr_accessor :idempotency_ttl
@@ -62,14 +75,33 @@ module Pgbus
       @polling_interval = 0.1
       @visibility_timeout = 30
 
+      @prefetch_limit = nil
+
       @max_jobs_per_worker = nil
       @max_memory_mb = nil
       @max_worker_lifetime = nil
 
       @dispatch_interval = 1.0
 
+      @circuit_breaker_enabled = true
+      @circuit_breaker_threshold = 5
+      @circuit_breaker_base_backoff = 30
+      @circuit_breaker_max_backoff = 600
+
       @max_retries = 5
       @dead_letter_queue_suffix = "_dlq"
+
+      @priority_levels = nil
+      @default_priority = 1
+
+      @archive_retention = 7 * 24 * 3600 # 7 days
+      @archive_compaction_interval = 3600
+      @archive_compaction_batch_size = 1000
+
+      @outbox_enabled = false
+      @outbox_poll_interval = 1.0
+      @outbox_batch_size = 100
+      @outbox_retention = 24 * 3600 # 1 day
 
       @idempotency_ttl = 7 * 24 * 3600 # 7 days
 
@@ -105,6 +137,16 @@ module Pgbus
       "#{queue_name(name)}#{dead_letter_queue_suffix}"
     end
 
+    def priority_queue_name(name, priority)
+      "#{queue_name(name)}_p#{priority}"
+    end
+
+    def priority_queue_names(name)
+      return [queue_name(name)] unless priority_levels && priority_levels > 1
+
+      (0...priority_levels).map { |p| priority_queue_name(name, p) }
+    end
+
     VALID_PGMQ_SCHEMA_MODES = %i[auto extension embedded].freeze
 
     def pgmq_schema_mode=(mode)
@@ -126,6 +168,12 @@ module Pgbus
       workers.each do |w|
         threads = w[:threads] || w["threads"] || 5
         raise ArgumentError, "worker threads must be > 0" unless threads.is_a?(Integer) && threads.positive?
+      end
+
+      raise ArgumentError, "prefetch_limit must be > 0" if prefetch_limit && !(prefetch_limit.is_a?(Integer) && prefetch_limit.positive?)
+
+      if priority_levels && !(priority_levels.is_a?(Integer) && priority_levels >= 1 && priority_levels <= 10)
+        raise ArgumentError, "priority_levels must be an integer between 1 and 10"
       end
 
       self

--- a/lib/pgbus/dedup_cache.rb
+++ b/lib/pgbus/dedup_cache.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Pgbus
+  # Thread-safe in-memory dedup cache with TTL.
+  # Sits in front of the pgbus_processed_events table to avoid
+  # hitting the database for recently-seen (event_id, handler_class) pairs.
+  #
+  # Inspired by LavinMQ's built-in message deduplication with LRU + TTL.
+  class DedupCache
+    DEFAULT_MAX_SIZE = 10_000
+    DEFAULT_TTL = 300 # 5 minutes
+
+    def initialize(max_size: DEFAULT_MAX_SIZE, ttl: DEFAULT_TTL)
+      @max_size = max_size
+      @ttl = ttl
+      @cache = Concurrent::Map.new
+      @insertion_order = Concurrent::Array.new
+    end
+
+    # Returns true if this key was already seen (duplicate).
+    # Returns false if it's new (first time seen — caller should proceed).
+    def seen?(key)
+      entry = @cache[key]
+      return false unless entry
+
+      if expired?(entry)
+        evict(key)
+        return false
+      end
+
+      true
+    end
+
+    # Mark a key as seen. Call this after successfully claiming idempotency
+    # in the database so future lookups skip the DB.
+    def mark!(key)
+      evict_oldest if @cache.size >= @max_size
+
+      @cache[key] = monotonic_now
+      @insertion_order << key
+    end
+
+    def size
+      @cache.size
+    end
+
+    def clear!
+      @cache.clear
+      @insertion_order.clear
+    end
+
+    private
+
+    def expired?(timestamp)
+      (monotonic_now - timestamp) > @ttl
+    end
+
+    def evict(key)
+      @cache.delete(key)
+    end
+
+    def evict_oldest
+      while @cache.size >= @max_size && !@insertion_order.empty?
+        oldest_key = @insertion_order.shift
+        @cache.delete(oldest_key)
+      end
+    end
+
+    def monotonic_now
+      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/pgbus/dedup_cache.rb
+++ b/lib/pgbus/dedup_cache.rb
@@ -36,10 +36,11 @@ module Pgbus
     # Mark a key as seen. Call this after successfully claiming idempotency
     # in the database so future lookups skip the DB.
     def mark!(key)
-      evict_oldest if @cache.size >= @max_size
+      already_present = @cache.key?(key)
+      evict_oldest if !already_present && @cache.size >= @max_size
 
       @cache[key] = monotonic_now
-      @insertion_order << key
+      @insertion_order << key unless already_present
     end
 
     def size

--- a/lib/pgbus/event_bus/handler.rb
+++ b/lib/pgbus/event_bus/handler.rb
@@ -11,6 +11,10 @@ module Pgbus
         def idempotent?
           @idempotent == true
         end
+
+        def dedup_cache
+          @dedup_cache ||= DedupCache.new
+        end
       end
 
       def process(message)
@@ -50,13 +54,20 @@ module Pgbus
       # Atomically claim idempotency: INSERT ... ON CONFLICT DO NOTHING.
       # Returns true if this handler claimed the event (row was inserted),
       # false if another handler already processed it (conflict, no insert).
+      #
+      # Uses an in-memory dedup cache to skip the DB for recently-seen events.
       def claim_idempotency?(event_id)
+        cache_key = "#{event_id}:#{self.class.name}"
+        return false if self.class.dedup_cache.seen?(cache_key)
+
         result = ProcessedEvent.insert(
           { event_id: event_id, handler_class: self.class.name, processed_at: Time.now.utc },
           unique_by: %i[event_id handler_class]
         )
-        # insert returns an InsertAll::Result; inserted row count > 0 means we claimed it
-        result.rows.any?
+
+        claimed = result.rows.any?
+        self.class.dedup_cache.mark!(cache_key)
+        claimed
       end
     end
   end

--- a/lib/pgbus/outbox.rb
+++ b/lib/pgbus/outbox.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Outbox
+    module_function
+
+    def publish(queue_name, payload, headers: nil, priority: nil, delay: 0)
+      OutboxEntry.create!(
+        queue_name: queue_name,
+        payload: payload,
+        headers: headers,
+        priority: priority || Pgbus.configuration.default_priority,
+        delay: delay
+      )
+    end
+
+    def publish_event(routing_key, payload, headers: nil)
+      event_data = EventBus::Publisher.build_event_data(payload)
+      OutboxEntry.create!(
+        routing_key: routing_key,
+        payload: event_data,
+        headers: headers
+      )
+    end
+
+    def flush!
+      Poller.new.poll_and_publish
+    end
+  end
+end

--- a/lib/pgbus/outbox/poller.rb
+++ b/lib/pgbus/outbox/poller.rb
@@ -44,19 +44,25 @@ module Pgbus
         published = 0
 
         loop do
-          entries = OutboxEntry.unpublished
-                               .order(:id)
-                               .limit(config.outbox_batch_size)
-                               .lock("FOR UPDATE SKIP LOCKED")
-                               .to_a
-          break if entries.empty?
+          succeeded = 0
 
-          entries.each do |entry|
-            publish_entry(entry)
-            published += 1
+          OutboxEntry.transaction do
+            entries = OutboxEntry.unpublished
+                                 .order(:id)
+                                 .limit(config.outbox_batch_size)
+                                 .lock("FOR UPDATE SKIP LOCKED")
+                                 .to_a
+            break if entries.empty?
+
+            entries.each do |entry|
+              succeeded += 1 if publish_entry(entry)
+            end
+
+            published += succeeded
+            break if succeeded.zero? || entries.size < config.outbox_batch_size
           end
 
-          break if entries.size < config.outbox_batch_size
+          break if succeeded.zero?
         end
 
         Pgbus.logger.debug { "[Pgbus] Outbox published #{published} entries" } if published.positive?
@@ -86,8 +92,10 @@ module Pgbus
         end
 
         entry.update!(published_at: Time.current)
+        true
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Failed to publish outbox entry #{entry.id}: #{e.message}" }
+        false
       end
 
       def start_heartbeat

--- a/lib/pgbus/outbox/poller.rb
+++ b/lib/pgbus/outbox/poller.rb
@@ -79,7 +79,8 @@ module Pgbus
           Pgbus.client.publish_to_topic(
             entry.routing_key,
             entry.payload,
-            headers: entry.headers
+            headers: entry.headers,
+            delay: entry.delay || 0
           )
         else
           Pgbus.client.send_message(

--- a/lib/pgbus/outbox/poller.rb
+++ b/lib/pgbus/outbox/poller.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Outbox
+    class Poller
+      include Process::SignalHandler
+
+      attr_reader :config
+
+      def initialize(config: Pgbus.configuration)
+        @config = config
+        @shutting_down = false
+      end
+
+      def run
+        setup_signals
+        start_heartbeat
+        Pgbus.logger.info { "[Pgbus] Outbox poller started: interval=#{config.outbox_poll_interval}s" }
+
+        loop do
+          break if @shutting_down
+
+          process_signals
+          break if @shutting_down
+
+          poll_and_publish
+          break if @shutting_down
+
+          interruptible_sleep(config.outbox_poll_interval)
+        end
+
+        shutdown
+      end
+
+      def graceful_shutdown
+        @shutting_down = true
+      end
+
+      def immediate_shutdown
+        @shutting_down = true
+      end
+
+      def poll_and_publish
+        published = 0
+
+        loop do
+          entries = OutboxEntry.unpublished
+                               .order(:id)
+                               .limit(config.outbox_batch_size)
+                               .lock("FOR UPDATE SKIP LOCKED")
+                               .to_a
+          break if entries.empty?
+
+          entries.each do |entry|
+            publish_entry(entry)
+            published += 1
+          end
+
+          break if entries.size < config.outbox_batch_size
+        end
+
+        Pgbus.logger.debug { "[Pgbus] Outbox published #{published} entries" } if published.positive?
+        published
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus] Outbox poll error: #{e.message}" }
+        0
+      end
+
+      private
+
+      def publish_entry(entry)
+        if entry.routing_key.present?
+          Pgbus.client.publish_to_topic(
+            entry.routing_key,
+            entry.payload,
+            headers: entry.headers
+          )
+        else
+          Pgbus.client.send_message(
+            entry.queue_name,
+            entry.payload,
+            headers: entry.headers,
+            delay: entry.delay || 0,
+            priority: entry.priority
+          )
+        end
+
+        entry.update!(published_at: Time.current)
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus] Failed to publish outbox entry #{entry.id}: #{e.message}" }
+      end
+
+      def start_heartbeat
+        @heartbeat = Process::Heartbeat.new(
+          kind: "outbox_poller",
+          metadata: { pid: ::Process.pid }
+        )
+        @heartbeat.start
+      end
+
+      def shutdown
+        @heartbeat&.stop
+        restore_signals
+        Pgbus.logger.info { "[Pgbus] Outbox poller stopped" }
+      end
+    end
+  end
+end

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -11,6 +11,8 @@ module Pgbus
       CONCURRENCY_INTERVAL = 300            # Run concurrency cleanup every 5 minutes
       BATCH_CLEANUP_INTERVAL = 3600         # Run batch cleanup every hour
       RECURRING_CLEANUP_INTERVAL = 3600     # Run recurring execution cleanup every hour
+      ARCHIVE_COMPACTION_INTERVAL = 3600    # Run archive compaction every hour
+      OUTBOX_CLEANUP_INTERVAL = 3600 # Run outbox cleanup every hour
 
       attr_reader :config
 
@@ -22,6 +24,8 @@ module Pgbus
         @last_concurrency_at = Time.now
         @last_batch_cleanup_at = Time.now
         @last_recurring_cleanup_at = Time.now
+        @last_archive_compaction_at = Time.now
+        @last_outbox_cleanup_at = Time.now
       end
 
       def run
@@ -64,6 +68,8 @@ module Pgbus
         run_if_due(now, :@last_concurrency_at, CONCURRENCY_INTERVAL) { cleanup_concurrency }
         run_if_due(now, :@last_batch_cleanup_at, BATCH_CLEANUP_INTERVAL) { cleanup_batches }
         run_if_due(now, :@last_recurring_cleanup_at, RECURRING_CLEANUP_INTERVAL) { cleanup_recurring_executions }
+        run_if_due(now, :@last_archive_compaction_at, archive_compaction_interval) { compact_archives }
+        run_if_due(now, :@last_outbox_cleanup_at, OUTBOX_CLEANUP_INTERVAL) { cleanup_outbox }
       end
 
       # Only update the timestamp when the block succeeds.
@@ -119,6 +125,46 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} finished batches" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Batch cleanup failed: #{e.message}" }
+      end
+
+      def cleanup_outbox
+        return unless config.outbox_enabled
+
+        retention = config.outbox_retention
+        return unless retention&.positive?
+
+        deleted = OutboxEntry.published_before(Time.now.utc - retention).delete_all
+        Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} published outbox entries" } if deleted.positive?
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Outbox cleanup failed: #{e.message}" }
+      end
+
+      def archive_compaction_interval
+        config.archive_compaction_interval || ARCHIVE_COMPACTION_INTERVAL
+      end
+
+      def compact_archives
+        retention = config.archive_retention
+        return unless retention&.positive?
+
+        cutoff = Time.now.utc - retention
+        batch_size = config.archive_compaction_batch_size || 1000
+        prefix = config.queue_prefix
+
+        conn = Pgbus.configuration.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
+        queue_names = conn.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
+
+        queue_names.each do |full_name|
+          next unless full_name.start_with?("#{prefix}_")
+
+          stripped = full_name.delete_prefix("#{prefix}_")
+          deleted = Pgbus.client.purge_archive(stripped, older_than: cutoff, batch_size: batch_size)
+          Pgbus.logger.debug { "[Pgbus] Compacted #{deleted} archive entries from #{full_name}" } if deleted.positive?
+        rescue StandardError => e
+          Pgbus.logger.warn { "[Pgbus] Archive compaction failed for #{full_name}: #{e.message}" }
+        end
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Archive compaction failed: #{e.message}" }
       end
 
       def cleanup_recurring_executions

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -151,7 +151,7 @@ module Pgbus
         batch_size = config.archive_compaction_batch_size || 1000
         prefix = config.queue_prefix
 
-        conn = Pgbus.configuration.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
+        conn = config.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
         queue_names = conn.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
 
         queue_names.each do |full_name|

--- a/lib/pgbus/process/heartbeat.rb
+++ b/lib/pgbus/process/heartbeat.rb
@@ -11,9 +11,10 @@ module Pgbus
 
       attr_reader :process_entry
 
-      def initialize(kind:, metadata: {})
+      def initialize(kind:, metadata: {}, on_beat: nil)
         @kind = kind
         @metadata = metadata
+        @on_beat = on_beat
         @timer = nil
       end
 
@@ -31,6 +32,7 @@ module Pgbus
       def beat
         return unless @process_id
 
+        @on_beat&.call
         ProcessEntry.where(id: @process_id).update_all(last_heartbeat_at: Time.current)
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Heartbeat failed: #{e.message}" }

--- a/lib/pgbus/process/lifecycle.rb
+++ b/lib/pgbus/process/lifecycle.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Pgbus
+  module Process
+    # Thread-safe worker lifecycle state machine inspired by LavinMQ's QueueState.
+    #
+    # States:
+    #   :starting  → initial state, setting up
+    #   :running   → actively processing messages
+    #   :paused    → temporarily stopped (manual or circuit breaker)
+    #   :draining  → finishing in-flight work before stopping
+    #   :stopped   → terminal state
+    #
+    # Transitions:
+    #   starting → running
+    #   running  → paused | draining | stopped
+    #   paused   → running | draining | stopped
+    #   draining → stopped
+    class Lifecycle
+      STATES = %i[starting running paused draining stopped].freeze
+
+      TRANSITIONS = {
+        starting: %i[running stopped],
+        running: %i[paused draining stopped],
+        paused: %i[running draining stopped],
+        draining: %i[stopped],
+        stopped: []
+      }.freeze
+
+      attr_reader :state
+
+      def initialize
+        @state = :starting
+        @mutex = Mutex.new
+        @callbacks = Hash.new { |h, k| h[k] = [] }
+      end
+
+      def transition_to!(new_state)
+        @mutex.synchronize do
+          validate_transition!(new_state)
+          old_state = @state
+          @state = new_state
+          fire_callbacks(old_state, new_state)
+          new_state
+        end
+      end
+
+      def transition_to(new_state)
+        transition_to!(new_state)
+      rescue InvalidTransition
+        false
+      end
+
+      def on(event, &block)
+        @callbacks[event] << block
+      end
+
+      def starting?
+        @state == :starting
+      end
+
+      def running?
+        @state == :running
+      end
+
+      def paused?
+        @state == :paused
+      end
+
+      def draining?
+        @state == :draining
+      end
+
+      def stopped?
+        @state == :stopped
+      end
+
+      def active?
+        running? || paused?
+      end
+
+      def can_process?
+        running?
+      end
+
+      def terminal?
+        stopped?
+      end
+
+      private
+
+      def validate_transition!(new_state)
+        raise ArgumentError, "Unknown state: #{new_state}. Valid states: #{STATES.join(", ")}" unless STATES.include?(new_state)
+
+        return if TRANSITIONS[@state].include?(new_state)
+
+        raise InvalidTransition, "Cannot transition from #{@state} to #{new_state}. " \
+                                 "Valid transitions: #{TRANSITIONS[@state].join(", ")}"
+      end
+
+      def fire_callbacks(old_state, new_state)
+        @callbacks[:"#{old_state}_to_#{new_state}"].each(&:call)
+        @callbacks[:any].each { |cb| cb.call(old_state, new_state) }
+      end
+    end
+
+    class InvalidTransition < Pgbus::Error; end
+  end
+end

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -66,7 +66,7 @@ module Pgbus
 
         pid = fork do
           restore_signals
-          setup_child_signals
+          setup_child_process
           load_rails_app
           worker = Worker.new(queues: queues, threads: threads, config: config)
           worker.run
@@ -86,7 +86,7 @@ module Pgbus
       def fork_dispatcher
         pid = fork do
           restore_signals
-          setup_child_signals
+          setup_child_process
           load_rails_app
           dispatcher = Dispatcher.new(config: config)
           dispatcher.run
@@ -113,7 +113,7 @@ module Pgbus
       def fork_scheduler
         pid = fork do
           restore_signals
-          setup_child_signals
+          setup_child_process
           load_rails_app
           load_recurring_config
           scheduler = Recurring::Scheduler.new(config: config)
@@ -168,7 +168,7 @@ module Pgbus
 
         pid = fork do
           restore_signals
-          setup_child_signals
+          setup_child_process
           load_rails_app
           consumer = Consumer.new(topics: topics, threads: threads, config: config)
           consumer.run
@@ -194,7 +194,7 @@ module Pgbus
       def fork_outbox_poller
         pid = fork do
           restore_signals
-          setup_child_signals
+          setup_child_process
           load_rails_app
           poller = Outbox::Poller.new(config: config)
           poller.run
@@ -265,7 +265,11 @@ module Pgbus
         end
       end
 
-      def setup_child_signals
+      def setup_child_process
+        # Reset the PGMQ client so this forked process gets a fresh
+        # PG::Connection instead of inheriting the parent's (which is
+        # in undefined state post-fork and not thread-safe to share).
+        Pgbus.reset_client!
         %w[INT TERM QUIT].each do |sig|
           trap(sig) { @shutting_down = true }
         end

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -55,6 +55,9 @@ module Pgbus
 
         # Boot event consumers if configured
         boot_consumers
+
+        # Boot outbox poller if configured
+        boot_outbox_poller
       end
 
       def fork_worker(worker_config)
@@ -182,6 +185,32 @@ module Pgbus
         Pgbus.logger.error { "[Pgbus] Fork failed for consumer: #{e.message}" }
       end
 
+      def boot_outbox_poller
+        return unless config.outbox_enabled
+
+        fork_outbox_poller
+      end
+
+      def fork_outbox_poller
+        pid = fork do
+          restore_signals
+          setup_child_signals
+          load_rails_app
+          poller = Outbox::Poller.new(config: config)
+          poller.run
+        end
+
+        unless pid
+          Pgbus.logger.error { "[Pgbus] Failed to fork outbox poller" }
+          return
+        end
+
+        @forks[pid] = { type: :outbox_poller }
+        Pgbus.logger.info { "[Pgbus] Forked outbox poller pid=#{pid}" }
+      rescue Errno::EAGAIN, Errno::ENOMEM => e
+        Pgbus.logger.error { "[Pgbus] Fork failed for outbox poller: #{e.message}" }
+      end
+
       def monitor_loop
         loop do
           break if @shutting_down && @forks.empty?
@@ -223,6 +252,8 @@ module Pgbus
           fork_scheduler
         when :consumer
           fork_consumer(info[:config])
+        when :outbox_poller
+          fork_outbox_poller
         end
       end
 

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -16,13 +16,20 @@ module Pgbus
         @shutting_down = false
         @jobs_processed = Concurrent::AtomicFixnum.new(0)
         @jobs_failed = Concurrent::AtomicFixnum.new(0)
+        @in_flight = Concurrent::AtomicFixnum.new(0)
         @started_at = Time.now
         @executor = Pgbus::ActiveJob::Executor.new
         @pool = Concurrent::FixedThreadPool.new(threads)
+        @circuit_breaker = Pgbus::CircuitBreaker.new(config: config)
       end
 
       def stats
-        { jobs_processed: @jobs_processed.value, jobs_failed: @jobs_failed.value, started_at: @started_at }
+        {
+          jobs_processed: @jobs_processed.value,
+          jobs_failed: @jobs_failed.value,
+          in_flight: @in_flight.value,
+          started_at: @started_at
+        }
       end
 
       def run
@@ -60,6 +67,13 @@ module Pgbus
         idle = @pool.max_length - @pool.queue_length
         return interruptible_sleep(config.polling_interval) if idle <= 0
 
+        if config.prefetch_limit
+          available = config.prefetch_limit - @in_flight.value
+          return interruptible_sleep(config.polling_interval) if available <= 0
+
+          idle = [idle, available].min
+        end
+
         tagged_messages = fetch_messages(idle)
 
         if tagged_messages.empty?
@@ -67,21 +81,27 @@ module Pgbus
           return
         end
 
-        tagged_messages.each do |queue_name, message|
-          @pool.post { process_message(message, queue_name) }
+        tagged_messages.each do |queue_name, message, source_queue|
+          @in_flight.increment
+          @pool.post { process_message(message, queue_name, source_queue: source_queue) }
         end
       end
 
       # Returns an array of [queue_name, message] pairs so we always know
       # which queue each message came from (PGMQ messages don't carry this).
       def fetch_messages(qty)
-        if queues.size == 1
-          queue = queues.first
+        active_queues = queues.reject { |q| @circuit_breaker.paused?(q) }
+        return [] if active_queues.empty?
+
+        if priority_enabled?
+          fetch_prioritized(active_queues, qty)
+        elsif active_queues.size == 1
+          queue = active_queues.first
           messages = Pgbus.client.read_batch(queue, qty: qty) || []
           messages.map { |m| [queue, m] }
         else
-          per_queue = [(qty / queues.size.to_f).ceil, 1].max
-          queues.flat_map do |q|
+          per_queue = [(qty / active_queues.size.to_f).ceil, 1].max
+          active_queues.flat_map do |q|
             (Pgbus.client.read_batch(q, qty: per_queue) || []).map { |m| [q, m] }
           end.first(qty)
         end
@@ -90,13 +110,42 @@ module Pgbus
         []
       end
 
-      def process_message(message, queue_name)
-        result = @executor.execute(message, queue_name)
+      def fetch_prioritized(active_queues, qty)
+        remaining = qty
+        results = []
+
+        active_queues.each do |q|
+          break if remaining <= 0
+
+          batch = Pgbus.client.read_batch_prioritized(q, qty: remaining)
+          batch.each do |physical_queue, message|
+            results << [q, message, physical_queue]
+          end
+          remaining -= batch.size
+        end
+
+        results
+      end
+
+      def priority_enabled?
+        config.priority_levels && config.priority_levels > 1
+      end
+
+      def process_message(message, queue_name, source_queue: nil)
+        result = @executor.execute(message, queue_name, source_queue: source_queue)
         @jobs_processed.increment
-        @jobs_failed.increment if result == :failed
+        if result == :failed
+          @jobs_failed.increment
+          @circuit_breaker.record_failure(queue_name)
+        else
+          @circuit_breaker.record_success(queue_name)
+        end
       rescue StandardError => e
         @jobs_failed.increment
+        @circuit_breaker.record_failure(queue_name)
         Pgbus.logger.error { "[Pgbus] Unhandled error processing message: #{e.message}" }
+      ensure
+        @in_flight.decrement
       end
 
       # Resolve "*" to all non-DLQ queues from pgmq.meta, stripping the prefix.

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -13,10 +13,11 @@ module Pgbus
         @queues = Array(queues)
         @threads = threads
         @config = config
-        @shutting_down = false
+        @lifecycle = Lifecycle.new
         @jobs_processed = Concurrent::AtomicFixnum.new(0)
         @jobs_failed = Concurrent::AtomicFixnum.new(0)
         @in_flight = Concurrent::AtomicFixnum.new(0)
+        @rate_counter = RateCounter.new(:processed, :failed, :dequeued)
         @started_at = Time.now
         @executor = Pgbus::ActiveJob::Executor.new
         @pool = Concurrent::FixedThreadPool.new(threads)
@@ -28,6 +29,8 @@ module Pgbus
           jobs_processed: @jobs_processed.value,
           jobs_failed: @jobs_failed.value,
           in_flight: @in_flight.value,
+          state: @lifecycle.state,
+          rates: @rate_counter.rates,
           started_at: @started_at
         }
       end
@@ -36,15 +39,18 @@ module Pgbus
         setup_signals
         start_heartbeat
         resolve_wildcard_queues
+        @lifecycle.transition_to!(:running)
         Pgbus.logger.info { "[Pgbus] Worker started: queues=#{queues.join(",")} threads=#{threads} pid=#{::Process.pid}" }
 
         loop do
           process_signals
-          break if @shutting_down && @pool.queue_length.zero?
-          break if recycle_needed? && @pool.queue_length.zero?
+          check_recycle
 
-          claim_and_execute unless @shutting_down || recycle_needed?
-          interruptible_sleep(config.polling_interval) if (@shutting_down || recycle_needed?) && !@pool.queue_length.zero?
+          break if @lifecycle.stopped?
+          break if @lifecycle.draining? && @pool.queue_length.zero?
+
+          claim_and_execute if @lifecycle.can_process?
+          interruptible_sleep(config.polling_interval) if @lifecycle.draining? || @lifecycle.paused?
         end
 
         shutdown
@@ -52,12 +58,12 @@ module Pgbus
 
       def graceful_shutdown
         Pgbus.logger.info { "[Pgbus] Worker shutting down gracefully..." }
-        @shutting_down = true
+        @lifecycle.transition_to(:draining)
       end
 
       def immediate_shutdown
         Pgbus.logger.warn { "[Pgbus] Worker shutting down immediately!" }
-        @shutting_down = true
+        @lifecycle.transition_to!(:stopped)
         @pool.kill
       end
 
@@ -81,6 +87,7 @@ module Pgbus
           return
         end
 
+        @rate_counter.increment(:dequeued, tagged_messages.size)
         tagged_messages.each do |queue_name, message, source_queue|
           @in_flight.increment
           @pool.post { process_message(message, queue_name, source_queue: source_queue) }
@@ -134,14 +141,17 @@ module Pgbus
       def process_message(message, queue_name, source_queue: nil)
         result = @executor.execute(message, queue_name, source_queue: source_queue)
         @jobs_processed.increment
+        @rate_counter.increment(:processed)
         if result == :failed
           @jobs_failed.increment
+          @rate_counter.increment(:failed)
           @circuit_breaker.record_failure(queue_name)
         else
           @circuit_breaker.record_success(queue_name)
         end
       rescue StandardError => e
         @jobs_failed.increment
+        @rate_counter.increment(:failed)
         @circuit_breaker.record_failure(queue_name)
         Pgbus.logger.error { "[Pgbus] Unhandled error processing message: #{e.message}" }
       ensure
@@ -172,6 +182,12 @@ module Pgbus
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Failed to resolve wildcard queues: #{e.message} — falling back to default" }
         @queues = [config.default_queue]
+      end
+
+      def check_recycle
+        return unless @lifecycle.running? && recycle_needed?
+
+        @lifecycle.transition_to(:draining)
       end
 
       def recycle_needed?
@@ -214,7 +230,8 @@ module Pgbus
       def start_heartbeat
         @heartbeat = Heartbeat.new(
           kind: "worker",
-          metadata: { queues: queues, threads: threads, pid: ::Process.pid }
+          metadata: { queues: queues, threads: threads, pid: ::Process.pid },
+          on_beat: -> { @rate_counter.snapshot! }
         )
         @heartbeat.start
       end

--- a/lib/pgbus/rate_counter.rb
+++ b/lib/pgbus/rate_counter.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Pgbus
+  # Thread-safe rate counter inspired by LavinMQ's rate_stats macro.
+  # Tracks absolute counts via AtomicFixnum and computes rates as
+  # deltas between periodic snapshots.
+  #
+  # Usage:
+  #   counter = RateCounter.new(:enqueued, :dequeued, :failed)
+  #   counter.increment(:enqueued)
+  #   counter.snapshot!          # call periodically (e.g. every 5s)
+  #   counter.rate(:enqueued)    # => msgs/s since last snapshot
+  #   counter.rates              # => { enqueued: 12.4, dequeued: 10.1, failed: 0.2 }
+  class RateCounter
+    attr_reader :names
+
+    def initialize(*names)
+      @names = names.map(&:to_sym)
+      @counters = {}
+      @last_values = {}
+      @rates = {}
+      @last_snapshot_at = monotonic_now
+
+      @names.each do |name|
+        @counters[name] = Concurrent::AtomicFixnum.new(0)
+        @last_values[name] = 0
+        @rates[name] = 0.0
+      end
+    end
+
+    def increment(name, delta = 1)
+      @counters.fetch(name).increment(delta)
+    end
+
+    def count(name)
+      @counters.fetch(name).value
+    end
+
+    def rate(name)
+      @rates.fetch(name)
+    end
+
+    def rates
+      @names.to_h { |name| [name, @rates[name]] }
+    end
+
+    def counts
+      @names.to_h { |name| [name, @counters[name].value] }
+    end
+
+    def snapshot!
+      now = monotonic_now
+      elapsed = now - @last_snapshot_at
+      return if elapsed <= 0
+
+      @names.each do |name|
+        current = @counters[name].value
+        delta = current - @last_values[name]
+        @rates[name] = (delta / elapsed).round(1)
+        @last_values[name] = current
+      end
+
+      @last_snapshot_at = now
+    end
+
+    def to_h
+      {
+        counts: counts,
+        rates: rates
+      }
+    end
+
+    private
+
+    def monotonic_now
+      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/pgbus/recurring/schedule.rb
+++ b/lib/pgbus/recurring/schedule.rb
@@ -87,7 +87,7 @@ module Pgbus
       end
 
       def resolve_queue(task)
-        @config.queue_name(task.queue_name || @config.default_queue)
+        task.queue_name || @config.default_queue
       end
 
       def build_headers(task, run_at)

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -33,7 +33,10 @@ module Pgbus
       # different connection lifecycle than the worker processes).
       def queues_with_metrics
         queue_names = connection.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
-        queue_names.map { |name| queue_metrics_via_sql(name) }.compact
+        paused_queues = paused_queue_names
+        queue_names.map { |name| queue_metrics_via_sql(name) }.compact.map do |q|
+          q.merge(paused: paused_queues.include?(q[:name]))
+        end
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus::Web] Error fetching queue metrics: #{e.class}: #{e.message}" }
         []
@@ -50,6 +53,24 @@ module Pgbus
 
       def purge_queue(name)
         @client.purge_queue(name)
+      end
+
+      def pause_queue(name, reason: nil)
+        QueueState.pause!(name, reason: reason)
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus::Web] Error pausing queue #{name}: #{e.message}" }
+      end
+
+      def resume_queue(name)
+        QueueState.resume!(name)
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus::Web] Error resuming queue #{name}: #{e.message}" }
+      end
+
+      def queue_paused?(name)
+        QueueState.paused?(name)
+      rescue StandardError
+        false
       end
 
       # Jobs (messages in queue tables)
@@ -451,6 +472,26 @@ module Pgbus
         0
       end
 
+      # Outbox
+      def outbox_stats
+        {
+          unpublished: OutboxEntry.unpublished.count,
+          total: OutboxEntry.count,
+          oldest_unpublished_age: oldest_unpublished_age
+        }
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching outbox stats: #{e.message}" }
+        { unpublished: 0, total: 0, oldest_unpublished_age: nil }
+      end
+
+      def outbox_entries(page: 1, per_page: 25)
+        offset = (page - 1) * per_page
+        OutboxEntry.order(id: :desc).limit(per_page).offset(offset).to_a
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching outbox entries: #{e.message}" }
+        []
+      end
+
       # Subscriber registry
       def registered_subscribers
         EventBus::Registry.instance.subscribers.map do |s|
@@ -569,6 +610,21 @@ module Pgbus
         raise ArgumentError, "Invalid queue name: #{name.inspect}" if sanitized.empty?
 
         sanitized
+      end
+
+      def paused_queue_names
+        QueueState.paused.pluck(:queue_name)
+      rescue StandardError
+        []
+      end
+
+      def oldest_unpublished_age
+        oldest = OutboxEntry.unpublished.order(:id).pick(:created_at)
+        return nil unless oldest
+
+        (Time.now - oldest).to_i
+      rescue StandardError
+        nil
       end
 
       def parse_arguments(args)

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -7,6 +7,8 @@ module Pgbus
     class DataSource
       def initialize(client: Pgbus.client)
         @client = client
+        @last_throughput_snapshot = nil
+        @last_throughput_at = nil
       end
 
       # Dashboard summary
@@ -17,6 +19,8 @@ module Pgbus
         dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix
         dlq_depth = queues.select { |q| q[:name].end_with?(dlq_suffix) }.sum { |q| q[:queue_length] }
 
+        throughput = compute_throughput(queues)
+
         {
           total_queues: queues.size,
           total_depth: total_depth,
@@ -24,7 +28,8 @@ module Pgbus
           active_processes: processes.count,
           failed_count: failed_events_count,
           dlq_depth: dlq_depth,
-          recurring_count: recurring_tasks_count
+          recurring_count: recurring_tasks_count,
+          throughput_rate: throughput
         }
       end
 
@@ -610,6 +615,24 @@ module Pgbus
         raise ArgumentError, "Invalid queue name: #{name.inspect}" if sanitized.empty?
 
         sanitized
+      end
+
+      def compute_throughput(queues)
+        current_totals = queues.sum { |q| q[:total_messages] }
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        if @last_throughput_snapshot && @last_throughput_at
+          elapsed = now - @last_throughput_at
+          delta = current_totals - @last_throughput_snapshot
+          rate = elapsed.positive? ? (delta / elapsed).round(1) : 0.0
+        end
+
+        @last_throughput_snapshot = current_totals
+        @last_throughput_at = now
+
+        rate || 0.0
+      rescue StandardError
+        0.0
       end
 
       def paused_queue_names

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -40,7 +40,7 @@ module Pgbus
         queue_names = connection.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
         paused_queues = paused_queue_names
         queue_names.map { |name| queue_metrics_via_sql(name) }.compact.map do |q|
-          q.merge(paused: paused_queues.include?(q[:name]))
+          q.merge(paused: paused_queues.include?(logical_queue_name(q[:name])))
         end
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus::Web] Error fetching queue metrics: #{e.class}: #{e.message}" }
@@ -61,19 +61,19 @@ module Pgbus
       end
 
       def pause_queue(name, reason: nil)
-        QueueState.pause!(name, reason: reason)
+        QueueState.pause!(logical_queue_name(name), reason: reason)
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus::Web] Error pausing queue #{name}: #{e.message}" }
       end
 
       def resume_queue(name)
-        QueueState.resume!(name)
+        QueueState.resume!(logical_queue_name(name))
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus::Web] Error resuming queue #{name}: #{e.message}" }
       end
 
       def queue_paused?(name)
-        QueueState.paused?(name)
+        QueueState.paused?(logical_queue_name(name))
       rescue StandardError
         false
       end
@@ -633,6 +633,12 @@ module Pgbus
         rate || 0.0
       rescue StandardError
         0.0
+      end
+
+      def logical_queue_name(name)
+        name
+          .delete_prefix("#{Pgbus.configuration.queue_prefix}_")
+          .sub(/_p\d+\z/, "")
       end
 
       def paused_queue_names

--- a/spec/pgbus/active_job/adapter_spec.rb
+++ b/spec/pgbus/active_job/adapter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
       result = adapter.enqueue(job)
 
       expect(Pgbus::Serializer).to have_received(:serialize_job_hash).with(job)
-      expect(mock_client).to have_received(:send_message).with("default", serialized_hash, delay: 0)
+      expect(mock_client).to have_received(:send_message).with("default", serialized_hash, delay: 0, priority: nil)
       expect(job).to have_received(:provider_job_id=).with(42)
       expect(result).to eq(job)
     end
@@ -39,7 +39,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
 
         adapter.enqueue(job)
 
-        expect(mock_client).to have_received(:send_message).with("default", anything, delay: 0)
+        expect(mock_client).to have_received(:send_message).with("default", anything, delay: 0, priority: nil)
       end
     end
   end
@@ -51,7 +51,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
 
       result = adapter.enqueue_at(job, future_time)
 
-      expect(mock_client).to have_received(:send_message).with("default", serialized_hash, delay: a_value_between(59, 61))
+      expect(mock_client).to have_received(:send_message).with("default", serialized_hash, delay: a_value_between(59, 61), priority: nil)
       expect(job).to have_received(:provider_job_id=).with(99)
       expect(result).to eq(job)
     end
@@ -63,7 +63,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
 
         adapter.enqueue_at(job, past_time)
 
-        expect(mock_client).to have_received(:send_message).with("default", serialized_hash, delay: 0)
+        expect(mock_client).to have_received(:send_message).with("default", serialized_hash, delay: 0, priority: nil)
       end
     end
   end
@@ -94,7 +94,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
       adapter.enqueue(job)
 
       expect(Pgbus::Concurrency::Semaphore).to have_received(:acquire).with("TestJob-42", 1, 900)
-      expect(mock_client).to have_received(:send_message).with("default", concurrency_payload, delay: 0)
+      expect(mock_client).to have_received(:send_message).with("default", concurrency_payload, delay: 0, priority: nil)
       expect(job).to have_received(:provider_job_id=).with(42)
     end
 
@@ -172,7 +172,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
 
       adapter.enqueue_all([job, job2])
 
-      expect(mock_client).to have_received(:send_message).with("default", serialized_hash, delay: a_value > 0)
+      expect(mock_client).to have_received(:send_message).with("default", serialized_hash, delay: a_value > 0, priority: nil)
       expect(mock_client).to have_received(:send_batch).with("default", [second_serialized_hash])
     end
 

--- a/spec/pgbus/allocation_budget_spec.rb
+++ b/spec/pgbus/allocation_budget_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Pgbus::Client do
     described_class.allocate.tap do |c|
       c.instance_variable_set(:@pgmq, mock_pgmq)
       c.instance_variable_set(:@config, Pgbus.configuration)
+      c.instance_variable_set(:@pgmq_mutex, Mutex.new)
       c.instance_variable_set(:@queues_created, all_queues_created)
     end
   end
@@ -97,6 +98,7 @@ RSpec.describe Pgbus::Client do
       described_class.allocate.tap do |c|
         c.instance_variable_set(:@pgmq, plain_pgmq)
         c.instance_variable_set(:@config, Pgbus.configuration)
+        c.instance_variable_set(:@pgmq_mutex, Mutex.new)
         c.instance_variable_set(:@queues_created, all_queues_created)
       end
     end

--- a/spec/pgbus/circuit_breaker_spec.rb
+++ b/spec/pgbus/circuit_breaker_spec.rb
@@ -20,13 +20,10 @@ RSpec.describe Pgbus::CircuitBreaker do
 
   before do
     queue_state_class
-    allow(Pgbus::QueueState).to receive(:find_by).and_return(nil)
-    allow(Pgbus::QueueState).to receive(:paused?).and_return(false)
     allow(Pgbus::QueueState).to receive(:pause!)
     allow(Pgbus::QueueState).to receive(:resume!)
-    allow(Pgbus::QueueState).to receive(:find_or_initialize_by).and_return(
-      double("QueueState", update!: true, circuit_breaker_trip_count: 0)
-    )
+    allow(Pgbus::QueueState).to receive_messages(find_by: nil, paused?: false,
+                                                 find_or_initialize_by: double("QueueState", update!: true, circuit_breaker_trip_count: 0))
   end
 
   describe "#record_success" do

--- a/spec/pgbus/circuit_breaker_spec.rb
+++ b/spec/pgbus/circuit_breaker_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::CircuitBreaker do
+  subject(:breaker) { described_class.new(config: config) }
+
+  let(:config) do
+    Pgbus::Configuration.new.tap do |c|
+      c.circuit_breaker_enabled = true
+      c.circuit_breaker_threshold = 3
+      c.circuit_breaker_base_backoff = 10
+      c.circuit_breaker_max_backoff = 60
+    end
+  end
+
+  let(:queue_state_class) do
+    stub_const("Pgbus::QueueState", Class.new)
+  end
+
+  before do
+    queue_state_class
+    allow(Pgbus::QueueState).to receive(:find_by).and_return(nil)
+    allow(Pgbus::QueueState).to receive(:paused?).and_return(false)
+    allow(Pgbus::QueueState).to receive(:pause!)
+    allow(Pgbus::QueueState).to receive(:resume!)
+    allow(Pgbus::QueueState).to receive(:find_or_initialize_by).and_return(
+      double("QueueState", update!: true, circuit_breaker_trip_count: 0)
+    )
+  end
+
+  describe "#record_success" do
+    it "resets the failure counter" do
+      breaker.record_failure("test_queue")
+      breaker.record_success("test_queue")
+      # After reset, we should be able to fail threshold-1 times without tripping
+      (config.circuit_breaker_threshold - 1).times { breaker.record_failure("test_queue") }
+      expect(Pgbus::QueueState).not_to have_received(:find_or_initialize_by)
+    end
+  end
+
+  describe "#record_failure" do
+    it "trips after reaching threshold" do
+      config.circuit_breaker_threshold.times { breaker.record_failure("test_queue") }
+      expect(Pgbus::QueueState).to have_received(:find_or_initialize_by).with(queue_name: "test_queue")
+    end
+
+    it "does not trip below threshold" do
+      (config.circuit_breaker_threshold - 1).times { breaker.record_failure("test_queue") }
+      expect(Pgbus::QueueState).not_to have_received(:find_or_initialize_by)
+    end
+
+    it "does nothing when circuit breaker is disabled" do
+      config.circuit_breaker_enabled = false
+      10.times { breaker.record_failure("test_queue") }
+      expect(Pgbus::QueueState).not_to have_received(:find_or_initialize_by)
+    end
+  end
+
+  describe "#paused?" do
+    it "returns false when queue is not paused" do
+      expect(breaker.paused?("test_queue")).to be false
+    end
+
+    it "returns true when queue is paused" do
+      state = double("QueueState", paused?: true, circuit_breaker_resume_at: nil)
+      allow(Pgbus::QueueState).to receive(:find_by).with(queue_name: "test_queue").and_return(state)
+      expect(breaker.paused?("test_queue")).to be true
+    end
+
+    it "auto-resumes when backoff has expired" do
+      state = double("QueueState",
+                     paused?: true,
+                     circuit_breaker_resume_at: Time.now - 1,
+                     update!: true)
+      allow(Pgbus::QueueState).to receive(:find_by).with(queue_name: "test_queue").and_return(state)
+      expect(breaker.paused?("test_queue")).to be false
+    end
+
+    it "caches the result for the TTL period" do
+      allow(Pgbus::QueueState).to receive(:find_by).and_return(nil)
+      breaker.paused?("test_queue")
+      breaker.paused?("test_queue")
+      expect(Pgbus::QueueState).to have_received(:find_by).once
+    end
+  end
+
+  describe "#pause!" do
+    it "delegates to QueueState.pause!" do
+      breaker.pause!("test_queue", reason: "manual")
+      expect(Pgbus::QueueState).to have_received(:pause!).with("test_queue", reason: "manual")
+    end
+  end
+
+  describe "#resume!" do
+    it "delegates to QueueState.resume! and clears failure counts" do
+      breaker.record_failure("test_queue")
+      breaker.resume!("test_queue")
+      expect(Pgbus::QueueState).to have_received(:resume!).with("test_queue")
+    end
+  end
+
+  describe "backoff calculation" do
+    it "uses exponential backoff capped at max" do
+      # First trip: base * 2^0 = 10
+      # Second trip: base * 2^1 = 20
+      # Third trip: base * 2^2 = 40
+      # Fourth trip: base * 2^3 = 80 -> capped to 60
+      backoff = breaker.send(:calculate_backoff, 1)
+      expect(backoff).to eq(10)
+
+      backoff = breaker.send(:calculate_backoff, 2)
+      expect(backoff).to eq(20)
+
+      backoff = breaker.send(:calculate_backoff, 4)
+      expect(backoff).to eq(60) # capped
+    end
+  end
+end

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -292,6 +292,135 @@ RSpec.describe Pgbus::Client do
     end
   end
 
+  describe "#purge_archive" do
+    let(:pool) { double("pool") }
+    let(:conn) { double("conn") }
+    let(:result) { double("result", cmd_tuples: 50) }
+
+    before do
+      allow(mock_pgmq).to receive(:pool).and_return(pool)
+      allow(pool).to receive(:with).and_yield(conn)
+      allow(conn).to receive(:exec_params).and_return(result)
+    end
+
+    it "deletes archive entries older than the given time" do
+      cutoff = Time.now - 3600
+      client.purge_archive("default", older_than: cutoff)
+
+      expect(conn).to have_received(:exec_params).with(
+        a_string_matching(/DELETE FROM pgmq\.a_pgbus_test_default/),
+        [cutoff, 1000]
+      )
+    end
+
+    it "loops until batch is not full" do
+      small_result = double("result", cmd_tuples: 10)
+      allow(conn).to receive(:exec_params).and_return(result, small_result)
+
+      total = client.purge_archive("default", older_than: Time.now, batch_size: 50)
+      expect(total).to eq(60) # 50 + 10
+    end
+  end
+
+  describe "#read_batch_prioritized" do
+    context "when priority is not enabled" do
+      it "falls back to regular read_batch" do
+        client.read_batch_prioritized("default", qty: 5)
+
+        expect(mock_pgmq).to have_received(:read_batch).with("pgbus_test_default", vt: config.visibility_timeout, qty: 5)
+      end
+    end
+
+    context "when priority is enabled" do
+      before { config.priority_levels = 3 }
+      after { config.priority_levels = nil }
+
+      it "reads from p0 first, then p1, then p2" do
+        # Ensure all sub-queues are created first
+        client.ensure_queue("default")
+
+        msg0 = build_message_double(msg_id: 1, message: '{"p":0}')
+        msg1 = build_message_double(msg_id: 2, message: '{"p":1}')
+
+        allow(mock_pgmq).to receive(:read_batch)
+          .with("pgbus_test_default_p0", anything).and_return([msg0])
+        allow(mock_pgmq).to receive(:read_batch)
+          .with("pgbus_test_default_p1", anything).and_return([msg1])
+        allow(mock_pgmq).to receive(:read_batch)
+          .with("pgbus_test_default_p2", anything).and_return([])
+
+        results = client.read_batch_prioritized("default", qty: 5)
+
+        expect(results.size).to eq(2)
+        expect(results[0][0]).to eq("pgbus_test_default_p0")
+        expect(results[1][0]).to eq("pgbus_test_default_p1")
+      end
+
+      it "stops when qty is filled" do
+        client.ensure_queue("default")
+
+        msgs = 3.times.map { |i| build_message_double(msg_id: i, message: '{}') }
+        allow(mock_pgmq).to receive(:read_batch)
+          .with("pgbus_test_default_p0", anything).and_return(msgs)
+
+        results = client.read_batch_prioritized("default", qty: 3)
+
+        expect(results.size).to eq(3)
+        # Should not read from p1 or p2
+        expect(mock_pgmq).not_to have_received(:read_batch).with("pgbus_test_default_p1", anything)
+      end
+    end
+  end
+
+  describe "#send_message with priority" do
+    context "when priority is enabled" do
+      before { config.priority_levels = 3 }
+      after { config.priority_levels = nil }
+
+      it "routes to the correct sub-queue" do
+        client.send_message("default", { "data" => "test" }, priority: 0)
+
+        expect(mock_pgmq).to have_received(:produce).with(
+          "pgbus_test_default_p0",
+          '{"data":"test"}',
+          headers: nil,
+          delay: 0
+        )
+      end
+
+      it "uses default_priority when none specified" do
+        config.default_priority = 1
+        client.send_message("default", { "data" => "test" })
+
+        expect(mock_pgmq).to have_received(:produce).with(
+          "pgbus_test_default_p1",
+          '{"data":"test"}',
+          headers: nil,
+          delay: 0
+        )
+      end
+
+      it "clamps priority to valid range" do
+        client.send_message("default", { "data" => "test" }, priority: 99)
+
+        expect(mock_pgmq).to have_received(:produce).with(
+          "pgbus_test_default_p2",
+          '{"data":"test"}',
+          headers: nil,
+          delay: 0
+        )
+      end
+    end
+  end
+
+  describe "#archive_from_queue" do
+    it "archives using the raw queue name" do
+      client.archive_from_queue("pgbus_test_default_p0", 42)
+
+      expect(mock_pgmq).to have_received(:archive).with("pgbus_test_default_p0", 42)
+    end
+  end
+
   describe "#bind_topic" do
     it "ensures the queue and binds the pattern" do
       client.bind_topic("orders.#", "events")

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Pgbus::Client do
       it "stops when qty is filled" do
         client.ensure_queue("default")
 
-        msgs = 3.times.map { |i| build_message_double(msg_id: i, message: '{}') }
+        msgs = 3.times.map { |i| build_message_double(msg_id: i, message: "{}") }
         allow(mock_pgmq).to receive(:read_batch)
           .with("pgbus_test_default_p0", anything).and_return(msgs)
 

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -40,6 +40,35 @@ RSpec.describe Pgbus::Configuration do
       expect(config.max_worker_lifetime).to be_nil
     end
 
+    it "has no prefetch_limit by default" do
+      expect(config.prefetch_limit).to be_nil
+    end
+
+    it "has circuit breaker enabled by default" do
+      expect(config.circuit_breaker_enabled).to be true
+      expect(config.circuit_breaker_threshold).to eq(5)
+      expect(config.circuit_breaker_base_backoff).to eq(30)
+      expect(config.circuit_breaker_max_backoff).to eq(600)
+    end
+
+    it "has no priority levels by default" do
+      expect(config.priority_levels).to be_nil
+      expect(config.default_priority).to eq(1)
+    end
+
+    it "has default archive retention of 7 days" do
+      expect(config.archive_retention).to eq(7 * 24 * 3600)
+      expect(config.archive_compaction_interval).to eq(3600)
+      expect(config.archive_compaction_batch_size).to eq(1000)
+    end
+
+    it "has outbox disabled by default" do
+      expect(config.outbox_enabled).to be false
+      expect(config.outbox_poll_interval).to eq(1.0)
+      expect(config.outbox_batch_size).to eq(100)
+      expect(config.outbox_retention).to eq(24 * 3600)
+    end
+
     it "has default recurring schedule interval" do
       expect(config.recurring_schedule_interval).to eq(1.0)
     end
@@ -66,6 +95,56 @@ RSpec.describe Pgbus::Configuration do
   describe "#dead_letter_queue_name" do
     it "appends dlq suffix to prefixed name" do
       expect(config.dead_letter_queue_name("critical")).to eq("pgbus_critical_dlq")
+    end
+  end
+
+  describe "#priority_queue_name" do
+    it "returns the priority sub-queue name" do
+      expect(config.priority_queue_name("critical", 0)).to eq("pgbus_critical_p0")
+      expect(config.priority_queue_name("critical", 2)).to eq("pgbus_critical_p2")
+    end
+  end
+
+  describe "#priority_queue_names" do
+    it "returns single queue name when priority_levels is nil" do
+      expect(config.priority_queue_names("default")).to eq(["pgbus_default"])
+    end
+
+    it "returns single queue name when priority_levels is 1" do
+      config.priority_levels = 1
+      expect(config.priority_queue_names("default")).to eq(["pgbus_default"])
+    end
+
+    it "returns sub-queue names when priority_levels > 1" do
+      config.priority_levels = 3
+      expect(config.priority_queue_names("default")).to eq(%w[pgbus_default_p0 pgbus_default_p1 pgbus_default_p2])
+    end
+  end
+
+  describe "#validate!" do
+    it "rejects invalid prefetch_limit" do
+      config.prefetch_limit = 0
+      expect { config.validate! }.to raise_error(ArgumentError, /prefetch_limit/)
+    end
+
+    it "accepts valid prefetch_limit" do
+      config.prefetch_limit = 10
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "rejects invalid priority_levels" do
+      config.priority_levels = 0
+      expect { config.validate! }.to raise_error(ArgumentError, /priority_levels/)
+    end
+
+    it "rejects priority_levels > 10" do
+      config.priority_levels = 11
+      expect { config.validate! }.to raise_error(ArgumentError, /priority_levels/)
+    end
+
+    it "accepts valid priority_levels" do
+      config.priority_levels = 3
+      expect { config.validate! }.not_to raise_error
     end
   end
 

--- a/spec/pgbus/dedup_cache_spec.rb
+++ b/spec/pgbus/dedup_cache_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::DedupCache do
+  subject(:cache) { described_class.new(max_size: 5, ttl: 10) }
+
+  describe "#seen?" do
+    it "returns false for unseen keys" do
+      expect(cache.seen?("event-1:Handler")).to be false
+    end
+
+    it "returns true for recently marked keys" do
+      cache.mark!("event-1:Handler")
+      expect(cache.seen?("event-1:Handler")).to be true
+    end
+
+    it "returns false for expired keys" do
+      cache.mark!("event-1:Handler")
+      # Simulate TTL expiry by backdating the entry
+      cache.instance_variable_get(:@cache)["event-1:Handler"] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 20
+      expect(cache.seen?("event-1:Handler")).to be false
+    end
+  end
+
+  describe "#mark!" do
+    it "adds the key to the cache" do
+      cache.mark!("event-1:Handler")
+      expect(cache.size).to eq(1)
+    end
+
+    it "evicts the oldest entry when max_size is reached" do
+      5.times { |i| cache.mark!("event-#{i}:Handler") }
+      expect(cache.size).to eq(5)
+
+      cache.mark!("event-new:Handler")
+      expect(cache.size).to eq(5)
+      # oldest entry should be gone
+      expect(cache.seen?("event-0:Handler")).to be false
+      # newest should still be there
+      expect(cache.seen?("event-new:Handler")).to be true
+    end
+  end
+
+  describe "#clear!" do
+    it "removes all entries" do
+      3.times { |i| cache.mark!("event-#{i}:Handler") }
+      cache.clear!
+      expect(cache.size).to eq(0)
+    end
+  end
+
+  describe "thread safety" do
+    it "handles concurrent access without errors" do
+      big_cache = described_class.new(max_size: 1000, ttl: 60)
+      threads = 10.times.map do |t|
+        Thread.new do
+          100.times do |i|
+            key = "event-#{t}-#{i}:Handler"
+            big_cache.mark!(key)
+            big_cache.seen?(key)
+          end
+        end
+      end
+      threads.each(&:join)
+      expect(big_cache.size).to be <= 1000
+    end
+  end
+end

--- a/spec/pgbus/outbox/poller_spec.rb
+++ b/spec/pgbus/outbox/poller_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe Pgbus::Outbox::Poller do
     before do
       outbox_entry_class
       allow(Pgbus::OutboxEntry).to receive(:unpublished).and_return(relation)
-      allow(relation).to receive(:order).and_return(relation)
-      allow(relation).to receive(:limit).and_return(relation)
-      allow(relation).to receive(:lock).and_return(relation)
+      allow(relation).to receive_messages(order: relation, limit: relation, lock: relation)
     end
 
     it "publishes entries to PGMQ via queue_name" do

--- a/spec/pgbus/outbox/poller_spec.rb
+++ b/spec/pgbus/outbox/poller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Pgbus::Outbox::Poller do
 
       result = poller.poll_and_publish
 
-      expect(mock_client).to have_received(:publish_to_topic).with("orders.created", { "event" => "data" }, headers: { "trace" => "id" })
+      expect(mock_client).to have_received(:publish_to_topic).with("orders.created", { "event" => "data" }, headers: { "trace" => "id" }, delay: 0)
       expect(result).to eq(1)
     end
 

--- a/spec/pgbus/outbox/poller_spec.rb
+++ b/spec/pgbus/outbox/poller_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Outbox::Poller do
+  let(:heartbeat) { instance_double(Pgbus::Process::Heartbeat, start: true, stop: true) }
+  let(:mock_client) { build_mock_client }
+  let(:poller) { described_class.new }
+
+  before do
+    allow(Pgbus::Process::Heartbeat).to receive(:new).and_return(heartbeat)
+    allow(Pgbus).to receive(:client).and_return(mock_client)
+  end
+
+  describe "#graceful_shutdown" do
+    it "sets shutting_down flag" do
+      poller.graceful_shutdown
+      expect(poller.instance_variable_get(:@shutting_down)).to be true
+    end
+  end
+
+  describe "#poll_and_publish" do
+    let(:outbox_entry_class) { stub_const("Pgbus::OutboxEntry", Class.new) }
+    let(:relation) { double("relation") }
+
+    before do
+      outbox_entry_class
+      allow(Pgbus::OutboxEntry).to receive(:unpublished).and_return(relation)
+      allow(relation).to receive(:order).and_return(relation)
+      allow(relation).to receive(:limit).and_return(relation)
+      allow(relation).to receive(:lock).and_return(relation)
+    end
+
+    it "publishes entries to PGMQ via queue_name" do
+      entry = double("entry",
+                     id: 1,
+                     queue_name: "default",
+                     routing_key: nil,
+                     payload: { "data" => "test" },
+                     headers: nil,
+                     delay: 0,
+                     priority: 1,
+                     update!: true)
+      allow(relation).to receive(:to_a).and_return([entry], [])
+
+      result = poller.poll_and_publish
+
+      expect(mock_client).to have_received(:send_message).with("default", { "data" => "test" }, headers: nil, delay: 0, priority: 1)
+      expect(entry).to have_received(:update!).with(published_at: a_kind_of(Time))
+      expect(result).to eq(1)
+    end
+
+    it "publishes entries via routing_key" do
+      routing_key = "orders.created"
+      entry = double("entry",
+                     id: 2,
+                     queue_name: nil,
+                     routing_key: routing_key,
+                     payload: { "event" => "data" },
+                     headers: { "trace" => "id" },
+                     delay: nil,
+                     priority: 0,
+                     update!: true)
+      allow(relation).to receive(:to_a).and_return([entry], [])
+
+      result = poller.poll_and_publish
+
+      expect(mock_client).to have_received(:publish_to_topic).with("orders.created", { "event" => "data" }, headers: { "trace" => "id" })
+      expect(result).to eq(1)
+    end
+
+    it "returns 0 when no entries" do
+      allow(relation).to receive(:to_a).and_return([])
+
+      result = poller.poll_and_publish
+      expect(result).to eq(0)
+    end
+
+    it "rescues errors gracefully" do
+      allow(relation).to receive(:to_a).and_raise(StandardError, "db error")
+
+      expect { poller.poll_and_publish }.not_to raise_error
+      expect(poller.poll_and_publish).to eq(0)
+    end
+  end
+end

--- a/spec/pgbus/outbox/poller_spec.rb
+++ b/spec/pgbus/outbox/poller_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Pgbus::Outbox::Poller do
     before do
       outbox_entry_class
       allow(Pgbus::OutboxEntry).to receive(:unpublished).and_return(relation)
+      allow(Pgbus::OutboxEntry).to receive(:transaction).and_yield
       allow(relation).to receive_messages(order: relation, limit: relation, lock: relation)
     end
 

--- a/spec/pgbus/outbox/poller_spec.rb
+++ b/spec/pgbus/outbox/poller_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe Pgbus::Outbox::Poller do
 
       result = poller.poll_and_publish
 
-      expect(mock_client).to have_received(:publish_to_topic).with("orders.created", { "event" => "data" }, headers: { "trace" => "id" }, delay: 0)
+      expect(mock_client).to have_received(:publish_to_topic)
+        .with("orders.created", { "event" => "data" }, headers: { "trace" => "id" }, delay: 0)
       expect(result).to eq(1)
     end
 

--- a/spec/pgbus/outbox_spec.rb
+++ b/spec/pgbus/outbox_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Outbox do
+  let(:outbox_entry_class) { stub_const("Pgbus::OutboxEntry", Class.new) }
+  let(:mock_client) { build_mock_client }
+
+  before do
+    outbox_entry_class
+    allow(Pgbus).to receive(:client).and_return(mock_client)
+    allow(Pgbus::OutboxEntry).to receive(:create!).and_return(double("entry", id: 1))
+  end
+
+  describe ".publish" do
+    it "creates an outbox entry with queue_name" do
+      described_class.publish("default", { "key" => "value" })
+
+      expect(Pgbus::OutboxEntry).to have_received(:create!).with(
+        queue_name: "default",
+        payload: { "key" => "value" },
+        headers: nil,
+        priority: 1,
+        delay: 0
+      )
+    end
+
+    it "passes priority and delay" do
+      described_class.publish("default", { "data" => 1 }, priority: 0, delay: 30)
+
+      expect(Pgbus::OutboxEntry).to have_received(:create!).with(
+        queue_name: "default",
+        payload: { "data" => 1 },
+        headers: nil,
+        priority: 0,
+        delay: 30
+      )
+    end
+
+    it "passes headers" do
+      described_class.publish("default", "body", headers: { "trace" => "abc" })
+
+      expect(Pgbus::OutboxEntry).to have_received(:create!).with(
+        queue_name: "default",
+        payload: "body",
+        headers: { "trace" => "abc" },
+        priority: 1,
+        delay: 0
+      )
+    end
+  end
+
+  describe ".publish_event" do
+    before do
+      allow(Pgbus::EventBus::Publisher).to receive(:build_event_data).and_return(
+        { "event_id" => "uuid", "payload" => { "data" => 1 }, "published_at" => "2026-01-01" }
+      )
+    end
+
+    it "creates an outbox entry with routing_key" do
+      described_class.publish_event("orders.created", { "id" => 42 })
+
+      expect(Pgbus::OutboxEntry).to have_received(:create!).with(
+        routing_key: "orders.created",
+        payload: { "event_id" => "uuid", "payload" => { "data" => 1 }, "published_at" => "2026-01-01" },
+        headers: nil
+      )
+    end
+  end
+end

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -192,6 +192,65 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
   end
 
+  describe "#compact_archives (private)" do
+    let(:connection) { double("connection") }
+
+    before do
+      dispatcher.config.archive_retention = 7 * 24 * 3600
+      prefix = dispatcher.config.queue_prefix
+      allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+      allow(connection).to receive(:select_values).and_return(["#{prefix}_default", "#{prefix}_events"])
+      allow(mock_client).to receive(:purge_archive).and_return(0)
+    end
+
+    it "purges archive entries older than retention period" do
+      allow(mock_client).to receive(:purge_archive).and_return(5)
+
+      dispatcher.send(:compact_archives)
+
+      expect(mock_client).to have_received(:purge_archive).with("default", older_than: a_kind_of(Time), batch_size: 1000)
+      expect(mock_client).to have_received(:purge_archive).with("events", older_than: a_kind_of(Time), batch_size: 1000)
+    end
+
+    it "skips when archive_retention is nil" do
+      dispatcher.config.archive_retention = nil
+
+      dispatcher.send(:compact_archives)
+
+      expect(mock_client).not_to have_received(:purge_archive)
+    end
+
+    it "rescues errors gracefully" do
+      allow(connection).to receive(:select_values).and_raise(StandardError, "db error")
+      expect { dispatcher.send(:compact_archives) }.not_to raise_error
+    end
+
+    it "rescues per-queue errors without stopping others" do
+      call_count = 0
+      allow(mock_client).to receive(:purge_archive) do |queue_name, **_opts|
+        call_count += 1
+        raise StandardError, "fail" if queue_name == "default"
+
+        3
+      end
+
+      dispatcher.send(:compact_archives)
+
+      expect(call_count).to eq(2)
+    end
+  end
+
+  describe "#run_maintenance includes archive compaction" do
+    it "runs compact_archives when interval has elapsed" do
+      allow(dispatcher).to receive(:compact_archives)
+
+      dispatcher.instance_variable_set(:@last_archive_compaction_at, Time.now - 3601)
+      dispatcher.send(:run_maintenance)
+
+      expect(dispatcher).to have_received(:compact_archives)
+    end
+  end
+
   describe "#cleanup_recurring_executions (private)" do
     it "deletes old recurring execution records" do
       relation = instance_double(ActiveRecord::Relation, delete_all: 5)

--- a/spec/pgbus/process/lifecycle_spec.rb
+++ b/spec/pgbus/process/lifecycle_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Process::Lifecycle do
+  subject(:lifecycle) { described_class.new }
+
+  describe "#initialize" do
+    it "starts in :starting state" do
+      expect(lifecycle.state).to eq(:starting)
+      expect(lifecycle).to be_starting
+    end
+  end
+
+  describe "#transition_to!" do
+    it "transitions from starting to running" do
+      lifecycle.transition_to!(:running)
+      expect(lifecycle).to be_running
+    end
+
+    it "transitions from running to draining" do
+      lifecycle.transition_to!(:running)
+      lifecycle.transition_to!(:draining)
+      expect(lifecycle).to be_draining
+    end
+
+    it "transitions from running to paused" do
+      lifecycle.transition_to!(:running)
+      lifecycle.transition_to!(:paused)
+      expect(lifecycle).to be_paused
+    end
+
+    it "transitions from paused to running" do
+      lifecycle.transition_to!(:running)
+      lifecycle.transition_to!(:paused)
+      lifecycle.transition_to!(:running)
+      expect(lifecycle).to be_running
+    end
+
+    it "transitions from draining to stopped" do
+      lifecycle.transition_to!(:running)
+      lifecycle.transition_to!(:draining)
+      lifecycle.transition_to!(:stopped)
+      expect(lifecycle).to be_stopped
+    end
+
+    it "raises InvalidTransition for invalid transitions" do
+      expect { lifecycle.transition_to!(:draining) }.to raise_error(Pgbus::Process::InvalidTransition)
+    end
+
+    it "raises for unknown states" do
+      expect { lifecycle.transition_to!(:exploding) }.to raise_error(ArgumentError, /Unknown state/)
+    end
+
+    it "does not allow transitions from stopped" do
+      lifecycle.transition_to!(:running)
+      lifecycle.transition_to!(:stopped)
+      expect { lifecycle.transition_to!(:running) }.to raise_error(Pgbus::Process::InvalidTransition)
+    end
+  end
+
+  describe "#transition_to (non-raising)" do
+    it "returns the new state on success" do
+      expect(lifecycle.transition_to(:running)).to eq(:running)
+    end
+
+    it "returns false on invalid transition" do
+      expect(lifecycle.transition_to(:draining)).to be false
+    end
+  end
+
+  describe "predicate methods" do
+    it "#active? returns true for running and paused" do
+      lifecycle.transition_to!(:running)
+      expect(lifecycle).to be_active
+
+      lifecycle.transition_to!(:paused)
+      expect(lifecycle).to be_active
+    end
+
+    it "#can_process? returns true only for running" do
+      lifecycle.transition_to!(:running)
+      expect(lifecycle).to be_can_process
+
+      lifecycle.transition_to!(:paused)
+      expect(lifecycle).not_to be_can_process
+    end
+
+    it "#terminal? returns true only for stopped" do
+      lifecycle.transition_to!(:running)
+      expect(lifecycle).not_to be_terminal
+
+      lifecycle.transition_to!(:stopped)
+      expect(lifecycle).to be_terminal
+    end
+  end
+
+  describe "callbacks" do
+    it "fires specific transition callbacks" do
+      called = false
+      lifecycle.on(:starting_to_running) { called = true }
+      lifecycle.transition_to!(:running)
+      expect(called).to be true
+    end
+
+    it "fires :any callbacks with old and new state" do
+      states = []
+      lifecycle.on(:any) { |old, new_state| states << [old, new_state] }
+      lifecycle.transition_to!(:running)
+      lifecycle.transition_to!(:draining)
+      expect(states).to eq([[:starting, :running], [:running, :draining]])
+    end
+
+    it "does not fire callbacks on failed transitions" do
+      called = false
+      lifecycle.on(:starting_to_draining) { called = true }
+      lifecycle.transition_to(:draining) # invalid, returns false
+      expect(called).to be false
+    end
+  end
+end

--- a/spec/pgbus/process/lifecycle_spec.rb
+++ b/spec/pgbus/process/lifecycle_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Pgbus::Process::Lifecycle do
       lifecycle.on(:any) { |old, new_state| states << [old, new_state] }
       lifecycle.transition_to!(:running)
       lifecycle.transition_to!(:draining)
-      expect(states).to eq([[:starting, :running], [:running, :draining]])
+      expect(states).to eq([%i[starting running], %i[running draining]])
     end
 
     it "does not fire callbacks on failed transitions" do

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Pgbus::Process::Worker do
   let(:mock_client) { build_mock_client }
   let(:executor) { instance_double(Pgbus::ActiveJob::Executor) }
   let(:pool) { instance_double(Concurrent::FixedThreadPool, max_length: 5, queue_length: 0, shutdown: true, kill: true) }
+  let(:circuit_breaker) { instance_double(Pgbus::CircuitBreaker, paused?: false, record_success: nil, record_failure: nil) }
   let(:worker) { described_class.new(queues: %w[default], threads: 5) }
 
   before do
@@ -14,6 +15,7 @@ RSpec.describe Pgbus::Process::Worker do
     allow(Pgbus).to receive(:client).and_return(mock_client)
     allow(Pgbus::ActiveJob::Executor).to receive(:new).and_return(executor)
     allow(Concurrent::FixedThreadPool).to receive(:new).and_return(pool)
+    allow(Pgbus::CircuitBreaker).to receive(:new).and_return(circuit_breaker)
   end
 
   describe "#initialize" do
@@ -27,6 +29,7 @@ RSpec.describe Pgbus::Process::Worker do
     it "initializes stats tracking" do
       expect(worker.stats[:jobs_processed]).to eq(0)
       expect(worker.stats[:jobs_failed]).to eq(0)
+      expect(worker.stats[:in_flight]).to eq(0)
       expect(worker.stats[:started_at]).to be_a(Time)
     end
   end
@@ -103,13 +106,74 @@ RSpec.describe Pgbus::Process::Worker do
     end
   end
 
+  describe "prefetch flow control" do
+    before { allow(worker).to receive(:interruptible_sleep) }
+
+    context "when prefetch_limit is nil (default)" do
+      before { worker.config.prefetch_limit = nil }
+
+      it "does not cap fetch quantity" do
+        allow(mock_client).to receive(:read_batch).and_return([])
+        worker.send(:claim_and_execute)
+        expect(mock_client).to have_received(:read_batch).with("default", qty: 5)
+      end
+    end
+
+    context "when prefetch_limit is configured" do
+      before { worker.config.prefetch_limit = 3 }
+      after { worker.config.prefetch_limit = nil }
+
+      it "caps fetch to prefetch_limit when below idle threads" do
+        allow(mock_client).to receive(:read_batch).and_return([])
+        worker.send(:claim_and_execute)
+        expect(mock_client).to have_received(:read_batch).with("default", qty: 3)
+      end
+
+      it "sleeps when in_flight >= prefetch_limit" do
+        worker.instance_variable_get(:@in_flight).value = 3
+        worker.send(:claim_and_execute)
+        expect(mock_client).not_to have_received(:read_batch)
+        expect(worker).to have_received(:interruptible_sleep)
+      end
+
+      it "uses min of idle and available prefetch" do
+        # 2 in flight, limit 3 => available = 1, idle = 5 => fetch 1
+        worker.instance_variable_get(:@in_flight).value = 2
+        allow(mock_client).to receive(:read_batch).and_return([])
+        worker.send(:claim_and_execute)
+        expect(mock_client).to have_received(:read_batch).with("default", qty: 1)
+      end
+    end
+
+    it "increments in_flight when messages are fetched" do
+      msg = build_message_double(msg_id: 1, message: '{"job_class":"TestJob"}')
+      allow(mock_client).to receive(:read_batch).and_return([msg])
+      allow(pool).to receive(:post).and_yield
+
+      allow(executor).to receive(:execute).and_return(:success)
+      worker.send(:claim_and_execute)
+      # After process_message completes (via yield), in_flight should be back to 0
+      expect(worker.stats[:in_flight]).to eq(0)
+    end
+
+    it "decrements in_flight even when executor raises" do
+      msg = build_message_double(msg_id: 1, message: '{"job_class":"TestJob"}')
+      allow(mock_client).to receive(:read_batch).and_return([msg])
+      allow(pool).to receive(:post).and_yield
+
+      allow(executor).to receive(:execute).and_raise(StandardError, "boom")
+      worker.send(:claim_and_execute)
+      expect(worker.stats[:in_flight]).to eq(0)
+    end
+  end
+
   describe "#process_message (private)" do
     let(:message) { build_message_double(msg_id: 1, message: '{"job_class":"TestJob"}') }
 
     it "executes the message and increments jobs_processed" do
       allow(executor).to receive(:execute).and_return(:success)
       worker.send(:process_message, message, "default")
-      expect(executor).to have_received(:execute).with(message, "default")
+      expect(executor).to have_received(:execute).with(message, "default", source_queue: nil)
       expect(worker.stats[:jobs_processed]).to eq(1)
     end
 
@@ -124,6 +188,51 @@ RSpec.describe Pgbus::Process::Worker do
       allow(executor).to receive(:execute).and_raise(StandardError, "boom")
       worker.send(:process_message, message, "default")
       expect(worker.stats[:jobs_failed]).to eq(1)
+    end
+
+    it "signals circuit breaker success on successful execution" do
+      allow(executor).to receive(:execute).and_return(:success)
+      worker.send(:process_message, message, "default")
+      expect(circuit_breaker).to have_received(:record_success).with("default")
+    end
+
+    it "signals circuit breaker failure on failed execution" do
+      allow(executor).to receive(:execute).and_return(:failed)
+      worker.send(:process_message, message, "default")
+      expect(circuit_breaker).to have_received(:record_failure).with("default")
+    end
+
+    it "signals circuit breaker failure when executor raises" do
+      allow(executor).to receive(:execute).and_raise(StandardError, "boom")
+      worker.send(:process_message, message, "default")
+      expect(circuit_breaker).to have_received(:record_failure).with("default")
+    end
+  end
+
+  describe "circuit breaker integration" do
+    before { allow(worker).to receive(:interruptible_sleep) }
+
+    it "skips paused queues" do
+      allow(circuit_breaker).to receive(:paused?).with("default").and_return(true)
+      allow(mock_client).to receive(:read_batch).and_return([])
+
+      worker.send(:claim_and_execute)
+      expect(mock_client).not_to have_received(:read_batch)
+    end
+
+    context "with multiple queues" do
+      let(:worker) { described_class.new(queues: %w[default events], threads: 4) }
+
+      it "only reads from non-paused queues" do
+        allow(circuit_breaker).to receive(:paused?).with("default").and_return(true)
+        allow(circuit_breaker).to receive(:paused?).with("events").and_return(false)
+        allow(mock_client).to receive(:read_batch).and_return([])
+
+        worker.send(:claim_and_execute)
+        expect(mock_client).not_to have_received(:read_batch).with("default", anything)
+        # With only one active queue, pool max_length (5) is the fetch qty
+        expect(mock_client).to have_received(:read_batch).with("events", qty: 5)
+      end
     end
   end
 end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -30,21 +30,24 @@ RSpec.describe Pgbus::Process::Worker do
       expect(worker.stats[:jobs_processed]).to eq(0)
       expect(worker.stats[:jobs_failed]).to eq(0)
       expect(worker.stats[:in_flight]).to eq(0)
+      expect(worker.stats[:state]).to eq(:starting)
       expect(worker.stats[:started_at]).to be_a(Time)
     end
   end
 
   describe "#graceful_shutdown" do
-    it "sets shutting_down flag" do
+    it "transitions to draining state" do
+      worker.instance_variable_get(:@lifecycle).transition_to!(:running)
       worker.graceful_shutdown
-      expect(worker.instance_variable_get(:@shutting_down)).to be true
+      expect(worker.instance_variable_get(:@lifecycle).state).to eq(:draining)
     end
   end
 
   describe "#immediate_shutdown" do
-    it "sets shutting_down flag and kills the pool" do
+    it "transitions to stopped state and kills the pool" do
+      worker.instance_variable_get(:@lifecycle).transition_to!(:running)
       worker.immediate_shutdown
-      expect(worker.instance_variable_get(:@shutting_down)).to be true
+      expect(worker.instance_variable_get(:@lifecycle).state).to eq(:stopped)
       expect(pool).to have_received(:kill)
     end
   end

--- a/spec/pgbus/rate_counter_spec.rb
+++ b/spec/pgbus/rate_counter_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::RateCounter do
+  subject(:counter) { described_class.new(:processed, :failed) }
+
+  describe "#increment" do
+    it "increments the named counter" do
+      counter.increment(:processed)
+      counter.increment(:processed)
+      expect(counter.count(:processed)).to eq(2)
+    end
+
+    it "accepts a delta" do
+      counter.increment(:processed, 5)
+      expect(counter.count(:processed)).to eq(5)
+    end
+
+    it "raises for unknown counter names" do
+      expect { counter.increment(:unknown) }.to raise_error(KeyError)
+    end
+  end
+
+  describe "#count" do
+    it "returns 0 for fresh counters" do
+      expect(counter.count(:processed)).to eq(0)
+      expect(counter.count(:failed)).to eq(0)
+    end
+  end
+
+  describe "#counts" do
+    it "returns all counters as a hash" do
+      counter.increment(:processed, 10)
+      counter.increment(:failed, 2)
+      expect(counter.counts).to eq(processed: 10, failed: 2)
+    end
+  end
+
+  describe "#snapshot! and #rate" do
+    it "computes rate as delta / elapsed" do
+      counter.increment(:processed, 100)
+      # Simulate time passing by manipulating the internal monotonic timestamp
+      counter.instance_variable_set(:@last_snapshot_at,
+                                    Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10.0)
+      counter.instance_variable_set(:@last_values, { processed: 0, failed: 0 })
+      counter.snapshot!
+
+      # 100 msgs over 10 seconds ≈ 10.0 msgs/s
+      expect(counter.rate(:processed)).to be_within(1.0).of(10.0)
+      expect(counter.rate(:failed)).to eq(0.0)
+    end
+
+    it "returns 0 before first snapshot" do
+      expect(counter.rate(:processed)).to eq(0.0)
+    end
+  end
+
+  describe "#rates" do
+    it "returns all rates as a hash" do
+      expect(counter.rates).to eq(processed: 0.0, failed: 0.0)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns counts and rates" do
+      counter.increment(:processed, 5)
+      result = counter.to_h
+      expect(result[:counts]).to eq(processed: 5, failed: 0)
+      expect(result[:rates]).to eq(processed: 0.0, failed: 0.0)
+    end
+  end
+
+  describe "#names" do
+    it "returns the configured counter names" do
+      expect(counter.names).to eq(%i[processed failed])
+    end
+  end
+end

--- a/spec/pgbus/recurring/schedule_spec.rb
+++ b/spec/pgbus/recurring/schedule_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Pgbus::Recurring::Schedule do
       schedule.enqueue_task(task, run_at: run_at)
 
       expect(mock_client).to have_received(:send_message).with(
-        "pgbus_maintenance",
+        "maintenance",
         anything,
         headers: anything
       )
@@ -115,7 +115,7 @@ RSpec.describe Pgbus::Recurring::Schedule do
       schedule.enqueue_task(task_no_queue, run_at: run_at)
 
       expect(mock_client).to have_received(:send_message).with(
-        "pgbus_default",
+        "default",
         anything,
         headers: anything
       )


### PR DESCRIPTION
## Summary

Adds five features inspired by [LavinMQ](https://lavinmq.com/)'s architecture, plus a queue naming bug fix:

- **Prefetch-window flow control** — configurable `prefetch_limit` caps in-flight messages per worker, preventing overload
- **Queue pause/resume + circuit breaker** — auto-pause queues after consecutive failures with exponential backoff; manual pause/resume via dashboard
- **Priority queues via sub-queues** — N physical PGMQ queues per logical queue (`_p0` through `_pN`), highest-priority-first reads, ActiveJob priority routing
- **Archive compaction / message TTL** — configurable retention with batch purge of old archive entries in Dispatcher maintenance loop
- **Transactional outbox** — publish events atomically inside ActiveRecord transactions; background poller moves entries to PGMQ
- **Bug fix** — double-prefixed queue names (`pgbus_pgbus_default`) caused by `Recurring::Schedule#resolve_queue`

### New configuration options

| Option | Default | Description |
|--------|---------|-------------|
| `prefetch_limit` | `nil` | Max in-flight messages per worker (nil = unlimited) |
| `circuit_breaker_enabled` | `true` | Enable auto-pause on consecutive failures |
| `circuit_breaker_threshold` | `5` | Consecutive failures before tripping |
| `circuit_breaker_base_backoff` | `30` | Base backoff seconds (doubles per trip) |
| `circuit_breaker_max_backoff` | `600` | Max backoff cap in seconds |
| `priority_levels` | `nil` | Number of priority sub-queues (nil = disabled, 2-10) |
| `default_priority` | `1` | Default priority level for jobs without explicit priority |
| `archive_retention` | `7 days` | How long to keep archived messages |
| `archive_compaction_interval` | `3600` | Seconds between archive cleanup runs |
| `outbox_enabled` | `false` | Enable transactional outbox poller process |
| `outbox_poll_interval` | `1.0` | Seconds between outbox poll cycles |
| `outbox_batch_size` | `100` | Max entries per poll cycle |
| `outbox_retention` | `24h` | How long to keep published outbox entries |

### New generators

```bash
rails generate pgbus:add_queue_states    # Circuit breaker / pause support
rails generate pgbus:add_outbox          # Transactional outbox
```

## Test plan

- [x] All 482 specs pass (multiple random seeds verified)
- [x] RuboCop clean
- [ ] Manual test: enqueue jobs with priority and verify highest-priority-first processing
- [ ] Manual test: trigger circuit breaker by failing jobs, verify auto-pause and auto-resume
- [ ] Manual test: publish via `Pgbus::Outbox.publish` inside a transaction, verify poller delivery
- [ ] Manual test: verify archive compaction deletes old entries after retention period
- [ ] Verify no more `pgbus_pgbus_*` double-prefixed queues after recurring scheduler fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbox UI, stats and background poller with nav link; generators to add outbox and queue state tables.
  * Queue pause/resume UI with “Paused” badge and reason; automatic circuit-breaker pausing with exponential backoff.
  * Priority-aware message routing and worker support; dashboard “Throughput” stat.
  * Periodic archive compaction and outbox cleanup; lifecycle and heartbeat improvements; in-memory dedup cache and rate counter.

* **Tests**
  * Extensive new/updated specs covering outbox, circuit breaker, client priority/archive, lifecycle, dedup, and rate counter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->