### PR TITLE
fix: move queue bootstrap into forked child processes

### DIFF
--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -42,11 +42,6 @@ module Pgbus
       private
 
       def boot_processes
-        # Bootstrap all configured queues before forking workers.
-        # Without this, workers start reading from non-existent queues
-        # and recurring task enqueues fail.
-        bootstrap_queues
-
         # Boot workers
         config.workers.each do |worker_config|
           fork_worker(worker_config)
@@ -75,6 +70,7 @@ module Pgbus
           restore_signals
           setup_child_process
           load_rails_app
+          bootstrap_queues
           worker = Worker.new(
             queues: queues, threads: threads, config: config,
             single_active_consumer: single_active, consumer_priority: priority
@@ -126,6 +122,7 @@ module Pgbus
           setup_child_process
           load_rails_app
           load_recurring_config
+          bootstrap_queues
           scheduler = Recurring::Scheduler.new(config: config)
           scheduler.run
         end

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -126,28 +126,27 @@ RSpec.describe Pgbus::Process::Supervisor do
     end
   end
 
-  describe "boot_processes (private)" do
+  describe "bootstrap_queues (private)" do
     let(:supervisor) { described_class.new }
     let(:mock_client) { build_mock_client }
 
     before do
       allow(Pgbus).to receive(:client).and_return(mock_client)
       allow(mock_client).to receive(:ensure_all_queues)
-      allow(supervisor).to receive(:fork).and_return(6001)
     end
 
-    it "bootstraps queues before forking workers" do
-      call_order = []
-      allow(mock_client).to receive(:ensure_all_queues) { call_order << :ensure_all_queues }
-      allow(supervisor).to receive(:fork) do
-        call_order << :fork
-        6001
-      end
+    it "calls ensure_all_queues on the client" do
+      supervisor.send(:bootstrap_queues)
 
-      supervisor.send(:boot_processes)
-
-      expect(call_order.first).to eq(:ensure_all_queues)
       expect(mock_client).to have_received(:ensure_all_queues).once
+    end
+
+    it "rescues errors and logs them" do
+      allow(mock_client).to receive(:ensure_all_queues).and_raise(StandardError, "connection failed")
+      allow(Pgbus.logger).to receive(:error)
+
+      expect { supervisor.send(:bootstrap_queues) }.not_to raise_error
+      expect(Pgbus.logger).to have_received(:error).at_least(:once)
     end
   end
 


### PR DESCRIPTION
## Summary
- **Root cause**: PGMQ schema was never installed in the database — the migration's embedded SQL execution silently failed
- Added `Client#ensure_pgmq_schema` — lazily checks for `pgmq.meta` on first queue operation and auto-installs embedded PGMQ SQL if missing
- Added `Client#ensure_all_queues` — creates all configured queues at startup  
- Moved `bootstrap_queues` into forked child processes (worker/scheduler) for proper PG connections post-fork
- **Moved `RecurringTask.sync_from_config!` from Rails initializer into scheduler startup** — no more database access during app boot
- Fixed `purge_archive` to use `resolve_raw_connection` instead of non-public `@pgmq.pool` API

## Key design decisions
- **Runtime over migrations**: PGMQ schema is ensured at runtime, not reliant on migrations executing correctly
- **No DB in initializers**: Recurring task sync happens in the forked scheduler process, not during Rails boot
- **Lazy installation**: Schema check only happens once per client instance (cached via `@schema_ensured`)

## Test plan
- [x] 3 specs for `ensure_pgmq_schema` (installs when missing, skips when present, caches check)
- [x] 8 specs for `ensure_all_queues` (default, worker, recurring, dedup, wildcards, priority, logging)
- [x] 2 specs for `bootstrap_queues` (success + error resilience)
- [x] 3 specs for `sync_recurring_tasks` (syncs config, skips when nil, handles errors)
- [x] Full suite passes (644 examples, 0 failures)
- [x] RuboCop clean
- [x] Verified locally in cosmos — queues created from scratch with no PGMQ schema
- [ ] Deploy and verify queues appear on dashboard
- [ ] Remove `config/initializers/pgbus.rb` DB access in cosmos (done locally)