### PR TITLE
feat: dashboard insights with dark mode, locks page, and ApexCharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,8 @@ The dispatcher runs archive compaction as part of its maintenance loop, deleting
 | `web_auth` | `nil` | Lambda for dashboard authentication |
 | `web_refresh_interval` | `5000` | Dashboard auto-refresh interval in milliseconds |
 | `web_live_updates` | `true` | Enable Turbo Frames auto-refresh on dashboard |
+| `stats_enabled` | `true` | Record job execution stats for insights dashboard |
+| `stats_retention` | `604800` | Seconds to keep job stats (7 days) |
 
 ## Architecture
 
@@ -684,14 +686,32 @@ pgbus help      # Show help
 
 The dashboard is a mountable Rails engine at `/pgbus` with:
 
-- **Overview** -- queue depths, enqueued count, active processes, failure count
-- **Queues** -- per-queue metrics, purge actions
+- **Overview** -- queue depths, enqueued count, active processes, failure count, throughput rate
+- **Queues** -- per-queue metrics, purge/pause/resume actions
 - **Jobs** -- enqueued and failed jobs, retry/discard actions
 - **Dead letter** -- DLQ messages with retry/discard, bulk actions
 - **Processes** -- active workers/dispatcher/consumers with heartbeat status
 - **Events** -- registered subscribers and processed events
+- **Outbox** -- transactional outbox entries pending publication
+- **Locks** -- active job uniqueness locks with state (queued/executing), owner PID@hostname, age
+- **Insights** -- throughput chart (jobs/min), status distribution donut, slowest job classes table
 
 All tables use Turbo Frames for periodic auto-refresh without page reloads.
+
+### Dark mode
+
+The dashboard supports dark mode via Tailwind CSS `dark:` classes. It respects your system preference on first visit and persists your choice via localStorage. Toggle with the sun/moon button in the nav bar.
+
+### Job stats and insights
+
+The executor records every job completion to `pgbus_job_stats` (job class, queue, status, duration). The insights page visualizes this data with ApexCharts (loaded via CDN, zero npm dependencies).
+
+```bash
+rails generate pgbus:add_job_stats           # Add the stats migration
+rails generate pgbus:add_job_stats --database=pgbus
+```
+
+Stats collection is enabled by default (`config.stats_enabled = true`). Old stats are cleaned up by the dispatcher based on `config.stats_retention` (default: 7 days). If the migration hasn't been run yet, stat recording is silently skipped.
 
 ## Database tables
 
@@ -708,6 +728,7 @@ Pgbus uses these tables (created via PGMQ and migrations):
 | `pgbus_blocked_executions` | Jobs waiting for a concurrency semaphore slot |
 | `pgbus_batches` | Batch tracking with job counters and callback config |
 | `pgbus_job_locks` | Job uniqueness locks (state, owner_pid, reaper correlation) |
+| `pgbus_job_stats` | Job execution metrics (class, queue, status, duration) |
 | `pgbus_queue_states` | Queue pause/resume and circuit breaker state |
 | `pgbus_outbox_entries` | Transactional outbox entries pending publication |
 | `pgbus_recurring_tasks` | Recurring job definitions |

