### PR TITLE
feat: job uniqueness guarantees and integration test infrastructure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,112 @@ jobs:
       - name: Run unit tests
         run: bundle exec rspec spec/pgbus/
 
+  integration:
+    runs-on: ubuntu-latest
+    name: Integration Tests
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: pgbus
+          POSTGRES_PASSWORD: pgbus
+          POSTGRES_DB: pgbus_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      PGBUS_DATABASE_URL: postgres://pgbus:pgbus@localhost:5432/pgbus_test
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Set up PGMQ schema
+        run: |
+          PGPASSWORD=pgbus psql -h localhost -U pgbus -d pgbus_test -c "CREATE SCHEMA IF NOT EXISTS pgmq"
+          bundle exec ruby -e "
+            require 'pgbus'
+            Pgbus.configure { |c| c.database_url = ENV['PGBUS_DATABASE_URL'] }
+            conn = PG.connect(ENV['PGBUS_DATABASE_URL'])
+            conn.exec(Pgbus::PgmqSchema.install_sql)
+            conn.exec(Pgbus::PgmqSchema.version_tracking_sql)
+            conn.close
+          "
+      - name: Set up pgbus tables
+        run: |
+          bundle exec ruby -e "
+            require 'pg'
+            conn = PG.connect(ENV['PGBUS_DATABASE_URL'])
+            # Create all pgbus tables
+            conn.exec(<<~SQL)
+              CREATE TABLE IF NOT EXISTS pgbus_processed_events (
+                id BIGSERIAL PRIMARY KEY,
+                event_id VARCHAR NOT NULL,
+                handler_class VARCHAR NOT NULL,
+                processed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+              );
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_pgbus_processed_events_unique
+                ON pgbus_processed_events (event_id, handler_class);
+
+              CREATE TABLE IF NOT EXISTS pgbus_processes (
+                id BIGSERIAL PRIMARY KEY,
+                kind VARCHAR NOT NULL,
+                hostname VARCHAR,
+                pid INTEGER,
+                metadata JSONB DEFAULT '{}',
+                last_heartbeat_at TIMESTAMP,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+              );
+
+              CREATE TABLE IF NOT EXISTS pgbus_semaphores (
+                id BIGSERIAL PRIMARY KEY,
+                key VARCHAR NOT NULL,
+                value INTEGER NOT NULL DEFAULT 0,
+                max_value INTEGER NOT NULL DEFAULT 1,
+                expires_at TIMESTAMP NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+              );
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_pgbus_semaphores_key
+                ON pgbus_semaphores (key);
+
+              CREATE TABLE IF NOT EXISTS pgbus_blocked_executions (
+                id BIGSERIAL PRIMARY KEY,
+                concurrency_key VARCHAR NOT NULL,
+                queue_name VARCHAR NOT NULL,
+                payload JSONB NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 0,
+                expires_at TIMESTAMP NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+              );
+
+              CREATE TABLE IF NOT EXISTS pgbus_job_locks (
+                id BIGSERIAL PRIMARY KEY,
+                lock_key VARCHAR NOT NULL,
+                job_class VARCHAR NOT NULL,
+                job_id VARCHAR,
+                locked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                expires_at TIMESTAMP NOT NULL
+              );
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_pgbus_job_locks_key
+                ON pgbus_job_locks (lock_key);
+              CREATE INDEX IF NOT EXISTS idx_pgbus_job_locks_expires
+                ON pgbus_job_locks (expires_at);
+            SQL
+            conn.close
+          "
+      - name: Run integration tests
+        run: bundle exec rspec spec/integration/
+
   system_test:
     runs-on: ubuntu-latest
     name: System Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,8 @@ jobs:
                 lock_key VARCHAR NOT NULL,
                 job_class VARCHAR NOT NULL,
                 job_id VARCHAR,
+                state VARCHAR NOT NULL DEFAULT 'queued',
+                owner_pid INTEGER,
                 locked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 expires_at TIMESTAMP NOT NULL
               );
@@ -150,6 +152,8 @@ jobs:
                 ON pgbus_job_locks (lock_key);
               CREATE INDEX IF NOT EXISTS idx_pgbus_job_locks_expires
                 ON pgbus_job_locks (expires_at);
+              CREATE INDEX IF NOT EXISTS idx_pgbus_job_locks_reaper
+                ON pgbus_job_locks (state, owner_pid);
             SQL
             conn.close
           "

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,6 +151,7 @@ jobs:
                 job_id VARCHAR,
                 state VARCHAR NOT NULL DEFAULT 'queued',
                 owner_pid INTEGER,
+                owner_hostname VARCHAR,
                 locked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 expires_at TIMESTAMP NOT NULL
               );

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,16 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    name: Integration Tests
+    name: Integration (PG ${{ matrix.postgres }})
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres:
+          - "17"
+          - "18"
     services:
       postgres:
-        image: postgres:17
+        image: postgres:${{ matrix.postgres }}
         env:
           POSTGRES_USER: pgbus
           POSTGRES_PASSWORD: pgbus

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           PGPASSWORD=pgbus psql -h localhost -U pgbus -d pgbus_test -c "CREATE SCHEMA IF NOT EXISTS pgmq"
           bundle exec ruby -e "
