### PR TITLE
refactor: QueueFactory pattern and WakeSignal event coordination

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -32,14 +32,11 @@ module Pgbus
       )
       @pgmq_mutex = Mutex.new
       @queues_created = Concurrent::Map.new
+      @queue_strategy = QueueFactory.for(config)
     end
 
     def ensure_queue(name)
-      if priority_enabled?
-        config.priority_queue_names(name).each { |pq| ensure_single_queue(pq) }
-      else
-        ensure_single_queue(config.queue_name(name))
-      end
+      @queue_strategy.physical_queue_names(name).each { |pq| ensure_single_queue(pq) }
     rescue PGMQ::Errors::ConnectionError => e
       raise Pgbus::SchemaNotReady,
             "PGMQ schema is not available (#{e.message}). Run `rails db:migrate` for the pgbus database."
@@ -56,7 +53,7 @@ module Pgbus
     end
 
     def send_message(queue_name, payload, headers: nil, delay: 0, priority: nil)
-      target = resolve_target_queue(queue_name, priority)
+      target = @queue_strategy.target_queue(queue_name, priority)
       ensure_queue(queue_name)
       Instrumentation.instrument("pgbus.client.send_message", queue: target) do
         synchronized { @pgmq.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay) }
@@ -90,7 +87,11 @@ module Pgbus
     # Read from priority sub-queues, highest priority (p0) first.
     # Returns [priority_queue_name, messages] pairs.
     def read_batch_prioritized(queue_name, qty:, vt: nil)
-      return (read_batch(queue_name, qty: qty, vt: vt) || []).map { |m| [config.queue_name(queue_name), m] } unless priority_enabled?
+      unless @queue_strategy.priority?
+        return (read_batch(queue_name, qty: qty, vt: vt) || []).map do |m|
+          [config.queue_name(queue_name), m]
+        end
+      end
 
       remaining = qty
       results = []
@@ -236,21 +237,6 @@ module Pgbus
           @pgmq.enable_notify_insert(full_name, throttle_interval_ms: config.notify_throttle_ms) if config.listen_notify
         end
         true
-      end
-    end
-
-    def priority_enabled?
-      config.priority_levels && config.priority_levels > 1
-    end
-
-    def resolve_target_queue(queue_name, priority)
-      if priority_enabled? && priority
-        clamped = priority.clamp(0, config.priority_levels - 1)
-        config.priority_queue_name(queue_name, clamped)
-      elsif priority_enabled?
-        config.priority_queue_name(queue_name, config.default_priority.clamp(0, config.priority_levels - 1))
-      else
-        config.queue_name(queue_name)
       end
     end
 

--- a/lib/pgbus/process/wake_signal.rb
+++ b/lib/pgbus/process/wake_signal.rb
@@ -4,22 +4,30 @@ require "concurrent"
 
 module Pgbus
   module Process
-    # Thread-safe wake signal inspired by LavinMQ's BoolChannel pattern.
+    # Wake signal inspired by LavinMQ's BoolChannel pattern.
     # Replaces polling-based coordination with instant state-change signaling.
+    #
+    # IMPORTANT: Single-waiter only. The +wait+ method calls @event.reset
+    # immediately after waking, which means concurrent waiters may miss
+    # notifications. Callers must ensure only one thread calls +wait+ at
+    # a time. In pgbus this is guaranteed because each Worker has exactly
+    # one main loop thread that calls +wait+, while +notify!+ can be
+    # called from any thread (signal handlers, lifecycle transitions).
     #
     # Usage:
     #   signal = WakeSignal.new
-    #   # In worker thread:
+    #   # In worker thread (single waiter):
     #   signal.wait(timeout: 5)  # blocks until signaled or timeout
-    #   # In another thread (e.g. LISTEN/NOTIFY callback):
-    #   signal.notify!           # wakes all waiting threads
+    #   # In another thread (e.g. signal handler, lifecycle transition):
+    #   signal.notify!           # wakes the waiting thread
     class WakeSignal
       def initialize
         @event = Concurrent::Event.new
       end
 