--- a/app/controllers/pgbus/api/insights_controller.rb
+++ b/app/controllers/pgbus/api/insights_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Api
+    class InsightsController < ApplicationController
+      def show
+        render json: {
+          summary: data_source.job_stats_summary,
+          throughput: data_source.job_throughput,
+          status_counts: data_source.job_status_counts,
+          slowest: data_source.slowest_job_classes
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/pgbus/insights_controller.rb
+++ b/app/controllers/pgbus/insights_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class InsightsController < ApplicationController
+    def show
+      @summary = data_source.job_stats_summary
+      @slowest = data_source.slowest_job_classes
+    end
+  end
+end

--- a/app/controllers/pgbus/locks_controller.rb
+++ b/app/controllers/pgbus/locks_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class LocksController < ApplicationController
+    def index
+      @locks = data_source.job_locks
+    end
+  end
+end

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -48,6 +48,7 @@ module Pgbus
     def pgbus_duration(seconds)
       return "—" unless seconds
 
+      seconds = seconds.to_i
       if seconds < 60
         "#{seconds}s"
       elsif seconds < 3600

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -45,6 +45,33 @@ module Pgbus
       end
     end
 
+    def pgbus_duration(seconds)
+      return "—" unless seconds
+
+      if seconds < 60
+        "#{seconds}s"
+      elsif seconds < 3600
+        "#{seconds / 60}m #{seconds % 60}s"
+      elsif seconds < 86_400
+        "#{seconds / 3600}h #{(seconds % 3600) / 60}m"
+      else
+        "#{seconds / 86_400}d #{(seconds % 86_400) / 3600}h"
+      end
+    end
+
+    def pgbus_ms_duration(millis)
+      return "—" unless millis
+
+      millis = millis.to_i
+      if millis < 1000
+        "#{millis}ms"
+      elsif millis < 60_000
+        "#{(millis / 1000.0).round(1)}s"
+      else
+        "#{(millis / 60_000.0).round(1)}m"
+      end
+    end
+
     def pgbus_paused_badge(paused)
       return unless paused
 

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -11,6 +11,8 @@ module Pgbus
 
     # Record a job execution stat. Called by the executor after each job.
     def self.record!(job_class:, queue_name:, status:, duration_ms:)
+      return unless table_exists?
+
       create!(
         job_class: job_class,
         queue_name: queue_name,
@@ -19,6 +21,14 @@ module Pgbus
       )
     rescue StandardError => e
       Pgbus.logger.debug { "[Pgbus] Failed to record job stat: #{e.message}" }
+    end
+
+    def self.table_exists?
+      return @table_exists if defined?(@table_exists)
+
+      @table_exists = connection.table_exists?(table_name)
+    rescue StandardError
+      @table_exists = false
     end
 
     # Throughput: jobs per minute bucketed by minute for the last N minutes

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -23,6 +23,9 @@ module Pgbus
       Pgbus.logger.debug { "[Pgbus] Failed to record job stat: #{e.message}" }
     end
 
+    # Memoized — intentionally never invalidated at runtime. If the
+    # pgbus_job_stats migration runs while the app is already running,
+    # a restart is required for stat recording to begin.
     def self.table_exists?
       return @table_exists if defined?(@table_exists)
 
@@ -62,16 +65,24 @@ module Pgbus
         .map { |cls, count, avg, max| { job_class: cls, count: count.to_i, avg_ms: avg.to_i, max_ms: max.to_i } }
     end
 
-    # Total stats summary
+    # Single-query aggregate summary using conditional counts.
     def self.summary(minutes: 60)
-      stats = since(minutes.minutes.ago)
+      row = since(minutes.minutes.ago).pick(
+        Arel.sql("COUNT(*)"),
+        Arel.sql("COUNT(*) FILTER (WHERE status = 'success')"),
+        Arel.sql("COUNT(*) FILTER (WHERE status = 'failed')"),
+        Arel.sql("COUNT(*) FILTER (WHERE status = 'dead_lettered')"),
+        Arel.sql("ROUND(AVG(duration_ms)::numeric, 1)"),
+        Arel.sql("MAX(duration_ms)")
+      )
+
       {
-        total: stats.count,
-        success: stats.successful.count,
-        failed: stats.failed.count,
-        dead_lettered: stats.dead_lettered.count,
-        avg_duration_ms: stats.average(:duration_ms)&.round(1) || 0,
-        max_duration_ms: stats.maximum(:duration_ms) || 0
+        total: row[0].to_i,
+        success: row[1].to_i,
+        failed: row[2].to_i,
+        dead_lettered: row[3].to_i,
+        avg_duration_ms: row[4]&.to_f || 0,
+        max_duration_ms: row[5].to_i
       }
     end
 

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class JobStat < Pgbus::ApplicationRecord
+    self.table_name = "pgbus_job_stats"
+
+    scope :since, ->(time) { where("created_at >= ?", time) }
+    scope :successful, -> { where(status: "success") }
+    scope :failed, -> { where(status: "failed") }
+    scope :dead_lettered, -> { where(status: "dead_lettered") }
+
+    # Record a job execution stat. Called by the executor after each job.
+    def self.record!(job_class:, queue_name:, status:, duration_ms:)
+      create!(
+        job_class: job_class,
+        queue_name: queue_name,
+        status: status,
+        duration_ms: duration_ms
+      )
+    rescue StandardError => e
+      Pgbus.logger.debug { "[Pgbus] Failed to record job stat: #{e.message}" }
+    end
+
+    # Throughput: jobs per minute bucketed by minute for the last N minutes
+    def self.throughput(minutes: 60)
+      since(minutes.minutes.ago)
+        .group("date_trunc('minute', created_at)")
+        .order(Arel.sql("date_trunc('minute', created_at)"))
+        .count
+    end
+
+    # Average duration by job class
+    def self.avg_duration_by_class(minutes: 60)
+      since(minutes.minutes.ago)
+        .group(:job_class)
+        .order(Arel.sql("AVG(duration_ms) DESC"))
+        .average(:duration_ms)
+    end
+
+    # Success/fail/DLQ counts
+    def self.status_counts(minutes: 60)
+      since(minutes.minutes.ago).group(:status).count
+    end
+
+    # Top N slowest job classes by average duration
+    def self.slowest_classes(limit: 10, minutes: 60)
+      since(minutes.minutes.ago)
+        .group(:job_class)
+        .order(Arel.sql("AVG(duration_ms) DESC"))
+        .limit(limit)
+        .pluck(:job_class, Arel.sql("COUNT(*)"), Arel.sql("ROUND(AVG(duration_ms))"), Arel.sql("MAX(duration_ms)"))
+        .map { |cls, count, avg, max| { job_class: cls, count: count.to_i, avg_ms: avg.to_i, max_ms: max.to_i } }
+    end
+
+    # Total stats summary
+    def self.summary(minutes: 60)
+      stats = since(minutes.minutes.ago)
+      {
+        total: stats.count,
+        success: stats.successful.count,
+        failed: stats.failed.count,
+        dead_lettered: stats.dead_lettered.count,
+        avg_duration_ms: stats.average(:duration_ms)&.round(1) || 0,
+        max_duration_ms: stats.maximum(:duration_ms) || 0
+      }
+    end
+
+    # Cleanup old stats
+    def self.cleanup!(older_than:)
+      where("created_at < ?", older_than).delete_all
+    end
+  end
+end

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -65,7 +65,7 @@
             </div>
           </div>
 
-          <button onclick="toggleDarkMode()" class="rounded-md p-2 text-gray-400 hover:text-white focus:outline-none" title="Toggle dark mode">
+          <button onclick="toggleDarkMode()" class="rounded-md p-2 text-gray-400 hover:text-white focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-900" aria-label="Toggle dark mode">
             <svg class="h-5 w-5 hidden dark:block" fill="currentColor" viewBox="0 0 20 20">
               <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/>
             </svg>

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -1,15 +1,22 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full bg-gray-50">
+<html lang="en" class="h-full">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pgbus Dashboard</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+    // Restore dark mode preference
+    if (localStorage.getItem('pgbus-dark') === 'true' ||
+        (!localStorage.getItem('pgbus-dark') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
   <script type="module">
     import * as Turbo from "https://cdn.jsdelivr.net/npm/@hotwired/turbo@8/dist/turbo.es2017.esm.js";
 
     <% if Pgbus.configuration.web_live_updates %>
-    // Auto-refresh turbo frames, pausing when tab is hidden
     const interval = <%= Pgbus.configuration.web_refresh_interval %>;
     if (interval > 0) {
       let timer;
@@ -24,12 +31,18 @@
       start();
     }
     <% end %>
+
+    // Dark mode toggle
+    window.toggleDarkMode = function() {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('pgbus-dark', isDark);
+    };
   </script>
 </head>
-<body class="h-full">
+<body class="h-full bg-gray-50 dark:bg-gray-950 transition-colors">
   <div class="min-h-full">
     <!-- Top nav -->
-    <nav class="bg-gray-900">
+    <nav class="bg-gray-900 dark:bg-gray-950 border-b border-gray-800">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-14 items-center justify-between">
           <div class="flex items-center space-x-8">
@@ -47,8 +60,19 @@
               <%= pgbus_nav_link "Events", pgbus.events_path %>
               <%= pgbus_nav_link "DLQ", pgbus.dead_letter_index_path %>
               <%= pgbus_nav_link "Outbox", pgbus.outbox_index_path %>
+              <%= pgbus_nav_link "Locks", pgbus.locks_path %>
+              <%= pgbus_nav_link "Insights", pgbus.insights_path %>
             </div>
           </div>
+
+          <button onclick="toggleDarkMode()" class="rounded-md p-2 text-gray-400 hover:text-white focus:outline-none" title="Toggle dark mode">
+            <svg class="h-5 w-5 hidden dark:block" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/>
+            </svg>
+            <svg class="h-5 w-5 block dark:hidden" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+            </svg>
+          </button>
         </div>
       </div>
     </nav>
@@ -56,15 +80,15 @@
     <!-- Flash messages -->
     <% if notice %>
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 mt-4">
-        <div class="rounded-md bg-green-50 p-3">
-          <p class="text-sm text-green-800"><%= notice %></p>
+        <div class="rounded-md bg-green-50 dark:bg-green-900/30 p-3">
+          <p class="text-sm text-green-800 dark:text-green-300"><%= notice %></p>
         </div>
       </div>
     <% end %>
     <% if alert %>
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 mt-4">
-        <div class="rounded-md bg-red-50 p-3">
-          <p class="text-sm text-red-800"><%= alert %></p>
+        <div class="rounded-md bg-red-50 dark:bg-red-900/30 p-3">
+          <p class="text-sm text-red-800 dark:text-red-300"><%= alert %></p>
         </div>
       </div>
     <% end %>

--- a/app/views/pgbus/dashboard/_stats_cards.html.erb
+++ b/app/views/pgbus/dashboard/_stats_cards.html.erb
@@ -1,41 +1,41 @@
 <turbo-frame id="dashboard-stats" data-auto-refresh src="<%= pgbus.root_path(frame: 'stats') %>">
   <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-6 mb-8">
-    <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
-      <p class="text-sm font-medium text-gray-500">Queues</p>
-      <p class="mt-1 text-3xl font-semibold text-gray-900"><%= @stats[:total_queues] %></p>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Queues</p>
+      <p class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white"><%= @stats[:total_queues] %></p>
     </div>
 
-    <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
-      <p class="text-sm font-medium text-gray-500">Enqueued</p>
-      <p class="mt-1 text-3xl font-semibold text-gray-900"><%= pgbus_number(@stats[:total_depth]) %></p>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Enqueued</p>
+      <p class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@stats[:total_depth]) %></p>
       <p class="text-xs text-gray-400"><%= pgbus_number(@stats[:total_visible]) %> visible</p>
     </div>
 
-    <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
-      <p class="text-sm font-medium text-gray-500">Processes</p>
-      <p class="mt-1 text-3xl font-semibold <%= @stats[:active_processes] > 0 ? 'text-green-600' : 'text-gray-400' %>">
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Processes</p>
+      <p class="mt-1 text-3xl font-semibold <%= @stats[:active_processes] > 0 ? 'text-green-600 dark:text-green-400' : 'text-gray-400' %>">
         <%= @stats[:active_processes] %>
       </p>
     </div>
 
-    <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
-      <p class="text-sm font-medium text-gray-500">Recurring</p>
-      <p class="mt-1 text-3xl font-semibold text-gray-900"><%= @stats[:recurring_count] %></p>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Recurring</p>
+      <p class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white"><%= @stats[:recurring_count] %></p>
       <p class="text-xs text-gray-400">
-        <%= link_to "View tasks", pgbus.recurring_tasks_path, class: "text-blue-500 hover:text-blue-700" %>
+        <%= link_to "View tasks", pgbus.recurring_tasks_path, class: "text-blue-500 hover:text-blue-700 dark:text-blue-400" %>
       </p>
     </div>
 
-    <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
-      <p class="text-sm font-medium text-gray-500">Failed / DLQ</p>
-      <p class="mt-1 text-3xl font-semibold <%= (@stats[:failed_count] + @stats[:dlq_depth]) > 0 ? 'text-red-600' : 'text-gray-900' %>">
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Failed / DLQ</p>
+      <p class="mt-1 text-3xl font-semibold <%= (@stats[:failed_count] + @stats[:dlq_depth]) > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white' %>">
         <%= @stats[:failed_count] %> / <%= @stats[:dlq_depth] %>
       </p>
     </div>
 
-    <div class="rounded-lg bg-white p-5 shadow ring-1 ring-gray-200">
-      <p class="text-sm font-medium text-gray-500">Throughput</p>
-      <p class="mt-1 text-3xl font-semibold text-gray-900"><%= @stats[:throughput_rate] %></p>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Throughput</p>
+      <p class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white"><%= @stats[:throughput_rate] %></p>
       <p class="text-xs text-gray-400">msgs/s</p>
     </div>
   </div>

--- a/app/views/pgbus/dashboard/_stats_cards.html.erb
+++ b/app/views/pgbus/dashboard/_stats_cards.html.erb
@@ -8,7 +8,7 @@
     <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
       <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Enqueued</p>
       <p class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@stats[:total_depth]) %></p>
-      <p class="text-xs text-gray-400"><%= pgbus_number(@stats[:total_visible]) %> visible</p>
+      <p class="text-xs text-gray-400 dark:text-gray-500"><%= pgbus_number(@stats[:total_visible]) %> visible</p>
     </div>
 
     <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -1,0 +1,144 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Insights</h1>
+  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Job performance metrics for the last hour</p>
+</div>
+
+<!-- Summary cards -->
+<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6 mb-8">
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Total Jobs</dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@summary[:total]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Succeeded</dt>
+    <dd class="mt-1 text-2xl font-semibold text-green-600 dark:text-green-400"><%= pgbus_number(@summary[:success]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Failed</dt>
+    <dd class="mt-1 text-2xl font-semibold text-red-600 dark:text-red-400"><%= pgbus_number(@summary[:failed]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Dead Lettered</dt>
+    <dd class="mt-1 text-2xl font-semibold text-orange-600 dark:text-orange-400"><%= pgbus_number(@summary[:dead_lettered]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Avg Duration</dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_ms_duration(@summary[:avg_duration_ms]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Max Duration</dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_ms_duration(@summary[:max_duration_ms]) %></dd>
+  </div>
+</div>
+
+<!-- Charts -->
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4">Throughput (jobs/min)</h3>
+    <div id="throughput-chart" style="height: 280px;"></div>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4">Status Distribution</h3>
+    <div id="status-chart" style="height: 280px;"></div>
+  </div>
+</div>
+
+<!-- Slowest job classes -->
+<div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+  <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">Slowest Job Classes (avg duration)</h3>
+  </div>
+  <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <thead class="bg-gray-50 dark:bg-gray-900">
+      <tr>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Job Class</th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Count</th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Avg</th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Max</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+      <% @slowest.each do |row| %>
+        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+          <td class="px-4 py-3 text-sm font-medium text-gray-700 dark:text-gray-300"><%= row[:job_class] %></td>
+          <td class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_number(row[:count]) %></td>
+          <td class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:avg_ms]) %></td>
+          <td class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:max_ms]) %></td>
+        </tr>
+      <% end %>
+      <% if @slowest.empty? %>
+        <tr><td colspan="4" class="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500">No job stats yet</td></tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/apexcharts@4"></script>
+<script>
+  const isDark = document.documentElement.classList.contains('dark');
+  const textColor = isDark ? '#9ca3af' : '#6b7280';
+  const gridColor = isDark ? '#374151' : '#e5e7eb';
+
+  // Fetch chart data from API
+  fetch('<%= pgbus.api_insights_path %>')
+    .then(r => r.json())
+    .then(data => {
+      // Throughput chart
+      const throughputData = data.throughput.map(p => ({
+        x: new Date(p.time).getTime(),
+        y: p.count
+      }));
+
+      new ApexCharts(document.querySelector('#throughput-chart'), {
+        series: [{ name: 'Jobs/min', data: throughputData }],
+        chart: {
+          type: 'area',
+          height: 280,
+          toolbar: { show: false },
+          background: 'transparent',
+          foreColor: textColor
+        },
+        stroke: { curve: 'smooth', width: 2 },
+        fill: {
+          type: 'gradient',
+          gradient: { shadeIntensity: 1, opacityFrom: 0.4, opacityTo: 0.05, stops: [0, 100] }
+        },
+        colors: ['#6366f1'],
+        xaxis: { type: 'datetime', labels: { style: { colors: textColor } } },
+        yaxis: { labels: { style: { colors: textColor } } },
+        grid: { borderColor: gridColor },
+        tooltip: { theme: isDark ? 'dark' : 'light' },
+        dataLabels: { enabled: false }
+      }).render();
+
+      // Status distribution chart
+      const statusLabels = Object.keys(data.status_counts);
+      const statusValues = Object.values(data.status_counts);
+      const statusColors = statusLabels.map(s => {
+        if (s === 'success') return '#10b981';
+        if (s === 'failed') return '#ef4444';
+        if (s === 'dead_lettered') return '#f97316';
+        return '#6b7280';
+      });
+
+      if (statusLabels.length > 0) {
+        new ApexCharts(document.querySelector('#status-chart'), {
+          series: statusValues,
+          labels: statusLabels,
+          chart: { type: 'donut', height: 280, background: 'transparent', foreColor: textColor },
+          colors: statusColors,
+          legend: { position: 'bottom', labels: { colors: textColor } },
+          plotOptions: { pie: { donut: { size: '60%' } } },
+          dataLabels: { style: { colors: [isDark ? '#fff' : '#000'] } },
+          tooltip: { theme: isDark ? 'dark' : 'light' }
+        }).render();
+      } else {
+        document.querySelector('#status-chart').innerHTML =
+          '<p class="text-center text-sm text-gray-400 pt-24">No data yet</p>';
+      }
+    })
+    .catch(() => {
+      document.querySelector('#throughput-chart').innerHTML =
+        '<p class="text-center text-sm text-gray-400 pt-24">Failed to load chart data</p>';
+    });
+</script>

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -75,70 +75,87 @@
 
 <script src="https://cdn.jsdelivr.net/npm/apexcharts@4"></script>
 <script>
-  const isDark = document.documentElement.classList.contains('dark');
-  const textColor = isDark ? '#9ca3af' : '#6b7280';
-  const gridColor = isDark ? '#374151' : '#e5e7eb';
+  let throughputChart, statusChart;
 
-  // Fetch chart data from API
+  function getThemeColors() {
+    const isDark = document.documentElement.classList.contains('dark');
+    return {
+      isDark,
+      text: isDark ? '#9ca3af' : '#6b7280',
+      grid: isDark ? '#374151' : '#e5e7eb',
+      tooltip: isDark ? 'dark' : 'light',
+      dataLabel: isDark ? '#fff' : '#000'
+    };
+  }
+
+  function renderCharts(data) {
+    const t = getThemeColors();
+
+    // Destroy existing charts before re-rendering
+    if (throughputChart) throughputChart.destroy();
+    if (statusChart) statusChart.destroy();
+
+    // Throughput chart
+    const throughputData = data.throughput.map(p => ({
+      x: new Date(p.time).getTime(), y: p.count
+    }));
+
+    throughputChart = new ApexCharts(document.querySelector('#throughput-chart'), {
+      series: [{ name: 'Jobs/min', data: throughputData }],
+      chart: { type: 'area', height: 280, toolbar: { show: false }, background: 'transparent', foreColor: t.text },
+      stroke: { curve: 'smooth', width: 2 },
+      fill: { type: 'gradient', gradient: { shadeIntensity: 1, opacityFrom: 0.4, opacityTo: 0.05, stops: [0, 100] } },
+      colors: ['#6366f1'],
+      xaxis: { type: 'datetime', labels: { style: { colors: t.text } } },
+      yaxis: { labels: { style: { colors: t.text } } },
+      grid: { borderColor: t.grid },
+      tooltip: { theme: t.tooltip },
+      dataLabels: { enabled: false }
+    });
+    throughputChart.render();
+
+    // Status distribution chart
+    const statusLabels = Object.keys(data.status_counts);
+    const statusValues = Object.values(data.status_counts);
+    const statusColors = statusLabels.map(s => {
+      if (s === 'success') return '#10b981';
+      if (s === 'failed') return '#ef4444';
+      if (s === 'dead_lettered') return '#f97316';
+      return '#6b7280';
+    });
+
+    if (statusLabels.length > 0) {
+      statusChart = new ApexCharts(document.querySelector('#status-chart'), {
+        series: statusValues, labels: statusLabels,
+        chart: { type: 'donut', height: 280, background: 'transparent', foreColor: t.text },
+        colors: statusColors,
+        legend: { position: 'bottom', labels: { colors: t.text } },
+        plotOptions: { pie: { donut: { size: '60%' } } },
+        dataLabels: { style: { colors: [t.dataLabel] } },
+        tooltip: { theme: t.tooltip }
+      });
+      statusChart.render();
+    } else {
+      document.querySelector('#status-chart').innerHTML =
+        '<p class="text-center text-sm text-gray-400 dark:text-gray-500 pt-24">No data yet</p>';
+    }
+  }
+
+  // Fetch data and render
+  let chartData = null;
   fetch('<%= pgbus.api_insights_path %>')
     .then(r => r.json())
-    .then(data => {
-      // Throughput chart
-      const throughputData = data.throughput.map(p => ({
-        x: new Date(p.time).getTime(),
-        y: p.count
-      }));
-
-      new ApexCharts(document.querySelector('#throughput-chart'), {
-        series: [{ name: 'Jobs/min', data: throughputData }],
-        chart: {
-          type: 'area',
-          height: 280,
-          toolbar: { show: false },
-          background: 'transparent',
-          foreColor: textColor
-        },
-        stroke: { curve: 'smooth', width: 2 },
-        fill: {
-          type: 'gradient',
-          gradient: { shadeIntensity: 1, opacityFrom: 0.4, opacityTo: 0.05, stops: [0, 100] }
-        },
-        colors: ['#6366f1'],
-        xaxis: { type: 'datetime', labels: { style: { colors: textColor } } },
-        yaxis: { labels: { style: { colors: textColor } } },
-        grid: { borderColor: gridColor },
-        tooltip: { theme: isDark ? 'dark' : 'light' },
-        dataLabels: { enabled: false }
-      }).render();
-
-      // Status distribution chart
-      const statusLabels = Object.keys(data.status_counts);
-      const statusValues = Object.values(data.status_counts);
-      const statusColors = statusLabels.map(s => {
-        if (s === 'success') return '#10b981';
-        if (s === 'failed') return '#ef4444';
-        if (s === 'dead_lettered') return '#f97316';
-        return '#6b7280';
-      });
-
-      if (statusLabels.length > 0) {
-        new ApexCharts(document.querySelector('#status-chart'), {
-          series: statusValues,
-          labels: statusLabels,
-          chart: { type: 'donut', height: 280, background: 'transparent', foreColor: textColor },
-          colors: statusColors,
-          legend: { position: 'bottom', labels: { colors: textColor } },
-          plotOptions: { pie: { donut: { size: '60%' } } },
-          dataLabels: { style: { colors: [isDark ? '#fff' : '#000'] } },
-          tooltip: { theme: isDark ? 'dark' : 'light' }
-        }).render();
-      } else {
-        document.querySelector('#status-chart').innerHTML =
-          '<p class="text-center text-sm text-gray-400 pt-24">No data yet</p>';
-      }
-    })
+    .then(data => { chartData = data; renderCharts(data); })
     .catch(() => {
-      document.querySelector('#throughput-chart').innerHTML =
-        '<p class="text-center text-sm text-gray-400 pt-24">Failed to load chart data</p>';
+      const msg = '<p class="text-center text-sm text-gray-400 dark:text-gray-500 pt-24">Failed to load chart data</p>';
+      document.querySelector('#throughput-chart').innerHTML = msg;
+      document.querySelector('#status-chart').innerHTML = msg;
     });
+
+  // Re-render charts when dark mode toggles
+  const origToggle = window.toggleDarkMode;
+  window.toggleDarkMode = function() {
+    origToggle();
+    if (chartData) renderCharts(chartData);
+  };
 </script>

--- a/app/views/pgbus/locks/index.html.erb
+++ b/app/views/pgbus/locks/index.html.erb
@@ -42,7 +42,7 @@
               <%= pgbus_duration(lock[:age_seconds]) %>
             <% end %>
           </td>
-          <td class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400"><%= pgbus_time_ago(lock[:expires_at]) %></td>
+          <td class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400"><%= pgbus_time_ago_future(lock[:expires_at]) %></td>
         </tr>
       <% end %>
       <% if @locks.empty? %>

--- a/app/views/pgbus/locks/index.html.erb
+++ b/app/views/pgbus/locks/index.html.erb
@@ -1,0 +1,53 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Job Locks</h1>
+  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Active uniqueness locks preventing duplicate job execution</p>
+</div>
+
+<div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+  <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <thead class="bg-gray-50 dark:bg-gray-900">
+      <tr>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Lock Key</th>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Job Class</th>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">State</th>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Owner</th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Age</th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Expires</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+      <% @locks.each do |lock| %>
+        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+          <td class="px-4 py-3 text-sm font-mono text-gray-700 dark:text-gray-300 max-w-xs truncate"><%= lock[:lock_key] %></td>
+          <td class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300"><%= lock[:job_class] %></td>
+          <td class="px-4 py-3 text-sm">
+            <% if lock[:state] == "executing" %>
+              <span class="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900/50 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">Executing</span>
+            <% else %>
+              <span class="inline-flex items-center rounded-full bg-yellow-100 dark:bg-yellow-900/50 px-2.5 py-0.5 text-xs font-medium text-yellow-800 dark:text-yellow-300">Queued</span>
+            <% end %>
+          </td>
+          <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+            <% if lock[:owner_pid] %>
+              <span class="font-mono"><%= lock[:owner_pid] %></span>
+              <% if lock[:owner_hostname] %>
+                <span class="text-xs text-gray-400 dark:text-gray-500">@<%= lock[:owner_hostname] %></span>
+              <% end %>
+            <% else %>
+              <span class="text-gray-400 dark:text-gray-500">—</span>
+            <% end %>
+          </td>
+          <td class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400">
+            <% if lock[:age_seconds] %>
+              <%= pgbus_duration(lock[:age_seconds]) %>
+            <% end %>
+          </td>
+          <td class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400"><%= pgbus_time_ago(lock[:expires_at]) %></td>
+        </tr>
+      <% end %>
+      <% if @locks.empty? %>
+        <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500">No active locks</td></tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -11,6 +11,7 @@ Pgbus.configure do |c|
   c.logger = Logger.new(IO::NULL)
   c.queue_prefix = "pgbus_bench"
   c.default_queue = "default"
+  c.stats_enabled = false # Don't record stats during benchmarks
 end
 
 # Stub PGMQ to isolate Pgbus overhead from database I/O.
@@ -25,8 +26,9 @@ module BenchStubs
     Pgbus::Client.allocate.tap do |client|
       client.instance_variable_set(:@pgmq, pgmq)
       client.instance_variable_set(:@config, Pgbus.configuration)
-      client.instance_variable_set(:@queues_created, Hash.new(true))
-      client.instance_variable_set(:@mutex, Mutex.new)
+      client.instance_variable_set(:@pgmq_mutex, Mutex.new)
+      client.instance_variable_set(:@queues_created, Concurrent::Map.new.tap { |m| m["pgbus_bench_default"] = true })
+      client.instance_variable_set(:@queue_strategy, Pgbus::QueueFactory.for(Pgbus.configuration))
     end
   end
 

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -4,6 +4,7 @@ require "benchmark/ips"
 require "memory_profiler"
 require "json"
 require "securerandom"
+require "concurrent"
 require "pgbus"
 
 # Suppress logging during benchmarks

--- a/benchmarks/executor_bench.rb
+++ b/benchmarks/executor_bench.rb
@@ -49,17 +49,20 @@ Benchmark.ips do |x|
 end
 
 puts "\n--- Executor#execute throughput (stats enabled) ---"
-Pgbus.configuration.stats_enabled = true
-Benchmark.ips do |x|
-  x.config(time: 5, warmup: 2)
+begin
+  Pgbus.configuration.stats_enabled = true
+  Benchmark.ips do |x|
+    x.config(time: 5, warmup: 2)
 
-  x.report("execute + stat recording") do
-    executor.execute(msg, "default")
+    x.report("execute + stat recording") do
+      executor.execute(msg, "default")
+    end
+
+    x.compare!
   end
-
-  x.compare!
+ensure
+  Pgbus.configuration.stats_enabled = false
 end
-Pgbus.configuration.stats_enabled = false
 
 puts "\n--- Memory: execute (1000 jobs) ---"
 report = MemoryProfiler.report { 1000.times { executor.execute(msg, "default") } }

--- a/benchmarks/executor_bench.rb
+++ b/benchmarks/executor_bench.rb
@@ -16,6 +16,16 @@ class BenchJob < ActiveJob::Base
   end
 end
 
+# Stub JobStat so it doesn't hit the DB
+stub_job_stat = Class.new do
+  def self.record!(**) = nil
+end
+Object.const_set(:PGBUS_BENCH_JOB_STAT_STUB, true) unless defined?(PGBUS_BENCH_JOB_STAT_STUB)
+
+# Replace JobStat with stub for benchmarks
+Pgbus.send(:remove_const, :JobStat) if defined?(Pgbus::JobStat)
+Pgbus.const_set(:JobStat, stub_job_stat)
+
 client = BenchStubs.build_mock_client
 executor = Pgbus::ActiveJob::Executor.new(client: client, config: Pgbus.configuration)
 
@@ -37,6 +47,19 @@ Benchmark.ips do |x|
 
   x.compare!
 end
+
+puts "\n--- Executor#execute throughput (stats enabled) ---"
+Pgbus.configuration.stats_enabled = true
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("execute + stat recording") do
+    executor.execute(msg, "default")
+  end
+
+  x.compare!
+end
+Pgbus.configuration.stats_enabled = false
 
 puts "\n--- Memory: execute (1000 jobs) ---"
 report = MemoryProfiler.report { 1000.times { executor.execute(msg, "default") } }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,8 +49,11 @@ Pgbus::Engine.routes.draw do
   end
 
   resources :outbox, only: [:index], controller: "outbox"
+  resources :locks, only: [:index]
+  resource :insights, only: [:show], controller: "insights"
 
   namespace :api do
     get :stats, to: "stats#show"
+    get :insights, to: "insights#show"
   end
 end

--- a/lib/generators/pgbus/add_job_stats_generator.rb
+++ b/lib/generators/pgbus/add_job_stats_generator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class AddJobStatsGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Add job stats table for dashboard insights and performance tracking"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
+      def create_migration_file
+        if separate_database?
+          migration_template "add_job_stats.rb.erb",
+                             "db/pgbus_migrate/add_pgbus_job_stats.rb"
+        else
+          migration_template "add_job_stats.rb.erb",
+                             "db/migrate/add_pgbus_job_stats.rb"
+        end
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus job stats table installed!", :green
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
+        say "  2. Stats collection is enabled by default"
+        say "  3. View insights at /pgbus/insights"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/templates/add_job_stats.rb.erb
+++ b/lib/generators/pgbus/templates/add_job_stats.rb.erb
@@ -1,0 +1,18 @@
+class AddPgbusJobStats < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :pgbus_job_stats do |t|
+      t.string :job_class, null: false
+      t.string :queue_name, null: false
+      t.string :status, null: false
+      t.integer :duration_ms, null: false, default: 0
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :pgbus_job_stats, :created_at,
+      name: "idx_pgbus_job_stats_time"
+    add_index :pgbus_job_stats, [:job_class, :created_at],
+      name: "idx_pgbus_job_stats_class_time"
+    add_index :pgbus_job_stats, [:status, :created_at],
+      name: "idx_pgbus_job_stats_status_time"
+  end
+end

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -14,11 +14,14 @@ module Pgbus
         payload = JSON.parse(message.message)
         read_count = message.read_ct.to_i
 
+        execution_start = monotonic_now
+
         if read_count > config.max_retries
           handle_dead_letter(message, queue_name, payload, source_queue: source_queue)
           signal_concurrency(payload)
           signal_batch_discarded(payload)
           Uniqueness.release_lock(Uniqueness.extract_key(payload))
+          record_stat(payload, queue_name, "dead_lettered", execution_start)
           return :dead_lettered
         end
 
@@ -54,10 +57,12 @@ module Pgbus
         end
 
         instrument("pgbus.job_completed", queue: queue_name, job_class: job_class)
+        record_stat(payload, queue_name, "success", execution_start)
         :success
       rescue StandardError => e
         handle_failure(message, queue_name, e)
         instrument("pgbus.job_failed", queue: queue_name, job_class: payload&.dig("job_class"), error: e.class.name)
+        record_stat(payload, queue_name, "failed", execution_start)
         # Don't signal concurrency on transient failure — the job will be retried.
         # Semaphore is released only on success or dead-lettering.
         :failed
@@ -81,6 +86,24 @@ module Pgbus
         else
           job.perform_now
         end
+      end
+
+      def monotonic_now
+        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      end
+
+      def record_stat(payload, queue_name, status, start_time)
+        return unless config.stats_enabled
+
+        duration_ms = ((monotonic_now - start_time) * 1000).round
+        JobStat.record!(
+          job_class: payload&.dig("job_class") || "unknown",
+          queue_name: queue_name,
+          status: status,
+          duration_ms: duration_ms
+        )
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus] Stat recording failed: #{e.message}" }
       end
 
       def handle_failure(_message, _queue_name, error)

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -11,10 +11,9 @@ module Pgbus
       end
 
       def execute(message, queue_name, source_queue: nil)
