### PR TITLE
refactor: remove respond_to?(:produce_topic) guard

### DIFF
--- a/lib/pgbus/event_bus/publisher.rb
+++ b/lib/pgbus/event_bus/publisher.rb
@@ -7,13 +7,7 @@ module Pgbus
 
       def publish(routing_key, payload, headers: nil, delay: 0)
         event_data = build_event_data(payload)
-
-        if Pgbus.client.pgmq.respond_to?(:produce_topic)
-          Pgbus.client.publish_to_topic(routing_key, event_data, headers: headers, delay: delay)
-        else
-          # Fallback: send directly to queues matching the routing key
-          Pgbus.client.send_message(routing_key, event_data, headers: headers, delay: delay)
-        end
+        Pgbus.client.publish_to_topic(routing_key, event_data, headers: headers, delay: delay)
       end
 
       def publish_later(routing_key, payload, delay:, headers: nil)

--- a/spec/pgbus/event_bus/publisher_spec.rb
+++ b/spec/pgbus/event_bus/publisher_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Pgbus::EventBus::Publisher do
   end
 
   describe ".publish" do
-    it "publishes via publish_to_topic" do
+    it "publishes via publish_to_topic and never falls back to send_message" do
       described_class.publish("orders.created", { "order_id" => 1 })
 
       expect(mock_client).to have_received(:publish_to_topic).with(
@@ -22,6 +22,7 @@ RSpec.describe Pgbus::EventBus::Publisher do
         headers: nil,
         delay: 0
       )
+      expect(mock_client).not_to have_received(:send_message)
     end
 
     it "forwards headers" do

--- a/spec/pgbus/event_bus/publisher_spec.rb
+++ b/spec/pgbus/event_bus/publisher_spec.rb
@@ -13,68 +13,41 @@ RSpec.describe Pgbus::EventBus::Publisher do
   end
 
   describe ".publish" do
-    context "when pgmq responds to produce_topic (topic support)" do
-      before do
-        allow(mock_pgmq).to receive(:respond_to?).with(:produce_topic).and_return(true)
-      end
+    it "publishes via publish_to_topic" do
+      described_class.publish("orders.created", { "order_id" => 1 })
 
-      it "publishes via publish_to_topic" do
-        described_class.publish("orders.created", { "order_id" => 1 })
-
-        expect(mock_client).to have_received(:publish_to_topic).with(
-          "orders.created",
-          hash_including("event_id" => a_kind_of(String), "payload" => { "order_id" => 1 }),
-          headers: nil,
-          delay: 0
-        )
-      end
-
-      it "forwards headers" do
-        described_class.publish("orders.created", { "order_id" => 1 }, headers: { "x-trace" => "abc" })
-
-        expect(mock_client).to have_received(:publish_to_topic).with(
-          "orders.created",
-          hash_including("payload" => { "order_id" => 1 }),
-          headers: { "x-trace" => "abc" },
-          delay: 0
-        )
-      end
-
-      it "forwards delay" do
-        described_class.publish("orders.created", { "order_id" => 1 }, delay: 30)
-
-        expect(mock_client).to have_received(:publish_to_topic).with(
-          "orders.created",
-          hash_including("payload" => { "order_id" => 1 }),
-          headers: nil,
-          delay: 30
-        )
-      end
+      expect(mock_client).to have_received(:publish_to_topic).with(
+        "orders.created",
+        hash_including("event_id" => a_kind_of(String), "payload" => { "order_id" => 1 }),
+        headers: nil,
+        delay: 0
+      )
     end
 
-    context "when pgmq does not respond to produce_topic (fallback)" do
-      before do
-        allow(mock_pgmq).to receive(:respond_to?).with(:produce_topic).and_return(false)
-      end
+    it "forwards headers" do
+      described_class.publish("orders.created", { "order_id" => 1 }, headers: { "x-trace" => "abc" })
 
-      it "falls back to send_message" do
-        described_class.publish("orders.created", { "order_id" => 1 })
+      expect(mock_client).to have_received(:publish_to_topic).with(
+        "orders.created",
+        hash_including("payload" => { "order_id" => 1 }),
+        headers: { "x-trace" => "abc" },
+        delay: 0
+      )
+    end
 
-        expect(mock_client).to have_received(:send_message).with(
-          "orders.created",
-          hash_including("event_id" => a_kind_of(String), "payload" => { "order_id" => 1 }),
-          headers: nil,
-          delay: 0
-        )
-      end
+    it "forwards delay" do
+      described_class.publish("orders.created", { "order_id" => 1 }, delay: 30)
+
+      expect(mock_client).to have_received(:publish_to_topic).with(
+        "orders.created",
+        hash_including("payload" => { "order_id" => 1 }),
+        headers: nil,
+        delay: 30
+      )
     end
   end
 
   describe ".publish_later" do
-    before do
-      allow(mock_pgmq).to receive(:respond_to?).with(:produce_topic).and_return(true)
-    end
-
     it "delegates to .publish with the specified delay" do
       described_class.publish_later("orders.shipped", { "order_id" => 2 }, delay: 60)
 

--- a/spec/support/pgmq_doubles.rb
+++ b/spec/support/pgmq_doubles.rb
@@ -13,9 +13,7 @@ module PgmqDoubles
         read_with_poll: [],
         read_multi: [],
         delete: true,
-        delete_batch: [],
         archive: true,
-        archive_batch: [],
         set_vt: nil,
         metrics: nil,
         metrics_all: [],
@@ -25,6 +23,9 @@ module PgmqDoubles
         produce_topic: nil,
         close: nil
       )
+      # Batch operations echo back the ids to mirror pgmq-ruby behavior
+      allow(pgmq).to receive(:delete_batch) { |_queue, ids| ids.map(&:to_s) }
+      allow(pgmq).to receive(:archive_batch) { |_queue, ids| ids.map(&:to_s) }
       allow(pgmq).to receive(:transaction).and_yield(pgmq)
     end
   end
@@ -42,9 +43,7 @@ module PgmqDoubles
         read_batch: [],
         read_multi: [],
         delete_message: true,
-        delete_batch_from_queue: [],
         archive_message: true,
-        archive_batch: [],
         extend_visibility: nil,
         move_to_dead_letter: nil,
         metrics: nil,
@@ -55,6 +54,9 @@ module PgmqDoubles
         close: nil,
         transaction: nil
       )
+      # Batch operations echo back the ids to mirror pgmq-ruby behavior
+      allow(client).to receive(:delete_batch_from_queue) { |_queue, ids| ids.map(&:to_s) }
+      allow(client).to receive(:archive_batch) { |_queue, ids| ids.map(&:to_s) }
     end
   end
 


### PR DESCRIPTION
## Summary
- Remove runtime `respond_to?(:produce_topic)` check in `EventBus::Publisher`
- Since pgbus pins `pgmq-ruby ~> 0.5`, `produce_topic` is always available
- Simplify to a direct `publish_to_topic` call — no fallback path
- Remove the now-unnecessary fallback test case

## Test plan
- [x] Publisher specs pass (11 examples)
- [x] Full suite passes (658 examples, 0 failures)
- [x] Rubocop clean

**PR 4 of 6** in the pgmq-ruby optimization series. Based on PR #30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing now always uses topic-based publish (no runtime fallback to queue send).

* **Tests**
  * Specs simplified to assert topic publishing and that queue-send is not used.
  * Test doubles updated to explicitly handle batch delete/archive behavior for message operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->