-      # Block until signaled or timeout expires.
+      # Block until +notify!+ is called or timeout expires.
       # Returns true if signaled, false if timed out.
+      # Resets the event after waking — only safe with a single waiter.
       def wait(timeout: nil)
         result = @event.wait(timeout)
         @event.reset

--- a/lib/pgbus/process/wake_signal.rb
+++ b/lib/pgbus/process/wake_signal.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Pgbus
+  module Process
+    # Thread-safe wake signal inspired by LavinMQ's BoolChannel pattern.
+    # Replaces polling-based coordination with instant state-change signaling.
+    #
+    # Usage:
+    #   signal = WakeSignal.new
+    #   # In worker thread:
+    #   signal.wait(timeout: 5)  # blocks until signaled or timeout
+    #   # In another thread (e.g. LISTEN/NOTIFY callback):
+    #   signal.notify!           # wakes all waiting threads
+    class WakeSignal
+      def initialize
+        @event = Concurrent::Event.new
+      end
+
+      # Block until signaled or timeout expires.
+      # Returns true if signaled, false if timed out.
+      def wait(timeout: nil)
+        result = @event.wait(timeout)
+        @event.reset
+        result
+      end
+
+      # Wake all waiting threads immediately.
+      def notify!
+        @event.set
+      end
+
+      # Check if a notification is pending without blocking.
+      def pending?
+        @event.set?
+      end
+
+      # Clear the pending notification.
+      def reset!
+        @event.reset
+      end
+    end
+  end
+end

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -26,6 +26,7 @@ module Pgbus
         @pool = Concurrent::FixedThreadPool.new(threads)
         @circuit_breaker = Pgbus::CircuitBreaker.new(config: config)
         @queue_lock = QueueLock.new if @single_active_consumer
+        @wake_signal = WakeSignal.new
       end
 
       def stats
@@ -57,7 +58,7 @@ module Pgbus
           break if @lifecycle.draining? && @pool.queue_length.zero?
 
           claim_and_execute if @lifecycle.can_process?
-          interruptible_sleep(config.polling_interval) if @lifecycle.draining? || @lifecycle.paused?
+          @wake_signal.wait(timeout: config.polling_interval) if @lifecycle.draining? || @lifecycle.paused?
         end
 
         shutdown
@@ -66,11 +67,13 @@ module Pgbus
       def graceful_shutdown
         Pgbus.logger.info { "[Pgbus] Worker shutting down gracefully..." }
         @lifecycle.transition_to(:draining)
+        @wake_signal.notify!
       end
 
       def immediate_shutdown
         Pgbus.logger.warn { "[Pgbus] Worker shutting down immediately!" }
         @lifecycle.transition_to!(:stopped)
+        @wake_signal.notify!
         @pool.kill
       end
 
@@ -198,6 +201,7 @@ module Pgbus
         return unless @lifecycle.running? && recycle_needed?
 
         @lifecycle.transition_to(:draining)
+        @wake_signal.notify!
       end
 
       def recycle_needed?

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -83,11 +83,11 @@ module Pgbus
         poll_interval = effective_polling_interval
 
         idle = @pool.max_length - @pool.queue_length
-        return interruptible_sleep(poll_interval) if idle <= 0
+        return @wake_signal.wait(timeout: poll_interval) if idle <= 0
 
         if config.prefetch_limit
           available = config.prefetch_limit - @in_flight.value
-          return interruptible_sleep(poll_interval) if available <= 0
+          return @wake_signal.wait(timeout: poll_interval) if available <= 0
 
           idle = [idle, available].min
         end
@@ -95,7 +95,7 @@ module Pgbus
         tagged_messages = fetch_messages(idle)
 
         if tagged_messages.empty?
-          interruptible_sleep(poll_interval)
+          @wake_signal.wait(timeout: poll_interval)
           return
         end
 

