### PR TITLE
fix: auto-install PGMQ schema at runtime and sync recurring tasks in scheduler

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -200,7 +200,9 @@ module Pgbus
 
       loop do
         deleted = synchronized do
-          resolve_raw_connection.exec_params(sql, [older_than, batch_size]).cmd_tuples
+          with_raw_connection do |conn|
+            conn.exec_params(sql, [older_than, batch_size]).cmd_tuples
+          end
         end
         total += deleted
         break if deleted < batch_size
@@ -259,28 +261,54 @@ module Pgbus
       synchronized do
         return if @schema_ensured
 
-        raw_conn = resolve_raw_connection
-        exists = raw_conn.exec("SELECT 1 FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'meta' LIMIT 1")
-        if exists.ntuples.zero?
-          Pgbus.logger.info { "[Pgbus] PGMQ schema not found — installing embedded SQL" }
-          raw_conn.exec(PgmqSchema.install_sql)
+        with_raw_connection do |raw_conn|
+          exists = raw_conn.exec("SELECT 1 FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'meta' LIMIT 1")
+          install_pgmq_schema(raw_conn) if exists.ntuples.zero?
         end
         @schema_ensured = true
       end
     end
 
-    def resolve_raw_connection
-      opts = config.connection_options
-      case opts
-      when Proc
-        opts.call
-      when String
-        PG.connect(opts)
-      when Hash
-        PG.connect(**opts)
-      else
-        raise ConfigurationError, "Cannot resolve raw PG connection from #{opts.class}"
+    def install_pgmq_schema(conn)
+      mode = config.pgmq_schema_mode
+
+      case mode
+      when :extension
+        Pgbus.logger.info { "[Pgbus] PGMQ schema not found — installing via extension" }
+        conn.exec("CREATE EXTENSION IF NOT EXISTS pgmq")
+      when :embedded
+        Pgbus.logger.info { "[Pgbus] PGMQ schema not found — installing embedded SQL" }
+        conn.exec(PgmqSchema.install_sql)
+      else # :auto
+        ext = conn.exec("SELECT 1 FROM pg_available_extensions WHERE name = 'pgmq' LIMIT 1")
+        if ext.ntuples.positive?
+          Pgbus.logger.info { "[Pgbus] PGMQ schema not found — installing via extension" }
+          conn.exec("CREATE EXTENSION IF NOT EXISTS pgmq")
+        else
+          Pgbus.logger.info { "[Pgbus] PGMQ schema not found — installing embedded SQL" }
+          conn.exec(PgmqSchema.install_sql)
+        end
       end
+    end
+
+    def with_raw_connection
+      opts = config.connection_options
+      owned = false
+      conn = case opts
+             when Proc
+               opts.call
+             when String
+               owned = true
+               PG.connect(opts)
+             when Hash
+               owned = true
+               PG.connect(**opts)
+             else
+               raise ConfigurationError, "Cannot resolve raw PG connection from #{opts.class}"
+             end
+      yield conn
+    ensure
+      conn&.close if owned
     end
 
     def ensure_single_queue(full_name)

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -267,6 +267,10 @@ module Pgbus
         end
         @schema_ensured = true
       end
+    rescue StandardError => e
+      raise Pgbus::SchemaNotReady,
+            "PGMQ schema installation failed (#{e.class}: #{e.message}). " \
+            "Ensure the pgbus database exists and migrations have been run."
     end
 
     def install_pgmq_schema(conn)

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -33,13 +33,12 @@ module Pgbus
       @pgmq_mutex = Mutex.new
       @queues_created = Concurrent::Map.new
       @queue_strategy = QueueFactory.for(config)
+      @schema_ensured = false
     end
 
     def ensure_queue(name)
+      ensure_pgmq_schema
       @queue_strategy.physical_queue_names(name).each { |pq| ensure_single_queue(pq) }
-    rescue PGMQ::Errors::ConnectionError => e
-      raise Pgbus::SchemaNotReady,
-            "PGMQ schema is not available (#{e.message}). Run `rails db:migrate` for the pgbus database."
     end
 
     def ensure_all_queues