+        execution_start = monotonic_now
         payload = JSON.parse(message.message)
         read_count = message.read_ct.to_i
-
-        execution_start = monotonic_now
 
         if read_count > config.max_retries
           handle_dead_letter(message, queue_name, payload, source_queue: source_queue)

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -59,6 +59,9 @@ module Pgbus
     # Requires a matching entry in config/database.yml under the "pgbus" key.
     attr_accessor :connects_to
 
+    # Job stats
+    attr_accessor :stats_retention, :stats_enabled
+
     # Web dashboard
     attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source
 
@@ -119,6 +122,9 @@ module Pgbus
       @recurring_tasks_file = nil
       @skip_recurring = false
       @recurring_execution_retention = 7 * 24 * 3600 # 7 days
+
+      @stats_enabled = true
+      @stats_retention = 7 * 24 * 3600 # 7 days
 
       @connects_to = nil
 

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -14,6 +14,7 @@ module Pgbus
       ARCHIVE_COMPACTION_INTERVAL = 3600    # Run archive compaction every hour
       OUTBOX_CLEANUP_INTERVAL = 3600 # Run outbox cleanup every hour
       JOB_LOCK_CLEANUP_INTERVAL = 300 # Run job lock cleanup every 5 minutes
+      STATS_CLEANUP_INTERVAL = 3600 # Run stats cleanup every hour
 
       attr_reader :config
 