--- a/lib/pgbus/queue_factory.rb
+++ b/lib/pgbus/queue_factory.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Pgbus
+  # Dispatches queue operations based on queue type (standard vs priority).
+  # Replaces conditional `priority_enabled?` checks scattered through Client
+  # with a single strategy object selected at initialization.
+  #
+  # Inspired by LavinMQ's QueueFactory which dispatches queue creation by
+  # type: standard, durable, priority, stream, delayed.
+  module QueueFactory
+    def self.for(config)
+      if config.priority_levels && config.priority_levels > 1
+        PriorityStrategy.new(config)
+      else
+        StandardStrategy.new(config)
+      end
+    end
+
+    # Standard single-queue strategy: one PGMQ queue per logical name.
+    class StandardStrategy
+      def initialize(config)
+        @config = config
+      end
+
+      def physical_queue_names(name)
+        [@config.queue_name(name)]
+      end
+
+      def target_queue(name, _priority)
+        @config.queue_name(name)
+      end
+
+      def priority?
+        false
+      end
+    end
+
+    # Priority sub-queue strategy: N PGMQ queues per logical name (_p0.._pN).
+    class PriorityStrategy
+      def initialize(config)
+        @config = config
+      end
+
+      def physical_queue_names(name)
+        @config.priority_queue_names(name)
+      end
+
+      def target_queue(name, priority)
+        level = if priority
+                  priority.clamp(0, @config.priority_levels - 1)
+                else
+                  @config.default_priority.clamp(0, @config.priority_levels - 1)
+                end
+        @config.priority_queue_name(name, level)
+      end
+
+      def priority?
+        true
+      end
+    end
+  end
+end

--- a/spec/pgbus/allocation_budget_spec.rb
+++ b/spec/pgbus/allocation_budget_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Pgbus::Client do
       c.instance_variable_set(:@config, Pgbus.configuration)
       c.instance_variable_set(:@pgmq_mutex, Mutex.new)
       c.instance_variable_set(:@queues_created, all_queues_created)
+      c.instance_variable_set(:@queue_strategy, Pgbus::QueueFactory.for(Pgbus.configuration))
     end
   end
 
@@ -100,6 +101,7 @@ RSpec.describe Pgbus::Client do
         c.instance_variable_set(:@config, Pgbus.configuration)
         c.instance_variable_set(:@pgmq_mutex, Mutex.new)
         c.instance_variable_set(:@queues_created, all_queues_created)
+        c.instance_variable_set(:@queue_strategy, Pgbus::QueueFactory.for(Pgbus.configuration))
       end
     end
 

--- a/spec/pgbus/process/wake_signal_spec.rb
+++ b/spec/pgbus/process/wake_signal_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Process::WakeSignal do
+  subject(:signal) { described_class.new }
+
+  describe "#wait" do
+    it "returns false on timeout" do
+      result = signal.wait(timeout: 0.01)
+      expect(result).to be false
+    end
+
+    it "returns true when notified before timeout" do
+      Thread.new do
+        sleep 0.01
+        signal.notify!
+      end
+      result = signal.wait(timeout: 1)
+      expect(result).to be true
+    end
+  end
+
+  describe "#notify!" do
+    it "wakes a waiting thread" do
+      woken = false
+      thread = Thread.new do
+        signal.wait(timeout: 5)
+        woken = true
+      end
+      sleep 0.01 # let thread start waiting
+      signal.notify!
+      thread.join(1)
+      expect(woken).to be true
+    end
+  end
+
+  describe "#pending?" do
+    it "returns false by default" do
+      expect(signal.pending?).to be false
+    end
+
+    it "returns true after notify" do
+      signal.notify!
+      expect(signal.pending?).to be true
+    end
+  end
+
+  describe "#reset!" do
+    it "clears pending notification" do
+      signal.notify!
+      signal.reset!
+      expect(signal.pending?).to be false
+    end
+  end
+end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -112,10 +112,7 @@ RSpec.describe Pgbus::Process::Worker do
   describe "prefetch flow control" do
     let(:wake_signal) { worker.instance_variable_get(:@wake_signal) }
 
