### PR TITLE
fix: bootstrap PGMQ queues on supervisor startup

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -42,6 +42,12 @@ module Pgbus
             "PGMQ schema is not available (#{e.message}). Run `rails db:migrate` for the pgbus database."
     end
 
+    def ensure_all_queues
+      queue_names = collect_configured_queues
+      Pgbus.logger.info { "[Pgbus] Bootstrapping #{queue_names.size} queue(s): #{queue_names.join(", ")}" }
+      queue_names.each { |name| ensure_queue(name) }
+    end
+
     def ensure_dead_letter_queue(name)
       dlq_name = config.dead_letter_queue_name(name)
       return if @queues_created[dlq_name]
@@ -227,6 +233,26 @@ module Pgbus
     end
 
     private
+
+    def collect_configured_queues
+      queues = Set.new
+      queues << config.default_queue
+
+      # Queues from worker configs
+      (config.workers || []).each do |w|
+        worker_queues = w[:queues] || w["queues"] || [config.default_queue]
+        worker_queues.each { |q| queues << q unless q == "*" }
+      end
+
+      # Queues from recurring tasks
+      (config.recurring_tasks || {}).each_value do |opts|
+        opts = opts.transform_keys(&:to_s) if opts.is_a?(Hash)
+        queue = opts["queue"] || opts[:queue]
+        queues << queue if queue
+      end
+
+      queues.to_a
+    end
 
     def ensure_single_queue(full_name)
       return if @queues_created[full_name]

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -42,6 +42,11 @@ module Pgbus
       private
 
       def boot_processes
+        # Bootstrap all configured queues before forking workers.
+        # Without this, workers start reading from non-existent queues
+        # and recurring task enqueues fail.
+        bootstrap_queues
+
         # Boot workers
         config.workers.each do |worker_config|
           fork_worker(worker_config)
@@ -278,6 +283,12 @@ module Pgbus
         %w[INT TERM QUIT].each do |sig|
           trap(sig) { @shutting_down = true }
         end
+      end
+
+      def bootstrap_queues
+        Pgbus.client.ensure_all_queues
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus] Failed to bootstrap queues: #{e.message}" }
       end
 
       def load_rails_app

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -454,6 +454,71 @@ RSpec.describe Pgbus::Client do
     end
   end
 
+  describe "#ensure_all_queues" do
+    it "creates the default queue" do
+      client.ensure_all_queues
+
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_default")
+    end
+
+    it "creates all queues from worker configs" do
+      config.workers = [
+        { queues: %w[default urgent], threads: 5 },
+        { queues: %w[emails], threads: 2 }
+      ]
+      client.ensure_all_queues
+
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_default")
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_urgent")
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_emails")
+    end
+
+    it "creates queues for recurring tasks" do
+      config.recurring_tasks = {
+        "daily_report" => { class: "ReportJob", schedule: "0 2 * * *", queue: "reports" }
+      }
+      client.ensure_all_queues
+
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_reports")
+    end
+
+    it "deduplicates queues" do
+      config.workers = [
+        { queues: %w[default], threads: 5 },
+        { queues: %w[default], threads: 3 }
+      ]
+      client.ensure_all_queues
+
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_default").once
+    end
+
+    it "skips wildcard queue entries" do
+      config.workers = [{ queues: %w[*], threads: 5 }]
+      client.ensure_all_queues
+
+      # Should still create default queue but not try to create "*"
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_default")
+      expect(mock_pgmq).not_to have_received(:create).with("pgbus_test_*")
+    end
+
+    it "creates priority sub-queues when priority is enabled" do
+      config.priority_levels = 3
+      client.ensure_all_queues
+
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_default_p0")
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_default_p1")
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_default_p2")
+      config.priority_levels = nil
+    end
+
+    it "logs the bootstrapped queues" do
+      allow(Pgbus.logger).to receive(:info)
+      client.ensure_all_queues
+
+      expect(Pgbus.logger).to have_received(:info).at_least(:once)
+    end
+  end
+
   describe "#close" do
     it "closes the pgmq connection" do
       client.close

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -126,6 +126,31 @@ RSpec.describe Pgbus::Process::Supervisor do
     end
   end
 
+  describe "boot_processes (private)" do
+    let(:supervisor) { described_class.new }
+    let(:mock_client) { build_mock_client }
+
+    before do
+      allow(Pgbus).to receive(:client).and_return(mock_client)
+      allow(mock_client).to receive(:ensure_all_queues)
+      allow(supervisor).to receive(:fork).and_return(6001)
+    end
+
+    it "bootstraps queues before forking workers" do
+      call_order = []
+      allow(mock_client).to receive(:ensure_all_queues) { call_order << :ensure_all_queues }
+      allow(supervisor).to receive(:fork) do
+        call_order << :fork
+        6001
+      end
+
+      supervisor.send(:boot_processes)
+
+      expect(call_order.first).to eq(:ensure_all_queues)
+      expect(mock_client).to have_received(:ensure_all_queues).once
+    end
+  end
+
   describe "recurring_tasks_configured? (private)" do
     let(:supervisor) { described_class.new }
 

--- a/spec/support/pgmq_doubles.rb
+++ b/spec/support/pgmq_doubles.rb
@@ -31,6 +31,7 @@ module PgmqDoubles
     double("Pgbus::Client", pgmq: pgmq).tap do |client|
       allow(client).to receive_messages(
         ensure_queue: nil,
+        ensure_all_queues: nil,
         ensure_dead_letter_queue: nil,
         send_message: 1,
         send_batch: [1, 2],


### PR DESCRIPTION
## Summary
- Queues were only created lazily (on first `send_message`/`enqueue_task`), so workers reading from non-existent queues failed silently and recurring task "Run Now" errored with "Failed to enqueue task"
- Added `Client#ensure_all_queues` that collects all configured queue names (default, worker, recurring) and creates them upfront
- Called from `Supervisor#boot_processes` before forking any child processes, so all queues exist before workers/scheduler start

## Test plan
- [x] 7 specs for `Client#ensure_all_queues` (default, worker, recurring, dedup, wildcards, priority sub-queues, logging)
- [x] 1 spec for `Supervisor#boot_processes` (verifies bootstrap runs before fork)
- [x] Full suite passes (637 examples, 0 failures)
- [x] RuboCop clean
- [ ] Deploy and verify queues appear on dashboard immediately after startup
- [ ] Verify "Run Now" on recurring tasks succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added queue initialization that creates all configured queues on startup, supporting default queue, worker configuration queues, and recurring task queues with priority level sub-queues.

* **Improvements**
  * Queue initialization now occurs before worker processes are forked, with informational logging and graceful error handling.

* **Tests**
  * Added comprehensive test coverage for queue initialization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->