### PR TITLE
fix: Rails 8.1 generator compatibility — rename create_migration

### DIFF
--- a/lib/generators/pgbus/add_outbox_generator.rb
+++ b/lib/generators/pgbus/add_outbox_generator.rb
@@ -17,7 +17,7 @@ module Pgbus
                    default: nil,
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
-      def create_migration
+      def create_migration_file
         if separate_database?
           migration_template "add_outbox.rb.erb",
                              "db/pgbus_migrate/add_pgbus_outbox.rb"

--- a/lib/generators/pgbus/add_queue_states_generator.rb
+++ b/lib/generators/pgbus/add_queue_states_generator.rb
@@ -17,7 +17,7 @@ module Pgbus
                    default: nil,
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
-      def create_migration
+      def create_migration_file
         if separate_database?
           migration_template "add_queue_states.rb.erb",
                              "db/pgbus_migrate/add_pgbus_queue_states.rb"

--- a/lib/generators/pgbus/add_recurring_generator.rb
+++ b/lib/generators/pgbus/add_recurring_generator.rb
@@ -17,7 +17,7 @@ module Pgbus
                    default: nil,
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
-      def create_migration
+      def create_migration_file
         if separate_database?
           migration_template "add_recurring_tables.rb.erb",
                              "db/pgbus_migrate/add_pgbus_recurring_tables.rb"

--- a/lib/generators/pgbus/install_generator.rb
+++ b/lib/generators/pgbus/install_generator.rb
@@ -24,7 +24,7 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus). " \
                          "Migrations go to db/pgbus_migrate/ and schema to db/pgbus_schema.rb"
 
-      def create_migration
+      def create_migration_file
         if separate_database?
           migration_template "migration.rb.erb",
                              "db/pgbus_migrate/create_pgbus_tables.rb"

--- a/lib/generators/pgbus/upgrade_pgmq_generator.rb
+++ b/lib/generators/pgbus/upgrade_pgmq_generator.rb
@@ -17,7 +17,7 @@ module Pgbus
                    default: nil,
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
-      def create_migration
+      def create_migration_file
         if separate_database?
           migration_template "upgrade_pgmq.rb.erb",
                              "db/pgbus_migrate/upgrade_pgmq_to_v#{target_version_slug}.rb"


### PR DESCRIPTION
## Summary

All 5 pgbus generators fail on Rails 8.1 with:

```
ArgumentError: wrong number of arguments (given 3, expected 0)
  add_queue_states_generator.rb:20:in 'create_migration'
```

**Root cause**: Rails 8.1's `migration_template` internally calls `create_migration` (defined in `Rails::Generators::Migration`). Our generators defined a public method with the same name. Ruby's method resolution finds OUR `create_migration` (arity 0) instead of Rails' `create_migration` (arity 3), causing the ArgumentError.

**Fix**: Rename `def create_migration` to `def create_migration_file` in all 5 generators. Rails' generator framework invokes public methods in definition order, so the renamed method still runs correctly.

Affected generators:
- `pgbus:install`
- `pgbus:add_recurring`
- `pgbus:add_queue_states`
- `pgbus:add_outbox`
- `pgbus:upgrade_pgmq`

## Test plan

- [x] 516 specs pass
- [x] RuboCop clean
- [x] Verified `create_migration` resolves to Rails' internal method (not ours)
- [ ] `bin/rails generate pgbus:add_queue_states --database=pgbus` succeeds on Rails 8.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal generator code structure for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->