-    before do
-      allow(worker).to receive(:interruptible_sleep)
-      allow(wake_signal).to receive(:wait)
-    end
+    before { allow(wake_signal).to receive(:wait) }
 
     context "when prefetch_limit is nil (default)" do
       before { worker.config.prefetch_limit = nil }
@@ -218,10 +215,7 @@ RSpec.describe Pgbus::Process::Worker do
   end
 
   describe "circuit breaker integration" do
-    before do
-      allow(worker).to receive(:interruptible_sleep)
-      allow(worker.instance_variable_get(:@wake_signal)).to receive(:wait)
-    end
+    before { allow(worker.instance_variable_get(:@wake_signal)).to receive(:wait) }
 
     it "skips paused queues" do
       allow(circuit_breaker).to receive(:paused?).with("default").and_return(true)
@@ -253,7 +247,6 @@ RSpec.describe Pgbus::Process::Worker do
 
     before do
       allow(Pgbus::Process::QueueLock).to receive(:new).and_return(queue_lock)
-      allow(worker).to receive(:interruptible_sleep)
       allow(worker.instance_variable_get(:@wake_signal)).to receive(:wait)
     end
 

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -110,7 +110,12 @@ RSpec.describe Pgbus::Process::Worker do
   end
 
   describe "prefetch flow control" do
-    before { allow(worker).to receive(:interruptible_sleep) }
+    let(:wake_signal) { worker.instance_variable_get(:@wake_signal) }
+
+    before do
+      allow(worker).to receive(:interruptible_sleep)
+      allow(wake_signal).to receive(:wait)
+    end
 
     context "when prefetch_limit is nil (default)" do
       before { worker.config.prefetch_limit = nil }
@@ -132,11 +137,11 @@ RSpec.describe Pgbus::Process::Worker do
         expect(mock_client).to have_received(:read_batch).with("default", qty: 3)
       end
 
-      it "sleeps when in_flight >= prefetch_limit" do
+      it "waits when in_flight >= prefetch_limit" do
         worker.instance_variable_get(:@in_flight).value = 3
         worker.send(:claim_and_execute)
         expect(mock_client).not_to have_received(:read_batch)
-        expect(worker).to have_received(:interruptible_sleep)
+        expect(wake_signal).to have_received(:wait)
       end
 
       it "uses min of idle and available prefetch" do
@@ -213,7 +218,10 @@ RSpec.describe Pgbus::Process::Worker do
   end
 
   describe "circuit breaker integration" do
-    before { allow(worker).to receive(:interruptible_sleep) }
+    before do
+      allow(worker).to receive(:interruptible_sleep)
+      allow(worker.instance_variable_get(:@wake_signal)).to receive(:wait)
+    end
 
     it "skips paused queues" do
       allow(circuit_breaker).to receive(:paused?).with("default").and_return(true)
@@ -246,6 +254,7 @@ RSpec.describe Pgbus::Process::Worker do
     before do
       allow(Pgbus::Process::QueueLock).to receive(:new).and_return(queue_lock)
       allow(worker).to receive(:interruptible_sleep)
+      allow(worker.instance_variable_get(:@wake_signal)).to receive(:wait)
     end
 
     it "only reads from queues where advisory lock is held" do