@@ -201,7 +200,7 @@ module Pgbus
 
       loop do
         deleted = synchronized do
-          @pgmq.pool.with { |conn| conn.exec_params(sql, [older_than, batch_size]).cmd_tuples }
+          resolve_raw_connection.exec_params(sql, [older_than, batch_size]).cmd_tuples
         end
         total += deleted
         break if deleted < batch_size
@@ -252,6 +251,36 @@ module Pgbus
       end
 
       queues.to_a
+    end
+
+    def ensure_pgmq_schema
+      return if @schema_ensured
+
+      synchronized do
+        return if @schema_ensured
+
+        raw_conn = resolve_raw_connection
+        exists = raw_conn.exec("SELECT 1 FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'meta' LIMIT 1")
+        if exists.ntuples.zero?
+          Pgbus.logger.info { "[Pgbus] PGMQ schema not found — installing embedded SQL" }
+          raw_conn.exec(PgmqSchema.install_sql)
+        end
+        @schema_ensured = true
+      end
+    end
+
+    def resolve_raw_connection
+      opts = config.connection_options
+      case opts
+      when Proc
+        opts.call
+      when String
+        PG.connect(opts)
+      when Hash
+        PG.connect(**opts)
+      else
+        raise ConfigurationError, "Cannot resolve raw PG connection from #{opts.class}"
+      end
     end
 
     def ensure_single_queue(full_name)

--- a/lib/pgbus/recurring/scheduler.rb
+++ b/lib/pgbus/recurring/scheduler.rb
@@ -17,6 +17,7 @@ module Pgbus
       def run
         setup_signals
         start_heartbeat
+        sync_recurring_tasks
 
         Pgbus.logger.info do
           "[Pgbus] Scheduler started: #{schedule.tasks.size} recurring tasks, " \
@@ -83,6 +84,15 @@ module Pgbus
       end
 
       private