@@ -28,6 +29,7 @@ module Pgbus
         @last_archive_compaction_at = Time.now
         @last_outbox_cleanup_at = Time.now
         @last_job_lock_cleanup_at = Time.now
+        @last_stats_cleanup_at = Time.now
       end
 
       def run
@@ -73,6 +75,7 @@ module Pgbus
         run_if_due(now, :@last_archive_compaction_at, archive_compaction_interval) { compact_archives }
         run_if_due(now, :@last_outbox_cleanup_at, OUTBOX_CLEANUP_INTERVAL) { cleanup_outbox }
         run_if_due(now, :@last_job_lock_cleanup_at, JOB_LOCK_CLEANUP_INTERVAL) { cleanup_job_locks }
+        run_if_due(now, :@last_stats_cleanup_at, STATS_CLEANUP_INTERVAL) { cleanup_stats }
       end
 
       # Only update the timestamp when the block succeeds.
@@ -128,6 +131,16 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} finished batches" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Batch cleanup failed: #{e.message}" }
+      end
+
+      def cleanup_stats
+        return unless config.stats_enabled
+
+        retention = config.stats_retention
+        return unless retention&.positive?
+
+        deleted = JobStat.cleanup!(older_than: Time.now.utc - retention)
+        Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} old job stats" } if deleted.positive?
       end
 
       def cleanup_job_locks

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -497,6 +497,55 @@ module Pgbus
         []
       end
 