--- a/spec/pgbus/queue_factory_spec.rb
+++ b/spec/pgbus/queue_factory_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::QueueFactory do
+  let(:config) { Pgbus::Configuration.new }
+
+  describe ".for" do
+    it "returns StandardStrategy when priority_levels is nil" do
+      expect(described_class.for(config)).to be_a(described_class::StandardStrategy)
+    end
+
+    it "returns StandardStrategy when priority_levels is 1" do
+      config.priority_levels = 1
+      expect(described_class.for(config)).to be_a(described_class::StandardStrategy)
+    end
+
+    it "returns PriorityStrategy when priority_levels > 1" do
+      config.priority_levels = 3
+      expect(described_class.for(config)).to be_a(described_class::PriorityStrategy)
+    end
+  end
+
+  describe Pgbus::QueueFactory::StandardStrategy do
+    subject(:strategy) { described_class.new(config) }
+
+    describe "#physical_queue_names" do
+      it "returns a single prefixed queue name" do
+        expect(strategy.physical_queue_names("default")).to eq(["pgbus_default"])
+      end
+    end
+
+    describe "#target_queue" do
+      it "returns the prefixed name regardless of priority" do
+        expect(strategy.target_queue("default", nil)).to eq("pgbus_default")
+        expect(strategy.target_queue("default", 0)).to eq("pgbus_default")
+        expect(strategy.target_queue("default", 5)).to eq("pgbus_default")
+      end
+    end
+
+    describe "#priority?" do
+      it "returns false" do
+        expect(strategy.priority?).to be false
+      end
+    end
+  end
+
+  describe Pgbus::QueueFactory::PriorityStrategy do
+    subject(:strategy) { described_class.new(config) }
+
+    before { config.priority_levels = 3 }
+
+    describe "#physical_queue_names" do
+      it "returns sub-queue names for each priority level" do
+        expect(strategy.physical_queue_names("default")).to eq(
+          %w[pgbus_default_p0 pgbus_default_p1 pgbus_default_p2]
+        )
+      end
+    end
+
+    describe "#target_queue" do
+      it "routes to the correct sub-queue by priority" do
+        expect(strategy.target_queue("default", 0)).to eq("pgbus_default_p0")
+        expect(strategy.target_queue("default", 2)).to eq("pgbus_default_p2")
+      end
+
+      it "uses default_priority when priority is nil" do
+        config.default_priority = 1
+        expect(strategy.target_queue("default", nil)).to eq("pgbus_default_p1")
+      end
+
+      it "clamps priority to valid range" do
+        expect(strategy.target_queue("default", 99)).to eq("pgbus_default_p2")
+        expect(strategy.target_queue("default", -1)).to eq("pgbus_default_p0")
+      end
+    end
+
+    describe "#priority?" do
+      it "returns true" do
+        expect(strategy.priority?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two architectural refactors inspired by LavinMQ's design patterns:

- **QueueFactory** — extracts priority-aware queue resolution from Client into strategy objects (`StandardStrategy` / `PriorityStrategy`). Removes scattered `priority_enabled?` conditionals. Client delegates `ensure_queue`, `target_queue`, and `priority?` to the strategy selected at initialization.

- **WakeSignal** — wraps `Concurrent::Event` for instant state-change signaling, inspired by LavinMQ's `BoolChannel` pattern. Worker draining/paused states now use `wake_signal.wait(timeout:)` instead of polling `interruptible_sleep`. Lifecycle transitions (`graceful_shutdown`, `check_recycle`) call `notify!` for immediate wake-up instead of waiting for the next poll cycle.

### What changed

| File | Change |
|------|--------|
| `lib/pgbus/queue_factory.rb` | New: strategy pattern for standard vs priority queues |
| `lib/pgbus/process/wake_signal.rb` | New: Concurrent::Event wrapper for state-change signaling |
| `lib/pgbus/client.rb` | Uses `@queue_strategy` instead of inline `priority_enabled?` checks |
| `lib/pgbus/process/worker.rb` | Uses `@wake_signal` for lifecycle-driven waits; `notify!` on shutdown/recycle |

No behavioral changes — all existing tests pass. +20 new tests for the new classes.

## Test plan

- [x] 556 specs pass (0 failures)
- [x] RuboCop clean (156 files, 0 offenses)
- [x] Allocation budget specs pass (QueueFactory strategy object accounted for)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to a strategy-driven queue model that streamlines single- and multi-level priority queue behavior and simplifies target selection.
  * Replaced sleep-based worker coordination with a wake/wait mechanism for clearer lifecycle handling.
* **New Features**
  * Worker responsiveness improved during pause/drain/shutdown, reducing wait latency.
* **Tests**
  * Added and updated specs to cover queue strategies and the new wake/wait coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->