+
+      def sync_recurring_tasks
+        return unless config.recurring_tasks.present?
+
+        RecurringTask.sync_from_config!(config.recurring_tasks)
+        Pgbus.logger.info { "[Pgbus] Synced #{config.recurring_tasks.size} recurring task(s) from configuration" }
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus] Failed to sync recurring tasks: #{e.class}: #{e.message}" }
+      end
 
       def start_heartbeat
         @heartbeat = Process::Heartbeat.new(

--- a/lib/pgbus/recurring/scheduler.rb
+++ b/lib/pgbus/recurring/scheduler.rb
@@ -86,10 +86,11 @@ module Pgbus
       private
 
       def sync_recurring_tasks
-        return unless config.recurring_tasks.present?
+        tasks = config.recurring_tasks
+        return if tasks.nil?
 
-        RecurringTask.sync_from_config!(config.recurring_tasks)
-        Pgbus.logger.info { "[Pgbus] Synced #{config.recurring_tasks.size} recurring task(s) from configuration" }
+        RecurringTask.sync_from_config!(tasks)
+        Pgbus.logger.info { "[Pgbus] Synced #{tasks.size} recurring task(s) from configuration" }
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Failed to sync recurring tasks: #{e.class}: #{e.message}" }
       end

--- a/spec/pgbus/allocation_budget_spec.rb
+++ b/spec/pgbus/allocation_budget_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Pgbus::Client do
       c.instance_variable_set(:@pgmq_mutex, Mutex.new)
       c.instance_variable_set(:@queues_created, all_queues_created)
       c.instance_variable_set(:@queue_strategy, Pgbus::QueueFactory.for(Pgbus.configuration))
+      c.instance_variable_set(:@schema_ensured, true)
     end
   end
 
@@ -102,6 +103,7 @@ RSpec.describe Pgbus::Client do
         c.instance_variable_set(:@pgmq_mutex, Mutex.new)
         c.instance_variable_set(:@queues_created, all_queues_created)
         c.instance_variable_set(:@queue_strategy, Pgbus::QueueFactory.for(Pgbus.configuration))
+        c.instance_variable_set(:@schema_ensured, true)
       end
     end
 

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe Pgbus::Client do
   # Stub pgmq-ruby so it never loads the real gem
   subject(:client) do
     allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
-    described_class.new(config)
+    c = described_class.new(config)
+    # Pre-mark PGMQ schema as ensured for most tests.
+    # Schema installation tests override this.
+    c.instance_variable_set(:@schema_ensured, true)
+    c
   end
 
   before do
@@ -23,6 +27,44 @@ RSpec.describe Pgbus::Client do
     end
   end
   let(:mock_pgmq) { build_mock_pgmq }
+
+  describe "#ensure_pgmq_schema (via ensure_queue)" do
+    let(:raw_conn) { double("raw_conn") }
+
+    before do
+      client.instance_variable_set(:@schema_ensured, false)
+      allow(client).to receive(:resolve_raw_connection).and_return(raw_conn)
+    end
+
+    it "installs PGMQ schema when pgmq.meta table does not exist" do
+      result = double("result", ntuples: 0)
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(result)
+      allow(raw_conn).to receive(:exec).with(Pgbus::PgmqSchema.install_sql).and_return(nil)
+
+      client.ensure_queue("jobs")
+
+      expect(raw_conn).to have_received(:exec).with(Pgbus::PgmqSchema.install_sql)
+    end
+
+    it "skips installation when pgmq.meta already exists" do
+      result = double("result", ntuples: 1)
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(result)
+
+      client.ensure_queue("jobs")
+
+      expect(raw_conn).not_to have_received(:exec).with(Pgbus::PgmqSchema.install_sql)
+    end
+
+    it "only checks once per client instance" do
+      result = double("result", ntuples: 1)
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(result)
+
+      client.ensure_queue("jobs")
+      client.ensure_queue("events")
+
+      expect(raw_conn).to have_received(:exec).with(/pg_tables.*pgmq.*meta/).once
+    end
+  end
 
   describe "#ensure_queue" do
     it "creates the queue with the prefixed name" do
@@ -60,17 +102,14 @@ RSpec.describe Pgbus::Client do
       expect(mock_pgmq).to have_received(:create).with("pgbus_test_events").once
     end
 
-    it "raises SchemaNotReady when PGMQ schema is missing" do
-      # PGMQ is lazy-loaded by the client, so define the error class if not yet available
+    it "propagates PGMQ connection errors when queue creation fails" do
       stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
 
       allow(mock_pgmq).to receive(:create).and_raise(
-        PGMQ::Errors::ConnectionError.new('Database connection error: ERROR:  relation "pgmq.meta" does not exist')
+        PGMQ::Errors::ConnectionError.new("Database connection error: connection refused")
       )
 
-      expect { client.ensure_queue("jobs") }.to raise_error(
-        Pgbus::SchemaNotReady, /PGMQ schema is not available/
-      )
+      expect { client.ensure_queue("jobs") }.to raise_error(PGMQ::Errors::ConnectionError)
     end
   end
 
@@ -293,13 +332,11 @@ RSpec.describe Pgbus::Client do
   end
 
   describe "#purge_archive" do
-    let(:pool) { double("pool") }
     let(:conn) { double("conn") }
     let(:result) { double("result", cmd_tuples: 50) }
 
     before do
-      allow(mock_pgmq).to receive(:pool).and_return(pool)
-      allow(pool).to receive(:with).and_yield(conn)
+      allow(client).to receive(:resolve_raw_connection).and_return(conn)
       allow(conn).to receive(:exec_params).and_return(result)
     end
 

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe Pgbus::Client do
       expect(raw_conn).not_to have_received(:exec).with(Pgbus::PgmqSchema.install_sql)
     end
 
+    it "wraps install failures as SchemaNotReady" do
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(double(ntuples: 0))
+      allow(raw_conn).to receive(:exec).with(/pg_available_extensions/).and_return(double(ntuples: 0))
+      allow(raw_conn).to receive(:exec).with(Pgbus::PgmqSchema.install_sql)
+                     .and_raise(StandardError, "permission denied for schema pgmq")
+
+      expect { client.ensure_queue("jobs") }.to raise_error(
+        Pgbus::SchemaNotReady, /PGMQ schema installation failed/
+      )
+    end
+
     it "only checks once per client instance" do
       allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(double(ntuples: 1))
 

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe Pgbus::Client do
 
     before do
       client.instance_variable_set(:@schema_ensured, false)
-      allow(client).to receive(:resolve_raw_connection).and_return(raw_conn)
+      allow(client).to receive(:with_raw_connection).and_yield(raw_conn)
     end
 
-    it "installs PGMQ schema when pgmq.meta table does not exist" do
-      result = double("result", ntuples: 0)
-      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(result)
+    it "installs via embedded SQL when pgmq.meta missing and no extension (auto mode)" do
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(double(ntuples: 0))
+      allow(raw_conn).to receive(:exec).with(/pg_available_extensions/).and_return(double(ntuples: 0))
       allow(raw_conn).to receive(:exec).with(Pgbus::PgmqSchema.install_sql).and_return(nil)
 
       client.ensure_queue("jobs")
@@ -46,9 +46,30 @@ RSpec.describe Pgbus::Client do
       expect(raw_conn).to have_received(:exec).with(Pgbus::PgmqSchema.install_sql)
     end
 
+    it "installs via extension when available in auto mode" do
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(double(ntuples: 0))
+      allow(raw_conn).to receive(:exec).with(/pg_available_extensions/).and_return(double(ntuples: 1))
+      allow(raw_conn).to receive(:exec).with("CREATE EXTENSION IF NOT EXISTS pgmq").and_return(nil)
+
+      client.ensure_queue("jobs")
+
+      expect(raw_conn).to have_received(:exec).with("CREATE EXTENSION IF NOT EXISTS pgmq")
+    end
+
+    it "respects :extension schema mode" do
+      config.pgmq_schema_mode = :extension
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(double(ntuples: 0))
+      allow(raw_conn).to receive(:exec).with("CREATE EXTENSION IF NOT EXISTS pgmq").and_return(nil)
+
+      client.ensure_queue("jobs")
+
+      expect(raw_conn).to have_received(:exec).with("CREATE EXTENSION IF NOT EXISTS pgmq")
+      expect(raw_conn).not_to have_received(:exec).with(Pgbus::PgmqSchema.install_sql)
+      config.pgmq_schema_mode = :auto
+    end
+
     it "skips installation when pgmq.meta already exists" do
-      result = double("result", ntuples: 1)
-      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(result)
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(double(ntuples: 1))
 
       client.ensure_queue("jobs")
 
@@ -56,8 +77,7 @@ RSpec.describe Pgbus::Client do
     end
 
     it "only checks once per client instance" do
-      result = double("result", ntuples: 1)
-      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(result)
+      allow(raw_conn).to receive(:exec).with(/pg_tables.*pgmq.*meta/).and_return(double(ntuples: 1))
 
       client.ensure_queue("jobs")
       client.ensure_queue("events")
@@ -336,7 +356,7 @@ RSpec.describe Pgbus::Client do
     let(:result) { double("result", cmd_tuples: 50) }
 
     before do
-      allow(client).to receive(:resolve_raw_connection).and_return(conn)
+      allow(client).to receive(:with_raw_connection).and_yield(conn)
       allow(conn).to receive(:exec_params).and_return(result)
     end
 

--- a/spec/pgbus/recurring/scheduler_spec.rb
+++ b/spec/pgbus/recurring/scheduler_spec.rb
@@ -100,6 +100,16 @@ RSpec.describe Pgbus::Recurring::Scheduler do
       expect(Pgbus::RecurringTask).not_to have_received(:sync_from_config!)
     end
 
+    it "syncs empty hash to remove stale tasks" do
+      config.recurring_tasks = {}
+      scheduler = described_class.new(config: config)
+      allow(Pgbus::RecurringTask).to receive(:sync_from_config!)
+
+      scheduler.send(:sync_recurring_tasks)
+
+      expect(Pgbus::RecurringTask).to have_received(:sync_from_config!).with({})
+    end
+
     it "handles errors gracefully" do
       scheduler = described_class.new(config: config)
       allow(Pgbus::RecurringTask).to receive(:sync_from_config!).and_raise(StandardError, "DB error")

--- a/spec/pgbus/recurring/scheduler_spec.rb
+++ b/spec/pgbus/recurring/scheduler_spec.rb
@@ -80,6 +80,34 @@ RSpec.describe Pgbus::Recurring::Scheduler do
     end
   end
 
+  describe "sync_recurring_tasks (private)" do
+    it "syncs recurring tasks from config on startup" do
+      scheduler = described_class.new(config: config)
+      allow(Pgbus::RecurringTask).to receive(:sync_from_config!)
+
+      scheduler.send(:sync_recurring_tasks)
+
+      expect(Pgbus::RecurringTask).to have_received(:sync_from_config!).with(config.recurring_tasks)
+    end
+
+    it "skips sync when no recurring tasks configured" do
+      config.recurring_tasks = nil
+      scheduler = described_class.new(config: config)
+      allow(Pgbus::RecurringTask).to receive(:sync_from_config!)
+
+      scheduler.send(:sync_recurring_tasks)
+
+      expect(Pgbus::RecurringTask).not_to have_received(:sync_from_config!)
+    end
+
+    it "handles errors gracefully" do
+      scheduler = described_class.new(config: config)
+      allow(Pgbus::RecurringTask).to receive(:sync_from_config!).and_raise(StandardError, "DB error")
+
+      expect { scheduler.send(:sync_recurring_tasks) }.not_to raise_error
+    end
+  end
+
   describe "#task_statuses" do
     it "returns status information for all tasks" do
       scheduler = described_class.new(config: config)


### PR DESCRIPTION
## Summary
Follow-up to #26. The previous fix moved queue bootstrap into forked child processes but didn't address the actual root cause.

**Root cause**: PGMQ schema (`pgmq.meta`, functions, queue tables) was never installed. The migration's 63KB multi-statement embedded SQL silently failed, so pgbus metadata tables exist but PGMQ infrastructure does not. Every queue operation fails with `relation "pgmq.meta" does not exist`.

### Changes

1. **`Client#ensure_pgmq_schema`** — On first queue operation, checks if `pgmq.meta` exists. If missing, auto-installs embedded PGMQ SQL. Cached per client instance.

2. **`Scheduler#sync_recurring_tasks`** — Moved `RecurringTask.sync_from_config!` from Rails initializer into the scheduler's `run` method. No more database access during app boot. Users should remove the `sync_from_config!` call from their initializer.

3. **Fixed `purge_archive`** — Was calling non-public `@pgmq.pool` API. Now uses `resolve_raw_connection`.

### Verified locally
Starting from empty pgbus database (no pgmq schema):
```
[Pgbus] PGMQ schema not found — installing embedded SQL
[Pgbus] Bootstrapping 1 queue(s): default
Queues: ["pgbus_default"]
```

## Test plan
- [x] 3 specs for `ensure_pgmq_schema` (installs when missing, skips when present, caches)
- [x] 3 specs for `sync_recurring_tasks` (syncs config, skips nil, handles errors)
- [x] Full suite: 644 examples, 0 failures
- [x] RuboCop clean
- [ ] Deploy, verify queues appear on dashboard, "Run Now" works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recurring tasks from app configuration are synchronized during scheduler startup.

* **Improvements**
  * Startup now proactively ensures the required database schema exists and can auto-install it when missing.
  * Archive purging and queue operations use a more direct raw DB connection path and resolve connection options robustly.
  * Connection/installation failures are surfaced or wrapped more explicitly.

* **Tests**
  * Expanded tests for schema installation, queue setup, archive purge, and recurring-task syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->