+      # Job locks
+      def job_locks
+        JobLock.order(locked_at: :desc).limit(100).map do |lock|
+          {
+            lock_key: lock.lock_key,
+            job_class: lock.job_class,
+            job_id: lock.job_id,
+            state: lock.state,
+            owner_pid: lock.owner_pid,
+            owner_hostname: lock.owner_hostname,
+            locked_at: lock.locked_at,
+            expires_at: lock.expires_at,
+            age_seconds: lock.locked_at ? (Time.current - lock.locked_at).to_i : nil
+          }
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching job locks: #{e.message}" }
+        []
+      end
+
+      # Job stats
+      def job_stats_summary(minutes: 60)
+        JobStat.summary(minutes: minutes)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching job stats summary: #{e.message}" }
+        { total: 0, success: 0, failed: 0, dead_lettered: 0, avg_duration_ms: 0, max_duration_ms: 0 }
+      end
+
+      def job_throughput(minutes: 60)
+        JobStat.throughput(minutes: minutes).map { |time, count| { time: time, count: count } }
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching throughput: #{e.message}" }
+        []
+      end
+
+      def job_status_counts(minutes: 60)
+        JobStat.status_counts(minutes: minutes)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching status counts: #{e.message}" }
+        {}
+      end
+
+      def slowest_job_classes(limit: 10, minutes: 60)
+        JobStat.slowest_classes(limit: limit, minutes: minutes)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching slowest classes: #{e.message}" }
+        []
+      end
+
       # Subscriber registry
       def registered_subscribers
         EventBus::Registry.instance.subscribers.map do |s|

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe Pgbus::ActiveJob::Executor do
     allow(ActiveJob::Base).to receive(:deserialize).with(job_payload).and_return(job_double)
     # By default, no concurrency key in payloads
     allow(Pgbus::Concurrency).to receive(:extract_key).and_return(nil)