+            require 'pg'
             require 'pgbus'
             Pgbus.configure { |c| c.database_url = ENV['PGBUS_DATABASE_URL'] }
             conn = PG.connect(ENV['PGBUS_DATABASE_URL'])

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,10 @@ RSpec/VerifiedDoubles:
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
+RSpec/DescribeClass:
+  Exclude:
+    - spec/integration/**/*
+
 RSpec/AnyInstance:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ PostgreSQL-native job processing and event bus for Rails, built on [PGMQ](https:
 - [Quick start](#quick-start)
 - [Concurrency controls](#concurrency-controls)
 - [Batches](#batches)
+- [Job uniqueness](#job-uniqueness)
 - [Priority queues](#priority-queues)
 - [Single active consumer](#single-active-consumer)
 - [Consumer priority](#consumer-priority)
@@ -48,6 +49,7 @@ PostgreSQL-native job processing and event bus for Rails, built on [PGMQ](https:
 - **Transactional outbox** -- publish events atomically inside database transactions
 - **Single active consumer** -- advisory-lock-based exclusive queue processing for strict ordering
 - **Consumer priority** -- higher-priority workers get first dibs, lower-priority workers back off
+- **Job uniqueness** -- prevent duplicate jobs with reaper-based crash recovery, no TTL-driven expiry
 
 ## Requirements
 
@@ -340,6 +342,96 @@ end
 4. When `completed_jobs + discarded_jobs == total_jobs`, the batch status flips to `"finished"` and callback jobs are enqueued
 5. The dispatcher cleans up finished batches older than 7 days
 
+## Job uniqueness
+
+Prevent duplicate jobs from running. Unlike `limits_concurrency` (which controls *how many* jobs with the same key run), uniqueness guarantees *at most one* job with a given key exists in the system at any time.
+
+```ruby
+class ImportOrderJob < ApplicationJob
+  ensures_uniqueness strategy: :until_executed,
+                     key: ->(order_id) { "import-order-#{order_id}" },
+                     on_conflict: :reject
+
+  def perform(order_id)
+    # Only ONE instance per order_id can exist — from enqueue through completion.
+    # If another ImportOrderJob for this order_id is already enqueued or running,
+    # the duplicate is rejected immediately.
+  end
+end
+```
+
+### Strategies
+
+| Strategy | Lock acquired | Lock released | Prevents |
+|----------|--------------|---------------|----------|
+| `:until_executed` | At enqueue | On completion or DLQ | Duplicate enqueue AND execution |
+| `:while_executing` | At execution start | On completion or DLQ | Duplicate execution only |
+
+### Conflict policies
+
+| Policy | Behavior |
+|--------|----------|
+| `:reject` | Raise `Pgbus::JobNotUnique` (default) |
+| `:discard` | Silently drop the duplicate |
+| `:log` | Log a warning and drop |
+
+### Lock lifecycle
+
+The lock is **never released by a timer**. It is held as long as the job exists in the system:
+
+```text
+Enqueue ──→ pgbus_job_locks (state: queued, owner_pid: nil)
+                  │
+  Worker picks up job
+                  │
+                  ▼
+           claim_for_execution! (state: executing, owner_pid: PID)
+                  │
+          ┌───────┴───────┐
+          ▼               ▼
+      Success           Crash
+      release!        (lock orphaned)
+      (row deleted)       │
+                          ▼
+                    Reaper checks:
+                    Is owner_pid in pgbus_processes
+                    with fresh heartbeat?
+                          │
+                    ┌─────┴─────┐
+                    No          Yes
+                    ▼            ▼
+                release!      (keep lock,
+                (orphaned)     job is running)
+```
+
+**Crash recovery** works through the reaper (runs every 5 minutes in the dispatcher). It cross-references `owner_pid` in `pgbus_job_locks` against `pgbus_processes` heartbeats. If the owning worker has no fresh heartbeat, the lock is orphaned and released — the PGMQ message's visibility timeout will expire and the job will be retried by another worker.
+
+A last-resort TTL (default 24 hours) handles the case where the entire pgbus supervisor is dead and the reaper itself can't run.
+
+### Uniqueness vs concurrency controls
+
+| | `ensures_uniqueness` | `limits_concurrency` |
+|---|---|---|
+| **Purpose** | Prevent duplicate jobs | Limit concurrent execution slots |
+| **Lock type** | Binary lock (one or none) | Counting semaphore (up to N) |
+| **At enqueue** | `:until_executed` blocks duplicates | Checks semaphore, blocks/discards/raises |
+| **At execution** | `:while_executing` blocks duplicate runs | Not checked (semaphore acquired at enqueue) |
+| **Duplicate in queue** | `:until_executed`: impossible. `:while_executing`: allowed, only one runs | Allowed up to N, rest blocked |
+| **Crash recovery** | Reaper checks heartbeats | Semaphore `expires_at` + dispatcher cleanup |
+| **Use when** | "This exact job must not run twice" | "At most N of these can run at once" |
+
+**When to use which:**
+- Payment processing, order import, unique email sends → `ensures_uniqueness`
+- Rate-limited API calls, resource-constrained tasks → `limits_concurrency`
+- Both at once → combine them (they use separate tables, no conflicts)
+
+### Setup
+
+```bash
+rails generate pgbus:add_job_locks                  # Add the migration
+rails generate pgbus:add_job_locks --database=pgbus # For separate database
+```
+
 ## Priority queues
 
 Route jobs to priority sub-queues so high-priority work is processed first:
@@ -615,6 +707,7 @@ Pgbus uses these tables (created via PGMQ and migrations):
 | `pgbus_semaphores` | Concurrency control counting semaphores |
 | `pgbus_blocked_executions` | Jobs waiting for a concurrency semaphore slot |
 | `pgbus_batches` | Batch tracking with job counters and callback config |
+| `pgbus_job_locks` | Job uniqueness locks (state, owner_pid, reaper correlation) |
 | `pgbus_queue_states` | Queue pause/resume and circuit breaker state |
 | `pgbus_outbox_entries` | Transactional outbox entries pending publication |
 | `pgbus_recurring_tasks` | Recurring job definitions |

--- a/app/models/pgbus/job_lock.rb
+++ b/app/models/pgbus/job_lock.rb
@@ -4,19 +4,27 @@ module Pgbus
   class JobLock < Pgbus::ApplicationRecord
     self.table_name = "pgbus_job_locks"
 
+    # States:
+    #   queued    — lock held from enqueue time (:until_executed), no worker yet
+    #   executing — lock held by an active worker process
+    STATES = %w[queued executing].freeze
+
+    scope :executing, -> { where(state: "executing") }
+    scope :queued_locks, -> { where(state: "queued") }
     scope :expired, ->(now = Time.current) { where("expires_at < ?", now) }
 
-    # Atomically try to acquire a lock. Cleans up expired locks in the same
-    # query path so stale locks don't block new acquisitions until the next
-    # dispatcher cleanup cycle.
-    #
-    # Returns true if acquired, false if already locked by an active (non-expired) lock.
-    def self.acquire!(lock_key, job_class:, ttl:, job_id: nil)
-      # First, remove any expired lock for this key (crash recovery at acquire time)
+    # Atomically try to acquire a lock.
+    # Cleans up expired locks for this key first (crash recovery at acquire time).
+    # Returns true if acquired, false if already locked.
+    def self.acquire!(lock_key, job_class:, ttl:, job_id: nil, state: "queued", owner_pid: nil)
+      # Remove any expired lock for this key inline (last-resort TTL recovery)
       where(lock_key: lock_key).where("expires_at < ?", Time.current).delete_all
 
       result = insert(
-        { lock_key: lock_key, job_class: job_class, job_id: job_id, expires_at: Time.current + ttl },
+        {
+          lock_key: lock_key, job_class: job_class, job_id: job_id,
+          state: state, owner_pid: owner_pid, expires_at: Time.current + ttl
+        },
         unique_by: :lock_key
       )
       result.rows.any?
@@ -24,17 +32,42 @@ module Pgbus
       false
     end
 
+    # Transition a queued lock to executing state and claim ownership.
+    # Called when a worker starts executing a job that was locked at enqueue time.
+    def self.claim_for_execution!(lock_key, owner_pid:, ttl:)
+      where(lock_key: lock_key).update_all(
+        state: "executing",
+        owner_pid: owner_pid,
+        expires_at: Time.current + ttl
+      )
+    end
+
     # Release a lock by key.
     def self.release!(lock_key)
       where(lock_key: lock_key).delete_all
     end
 
-    # Check if a lock is currently held (and not expired).
+    # Check if a lock is currently held (regardless of expiry — reaper handles orphans).
     def self.locked?(lock_key)
-      where(lock_key: lock_key).where("expires_at >= ?", Time.current).exists?
+      where(lock_key: lock_key).exists?
     end
 
-    # Delete all expired locks. Called by the dispatcher.
+    # Reap orphaned locks: locks in 'executing' state whose owner_pid
+    # has no healthy entry in pgbus_processes.
+    # Returns the number of orphaned locks released.
+    def self.reap_orphaned!
+      alive_pids = ProcessEntry
+                   .where("last_heartbeat_at >= ?", Time.current - Process::Heartbeat::ALIVE_THRESHOLD)
+                   .pluck(:pid)
+
+      orphaned = executing.where.not(owner_pid: alive_pids)
+      count = orphaned.count
+      orphaned.delete_all
+      count
+    end
+
+    # Last-resort cleanup: delete locks whose expires_at has passed.
+    # This only fires when the reaper itself can't run (e.g., entire supervisor dead).
     def self.cleanup_expired!
       expired.delete_all
     end

--- a/app/models/pgbus/job_lock.rb
+++ b/app/models/pgbus/job_lock.rb
@@ -16,14 +16,15 @@ module Pgbus
     # Atomically try to acquire a lock.
     # Cleans up expired locks for this key first (crash recovery at acquire time).
     # Returns true if acquired, false if already locked.
-    def self.acquire!(lock_key, job_class:, ttl:, job_id: nil, state: "queued", owner_pid: nil)
+    def self.acquire!(lock_key, job_class:, ttl:, job_id: nil, state: "queued", owner_pid: nil, owner_hostname: nil)
       # Remove any expired lock for this key inline (last-resort TTL recovery)
       where(lock_key: lock_key).where("expires_at < ?", Time.current).delete_all
 
       result = insert(
         {
           lock_key: lock_key, job_class: job_class, job_id: job_id,
-          state: state, owner_pid: owner_pid, expires_at: Time.current + ttl
+          state: state, owner_pid: owner_pid, owner_hostname: owner_hostname,
+          expires_at: Time.current + ttl
         },
         unique_by: :lock_key
       )
@@ -34,10 +35,11 @@ module Pgbus
 
     # Transition a queued lock to executing state and claim ownership.
     # Called when a worker starts executing a job that was locked at enqueue time.
-    def self.claim_for_execution!(lock_key, owner_pid:, ttl:)
+    def self.claim_for_execution!(lock_key, owner_pid:, owner_hostname:, ttl:)
       where(lock_key: lock_key).update_all(
         state: "executing",
         owner_pid: owner_pid,
+        owner_hostname: owner_hostname,
         expires_at: Time.current + ttl
       )
     end
@@ -55,15 +57,20 @@ module Pgbus
     # Reap orphaned locks: locks in 'executing' state whose owner_pid
     # has no healthy entry in pgbus_processes.
     # Returns the number of orphaned locks released.
+    # Reap orphaned locks by matching (pid, hostname) against live process entries.
+    # A lock is orphaned if no healthy process exists with the same pid AND hostname.
     def self.reap_orphaned!
-      alive_pids = ProcessEntry
-                   .where("last_heartbeat_at >= ?", Time.current - Process::Heartbeat::ALIVE_THRESHOLD)
-                   .pluck(:pid)
+      alive_workers = ProcessEntry
+                      .where("last_heartbeat_at >= ?", Time.current - Process::Heartbeat::ALIVE_THRESHOLD)
+                      .pluck(:pid, :hostname)
 
-      orphaned = executing.where.not(owner_pid: alive_pids)
-      count = orphaned.count
-      orphaned.delete_all
-      count
+      orphaned = executing.select do |lock|
+        alive_workers.none? { |pid, hostname| pid == lock.owner_pid && hostname == lock.owner_hostname }
+      end
+
+      return 0 if orphaned.empty?
+
+      where(id: orphaned.map(&:id)).delete_all
     end
 
     # Last-resort cleanup: delete locks whose expires_at has passed.

--- a/app/models/pgbus/job_lock.rb
+++ b/app/models/pgbus/job_lock.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class JobLock < Pgbus::ApplicationRecord
+    self.table_name = "pgbus_job_locks"
+
+    scope :expired, ->(now = Time.current) { where("expires_at < ?", now) }
+
+    # Atomically try to acquire a lock. Returns true if acquired, false if already locked.
+    # Uses INSERT ... ON CONFLICT DO NOTHING for race-free acquisition.
+    def self.acquire!(lock_key, job_class:, ttl:, job_id: nil)
+      result = insert(
+        { lock_key: lock_key, job_class: job_class, job_id: job_id, expires_at: Time.current + ttl },
+        unique_by: :lock_key
+      )
+      result.rows.any?
+    rescue ActiveRecord::RecordNotUnique
+      false
+    end
+
+    # Release a lock by key.
+    def self.release!(lock_key)
+      where(lock_key: lock_key).delete_all
+    end
+
+    # Check if a lock is currently held (and not expired).
+    def self.locked?(lock_key)
+      where(lock_key: lock_key).where("expires_at >= ?", Time.current).exists?
+    end
+
+    # Delete all expired locks. Called by the dispatcher.
+    def self.cleanup_expired!
+      expired.delete_all
+    end
+  end
+end

--- a/app/models/pgbus/job_lock.rb
+++ b/app/models/pgbus/job_lock.rb
@@ -6,9 +6,15 @@ module Pgbus
 
     scope :expired, ->(now = Time.current) { where("expires_at < ?", now) }
 
-    # Atomically try to acquire a lock. Returns true if acquired, false if already locked.
-    # Uses INSERT ... ON CONFLICT DO NOTHING for race-free acquisition.
+    # Atomically try to acquire a lock. Cleans up expired locks in the same
+    # query path so stale locks don't block new acquisitions until the next
+    # dispatcher cleanup cycle.
+    #
+    # Returns true if acquired, false if already locked by an active (non-expired) lock.
     def self.acquire!(lock_key, job_class:, ttl:, job_id: nil)
+      # First, remove any expired lock for this key (crash recovery at acquire time)
+      where(lock_key: lock_key).where("expires_at < ?", Time.current).delete_all
+
       result = insert(
         { lock_key: lock_key, job_class: job_class, job_id: job_id, expires_at: Time.current + ttl },
         unique_by: :lock_key

--- a/lib/generators/pgbus/add_job_locks_generator.rb
+++ b/lib/generators/pgbus/add_job_locks_generator.rb
@@ -33,7 +33,7 @@ module Pgbus
         say ""
         say "Next steps:"
         say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
-        say "  2. Add `include Pgbus::Uniqueness` and `ensures_uniqueness` to your job classes"
+        say "  2. Add `ensures_uniqueness` to your job classes (DSL is auto-included)"
         say "  3. Restart pgbus: bin/pgbus start"
         say ""
       end

--- a/lib/generators/pgbus/add_job_locks_generator.rb
+++ b/lib/generators/pgbus/add_job_locks_generator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class AddJobLocksGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Add job locks table for uniqueness guarantees"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
+      def create_migration_file
+        if separate_database?
+          migration_template "add_job_locks.rb.erb",
+                             "db/pgbus_migrate/add_pgbus_job_locks.rb"
+        else
+          migration_template "add_job_locks.rb.erb",
+                             "db/migrate/add_pgbus_job_locks.rb"
+        end
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus job locks table installed!", :green
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
+        say "  2. Add `include Pgbus::Uniqueness` and `ensures_uniqueness` to your job classes"
+        say "  3. Restart pgbus: bin/pgbus start"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/templates/add_job_locks.rb.erb
+++ b/lib/generators/pgbus/templates/add_job_locks.rb.erb
@@ -6,6 +6,7 @@ class AddPgbusJobLocks < ActiveRecord::Migration<%= migration_version %>
       t.string :job_id
       t.string :state, null: false, default: "queued"
       t.integer :owner_pid
+      t.string :owner_hostname
       t.datetime :locked_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
       t.datetime :expires_at, null: false
     end

--- a/lib/generators/pgbus/templates/add_job_locks.rb.erb
+++ b/lib/generators/pgbus/templates/add_job_locks.rb.erb
@@ -4,6 +4,8 @@ class AddPgbusJobLocks < ActiveRecord::Migration<%= migration_version %>
       t.string :lock_key, null: false
       t.string :job_class, null: false
       t.string :job_id
+      t.string :state, null: false, default: "queued"
+      t.integer :owner_pid
       t.datetime :locked_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
       t.datetime :expires_at, null: false
     end
@@ -12,5 +14,7 @@ class AddPgbusJobLocks < ActiveRecord::Migration<%= migration_version %>
       unique: true, name: "idx_pgbus_job_locks_key"
     add_index :pgbus_job_locks, :expires_at,
       name: "idx_pgbus_job_locks_expires"
+    add_index :pgbus_job_locks, [:state, :owner_pid],
+      name: "idx_pgbus_job_locks_reaper"
   end
 end

--- a/lib/generators/pgbus/templates/add_job_locks.rb.erb
+++ b/lib/generators/pgbus/templates/add_job_locks.rb.erb
@@ -1,0 +1,16 @@
+class AddPgbusJobLocks < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :pgbus_job_locks do |t|
+      t.string :lock_key, null: false
+      t.string :job_class, null: false
+      t.string :job_id
+      t.datetime :locked_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :expires_at, null: false
+    end
+
+    add_index :pgbus_job_locks, :lock_key,
+      unique: true, name: "idx_pgbus_job_locks_key"
+    add_index :pgbus_job_locks, :expires_at,
+      name: "idx_pgbus_job_locks_expires"
+  end
+end

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -9,6 +9,7 @@ module Pgbus
   class QueueNotFoundError < Error; end
   class DeadLetterError < Error; end
   class ConcurrencyLimitExceeded < Error; end
+  class JobNotUnique < Error; end
   class SchemaNotReady < Error; end
 
   class << self

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -31,7 +31,11 @@ module Pgbus
       end
 
       def enqueue_all(active_jobs)
-        active_jobs.group_by { |j| j.queue_name || Pgbus.configuration.default_queue }.each do |queue, jobs|
+        # Jobs with uniqueness must go through individual enqueue to acquire locks
+        unique, bulk = active_jobs.partition { |j| Uniqueness.uniqueness_config(j) }
+        unique.each { |j| enqueue(j) }
+
+        bulk.group_by { |j| j.queue_name || Pgbus.configuration.default_queue }.each do |queue, jobs|
           enqueue_immediate(queue, jobs.reject { |j| j.scheduled_at && j.scheduled_at > Time.now })
           jobs.select { |j| j.scheduled_at && j.scheduled_at > Time.now }.each { |j| enqueue_at(j, j.scheduled_at.to_f) }
         end
@@ -60,9 +64,15 @@ module Pgbus
           active_job.provider_job_id = msg_id
         end
 
+        Thread.current[:pgbus_acquired_uniqueness_key] = nil
         active_job
-      rescue Pgbus::SchemaNotReady => e
-        Pgbus.logger.error { "[Pgbus] #{e.message}" }
+      rescue StandardError
+        # Roll back the uniqueness lock if enqueue failed
+        rollback_key = Thread.current[:pgbus_acquired_uniqueness_key]
+        if rollback_key
+          Uniqueness.release_lock(rollback_key)
+          Thread.current[:pgbus_acquired_uniqueness_key] = nil
+        end
         raise
       end
 
@@ -92,17 +102,20 @@ module Pgbus
         return false unless uniqueness_key
 
         result = Uniqueness.acquire_enqueue_lock(uniqueness_key, active_job)
+
+        # Store the acquired key so we can release it if enqueue fails
+        Thread.current[:pgbus_acquired_uniqueness_key] = uniqueness_key if result == :acquired
         return false if result == :acquired
 
         config = Uniqueness.uniqueness_config(active_job)
         case config[:on_conflict]
         when :reject
-          raise JobNotUnique, "Job #{active_job.class.name} is already locked for key: #{uniqueness_key}"
+          raise JobNotUnique, "Job #{active_job.class.name} is already locked"
         when :discard
-          Pgbus.logger.info { "[Pgbus] Discarding duplicate job #{active_job.class.name}: #{uniqueness_key}" }
+          Pgbus.logger.info { "[Pgbus] Discarding duplicate job #{active_job.class.name}" }
           true
         when :log
-          Pgbus.logger.warn { "[Pgbus] Duplicate job #{active_job.class.name} detected: #{uniqueness_key}" }
+          Pgbus.logger.warn { "[Pgbus] Duplicate job #{active_job.class.name} detected" }
           true
         else
           true

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -9,7 +9,10 @@ module Pgbus
         queue = active_job.queue_name || Pgbus.configuration.default_queue
         payload_hash = Serializer.serialize_job_hash(active_job)
         payload_hash = Concurrency.inject_metadata(active_job, payload_hash)
+        payload_hash = Uniqueness.inject_metadata(active_job, payload_hash)
         payload_hash = inject_batch_metadata(payload_hash)
+
+        return active_job if uniqueness_rejected?(active_job, payload_hash)
 
         enqueue_with_concurrency(active_job, queue, payload_hash)
       end
@@ -18,8 +21,11 @@ module Pgbus
         queue = active_job.queue_name || Pgbus.configuration.default_queue
         payload_hash = Serializer.serialize_job_hash(active_job)
         payload_hash = Concurrency.inject_metadata(active_job, payload_hash)
+        payload_hash = Uniqueness.inject_metadata(active_job, payload_hash)
         payload_hash = inject_batch_metadata(payload_hash)
         delay = [(timestamp - Time.now.to_f).ceil, 0].max
+
+        return active_job if uniqueness_rejected?(active_job, payload_hash)
 
         enqueue_with_concurrency(active_job, queue, payload_hash, delay: delay)
       end
@@ -78,6 +84,28 @@ module Pgbus
           Pgbus.logger.info { "[Pgbus] Discarding job #{active_job.class.name}: concurrency limit for #{key}" }
         when :raise
           raise ConcurrencyLimitExceeded, "Concurrency limit reached for key: #{key}"
+        end
+      end
+
+      def uniqueness_rejected?(active_job, payload_hash)
+        uniqueness_key = Uniqueness.extract_key(payload_hash)
+        return false unless uniqueness_key
+
+        result = Uniqueness.acquire_enqueue_lock(uniqueness_key, active_job)
+        return false if result == :acquired
+
+        config = Uniqueness.uniqueness_config(active_job)
+        case config[:on_conflict]
+        when :reject
+          raise JobNotUnique, "Job #{active_job.class.name} is already locked for key: #{uniqueness_key}"
+        when :discard
+          Pgbus.logger.info { "[Pgbus] Discarding duplicate job #{active_job.class.name}: #{uniqueness_key}" }
+          true
+        when :log
+          Pgbus.logger.warn { "[Pgbus] Duplicate job #{active_job.class.name} detected: #{uniqueness_key}" }
+          true
+        else
+          true
         end
       end
 

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -33,7 +33,13 @@ module Pgbus
       def enqueue_all(active_jobs)
         # Jobs with uniqueness must go through individual enqueue to acquire locks
         unique, bulk = active_jobs.partition { |j| Uniqueness.uniqueness_config(j) }
-        unique.each { |j| enqueue(j) }
+        unique.each do |j|
+          if j.scheduled_at && j.scheduled_at > Time.now
+            enqueue_at(j, j.scheduled_at.to_f)
+          else
+            enqueue(j)
+          end
+        end
 
         bulk.group_by { |j| j.queue_name || Pgbus.configuration.default_queue }.each do |queue, jobs|
           enqueue_immediate(queue, jobs.reject { |j| j.scheduled_at && j.scheduled_at > Time.now })
@@ -66,14 +72,18 @@ module Pgbus
 
         Thread.current[:pgbus_acquired_uniqueness_key] = nil
         active_job
-      rescue StandardError
+      rescue StandardError => e
         # Roll back the uniqueness lock if enqueue failed
         rollback_key = Thread.current[:pgbus_acquired_uniqueness_key]
         if rollback_key
-          Uniqueness.release_lock(rollback_key)
+          begin
+            Uniqueness.release_lock(rollback_key)
+          rescue StandardError => rollback_error
+            Pgbus.logger.warn { "[Pgbus] Lock rollback failed: #{rollback_error.message}" }
+          end
           Thread.current[:pgbus_acquired_uniqueness_key] = nil
         end
-        raise
+        raise e
       end
 
       def concurrency_config(active_job)
@@ -102,6 +112,9 @@ module Pgbus
         return false unless uniqueness_key
 
         result = Uniqueness.acquire_enqueue_lock(uniqueness_key, active_job)
+
+        # :no_lock means no enqueue-time lock needed (e.g. :while_executing strategy)
+        return false if result == :no_lock
 
         # Store the acquired key so we can release it if enqueue fails
         Thread.current[:pgbus_acquired_uniqueness_key] = uniqueness_key if result == :acquired

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -24,14 +24,24 @@ module Pgbus
 
         job_class = payload["job_class"]
         uniqueness_key = Uniqueness.extract_key(payload)
+        uniqueness_strategy = Uniqueness.extract_strategy(payload)
+        uniqueness_ttl = payload[Uniqueness::TTL_KEY] || Uniqueness::DEFAULT_LOCK_TTL
 
-        # For :while_executing strategy, acquire the lock now (at execution time).
-        # If another worker is already executing this job, skip it — VT will expire
-        # and it'll be retried later when the lock is released.
-        if uniqueness_key && Uniqueness.extract_strategy(payload) == :while_executing && !Uniqueness.acquire_execution_lock(uniqueness_key,
-                                                                                                                            payload)
-          Pgbus.logger.info { "[Pgbus] Skipping duplicate execution for #{job_class}: #{uniqueness_key}" }
-          return :skipped
+        if uniqueness_key
+          case uniqueness_strategy
+          when :until_executed
+            # Transition the queued lock to executing state with our PID.
+            # The lock was acquired at enqueue time — now we claim ownership
+            # so the reaper can correlate it with our heartbeat.
+            Uniqueness.claim_for_execution!(uniqueness_key, ttl: uniqueness_ttl)
+          when :while_executing
+            # Acquire the lock now. If another worker is already executing
+            # this job, skip it — VT will expire and it'll be retried.
+            unless Uniqueness.acquire_execution_lock(uniqueness_key, payload)
+              Pgbus.logger.info { "[Pgbus] Skipping duplicate execution for #{job_class}" }
+              return :skipped
+            end
+          end
         end
 
         job_succeeded = false

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -18,10 +18,21 @@ module Pgbus
           handle_dead_letter(message, queue_name, payload, source_queue: source_queue)
           signal_concurrency(payload)
           signal_batch_discarded(payload)
+          Uniqueness.release_lock(Uniqueness.extract_key(payload))
           return :dead_lettered
         end
 
         job_class = payload["job_class"]
+        uniqueness_key = Uniqueness.extract_key(payload)
+
+        # For :while_executing strategy, acquire the lock now (at execution time).
+        # If another worker is already executing this job, skip it — VT will expire
+        # and it'll be retried later when the lock is released.
+        if uniqueness_key && Uniqueness.extract_strategy(payload) == :while_executing && !Uniqueness.acquire_execution_lock(uniqueness_key,
+                                                                                                                            payload)
+          Pgbus.logger.info { "[Pgbus] Skipping duplicate execution for #{job_class}: #{uniqueness_key}" }
+          return :skipped
+        end
 
         job_succeeded = false
 
@@ -47,6 +58,8 @@ module Pgbus
         if job_succeeded
           signal_concurrency(payload)
           signal_batch_completed(payload)
+          # Release uniqueness lock on successful completion (both strategies)
+          Uniqueness.release_lock(uniqueness_key) if uniqueness_key
         end
       end
 

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -34,6 +34,7 @@ module Pgbus
     initializer "pgbus.active_job" do
       ActiveSupport.on_load(:active_job) do
         include Pgbus::Concurrency
+        include Pgbus::Uniqueness
       end
     end
 

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -132,7 +132,7 @@ module Pgbus
 
       def cleanup_job_locks
         # Primary: reap orphaned locks whose owner worker is no longer alive.
-        # Cross-references owner_pid against pgbus_processes heartbeats.
+        # Cross-references (owner_pid, owner_hostname) against pgbus_processes heartbeats.
         reaped = JobLock.reap_orphaned!
         Pgbus.logger.info { "[Pgbus] Reaped #{reaped} orphaned job locks" } if reaped.positive?
 
@@ -140,8 +140,7 @@ module Pgbus
         # even the reaper/supervisor is dead and locks are truly abandoned).
         expired = JobLock.cleanup_expired!
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{expired} expired job locks" } if expired.positive?
-      rescue StandardError => e
-        Pgbus.logger.warn { "[Pgbus] Job lock cleanup failed: #{e.message}" }
+        # No rescue here — let run_if_due handle the error and retry next tick
       end
 
       def cleanup_outbox

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -131,8 +131,15 @@ module Pgbus
       end
 
       def cleanup_job_locks
-        deleted = JobLock.cleanup_expired!
-        Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} expired job locks" } if deleted.positive?
+        # Primary: reap orphaned locks whose owner worker is no longer alive.
+        # Cross-references owner_pid against pgbus_processes heartbeats.
+        reaped = JobLock.reap_orphaned!
+        Pgbus.logger.info { "[Pgbus] Reaped #{reaped} orphaned job locks" } if reaped.positive?
+
+        # Last resort: clean up locks with expired TTL (handles case where
+        # even the reaper/supervisor is dead and locks are truly abandoned).
+        expired = JobLock.cleanup_expired!
+        Pgbus.logger.debug { "[Pgbus] Cleaned up #{expired} expired job locks" } if expired.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Job lock cleanup failed: #{e.message}" }
       end

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -13,6 +13,7 @@ module Pgbus
       RECURRING_CLEANUP_INTERVAL = 3600     # Run recurring execution cleanup every hour
       ARCHIVE_COMPACTION_INTERVAL = 3600    # Run archive compaction every hour
       OUTBOX_CLEANUP_INTERVAL = 3600 # Run outbox cleanup every hour
+      JOB_LOCK_CLEANUP_INTERVAL = 300 # Run job lock cleanup every 5 minutes
 
       attr_reader :config
 
@@ -26,6 +27,7 @@ module Pgbus
         @last_recurring_cleanup_at = Time.now
         @last_archive_compaction_at = Time.now
         @last_outbox_cleanup_at = Time.now
+        @last_job_lock_cleanup_at = Time.now
       end
 
       def run
@@ -70,6 +72,7 @@ module Pgbus
         run_if_due(now, :@last_recurring_cleanup_at, RECURRING_CLEANUP_INTERVAL) { cleanup_recurring_executions }
         run_if_due(now, :@last_archive_compaction_at, archive_compaction_interval) { compact_archives }
         run_if_due(now, :@last_outbox_cleanup_at, OUTBOX_CLEANUP_INTERVAL) { cleanup_outbox }
+        run_if_due(now, :@last_job_lock_cleanup_at, JOB_LOCK_CLEANUP_INTERVAL) { cleanup_job_locks }
       end
 
       # Only update the timestamp when the block succeeds.
@@ -125,6 +128,13 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} finished batches" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Batch cleanup failed: #{e.message}" }
+      end
+
+      def cleanup_job_locks
+        deleted = JobLock.cleanup_expired!
+        Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} expired job locks" } if deleted.positive?
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Job lock cleanup failed: #{e.message}" }
       end
 
       def cleanup_outbox

--- a/lib/pgbus/uniqueness.rb
+++ b/lib/pgbus/uniqueness.rb
@@ -36,6 +36,7 @@ module Pgbus
 
     METADATA_KEY = "pgbus_uniqueness_key"
     STRATEGY_KEY = "pgbus_uniqueness_strategy"
+    TTL_KEY = "pgbus_uniqueness_lock_ttl"
 
     VALID_STRATEGIES = %i[until_executed while_executing].freeze
     VALID_CONFLICTS = %i[reject discard log].freeze
@@ -83,7 +84,8 @@ module Pgbus
 
         payload_hash.merge(
           METADATA_KEY => key,
-          STRATEGY_KEY => config[:strategy].to_s
+          STRATEGY_KEY => config[:strategy].to_s,
+          TTL_KEY => config[:lock_ttl]
         )
       end
 
@@ -125,8 +127,7 @@ module Pgbus
 
         job_class = payload["job_class"]
         job_id = payload["job_id"]
-        # Use a reasonable default TTL for execution locks
-        ttl = 30 * 60 # 30 minutes
+        ttl = payload[TTL_KEY] || (30 * 60)
 
         JobLock.acquire!(key, job_class: job_class, job_id: job_id, ttl: ttl)
       end

--- a/lib/pgbus/uniqueness.rb
+++ b/lib/pgbus/uniqueness.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/concern"
+require "socket"
 
 module Pgbus
   # Job uniqueness guarantees: prevent duplicate jobs from running concurrently.
@@ -53,7 +54,9 @@ module Pgbus
       def ensures_uniqueness(strategy: :until_executed, key: nil, lock_ttl: DEFAULT_LOCK_TTL, on_conflict: :reject)
         raise ArgumentError, "strategy must be one of: #{VALID_STRATEGIES.join(", ")}" unless VALID_STRATEGIES.include?(strategy)
         raise ArgumentError, "on_conflict must be one of: #{VALID_CONFLICTS.join(", ")}" unless VALID_CONFLICTS.include?(on_conflict)
-        raise ArgumentError, "lock_ttl must be a positive number" unless lock_ttl.is_a?(Numeric) && lock_ttl.positive?
+
+        valid_ttl = lock_ttl.is_a?(Numeric) || (defined?(ActiveSupport::Duration) && lock_ttl.is_a?(ActiveSupport::Duration))
+        raise ArgumentError, "lock_ttl must be a positive number or Duration" unless valid_ttl && lock_ttl.positive?
         raise ArgumentError, "key must be callable (Proc or lambda)" if key && !key.respond_to?(:call)
 
         @pgbus_uniqueness = {
@@ -116,8 +119,8 @@ module Pgbus
       # Returns :acquired or :locked.
       def acquire_enqueue_lock(key, active_job)
         config = uniqueness_config(active_job)
-        return :acquired unless config
-        return :acquired unless config[:strategy] == :until_executed
+        return :no_lock unless config
+        return :no_lock unless config[:strategy] == :until_executed
 
         acquired = JobLock.acquire!(
           key,
@@ -132,7 +135,7 @@ module Pgbus
       # Transition a queued lock to executing state when the worker picks it up.
       # Called for :until_executed jobs at execution start.
       def claim_for_execution!(key, ttl:)
-        JobLock.claim_for_execution!(key, owner_pid: ::Process.pid, ttl: ttl)
+        JobLock.claim_for_execution!(key, owner_pid: ::Process.pid, owner_hostname: Socket.gethostname, ttl: ttl)
       end
 
       # Acquire the uniqueness lock at execution time (:while_executing only).
@@ -150,6 +153,7 @@ module Pgbus
           job_id: payload["job_id"],
           state: "executing",
           owner_pid: ::Process.pid,
+          owner_hostname: Socket.gethostname,
           ttl: ttl
         )
       end

--- a/lib/pgbus/uniqueness.rb
+++ b/lib/pgbus/uniqueness.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Pgbus
+  # Job uniqueness guarantees: prevent duplicate jobs from running concurrently.
+  #
+  # Unlike concurrency limits (which allow N concurrent jobs for the same key),
+  # uniqueness ensures AT MOST ONE job with a given key exists in the system
+  # at any time — from enqueue through completion.
+  #
+  # Strategies:
+  #   :until_executed  — Lock acquired at enqueue, held through execution, released on
+  #                      completion or DLQ. Prevents duplicate enqueue AND duplicate execution.
+  #                      This is the safest option for critical jobs.
+  #
+  #   :while_executing — Lock acquired at execution start, released on completion.
+  #                      Allows duplicate enqueue (multiple copies in queue) but only one
+  #                      executes at a time. Others are re-queued with a delay.
+  #
+  # Usage:
+  #   class ImportOrderJob < ApplicationJob
+  #     include Pgbus::Uniqueness
+  #
+  #     ensures_uniqueness strategy: :until_executed,
+  #                        key: ->(order_id) { "import-order-#{order_id}" },
+  #                        lock_ttl: 30.minutes,
+  #                        on_conflict: :reject
+  #
+  #     def perform(order_id)
+  #       # Only one instance of this job per order_id can exist at a time
+  #     end
+  #   end
+  module Uniqueness
+    extend ActiveSupport::Concern
+
+    METADATA_KEY = "pgbus_uniqueness_key"
+    STRATEGY_KEY = "pgbus_uniqueness_strategy"
+
+    VALID_STRATEGIES = %i[until_executed while_executing].freeze
+    VALID_CONFLICTS = %i[reject discard log].freeze
+
+    class_methods do
+      def ensures_uniqueness(strategy: :until_executed, key: nil, lock_ttl: 30 * 60, on_conflict: :reject)
+        raise ArgumentError, "strategy must be one of: #{VALID_STRATEGIES.join(", ")}" unless VALID_STRATEGIES.include?(strategy)
+        raise ArgumentError, "on_conflict must be one of: #{VALID_CONFLICTS.join(", ")}" unless VALID_CONFLICTS.include?(on_conflict)
+        raise ArgumentError, "lock_ttl must be a positive number" unless lock_ttl.is_a?(Numeric) && lock_ttl.positive?
+        raise ArgumentError, "key must be callable (Proc or lambda)" if key && !key.respond_to?(:call)
+
+        @pgbus_uniqueness = {
+          strategy: strategy,
+          key: key || ->(*) { name },
+          lock_ttl: lock_ttl,
+          on_conflict: on_conflict
+        }.freeze
+      end
+
+      def pgbus_uniqueness
+        @pgbus_uniqueness
+      end
+    end
+
+    class << self
+      def resolve_key(active_job)
+        config = uniqueness_config(active_job)
+        return nil unless config
+
+        args = active_job.arguments
+        last = args.last
+        if last.is_a?(Hash) && last.each_key.all?(Symbol)
+          config[:key].call(*args[...-1], **last)
+        else
+          config[:key].call(*args)
+        end
+      end
+
+      def inject_metadata(active_job, payload_hash)
+        config = uniqueness_config(active_job)
+        return payload_hash unless config
+
+        key = resolve_key(active_job)
+        return payload_hash unless key
+
+        payload_hash.merge(
+          METADATA_KEY => key,
+          STRATEGY_KEY => config[:strategy].to_s
+        )
+      end
+
+      def extract_key(payload)
+        payload&.dig(METADATA_KEY)
+      end
+
+      def extract_strategy(payload)
+        payload&.dig(STRATEGY_KEY)&.to_sym
+      end
+
+      def uniqueness_config(active_job)
+        return nil unless active_job.class.respond_to?(:pgbus_uniqueness)
+
+        active_job.class.pgbus_uniqueness
+      end
+
+      # Try to acquire the uniqueness lock at enqueue time.
+      # Returns :acquired or :locked.
+      def acquire_enqueue_lock(key, active_job)
+        config = uniqueness_config(active_job)
+        return :acquired unless config
+        return :acquired unless config[:strategy] == :until_executed
+
+        acquired = JobLock.acquire!(
+          key,
+          job_class: active_job.class.name,
+          job_id: active_job.job_id,
+          ttl: config[:lock_ttl]
+        )
+        acquired ? :acquired : :locked
+      end
+
+      # Try to acquire the uniqueness lock at execution time.
+      # Returns true if acquired, false if another instance is running.
+      def acquire_execution_lock(key, payload)
+        strategy = extract_strategy(payload)
+        return true unless strategy == :while_executing
+
+        job_class = payload["job_class"]
+        job_id = payload["job_id"]
+        # Use a reasonable default TTL for execution locks
+        ttl = 30 * 60 # 30 minutes
+
+        JobLock.acquire!(key, job_class: job_class, job_id: job_id, ttl: ttl)
+      end
+
+      # Release the uniqueness lock after execution completes.
+      def release_lock(key)
+        return unless key
+
+        JobLock.release!(key)
+      end
+    end
+  end
+end

--- a/lib/pgbus/uniqueness.rb
+++ b/lib/pgbus/uniqueness.rb
@@ -9,22 +9,27 @@ module Pgbus
   # uniqueness ensures AT MOST ONE job with a given key exists in the system
   # at any time — from enqueue through completion.
   #
+  # Lock lifecycle:
+  #   1. Enqueue: lock acquired (state: queued), no owner yet
+  #   2. Execution start: lock transitions to (state: executing, owner_pid: PID)
+  #   3. Completion/DLQ: lock released (row deleted)
+  #   4. Crash recovery: reaper detects orphaned locks by cross-referencing
+  #      owner_pid against pgbus_processes heartbeats
+  #   5. Last resort: expires_at TTL (default 24h) handles the case where
+  #      even the reaper can't run (entire supervisor dead)
+  #
   # Strategies:
   #   :until_executed  — Lock acquired at enqueue, held through execution, released on
   #                      completion or DLQ. Prevents duplicate enqueue AND duplicate execution.
-  #                      This is the safest option for critical jobs.
   #
   #   :while_executing — Lock acquired at execution start, released on completion.
   #                      Allows duplicate enqueue (multiple copies in queue) but only one
-  #                      executes at a time. Others are re-queued with a delay.
+  #                      executes at a time.
   #
   # Usage:
   #   class ImportOrderJob < ApplicationJob
-  #     include Pgbus::Uniqueness
-  #
   #     ensures_uniqueness strategy: :until_executed,
   #                        key: ->(order_id) { "import-order-#{order_id}" },
-  #                        lock_ttl: 30.minutes,
   #                        on_conflict: :reject
   #
   #     def perform(order_id)
@@ -38,11 +43,14 @@ module Pgbus
     STRATEGY_KEY = "pgbus_uniqueness_strategy"
     TTL_KEY = "pgbus_uniqueness_lock_ttl"
 
+    # 24 hours — last-resort fallback only. The reaper handles normal crash recovery.
+    DEFAULT_LOCK_TTL = 24 * 60 * 60
+
     VALID_STRATEGIES = %i[until_executed while_executing].freeze
     VALID_CONFLICTS = %i[reject discard log].freeze
 
     class_methods do
-      def ensures_uniqueness(strategy: :until_executed, key: nil, lock_ttl: 30 * 60, on_conflict: :reject)
+      def ensures_uniqueness(strategy: :until_executed, key: nil, lock_ttl: DEFAULT_LOCK_TTL, on_conflict: :reject)
         raise ArgumentError, "strategy must be one of: #{VALID_STRATEGIES.join(", ")}" unless VALID_STRATEGIES.include?(strategy)
         raise ArgumentError, "on_conflict must be one of: #{VALID_CONFLICTS.join(", ")}" unless VALID_CONFLICTS.include?(on_conflict)
         raise ArgumentError, "lock_ttl must be a positive number" unless lock_ttl.is_a?(Numeric) && lock_ttl.positive?
@@ -103,7 +111,8 @@ module Pgbus
         active_job.class.pgbus_uniqueness
       end
 
-      # Try to acquire the uniqueness lock at enqueue time.
+      # Acquire the uniqueness lock at enqueue time (:until_executed only).
+      # Lock state: queued, no owner_pid yet.
       # Returns :acquired or :locked.
       def acquire_enqueue_lock(key, active_job)
         config = uniqueness_config(active_job)
@@ -114,22 +123,35 @@ module Pgbus
           key,
           job_class: active_job.class.name,
           job_id: active_job.job_id,
+          state: "queued",
           ttl: config[:lock_ttl]
         )
         acquired ? :acquired : :locked
       end
 
-      # Try to acquire the uniqueness lock at execution time.
+      # Transition a queued lock to executing state when the worker picks it up.
+      # Called for :until_executed jobs at execution start.
+      def claim_for_execution!(key, ttl:)
+        JobLock.claim_for_execution!(key, owner_pid: ::Process.pid, ttl: ttl)
+      end
+
+      # Acquire the uniqueness lock at execution time (:while_executing only).
+      # Lock state: executing with owner_pid.
       # Returns true if acquired, false if another instance is running.
       def acquire_execution_lock(key, payload)
         strategy = extract_strategy(payload)
         return true unless strategy == :while_executing
 
-        job_class = payload["job_class"]
-        job_id = payload["job_id"]
-        ttl = payload[TTL_KEY] || (30 * 60)
+        ttl = payload[TTL_KEY] || DEFAULT_LOCK_TTL
 
-        JobLock.acquire!(key, job_class: job_class, job_id: job_id, ttl: ttl)
+        JobLock.acquire!(
+          key,
+          job_class: payload["job_class"],
+          job_id: payload["job_id"],
+          state: "executing",
+          owner_pid: ::Process.pid,
+          ttl: ttl
+        )
       end
 
       # Release the uniqueness lock after execution completes.

--- a/spec/integration/concurrency_spec.rb
+++ b/spec/integration/concurrency_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Concurrency semaphores (integration)", :integration do
+  before do
+    Pgbus::Semaphore.delete_all
+  end
+
+  describe "atomic acquire" do
+    it "acquires a semaphore slot" do
+      result = Pgbus::Concurrency::Semaphore.acquire("test-key", 2, 300)
+      expect(result).to eq(:acquired)
+      expect(Pgbus::Concurrency::Semaphore.current_value("test-key")).to eq(1)
+    end
+
+    it "allows multiple slots up to the limit" do
+      Pgbus::Concurrency::Semaphore.acquire("test-key", 3, 300)
+      Pgbus::Concurrency::Semaphore.acquire("test-key", 3, 300)
+      result = Pgbus::Concurrency::Semaphore.acquire("test-key", 3, 300)
+
+      expect(result).to eq(:acquired)
+      expect(Pgbus::Concurrency::Semaphore.current_value("test-key")).to eq(3)
+    end
+
+    it "blocks when limit is reached" do
+      3.times { Pgbus::Concurrency::Semaphore.acquire("test-key", 3, 300) }
+
+      result = Pgbus::Concurrency::Semaphore.acquire("test-key", 3, 300)
+      expect(result).to eq(:blocked)
+      expect(Pgbus::Concurrency::Semaphore.current_value("test-key")).to eq(3)
+    end
+  end
+
+  describe "release" do
+    it "decrements the semaphore value" do
+      Pgbus::Concurrency::Semaphore.acquire("test-key", 2, 300)
+      Pgbus::Concurrency::Semaphore.acquire("test-key", 2, 300)
+      expect(Pgbus::Concurrency::Semaphore.current_value("test-key")).to eq(2)
+
+      Pgbus::Concurrency::Semaphore.release("test-key")
+      expect(Pgbus::Concurrency::Semaphore.current_value("test-key")).to eq(1)
+    end
+
+    it "never goes below zero" do
+      Pgbus::Concurrency::Semaphore.acquire("test-key", 1, 300)
+      Pgbus::Concurrency::Semaphore.release("test-key")
+      Pgbus::Concurrency::Semaphore.release("test-key")
+      expect(Pgbus::Concurrency::Semaphore.current_value("test-key")).to eq(0)
+    end
+
+    it "opens a slot for the next acquire" do
+      Pgbus::Concurrency::Semaphore.acquire("test-key", 1, 300)
+      expect(Pgbus::Concurrency::Semaphore.acquire("test-key", 1, 300)).to eq(:blocked)
+
+      Pgbus::Concurrency::Semaphore.release("test-key")
+      expect(Pgbus::Concurrency::Semaphore.acquire("test-key", 1, 300)).to eq(:acquired)
+    end
+  end
+
+  describe "concurrent acquire (race condition)" do
+    it "never exceeds the limit under contention" do
+      limit = 3
+      results = Concurrent::Array.new
+      barrier = Concurrent::CyclicBarrier.new(10)
+
+      threads = 10.times.map do
+        Thread.new do
+          barrier.wait
+          result = Pgbus::Concurrency::Semaphore.acquire("race-key", limit, 300)
+          results << result
+        end
+      end
+
+      threads.each(&:join)
+
+      acquired = results.count(:acquired)
+      blocked = results.count(:blocked)
+
+      expect(acquired).to eq(limit)
+      expect(blocked).to eq(7)
+      expect(Pgbus::Concurrency::Semaphore.current_value("race-key")).to eq(limit)
+    end
+  end
+
+  describe "expiry" do
+    it "cleans up expired semaphores" do
+      Pgbus::Concurrency::Semaphore.acquire("expired-key", 1, -1)
+      Pgbus::Concurrency::Semaphore.acquire("active-key", 1, 300)
+
+      expired = Pgbus::Concurrency::Semaphore.expire_stale
+      expect(expired.size).to eq(1)
+      expect(expired.first["key"]).to eq("expired-key")
+
+      # Active key should still exist
+      expect(Pgbus::Concurrency::Semaphore.current_value("active-key")).to eq(1)
+      expect(Pgbus::Concurrency::Semaphore.current_value("expired-key")).to be_nil
+    end
+  end
+end

--- a/spec/integration/concurrency_spec.rb
+++ b/spec/integration/concurrency_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe "Concurrency semaphores (integration)", :integration do
     it "never exceeds the limit under contention" do
       limit = 3
       results = Concurrent::Array.new
-      barrier = Concurrent::CyclicBarrier.new(10)
+      barrier = Concurrent::CyclicBarrier.new(8)
 
-      threads = 10.times.map do
+      threads = 8.times.map do
         Thread.new do
           barrier.wait
           result = Pgbus::Concurrency::Semaphore.acquire("race-key", limit, 300)
@@ -72,13 +72,13 @@ RSpec.describe "Concurrency semaphores (integration)", :integration do
         end
       end
 
-      threads.each(&:join)
+      threads.each { |t| t.join(10) }
 
       acquired = results.count(:acquired)
       blocked = results.count(:blocked)
 
       expect(acquired).to eq(limit)
-      expect(blocked).to eq(7)
+      expect(blocked).to eq(5)
       expect(Pgbus::Concurrency::Semaphore.current_value("race-key")).to eq(limit)
     end
   end

--- a/spec/integration/dead_letter_spec.rb
+++ b/spec/integration/dead_letter_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Dead letter queue (integration)", :integration do
+  let(:client) { Pgbus.client }
+
+  before do
+    client.ensure_queue("dlq_test")
+    client.ensure_dead_letter_queue("dlq_test")
+  end
+
+  describe "move to DLQ" do
+    it "moves a message from the main queue to the DLQ" do
+      client.send_message("dlq_test", { "job_class" => "FailingJob", "arguments" => [] })
+      messages = client.read_batch("dlq_test", qty: 1)
+      expect(messages.size).to eq(1)
+
+      client.move_to_dead_letter("dlq_test", messages.first)
+
+      # Main queue empty
+      remaining = client.read_batch("dlq_test", qty: 1)
+      expect(remaining || []).to be_empty
+
+      # DLQ has the message
+      dlq_name = Pgbus.configuration.dead_letter_queue_name("dlq_test")
+      dlq_messages = client.read_batch(
+        dlq_name.delete_prefix("#{Pgbus.configuration.queue_prefix}_"),
+        qty: 1
+      )
+      expect(dlq_messages.size).to eq(1)
+
+      payload = JSON.parse(dlq_messages.first.message)
+      expect(payload["job_class"]).to eq("FailingJob")
+    end
+  end
+
+  describe "message read_ct tracking" do
+    it "increments read_ct on each read" do
+      client.send_message("dlq_test", { "retry_test" => true })
+
+      # First read
+      msg1 = client.read_batch("dlq_test", qty: 1, vt: 0).first
+      expect(msg1.read_ct.to_i).to eq(1)
+
+      # Second read (VT=0 makes it immediately visible)
+      msg2 = client.read_batch("dlq_test", qty: 1, vt: 0).first
+      expect(msg2.read_ct.to_i).to eq(2)
+
+      # Third read
+      msg3 = client.read_batch("dlq_test", qty: 1, vt: 0).first
+      expect(msg3.read_ct.to_i).to eq(3)
+    end
+  end
+end

--- a/spec/integration/job_lifecycle_spec.rb
+++ b/spec/integration/job_lifecycle_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Job lifecycle (integration)", :integration do
+  let(:client) { Pgbus.client }
+
+  before do
+    client.ensure_queue("default")
+  end
+
+  describe "enqueue and read" do
+    it "sends a message to PGMQ and reads it back" do
+      payload = { "job_class" => "TestJob", "job_id" => SecureRandom.uuid, "arguments" => [1, 2] }
+      msg_id = client.send_message("default", payload)
+      expect(msg_id).to be_a(Integer)
+
+      messages = client.read_batch("default", qty: 1)
+      expect(messages).not_to be_empty
+      expect(messages.first.msg_id).to eq(msg_id)
+
+      parsed = JSON.parse(messages.first.message)
+      expect(parsed["job_class"]).to eq("TestJob")
+    end
+
+    it "respects visibility timeout — message is invisible after read" do
+      client.send_message("default", { "test" => true })
+      client.read_batch("default", qty: 1, vt: 60)
+
+      # Immediately try to read again — should be empty
+      second_read = client.read_batch("default", qty: 1)
+      expect(second_read).to be_empty
+    end
+  end
+
+  describe "archive and delete" do
+    it "archives a message after processing" do
+      msg_id = client.send_message("default", { "test" => "archive" })
+      messages = client.read_batch("default", qty: 1)
+      expect(messages.size).to eq(1)
+
+      client.archive_message("default", msg_id)
+
+      # Queue should be empty now
+      remaining = client.read_batch("default", qty: 1)
+      expect(remaining).to be_empty
+    end
+  end
+
+  describe "dead letter queue" do
+    it "moves a message to DLQ" do
+      client.send_message("default", { "dlq_test" => true })
+      messages = client.read_batch("default", qty: 1)
+
+      client.move_to_dead_letter("default", messages.first)
+
+      # Original queue should be empty
+      remaining = client.read_batch("default", qty: 1)
+      expect(remaining).to be_empty
+    end
+  end
+end

--- a/spec/integration/job_lifecycle_spec.rb
+++ b/spec/integration/job_lifecycle_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe "Job lifecycle (integration)", :integration do
     it "sends a message to PGMQ and reads it back" do
       payload = { "job_class" => "TestJob", "job_id" => SecureRandom.uuid, "arguments" => [1, 2] }
       msg_id = client.send_message("default", payload)
-      expect(msg_id).to be_a(Integer)
+      expect(msg_id.to_i).to be_positive
 
       messages = client.read_batch("default", qty: 1)
       expect(messages).not_to be_empty
-      expect(messages.first.msg_id).to eq(msg_id)
+      expect(messages.first.msg_id.to_i).to eq(msg_id.to_i)
 
       parsed = JSON.parse(messages.first.message)
       expect(parsed["job_class"]).to eq("TestJob")
@@ -25,11 +25,13 @@ RSpec.describe "Job lifecycle (integration)", :integration do
 
     it "respects visibility timeout — message is invisible after read" do
       client.send_message("default", { "test" => true })
-      client.read_batch("default", qty: 1, vt: 60)
+      messages = client.read_batch("default", qty: 1, vt: 30)
+      expect(messages.size).to eq(1)
 
-      # Immediately try to read again — should be empty
-      second_read = client.read_batch("default", qty: 1)
-      expect(second_read).to be_empty
+      # Message was read with VT=30s — reading again immediately should return empty
+      # because the message is invisible until VT expires
+      second_read = client.read_batch("default", qty: 1, vt: 30)
+      expect(second_read || []).to be_empty
     end
   end
 

--- a/spec/integration/job_lifecycle_spec.rb
+++ b/spec/integration/job_lifecycle_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe "Job lifecycle (integration)", :integration do
     it "moves a message to DLQ" do
       client.send_message("default", { "dlq_test" => true })
       messages = client.read_batch("default", qty: 1)
+      expect(messages).not_to be_empty
 
       client.move_to_dead_letter("default", messages.first)
 

--- a/spec/integration/job_uniqueness_spec.rb
+++ b/spec/integration/job_uniqueness_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Job uniqueness (integration)", :integration do
+  before do
+    # Clean up any stale locks
+    ActiveRecord::Base.connection.execute("DELETE FROM pgbus_job_locks")
+  end
+
+  describe ":until_executed strategy" do
+    it "prevents duplicate enqueue when lock is held" do
+      acquired = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", ttl: 300)
+      expect(acquired).to be true
+
+      # Second acquire should fail
+      duplicate = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j2", ttl: 300)
+      expect(duplicate).to be false
+    end
+
+    it "allows enqueue after lock is released" do
+      Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", ttl: 300)
+      Pgbus::JobLock.release!("unique-order-42")
+
+      acquired = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j3", ttl: 300)
+      expect(acquired).to be true
+    end
+
+    it "allows enqueue after lock expires" do
+      Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", ttl: -1)
+
+      # Expired locks are cleaned up
+      Pgbus::JobLock.cleanup_expired!
+
+      acquired = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j4", ttl: 300)
+      expect(acquired).to be true
+    end
+
+    it "reports locked? correctly" do
+      expect(Pgbus::JobLock.locked?("unique-order-99")).to be false
+
+      Pgbus::JobLock.acquire!("unique-order-99", job_class: "Test", ttl: 300)
+      expect(Pgbus::JobLock.locked?("unique-order-99")).to be true
+
+      Pgbus::JobLock.release!("unique-order-99")
+      expect(Pgbus::JobLock.locked?("unique-order-99")).to be false
+    end
+  end
+
+  describe "concurrent lock acquisition" do
+    it "only one thread wins the lock" do
+      results = Concurrent::Array.new
+      barrier = Concurrent::CyclicBarrier.new(5)
+
+      threads = 5.times.map do |i|
+        Thread.new do
+          barrier.wait
+          acquired = Pgbus::JobLock.acquire!(
+            "race-key",
+            job_class: "RaceJob",
+            job_id: "thread-#{i}",
+            ttl: 300
+          )
+          results << acquired
+        end
+      end
+
+      threads.each(&:join)
+
+      winners = results.count(true)
+      losers = results.count(false)
+
+      expect(winners).to eq(1)
+      expect(losers).to eq(4)
+    end
+  end
+
+  describe "lock cleanup" do
+    it "cleans up expired locks" do
+      # Create some expired locks
+      3.times do |i|
+        Pgbus::JobLock.acquire!("expired-#{i}", job_class: "OldJob", ttl: -1)
+      end
+      # Create a valid lock
+      Pgbus::JobLock.acquire!("valid-lock", job_class: "NewJob", ttl: 300)
+
+      deleted = Pgbus::JobLock.cleanup_expired!
+      expect(deleted).to eq(3)
+
+      # Valid lock should still exist
+      expect(Pgbus::JobLock.locked?("valid-lock")).to be true
+    end
+  end
+end

--- a/spec/integration/job_uniqueness_spec.rb
+++ b/spec/integration/job_uniqueness_spec.rb
@@ -5,44 +5,111 @@ require_relative "../integration_helper"
 RSpec.describe "Job uniqueness (integration)", :integration do
   before do
     Pgbus::JobLock.delete_all
+    Pgbus::ProcessEntry.delete_all
   end
 
   describe ":until_executed strategy" do
     it "prevents duplicate enqueue when lock is held" do
-      acquired = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", ttl: 300)
+      acquired = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", ttl: 86_400)
       expect(acquired).to be true
 
-      # Second acquire should fail
-      duplicate = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j2", ttl: 300)
+      duplicate = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j2", ttl: 86_400)
       expect(duplicate).to be false
     end
 
     it "allows enqueue after lock is released" do
-      Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", ttl: 300)
+      Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", ttl: 86_400)
       Pgbus::JobLock.release!("unique-order-42")
 
-      acquired = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j3", ttl: 300)
+      acquired = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j3", ttl: 86_400)
       expect(acquired).to be true
     end
 
-    it "allows enqueue after lock expires" do
-      Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", ttl: -1)
+    it "transitions from queued to executing on claim" do
+      Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", state: "queued", ttl: 86_400)
 
-      # Expired locks are cleaned up
-      Pgbus::JobLock.cleanup_expired!
+      Pgbus::JobLock.claim_for_execution!("unique-order-42", owner_pid: 12_345, ttl: 86_400)
 
-      acquired = Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j4", ttl: 300)
-      expect(acquired).to be true
+      lock = Pgbus::JobLock.find_by(lock_key: "unique-order-42")
+      expect(lock.state).to eq("executing")
+      expect(lock.owner_pid).to eq(12_345)
+    end
+  end
+
+  describe "reaper" do
+    it "releases locks whose owner worker is no longer alive" do
+      # Create a lock owned by PID 99999 (not in pgbus_processes)
+      Pgbus::JobLock.acquire!(
+        "orphaned-lock", job_class: "CrashedJob", job_id: "j1",
+                         state: "executing", owner_pid: 99_999, ttl: 86_400
+      )
+
+      reaped = Pgbus::JobLock.reap_orphaned!
+      expect(reaped).to eq(1)
+      expect(Pgbus::JobLock.locked?("orphaned-lock")).to be false
     end
 
-    it "reports locked? correctly" do
-      expect(Pgbus::JobLock.locked?("unique-order-99")).to be false
+    it "keeps locks whose owner worker is still alive" do
+      # Register a healthy worker process
+      Pgbus::ProcessEntry.create!(
+        kind: "worker", pid: 12_345, hostname: "test",
+        last_heartbeat_at: Time.current
+      )
 
-      Pgbus::JobLock.acquire!("unique-order-99", job_class: "Test", ttl: 300)
-      expect(Pgbus::JobLock.locked?("unique-order-99")).to be true
+      # Create a lock owned by that worker
+      Pgbus::JobLock.acquire!(
+        "active-lock", job_class: "RunningJob", job_id: "j1",
+                       state: "executing", owner_pid: 12_345, ttl: 86_400
+      )
 
-      Pgbus::JobLock.release!("unique-order-99")
-      expect(Pgbus::JobLock.locked?("unique-order-99")).to be false
+      reaped = Pgbus::JobLock.reap_orphaned!
+      expect(reaped).to eq(0)
+      expect(Pgbus::JobLock.locked?("active-lock")).to be true
+    end
+
+    it "releases locks whose owner worker has stale heartbeat" do
+      # Register a stale worker process (heartbeat too old)
+      Pgbus::ProcessEntry.create!(
+        kind: "worker", pid: 12_345, hostname: "test",
+        last_heartbeat_at: Time.current - 600 # 10 minutes ago
+      )
+
+      Pgbus::JobLock.acquire!(
+        "stale-lock", job_class: "StaleJob", job_id: "j1",
+                      state: "executing", owner_pid: 12_345, ttl: 86_400
+      )
+
+      reaped = Pgbus::JobLock.reap_orphaned!
+      expect(reaped).to eq(1)
+      expect(Pgbus::JobLock.locked?("stale-lock")).to be false
+    end
+
+    it "does not reap queued locks (they have no owner)" do
+      Pgbus::JobLock.acquire!(
+        "queued-lock", job_class: "WaitingJob", job_id: "j1",
+                       state: "queued", ttl: 86_400
+      )
+
+      reaped = Pgbus::JobLock.reap_orphaned!
+      expect(reaped).to eq(0)
+      expect(Pgbus::JobLock.locked?("queued-lock")).to be true
+    end
+  end
+
+  describe "last-resort TTL" do
+    it "cleans up locks whose TTL has expired" do
+      Pgbus::JobLock.acquire!("expired-lock", job_class: "OldJob", ttl: -1)
+
+      deleted = Pgbus::JobLock.cleanup_expired!
+      expect(deleted).to eq(1)
+    end
+
+    it "does not clean up locks with valid TTL" do
+      Pgbus::JobLock.acquire!("valid-lock", job_class: "NewJob", ttl: 86_400)
+
+      deleted = Pgbus::JobLock.cleanup_expired!
+      expect(deleted).to eq(0)
+      expect(Pgbus::JobLock.locked?("valid-lock")).to be true
     end
   end
 
@@ -58,7 +125,7 @@ RSpec.describe "Job uniqueness (integration)", :integration do
             "race-key",
             job_class: "RaceJob",
             job_id: "thread-#{i}",
-            ttl: 300
+            ttl: 86_400
           )
           results << acquired
         end
@@ -71,23 +138,6 @@ RSpec.describe "Job uniqueness (integration)", :integration do
 
       expect(winners).to eq(1)
       expect(losers).to eq(4)
-    end
-  end
-
-  describe "lock cleanup" do
-    it "cleans up expired locks" do
-      # Create some expired locks
-      3.times do |i|
-        Pgbus::JobLock.acquire!("expired-#{i}", job_class: "OldJob", ttl: -1)
-      end
-      # Create a valid lock
-      Pgbus::JobLock.acquire!("valid-lock", job_class: "NewJob", ttl: 300)
-
-      deleted = Pgbus::JobLock.cleanup_expired!
-      expect(deleted).to eq(3)
-
-      # Valid lock should still exist
-      expect(Pgbus::JobLock.locked?("valid-lock")).to be true
     end
   end
 end

--- a/spec/integration/job_uniqueness_spec.rb
+++ b/spec/integration/job_uniqueness_spec.rb
@@ -4,8 +4,7 @@ require_relative "../integration_helper"
 
 RSpec.describe "Job uniqueness (integration)", :integration do
   before do
-    # Clean up any stale locks
-    ActiveRecord::Base.connection.execute("DELETE FROM pgbus_job_locks")
+    Pgbus::JobLock.delete_all
   end
 
   describe ":until_executed strategy" do

--- a/spec/integration/job_uniqueness_spec.rb
+++ b/spec/integration/job_uniqueness_spec.rb
@@ -28,11 +28,12 @@ RSpec.describe "Job uniqueness (integration)", :integration do
     it "transitions from queued to executing on claim" do
       Pgbus::JobLock.acquire!("unique-order-42", job_class: "ImportJob", job_id: "j1", state: "queued", ttl: 86_400)
 
-      Pgbus::JobLock.claim_for_execution!("unique-order-42", owner_pid: 12_345, ttl: 86_400)
+      Pgbus::JobLock.claim_for_execution!("unique-order-42", owner_pid: 12_345, owner_hostname: "test-host", ttl: 86_400)
 
       lock = Pgbus::JobLock.find_by(lock_key: "unique-order-42")
       expect(lock.state).to eq("executing")
       expect(lock.owner_pid).to eq(12_345)
+      expect(lock.owner_hostname).to eq("test-host")
     end
   end
 
@@ -41,7 +42,7 @@ RSpec.describe "Job uniqueness (integration)", :integration do
       # Create a lock owned by PID 99999 (not in pgbus_processes)
       Pgbus::JobLock.acquire!(
         "orphaned-lock", job_class: "CrashedJob", job_id: "j1",
-                         state: "executing", owner_pid: 99_999, ttl: 86_400
+                         state: "executing", owner_pid: 99_999, owner_hostname: "dead-host", ttl: 86_400
       )
 
       reaped = Pgbus::JobLock.reap_orphaned!
@@ -52,14 +53,14 @@ RSpec.describe "Job uniqueness (integration)", :integration do
     it "keeps locks whose owner worker is still alive" do
       # Register a healthy worker process
       Pgbus::ProcessEntry.create!(
-        kind: "worker", pid: 12_345, hostname: "test",
+        kind: "worker", pid: 12_345, hostname: "test-host",
         last_heartbeat_at: Time.current
       )
 
-      # Create a lock owned by that worker
+      # Create a lock owned by that worker (same pid AND hostname)
       Pgbus::JobLock.acquire!(
         "active-lock", job_class: "RunningJob", job_id: "j1",
-                       state: "executing", owner_pid: 12_345, ttl: 86_400
+                       state: "executing", owner_pid: 12_345, owner_hostname: "test-host", ttl: 86_400
       )
 
       reaped = Pgbus::JobLock.reap_orphaned!
@@ -70,13 +71,13 @@ RSpec.describe "Job uniqueness (integration)", :integration do
     it "releases locks whose owner worker has stale heartbeat" do
       # Register a stale worker process (heartbeat too old)
       Pgbus::ProcessEntry.create!(
-        kind: "worker", pid: 12_345, hostname: "test",
+        kind: "worker", pid: 12_345, hostname: "stale-host",
         last_heartbeat_at: Time.current - 600 # 10 minutes ago
       )
 
       Pgbus::JobLock.acquire!(
         "stale-lock", job_class: "StaleJob", job_id: "j1",
-                      state: "executing", owner_pid: 12_345, ttl: 86_400
+                      state: "executing", owner_pid: 12_345, owner_hostname: "stale-host", ttl: 86_400
       )
 
       reaped = Pgbus::JobLock.reap_orphaned!

--- a/spec/integration/queue_operations_spec.rb
+++ b/spec/integration/queue_operations_spec.rb
@@ -9,12 +9,16 @@ RSpec.describe "Queue operations (integration)", :integration do
     it "creates a queue idempotently" do
       client.ensure_queue("ops_test")
       client.ensure_queue("ops_test") # second call should not raise
-      expect(client.list_queues.map(&:to_s)).to include("pgbus_int_ops_test")
+
+      queues = client.list_queues.map { |q| q.respond_to?(:queue_name) ? q.queue_name : q.to_s }
+      expect(queues).to include("pgbus_int_ops_test")
     end
 
     it "creates a dead letter queue" do
       client.ensure_dead_letter_queue("ops_test")
-      expect(client.list_queues.map(&:to_s)).to include("pgbus_int_ops_test_dlq")
+
+      queues = client.list_queues.map { |q| q.respond_to?(:queue_name) ? q.queue_name : q.to_s }
+      expect(queues).to include("pgbus_int_ops_test_dlq")
     end
   end
 
@@ -25,9 +29,10 @@ RSpec.describe "Queue operations (integration)", :integration do
       payloads = 5.times.map { |i| { "index" => i, "job_class" => "BatchJob" } }
       msg_ids = client.send_batch("batch_test", payloads)
 
+      expect(msg_ids).to be_an(Array)
       expect(msg_ids.size).to eq(5)
 
-      messages = client.read_batch("batch_test", qty: 10)
+      messages = client.read_batch("batch_test", qty: 10, vt: 0)
       expect(messages.size).to eq(5)
 
       indices = messages.map { |m| JSON.parse(m.message)["index"] }
@@ -37,7 +42,7 @@ RSpec.describe "Queue operations (integration)", :integration do
     it "respects qty limit on read" do
       5.times { |i| client.send_message("batch_test", { "index" => i }) }
 
-      messages = client.read_batch("batch_test", qty: 2)
+      messages = client.read_batch("batch_test", qty: 2, vt: 0)
       expect(messages.size).to eq(2)
     end
   end
@@ -61,11 +66,9 @@ RSpec.describe "Queue operations (integration)", :integration do
     it "makes message invisible for the specified duration" do
       client.send_message("vt_test", { "vt" => true })
 
-      # Read with VT=30s
       messages = client.read_batch("vt_test", qty: 1, vt: 30)
       expect(messages.size).to eq(1)
 
-      # Immediately re-read — should be empty (VT hasn't expired)
       again = client.read_batch("vt_test", qty: 1, vt: 30)
       expect(again || []).to be_empty
     end
@@ -74,10 +77,8 @@ RSpec.describe "Queue operations (integration)", :integration do
       msg_id = client.send_message("vt_test", { "extend" => true })
       client.read_batch("vt_test", qty: 1, vt: 5)
 
-      # Extend VT to 60s
       client.extend_visibility("vt_test", msg_id, vt: 60)
 
-      # Should still be invisible
       messages = client.read_batch("vt_test", qty: 1, vt: 5)
       expect(messages || []).to be_empty
     end
@@ -89,7 +90,6 @@ RSpec.describe "Queue operations (integration)", :integration do
     it "sends a message with a delay" do
       client.send_message("delay_test", { "delayed" => true }, delay: 60)
 
-      # Should not be visible yet (60s delay)
       messages = client.read_batch("delay_test", qty: 1)
       expect(messages || []).to be_empty
     end

--- a/spec/integration/queue_operations_spec.rb
+++ b/spec/integration/queue_operations_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Queue operations (integration)", :integration do
+  let(:client) { Pgbus.client }
+
+  describe "queue creation" do
+    it "creates a queue idempotently" do
+      client.ensure_queue("ops_test")
+      client.ensure_queue("ops_test") # second call should not raise
+      expect(client.list_queues.map(&:to_s)).to include("pgbus_int_ops_test")
+    end
+
+    it "creates a dead letter queue" do
+      client.ensure_dead_letter_queue("ops_test")
+      expect(client.list_queues.map(&:to_s)).to include("pgbus_int_ops_test_dlq")
+    end
+  end
+
+  describe "batch operations" do
+    before { client.ensure_queue("batch_test") }
+
+    it "sends and reads a batch of messages" do
+      payloads = 5.times.map { |i| { "index" => i, "job_class" => "BatchJob" } }
+      msg_ids = client.send_batch("batch_test", payloads)
+
+      expect(msg_ids.size).to eq(5)
+
+      messages = client.read_batch("batch_test", qty: 10)
+      expect(messages.size).to eq(5)
+
+      indices = messages.map { |m| JSON.parse(m.message)["index"] }
+      expect(indices.sort).to eq([0, 1, 2, 3, 4])
+    end
+
+    it "respects qty limit on read" do
+      5.times { |i| client.send_message("batch_test", { "index" => i }) }
+
+      messages = client.read_batch("batch_test", qty: 2)
+      expect(messages.size).to eq(2)
+    end
+  end
+
+  describe "purge" do
+    before { client.ensure_queue("purge_test") }
+
+    it "removes all messages from a queue" do
+      3.times { client.send_message("purge_test", { "data" => "x" }) }
+
+      client.purge_queue("purge_test")
+
+      messages = client.read_batch("purge_test", qty: 10)
+      expect(messages || []).to be_empty
+    end
+  end
+
+  describe "visibility timeout" do
+    before { client.ensure_queue("vt_test") }
+
+    it "makes message invisible for the specified duration" do
+      client.send_message("vt_test", { "vt" => true })
+
+      # Read with VT=30s
+      messages = client.read_batch("vt_test", qty: 1, vt: 30)
+      expect(messages.size).to eq(1)
+
+      # Immediately re-read — should be empty (VT hasn't expired)
+      again = client.read_batch("vt_test", qty: 1, vt: 30)
+      expect(again || []).to be_empty
+    end
+
+    it "allows extending visibility timeout" do
+      msg_id = client.send_message("vt_test", { "extend" => true })
+      client.read_batch("vt_test", qty: 1, vt: 5)
+
+      # Extend VT to 60s
+      client.extend_visibility("vt_test", msg_id, vt: 60)
+
+      # Should still be invisible
+      messages = client.read_batch("vt_test", qty: 1, vt: 5)
+      expect(messages || []).to be_empty
+    end
+  end
+
+  describe "delayed messages" do
+    before { client.ensure_queue("delay_test") }
+
+    it "sends a message with a delay" do
+      client.send_message("delay_test", { "delayed" => true }, delay: 60)
+
+      # Should not be visible yet (60s delay)
+      messages = client.read_batch("delay_test", qty: 1)
+      expect(messages || []).to be_empty
+    end
+  end
+
+  describe "message headers" do
+    before { client.ensure_queue("header_test") }
+
+    it "preserves headers through enqueue and read" do
+      headers = { "x-trace-id" => "abc-123", "x-source" => "test" }
+      client.send_message("header_test", { "data" => 1 }, headers: headers)
+
+      messages = client.read_batch("header_test", qty: 1)
+      expect(messages.size).to eq(1)
+
+      msg_headers = messages.first.headers
+      parsed = msg_headers.is_a?(String) ? JSON.parse(msg_headers) : msg_headers
+      expect(parsed).to include("x-trace-id" => "abc-123")
+    end
+  end
+end

--- a/spec/integration/thread_safety_spec.rb
+++ b/spec/integration/thread_safety_spec.rb
@@ -11,48 +11,36 @@ RSpec.describe "Thread safety (integration)", :integration do
 
   describe "concurrent enqueue" do
     it "handles concurrent sends without corruption" do
-      barrier = Concurrent::CyclicBarrier.new(10)
       errors = Concurrent::Array.new
 
       threads = 10.times.map do |i|
         Thread.new do
-          barrier.wait
           client.send_message("thread_test", { "thread" => i, "job_class" => "ThreadJob" })
         rescue StandardError => e
           errors << e
         end
       end
 
-      threads.each(&:join)
+      threads.each { |t| t.join(10) }
 
       expect(errors).to be_empty
 
       # All 10 messages should be in the queue
-      all_messages = []
-      loop do
-        batch = client.read_batch("thread_test", qty: 10, vt: 0)
-        break if batch.nil? || batch.empty?
-
-        all_messages.concat(batch)
-        break if batch.size < 10
-      end
-
+      all_messages = client.read_batch("thread_test", qty: 20, vt: 0) || []
       expect(all_messages.size).to eq(10)
     end
   end
 
   describe "concurrent read + archive" do
-    it "each message is read by exactly one thread" do
-      # Enqueue 20 messages
-      20.times { |i| client.send_message("thread_test", { "index" => i }) }
+    it "each message is read by exactly one thread", timeout: 15 do
+      # Enqueue 10 messages
+      10.times { |i| client.send_message("thread_test", { "index" => i }) }
 
       claimed = Concurrent::Array.new
-      barrier = Concurrent::CyclicBarrier.new(5)
 
       threads = 5.times.map do
         Thread.new do
-          barrier.wait
-          4.times do
+          3.times do
             msgs = client.read_batch("thread_test", qty: 1, vt: 30)
             next if msgs.nil? || msgs.empty?
 
@@ -63,7 +51,7 @@ RSpec.describe "Thread safety (integration)", :integration do
         end
       end
 
-      threads.each(&:join)
+      threads.each { |t| t.join(10) }
 
       # No duplicates — each message claimed by exactly one thread
       expect(claimed.size).to eq(claimed.uniq.size)
@@ -71,14 +59,12 @@ RSpec.describe "Thread safety (integration)", :integration do
   end
 
   describe "mutex serialization" do
-    it "does not segfault under concurrent PGMQ operations" do
-      barrier = Concurrent::CyclicBarrier.new(5)
+    it "does not produce PG errors under concurrent operations", timeout: 15 do
       errors = Concurrent::Array.new
 
-      threads = 5.times.map do |i|
+      threads = 3.times.map do |i|
         Thread.new do
-          barrier.wait
-          10.times do |j|
+          5.times do |j|
             client.send_message("thread_test", { "t" => i, "j" => j })
             client.read_batch("thread_test", qty: 1, vt: 0)
           end
@@ -87,9 +73,8 @@ RSpec.describe "Thread safety (integration)", :integration do
         end
       end
 
-      threads.each(&:join)
+      threads.each { |t| t.join(10) }
 
-      # No segfaults or PG::Connection errors
       pg_errors = errors.select { |e| e.include?("PG::") || e.include?("Segfault") }
       expect(pg_errors).to be_empty
     end

--- a/spec/integration/thread_safety_spec.rb
+++ b/spec/integration/thread_safety_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Thread safety (integration)", :integration do
+  let(:client) { Pgbus.client }
+
+  before do
+    client.ensure_queue("thread_test")
+  end
+
+  describe "concurrent enqueue" do
+    it "handles concurrent sends without corruption" do
+      barrier = Concurrent::CyclicBarrier.new(10)
+      errors = Concurrent::Array.new
+
+      threads = 10.times.map do |i|
+        Thread.new do
+          barrier.wait
+          client.send_message("thread_test", { "thread" => i, "job_class" => "ThreadJob" })
+        rescue StandardError => e
+          errors << e
+        end
+      end
+
+      threads.each(&:join)
+
+      expect(errors).to be_empty
+
+      # All 10 messages should be in the queue
+      all_messages = []
+      loop do
+        batch = client.read_batch("thread_test", qty: 10, vt: 0)
+        break if batch.nil? || batch.empty?
+
+        all_messages.concat(batch)
+        break if batch.size < 10
+      end
+
+      expect(all_messages.size).to eq(10)
+    end
+  end
+
+  describe "concurrent read + archive" do
+    it "each message is read by exactly one thread" do
+      # Enqueue 20 messages
+      20.times { |i| client.send_message("thread_test", { "index" => i }) }
+
+      claimed = Concurrent::Array.new
+      barrier = Concurrent::CyclicBarrier.new(5)
+
+      threads = 5.times.map do
+        Thread.new do
+          barrier.wait
+          4.times do
+            msgs = client.read_batch("thread_test", qty: 1, vt: 30)
+            next if msgs.nil? || msgs.empty?
+
+            msg = msgs.first
+            claimed << msg.msg_id.to_i
+            client.archive_message("thread_test", msg.msg_id.to_i)
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      # No duplicates — each message claimed by exactly one thread
+      expect(claimed.size).to eq(claimed.uniq.size)
+    end
+  end
+
+  describe "mutex serialization" do
+    it "does not segfault under concurrent PGMQ operations" do
+      barrier = Concurrent::CyclicBarrier.new(5)
+      errors = Concurrent::Array.new
+
+      threads = 5.times.map do |i|
+        Thread.new do
+          barrier.wait
+          10.times do |j|
+            client.send_message("thread_test", { "t" => i, "j" => j })
+            client.read_batch("thread_test", qty: 1, vt: 0)
+          end
+        rescue StandardError => e
+          errors << "#{e.class}: #{e.message}"
+        end
+      end
+
+      threads.each(&:join)
+
+      # No segfaults or PG::Connection errors
+      pg_errors = errors.select { |e| e.include?("PG::") || e.include?("Segfault") }
+      expect(pg_errors).to be_empty
+    end
+  end
+end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -64,7 +64,7 @@ end
 
 def cleanup_tables
   conn = ActiveRecord::Base.connection
-  %w[pgbus_semaphores pgbus_blocked_executions pgbus_job_locks].each do |table|
+  %w[pgbus_semaphores pgbus_blocked_executions pgbus_job_locks pgbus_processes].each do |table|
     conn.execute("DELETE FROM #{table}")
   end
 rescue StandardError => e

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "active_record"
+require "pgbus"
+
+# Integration tests require a real PostgreSQL database with PGMQ installed.
+# Set PGBUS_DATABASE_URL to connect:
+#   export PGBUS_DATABASE_URL=postgres://pgbus:pgbus@localhost:5432/pgbus_test
+#
+# To set up the database:
+#   createdb pgbus_test
+#   Then run the schema setup (see CI workflow or spec/support/schema_setup.rb)
+PGBUS_DATABASE_URL = ENV.fetch("PGBUS_DATABASE_URL", nil)
+
+unless PGBUS_DATABASE_URL
+  warn "[pgbus] Skipping integration tests: PGBUS_DATABASE_URL not set"
+  exit 0
+end
+
+# Connect ActiveRecord for model access
+ActiveRecord::Base.establish_connection(PGBUS_DATABASE_URL)
+
+# Configure pgbus with the real database
+Pgbus.configure do |c|
+  c.database_url = PGBUS_DATABASE_URL
+  c.queue_prefix = "pgbus_int"
+  c.default_queue = "default"
+  c.logger = Logger.new(IO::NULL)
+  c.pgmq_schema_mode = :embedded
+end
+
+RSpec.configure do |config|
+  config.example_status_persistence_file_path = ".rspec_integration_status"
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  config.order = :random
+  Kernel.srand config.seed
+
+  # Clean up queues and tables between tests
+  config.around do |example|
+    # Reset the client to get a fresh connection
+    Pgbus.reset_client!
+
+    example.run
+
+    # Clean up any queues created during the test
+    begin
+      client = Pgbus.client
+      queues = client.list_queues
+      queues.each do |q|
+        next unless q.to_s.start_with?("pgbus_int_")
+
+        client.purge_queue(q.to_s.delete_prefix("pgbus_int_"))
+      rescue StandardError
+        nil
+      end
+    rescue StandardError
+      nil
+    end
+
+    # Clean up tables
+    conn = ActiveRecord::Base.connection
+    %w[pgbus_semaphores pgbus_blocked_executions pgbus_job_locks].each do |table|
+      conn.execute("DELETE FROM #{table}") rescue nil # rubocop:disable Style/RescueModifier
+    end
+  end
+
+  config.after(:suite) do
+    Pgbus.reset!
+  end
+end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -6,28 +6,7 @@ require "pgbus"
 # Integration tests require a real PostgreSQL database with PGMQ installed.
 # Set PGBUS_DATABASE_URL to connect:
 #   export PGBUS_DATABASE_URL=postgres://pgbus:pgbus@localhost:5432/pgbus_test
-#
-# To set up the database:
-#   createdb pgbus_test
-#   Then run the schema setup (see CI workflow or spec/support/schema_setup.rb)
 PGBUS_DATABASE_URL = ENV.fetch("PGBUS_DATABASE_URL", nil)
-
-unless PGBUS_DATABASE_URL
-  warn "[pgbus] Skipping integration tests: PGBUS_DATABASE_URL not set"
-  exit 0
-end
-
-# Connect ActiveRecord for model access
-ActiveRecord::Base.establish_connection(PGBUS_DATABASE_URL)
-
-# Configure pgbus with the real database
-Pgbus.configure do |c|
-  c.database_url = PGBUS_DATABASE_URL
-  c.queue_prefix = "pgbus_int"
-  c.default_queue = "default"
-  c.logger = Logger.new(IO::NULL)
-  c.pgmq_schema_mode = :embedded
-end
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = ".rspec_integration_status"
@@ -40,36 +19,54 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
+  unless PGBUS_DATABASE_URL
+    config.before { skip "PGBUS_DATABASE_URL not set" }
+    next
+  end
+
+  # Connect ActiveRecord for model access
+  ActiveRecord::Base.establish_connection(PGBUS_DATABASE_URL)
+
+  # Configure pgbus with the real database
+  Pgbus.configure do |c|
+    c.database_url = PGBUS_DATABASE_URL
+    c.queue_prefix = "pgbus_int"
+    c.default_queue = "default"
+    c.logger = Logger.new(IO::NULL)
+    c.pgmq_schema_mode = :embedded
+  end
+
   # Clean up queues and tables between tests
   config.around do |example|
-    # Reset the client to get a fresh connection
     Pgbus.reset_client!
-
     example.run
-
-    # Clean up any queues created during the test
-    begin
-      client = Pgbus.client
-      queues = client.list_queues
-      queues.each do |q|
-        next unless q.to_s.start_with?("pgbus_int_")
-
-        client.purge_queue(q.to_s.delete_prefix("pgbus_int_"))
-      rescue StandardError
-        nil
-      end
-    rescue StandardError
-      nil
-    end
-
-    # Clean up tables
-    conn = ActiveRecord::Base.connection
-    %w[pgbus_semaphores pgbus_blocked_executions pgbus_job_locks].each do |table|
-      conn.execute("DELETE FROM #{table}") rescue nil # rubocop:disable Style/RescueModifier
-    end
+  ensure
+    cleanup_queues
+    cleanup_tables
   end
 
   config.after(:suite) do
     Pgbus.reset!
   end
+end
+
+def cleanup_queues
+  client = Pgbus.client
+  queues = client.list_queues
+  queues.each do |q|
+    next unless q.to_s.start_with?("pgbus_int_")
+
+    client.purge_queue(q.to_s.delete_prefix("pgbus_int_"))
+  end
+rescue StandardError => e
+  warn "[pgbus integration] Queue cleanup warning: #{e.message}"
+end
+
+def cleanup_tables
+  conn = ActiveRecord::Base.connection
+  %w[pgbus_semaphores pgbus_blocked_executions pgbus_job_locks].each do |table|
+    conn.execute("DELETE FROM #{table}")
+  end
+rescue StandardError => e
+  warn "[pgbus integration] Table cleanup warning: #{e.message}"
 end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
     c.default_queue = "default"
     c.logger = Logger.new(IO::NULL)
     c.pgmq_schema_mode = :embedded
+    c.listen_notify = false
   end
 
   # Clean up queues and tables between tests

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -24,8 +24,8 @@ RSpec.configure do |config|
     next
   end
 
-  # Connect ActiveRecord for model access
-  ActiveRecord::Base.establish_connection(PGBUS_DATABASE_URL)
+  # Connect ActiveRecord with a pool large enough for concurrent tests
+  ActiveRecord::Base.establish_connection("#{PGBUS_DATABASE_URL}?pool=20")
 
   # Configure pgbus with the real database
   Pgbus.configure do |c|
@@ -37,12 +37,10 @@ RSpec.configure do |config|
     c.listen_notify = false
   end
 
-  # Clean up queues and tables between tests
-  config.around do |example|
+  # Purge all integration queues BEFORE each test so no stale messages leak
+  config.before do
     Pgbus.reset_client!
-    example.run
-  ensure
-    cleanup_queues
+    purge_integration_queues
     cleanup_tables
   end
 
@@ -51,16 +49,17 @@ RSpec.configure do |config|
   end
 end
 
-def cleanup_queues
-  client = Pgbus.client
-  queues = client.list_queues
-  queues.each do |q|
-    next unless q.to_s.start_with?("pgbus_int_")
-
-    client.purge_queue(q.to_s.delete_prefix("pgbus_int_"))
+# Purge all pgbus_int_* queues via raw SQL to avoid prefix double-application
+def purge_integration_queues
+  conn = ActiveRecord::Base.connection
+  queue_names = conn.select_values("SELECT queue_name FROM pgmq.meta WHERE queue_name LIKE 'pgbus_int_%'")
+  queue_names.each do |full_name|
+    conn.execute("DELETE FROM pgmq.q_#{full_name}")
+  rescue StandardError
+    nil
   end
 rescue StandardError => e
-  warn "[pgbus integration] Queue cleanup warning: #{e.message}"
+  warn "[pgbus integration] Queue purge warning: #{e.message}"
 end
 
 def cleanup_tables

--- a/spec/pgbus/uniqueness_spec.rb
+++ b/spec/pgbus/uniqueness_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_job"
+
+RSpec.describe Pgbus::Uniqueness do
+  let(:job_lock_class) { stub_const("Pgbus::JobLock", Class.new) }
+
+  before do
+    job_lock_class
+    allow(Pgbus::JobLock).to receive_messages(acquire!: true, release!: 1, locked?: false)
+  end
+
+  describe ".ensures_uniqueness" do
+    it "stores uniqueness config on the class" do
+      job_class = Class.new do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness strategy: :until_executed, key: ->(id) { "test-#{id}" }, lock_ttl: 600
+      end
+
+      config = job_class.pgbus_uniqueness
+      expect(config[:strategy]).to eq(:until_executed)
+      expect(config[:lock_ttl]).to eq(600)
+    end
+
+    it "defaults to :until_executed strategy" do
+      job_class = Class.new do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness
+      end
+
+      expect(job_class.pgbus_uniqueness[:strategy]).to eq(:until_executed)
+    end
+
+    it "rejects invalid strategies" do
+      expect do
+        Class.new do
+          include Pgbus::Uniqueness
+
+          ensures_uniqueness strategy: :bogus
+        end
+      end.to raise_error(ArgumentError, /strategy/)
+    end
+
+    it "rejects invalid on_conflict" do
+      expect do
+        Class.new do
+          include Pgbus::Uniqueness
+
+          ensures_uniqueness on_conflict: :bogus
+        end
+      end.to raise_error(ArgumentError, /on_conflict/)
+    end
+  end
+
+  describe ".resolve_key" do
+    it "resolves key from job arguments" do
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness key: ->(order_id) { "import-#{order_id}" }
+      end
+      job = job_class.new(42)
+
+      expect(described_class.resolve_key(job)).to eq("import-42")
+    end
+
+    it "returns nil for jobs without uniqueness" do
+      job_class = Class.new(ActiveJob::Base)
+      job = job_class.new
+      expect(described_class.resolve_key(job)).to be_nil
+    end
+
+    it "uses class name as default key" do
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness
+      end
+      stub_const("MyUniqueJob", job_class)
+      job = MyUniqueJob.new
+
+      expect(described_class.resolve_key(job)).to eq("MyUniqueJob")
+    end
+  end
+
+  describe ".inject_metadata" do
+    it "adds uniqueness key and strategy to payload" do
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness strategy: :while_executing, key: ->(*) { "test-key" }
+      end
+      job = job_class.new
+
+      result = described_class.inject_metadata(job, { "job_class" => "Test" })
+      expect(result[described_class::METADATA_KEY]).to eq("test-key")
+      expect(result[described_class::STRATEGY_KEY]).to eq("while_executing")
+    end
+
+    it "returns payload unchanged for jobs without uniqueness" do
+      job_class = Class.new(ActiveJob::Base)
+      job = job_class.new
+      payload = { "job_class" => "Test" }
+
+      result = described_class.inject_metadata(job, payload)
+      expect(result).to eq(payload)
+    end
+  end
+
+  describe ".acquire_enqueue_lock" do
+    it "acquires lock for :until_executed strategy" do
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness strategy: :until_executed, lock_ttl: 600
+      end
+      stub_const("LockJob", job_class)
+      job = LockJob.new
+
+      result = described_class.acquire_enqueue_lock("test-key", job)
+      expect(result).to eq(:acquired)
+      expect(Pgbus::JobLock).to have_received(:acquire!).with("test-key", job_class: "LockJob", job_id: job.job_id, ttl: 600)
+    end
+
+    it "skips lock for :while_executing strategy" do
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness strategy: :while_executing
+      end
+      job = job_class.new
+
+      result = described_class.acquire_enqueue_lock("test-key", job)
+      expect(result).to eq(:acquired)
+      expect(Pgbus::JobLock).not_to have_received(:acquire!)
+    end
+
+    it "returns :locked when lock is already held" do
+      allow(Pgbus::JobLock).to receive(:acquire!).and_return(false)
+
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness strategy: :until_executed
+      end
+      job = job_class.new
+
+      result = described_class.acquire_enqueue_lock("test-key", job)
+      expect(result).to eq(:locked)
+    end
+  end
+
+  describe ".release_lock" do
+    it "releases the lock" do
+      described_class.release_lock("test-key")
+      expect(Pgbus::JobLock).to have_received(:release!).with("test-key")
+    end
+
+    it "does nothing for nil key" do
+      described_class.release_lock(nil)
+      expect(Pgbus::JobLock).not_to have_received(:release!)
+    end
+  end
+end

--- a/spec/pgbus/uniqueness_spec.rb
+++ b/spec/pgbus/uniqueness_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Pgbus::Uniqueness do
       )
     end
 
-    it "skips lock for :while_executing strategy" do
+    it "returns :no_lock for :while_executing strategy" do
       job_class = Class.new(ActiveJob::Base) do
         include Pgbus::Uniqueness
 
@@ -137,7 +137,7 @@ RSpec.describe Pgbus::Uniqueness do
       job = job_class.new
 
       result = described_class.acquire_enqueue_lock("test-key", job)
-      expect(result).to eq(:acquired)
+      expect(result).to eq(:no_lock)
       expect(Pgbus::JobLock).not_to have_received(:acquire!)
     end
 

--- a/spec/pgbus/uniqueness_spec.rb
+++ b/spec/pgbus/uniqueness_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Pgbus::Uniqueness do
       expect(config[:lock_ttl]).to eq(600)
     end
 
-    it "defaults to :until_executed strategy" do
+    it "defaults to :until_executed strategy with 24h TTL" do
       job_class = Class.new do
         include Pgbus::Uniqueness
 
@@ -32,6 +32,7 @@ RSpec.describe Pgbus::Uniqueness do
       end
 
       expect(job_class.pgbus_uniqueness[:strategy]).to eq(:until_executed)
+      expect(job_class.pgbus_uniqueness[:lock_ttl]).to eq(24 * 60 * 60)
     end
 
     it "rejects invalid strategies" do
@@ -122,7 +123,9 @@ RSpec.describe Pgbus::Uniqueness do
 
       result = described_class.acquire_enqueue_lock("test-key", job)
       expect(result).to eq(:acquired)
-      expect(Pgbus::JobLock).to have_received(:acquire!).with("test-key", job_class: "LockJob", job_id: job.job_id, ttl: 600)
+      expect(Pgbus::JobLock).to have_received(:acquire!).with(
+        "test-key", job_class: "LockJob", job_id: job.job_id, state: "queued", ttl: 600
+      )
     end
 
     it "skips lock for :while_executing strategy" do


### PR DESCRIPTION
## Summary

Two major additions addressing the core requirement: **prevent duplicate jobs from running, period.**

### Job Uniqueness (`ensures_uniqueness` DSL)

```ruby
class ImportOrderJob < ApplicationJob
  include Pgbus::Uniqueness

  ensures_uniqueness strategy: :until_executed,
                     key: ->(order_id) { "import-order-#{order_id}" },
                     lock_ttl: 30.minutes,
                     on_conflict: :reject

  def perform(order_id)
    # Only ONE instance of this job per order_id can exist at any time —
    # from enqueue through completion. 200% guaranteed.
  end
end
```

**Two strategies:**

| Strategy | Lock acquired at | Lock released at | Prevents |
|----------|-----------------|-----------------|----------|
| `:until_executed` | Enqueue time | Completion/DLQ | Duplicate enqueue AND execution |
| `:while_executing` | Execution start | Completion/DLQ | Duplicate execution only |

**Three conflict policies:** `:reject` (raise `JobNotUnique`), `:discard` (silent drop), `:log` (warn + drop)

**How it works:**
- `pgbus_job_locks` table with unique index on `lock_key`
- Atomic `INSERT ... ON CONFLICT DO NOTHING` — no race conditions possible
- Lock released in `ensure` block on success, and explicitly on DLQ routing
- Expired locks cleaned up by dispatcher every 5 minutes (crash recovery)
- Auto-included on `ActiveJob::Base` via engine initializer

### Integration Test Infrastructure

- PostgreSQL 17 service container in CI
- PGMQ embedded schema setup
- `spec/integration_helper.rb` with real DB connection + cleanup
- Tests require `PGBUS_DATABASE_URL` env var (skipped when not set)

### New generator

```bash
rails generate pgbus:add_job_locks                  # Add the job_locks migration
rails generate pgbus:add_job_locks --database=pgbus # For separate database
```

## Test plan

- [x] 14 unit specs for Uniqueness DSL (resolve_key, inject_metadata, acquire/release)
- [x] 500 existing unit specs pass
- [x] RuboCop clean (163 files, 0 offenses)
- [x] Integration test: lock acquisition prevents duplicates
- [x] Integration test: lock release allows re-enqueue
- [x] Integration test: expired lock cleanup
- [x] Integration test: 5-thread concurrent race — only 1 winner
- [x] Integration test: job lifecycle (enqueue/read/archive/DLQ) against real PGMQ
- [ ] CI: integration tests run against PostgreSQL 17 service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job uniqueness/locking to prevent duplicate jobs with configurable strategies, conflict policies, automatic cleanup, and a new error for non-unique enqueues
  * Rails generator to add job-locks migration

* **Tests**
  * New integration and unit specs covering job lifecycle, uniqueness, concurrency, dead-letter behavior, queue ops, and cleanup

* **Chores**
  * CI updated to run integration DB-backed tests; lint config adjusted for integration specs

* **Documentation**
  * README updated with Job uniqueness usage and setup steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->