### PR TITLE
perf: use pgmq-ruby connection pool for dedicated connections

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -19,18 +19,26 @@ module Pgbus
         require "pgmq"
       end
       @config = config
-      # Force pool_size=1. PG::Connection (libpq) is not thread-safe.
-      # When using the Rails lambda path (-> { AR::Base.connection.raw_connection }),
-      # the pool would return the same underlying PG::Connection that ActiveRecord
-      # also uses, causing concurrent access corruption (segfaults, result.ntuples
-      # NoMethodError). A single-connection pool combined with @pgmq_mutex ensures
-      # all PGMQ operations are serialized.
-      @pgmq = PGMQ::Client.new(
-        config.connection_options,
-        pool_size: 1,
-        pool_timeout: config.pool_timeout
-      )
-      @pgmq_mutex = Mutex.new
+      conn_opts = config.connection_options
+      @shared_connection = conn_opts.is_a?(Proc)
+
+      if @shared_connection
+        # When using the Rails lambda path (-> { AR::Base.connection.raw_connection }),
+        # the Proc returns the same underlying PG::Connection that ActiveRecord uses.
+        # PG::Connection (libpq) is not thread-safe — concurrent access causes
+        # segfaults and result corruption. Force pool_size=1 and serialize all
+        # operations through a mutex.
+        @pgmq = PGMQ::Client.new(conn_opts, pool_size: 1, pool_timeout: config.pool_timeout)
+        @pgmq_mutex = Mutex.new
+      else
+        # With a String URL or Hash params, pgmq-ruby creates its own dedicated
+        # PG::Connection per pool slot — no shared state with ActiveRecord.
+        # Use the configured pool_size and let pgmq-ruby's connection_pool handle
+        # concurrency internally (no mutex needed).
+        @pgmq = PGMQ::Client.new(conn_opts, pool_size: config.pool_size, pool_timeout: config.pool_timeout)
+        @pgmq_mutex = nil
+      end
+
       @queues_created = Concurrent::Map.new
       @queue_strategy = QueueFactory.for(config)
       @schema_ensured = false
@@ -327,11 +335,15 @@ module Pgbus
       end
     end
 
-    # Serialize all PGMQ operations through a single mutex.
-    # PG::Connection is not thread-safe — concurrent access from worker
-    # threads causes segfaults and result corruption.
+    # Serialize PGMQ operations through a mutex when sharing a connection
+    # with ActiveRecord (Proc path). When pgmq-ruby owns its own connections
+    # (String/Hash path), the internal connection_pool handles concurrency.
     def synchronized(&)
-      @pgmq_mutex.synchronize(&)
+      if @pgmq_mutex
+        @pgmq_mutex.synchronize(&)
+      else
+        yield
+      end
     end
 
     def serialize(data)

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -594,4 +594,93 @@ RSpec.describe Pgbus::Client do
       expect(mock_pgmq).to have_received(:close)
     end
   end
+
+  describe "connection pooling strategy" do
+    it "uses configured pool_size when database_url is set (dedicated connections)" do
+      url_config = Pgbus::Configuration.new.tap do |c|
+        c.database_url = "postgres://localhost/pgbus_test"
+        c.connection_params = nil
+        c.pool_size = 5
+        c.queue_prefix = "pgbus_test"
+      end
+
+      allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+      described_class.new(url_config)
+
+      expect(PGMQ::Client).to have_received(:new).with(
+        "postgres://localhost/pgbus_test",
+        pool_size: 5,
+        pool_timeout: url_config.pool_timeout
+      )
+    end
+
+    it "uses configured pool_size when connection_params is set (dedicated connections)" do
+      url_config = Pgbus::Configuration.new.tap do |c|
+        c.database_url = nil
+        c.connection_params = { host: "localhost", dbname: "pgbus_test" }
+        c.pool_size = 3
+        c.queue_prefix = "pgbus_test"
+      end
+
+      allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+      described_class.new(url_config)
+
+      expect(PGMQ::Client).to have_received(:new).with(
+        { host: "localhost", dbname: "pgbus_test" },
+        pool_size: 3,
+        pool_timeout: url_config.pool_timeout
+      )
+    end
+
+    it "forces pool_size=1 when connection_options returns a Proc (shared connection)" do
+      lambda_config = Pgbus::Configuration.new.tap do |c|
+        c.database_url = nil
+        c.connection_params = nil
+        c.pool_size = 5
+        c.queue_prefix = "pgbus_test"
+      end
+
+      # Simulate the Rails path where connection_options returns a lambda
+      raw_conn = double("PG::Connection")
+      ar_connection = double("AR::ConnectionAdapter", raw_connection: raw_conn)
+      stub_const("ActiveRecord::Base", double("AR::Base", connection: ar_connection))
+
+      allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+      described_class.new(lambda_config)
+
+      expect(PGMQ::Client).to have_received(:new).with(
+        an_instance_of(Proc),
+        pool_size: 1,
+        pool_timeout: lambda_config.pool_timeout
+      )
+    end
+
+    it "does not use mutex synchronization for dedicated connections" do
+      config.database_url = "postgres://localhost/pgbus_test"
+      config.pool_size = 5
+
+      # With dedicated connections, operations should not go through the mutex.
+      # We test this by verifying that the client does not have a @pgmq_mutex.
+      expect(client.instance_variable_get(:@pgmq_mutex)).to be_nil
+    end
+
+    it "uses mutex synchronization for shared (Proc) connections" do
+      lambda_config = Pgbus::Configuration.new.tap do |c|
+        c.database_url = nil
+        c.connection_params = nil
+        c.pool_size = 5
+        c.queue_prefix = "pgbus_test"
+      end
+
+      raw_conn = double("PG::Connection")
+      ar_connection = double("AR::ConnectionAdapter", raw_connection: raw_conn)
+      stub_const("ActiveRecord::Base", double("AR::Base", connection: ar_connection))
+
+      allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+      shared_client = described_class.new(lambda_config)
+      shared_client.instance_variable_set(:@schema_ensured, true)
+
+      expect(shared_client.instance_variable_get(:@pgmq_mutex)).to be_a(Mutex)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- When `database_url` or `connection_params` are configured, pgmq-ruby creates its own dedicated `PG::Connection` per pool slot — no shared state with ActiveRecord
- Use the configured `pool_size` (default 5) and let pgmq-ruby's `connection_pool` handle concurrency, removing the mutex bottleneck
- Preserve `pool_size: 1` + mutex only for the Proc/lambda path (Rails shared connection) where concurrent access is unsafe
- This is the single biggest performance win: with 5 worker threads, 4 were previously blocked waiting on the mutex while 1 reads

## Test plan
- [x] New specs verify dedicated connections use configured pool_size
- [x] New specs verify Proc connections still force pool_size=1 + mutex
- [x] New spec verifies no mutex for dedicated connections
- [x] All 61 client specs pass
- [x] Full suite (653 examples) passes
- [x] Rubocop clean

**PR 1 of 6** in the pgmq-ruby optimization series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database connection pooling logic to intelligently handle different connection configuration scenarios, enabling more efficient resource management.

* **Tests**
  * Added comprehensive test coverage for connection pooling behavior across various configuration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->