+    # Stub stat recording
+    stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
+    allow(Pgbus::JobStat).to receive(:record!)
   end
 
   describe "#execute" do
@@ -185,6 +188,57 @@ RSpec.describe Pgbus::ActiveJob::Executor do
 
         expect(Pgbus::Concurrency::Semaphore).not_to have_received(:release)
         expect(Pgbus::Concurrency::BlockedExecution).not_to have_received(:promote_next)
+      end
+    end
+
+    context "with job stat recording" do
+      let(:message) { build_message_double(msg_id: 1, message: message_json, read_ct: 1) }
+
+      it "records a success stat after successful execution" do
+        executor.execute(message, queue_name)
+
+        expect(Pgbus::JobStat).to have_received(:record!).with(
+          job_class: "TestJob",
+          queue_name: queue_name,
+          status: "success",
+          duration_ms: an_instance_of(Integer)
+        )
+      end
+
+      it "records a failed stat when job raises" do
+        allow(job_double).to receive(:perform_now).and_raise(StandardError, "boom")
+
+        executor.execute(message, queue_name)
+
+        expect(Pgbus::JobStat).to have_received(:record!).with(
+          job_class: "TestJob",
+          queue_name: queue_name,
+          status: "failed",
+          duration_ms: an_instance_of(Integer)
+        )
+      end
+
+      it "records a dead_lettered stat for DLQ routing" do
+        dlq_message = build_message_double(msg_id: 99, message: message_json, read_ct: config.max_retries + 1)
+
+        executor.execute(dlq_message, queue_name)
+
+        expect(Pgbus::JobStat).to have_received(:record!).with(
+          job_class: "TestJob",
+          queue_name: queue_name,
+          status: "dead_lettered",
+          duration_ms: an_instance_of(Integer)
+        )
+      end
+
+      it "does not record stats when stats_enabled is false" do
+        config.stats_enabled = false
+
+        executor.execute(message, queue_name)
+
+        expect(Pgbus::JobStat).not_to have_received(:record!)
+      ensure
+        config.stats_enabled = true
       end
     end
   end

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Pgbus::ActiveJob::Executor do
     allow(Pgbus::Concurrency).to receive(:extract_key).and_return(nil)
     # Stub stat recording
     stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
-    allow(Pgbus::JobStat).to receive(:record!)
+    allow(Pgbus::JobStat).to receive_messages(record!: nil, table_exists?: true)
   end
 
   describe "#execute" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe Pgbus::Configuration do
       expect(config.archive_compaction_batch_size).to eq(1000)
     end
 
+    it "has stats enabled by default" do
+      expect(config.stats_enabled).to be true
+      expect(config.stats_retention).to eq(7 * 24 * 3600)
+    end
+
     it "has outbox disabled by default" do
       expect(config.outbox_enabled).to be false
       expect(config.outbox_poll_interval).to eq(1.0)

--- a/spec/pgbus/helpers/application_helper_spec.rb
+++ b/spec/pgbus/helpers/application_helper_spec.rb
@@ -51,6 +51,46 @@ RSpec.describe Pgbus::ApplicationHelper do
     end
   end
 
+  describe "#pgbus_duration" do
+    it "returns dash for nil" do
+      expect(helper.pgbus_duration(nil)).to eq("—")
+    end
+
+    it "formats seconds" do
+      expect(helper.pgbus_duration(45)).to eq("45s")
+    end
+
+    it "formats minutes and seconds" do
+      expect(helper.pgbus_duration(125)).to eq("2m 5s")
+    end
+
+    it "formats hours and minutes" do
+      expect(helper.pgbus_duration(3725)).to eq("1h 2m")
+    end
+
+    it "formats days and hours" do
+      expect(helper.pgbus_duration(90_000)).to eq("1d 1h")
+    end
+  end
+
+  describe "#pgbus_ms_duration" do
+    it "returns dash for nil" do
+      expect(helper.pgbus_ms_duration(nil)).to eq("—")
+    end
+
+    it "formats milliseconds" do
+      expect(helper.pgbus_ms_duration(42)).to eq("42ms")
+    end
+
+    it "formats seconds" do
+      expect(helper.pgbus_ms_duration(1500)).to eq("1.5s")
+    end
+
+    it "formats minutes" do
+      expect(helper.pgbus_ms_duration(120_000)).to eq("2.0m")
+    end
+  end
+
   describe "#pgbus_json_preview" do
     it "returns dash for nil" do
       expect(helper.pgbus_json_preview(nil)).to eq("—")

--- a/spec/pgbus/helpers/application_helper_spec.rb
+++ b/spec/pgbus/helpers/application_helper_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe Pgbus::ApplicationHelper do
     it "formats minutes" do
       expect(helper.pgbus_ms_duration(120_000)).to eq("2.0m")
     end
+
+    it "formats exact second boundary" do
+      expect(helper.pgbus_ms_duration(1000)).to eq("1.0s")
+    end
+
+    it "formats exact minute boundary" do
+      expect(helper.pgbus_ms_duration(60_000)).to eq("1.0m")
+    end
+
+    it "rounds just below minute boundary" do
+      expect(helper.pgbus_ms_duration(59_950)).to eq("60.0s")
+    end
   end
 
   describe "#pgbus_json_preview" do

--- a/spec/pgbus/job_stat_spec.rb
+++ b/spec/pgbus/job_stat_spec.rb
@@ -4,17 +4,7 @@ require "spec_helper"
 
 RSpec.describe Pgbus::JobStat do
   before do
-    stub_const("Pgbus::JobStat", Class.new do
-      def self.create!(**attrs); end
-
-      def self.record!(job_class:, queue_name:, status:, duration_ms:)
-        create!(job_class: job_class, queue_name: queue_name, status: status, duration_ms: duration_ms)
-      rescue StandardError => e
-        Pgbus.logger.debug { "[Pgbus] Failed to record job stat: #{e.message}" }
-      end
-    end)
-
-    allow(described_class).to receive(:create!)
+    allow(described_class).to receive_messages(create!: nil, table_exists?: true)
   end
 
   describe ".record!" do
@@ -32,6 +22,14 @@ RSpec.describe Pgbus::JobStat do
         status: "success",
         duration_ms: 42
       )
+    end
+
+    it "skips when table does not exist" do
+      allow(described_class).to receive(:table_exists?).and_return(false)
+
+      described_class.record!(job_class: "X", queue_name: "q", status: "s", duration_ms: 0)
+
+      expect(described_class).not_to have_received(:create!)
     end
 
     it "rescues errors gracefully" do

--- a/spec/pgbus/job_stat_spec.rb
+++ b/spec/pgbus/job_stat_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::JobStat do
+  before do
+    stub_const("Pgbus::JobStat", Class.new do
+      def self.create!(**attrs); end
+
+      def self.record!(job_class:, queue_name:, status:, duration_ms:)
+        create!(job_class: job_class, queue_name: queue_name, status: status, duration_ms: duration_ms)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus] Failed to record job stat: #{e.message}" }
+      end
+    end)
+
+    allow(described_class).to receive(:create!)
+  end
+
+  describe ".record!" do
+    it "creates a stat record" do
+      described_class.record!(
+        job_class: "TestJob",
+        queue_name: "default",
+        status: "success",
+        duration_ms: 42
+      )
+
+      expect(described_class).to have_received(:create!).with(
+        job_class: "TestJob",
+        queue_name: "default",
+        status: "success",
+        duration_ms: 42
+      )
+    end
+
+    it "rescues errors gracefully" do
+      allow(described_class).to receive(:create!).and_raise(StandardError, "db error")
+
+      expect do
+        described_class.record!(job_class: "X", queue_name: "q", status: "s", duration_ms: 0)
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -277,6 +277,35 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
   end
 
+  describe "#cleanup_stats (private)" do
+    before do
+      stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
+      allow(Pgbus::JobStat).to receive(:cleanup!).and_return(10)
+    end
+
+    it "cleans up old job stats" do
+      dispatcher.send(:cleanup_stats)
+
+      expect(Pgbus::JobStat).to have_received(:cleanup!).with(older_than: a_kind_of(Time))
+    end
+
+    it "skips when stats_enabled is false" do
+      allow(dispatcher.config).to receive(:stats_enabled).and_return(false)
+
+      dispatcher.send(:cleanup_stats)
+
+      expect(Pgbus::JobStat).not_to have_received(:cleanup!)
+    end
+
+    it "skips when stats_retention is not positive" do
+      allow(dispatcher.config).to receive(:stats_retention).and_return(0)
+
+      dispatcher.send(:cleanup_stats)
+
+      expect(Pgbus::JobStat).not_to have_received(:cleanup!)
+    end
+  end
+
   describe "#start_heartbeat (private)" do
     it "creates and starts a heartbeat" do
       dispatcher.send(:start_heartbeat)


### PR DESCRIPTION
## Summary

Professional dashboard upgrade with zero new gem dependencies:

### Job Stats Collection
- **`pgbus_job_stats` table** records every job execution: class, queue, status, duration_ms
- Executor writes stats on success, failure, and DLQ routing
- Configurable: `stats_enabled` (default true), `stats_retention` (7 days)
- Dispatcher cleans up old stats hourly

### Dark Mode
- Tailwind `dark:` class strategy with localStorage persistence
- Respects `prefers-color-scheme` on first visit
- Sun/moon toggle button in nav bar
- All existing dashboard views have dark variants

### Locks Page (`/locks`)
- Active job uniqueness locks with state badges (Queued/Executing)
- Owner column shows PID@hostname
- Age and expiry columns

### Insights Page (`/insights`)
- Summary cards: total, success, failed, dead_lettered, avg/max duration
- **Throughput chart**: jobs/min over last hour (ApexCharts area chart)
- **Status distribution**: donut chart (success/failed/DLQ)
- **Slowest job classes** table: count, avg, max duration
- API endpoint (`/api/insights`) returns JSON for chart rendering
- ApexCharts v4 loaded via CDN — no npm required
- Charts are dark mode aware

### New generator

```bash
rails generate pgbus:add_job_stats
```

## Test plan

- [x] 500 unit specs pass
- [x] RuboCop clean (172 files, 0 offenses)
- [ ] Manual: verify dark mode toggle persists across page navigations
- [ ] Manual: verify charts render with real job data
- [ ] Manual: verify locks page shows active locks with correct state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insights dashboard with summary metrics, live throughput and status charts, and slowest job-classes table.
  * Locks page listing current job locks.

* **Enhancements**
  * Dark mode toggle with persistent preference and theme-aware charts.
  * Human-friendly duration formatting across the UI.
  * Job-statistics collection enabled by default with configurable retention and periodic cleanup.

* **Chores**
  * Installer generator to add the job-stats database migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->