### PR TITLE
refactor: consolidate prefixed/unprefixed client method pairs

### DIFF
--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -156,7 +156,7 @@ module Pgbus
 
       def archive_from(queue_name, msg_id, source_queue: nil)
         if source_queue
-          client.archive_from_queue(source_queue, msg_id)
+          client.archive_message(source_queue, msg_id, prefixed: false)
         else
           client.archive_message(queue_name, msg_id)
         end

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -146,44 +146,37 @@ module Pgbus
       end
     end
 
-    def delete_message(queue_name, msg_id)
-      full_name = config.queue_name(queue_name)
-      synchronized { @pgmq.delete(full_name, msg_id) }
+    # Delete a message. Pass prefixed: false when queue_name is already
+    # the full PGMQ queue name (e.g. from priority sub-queues or dashboard).
+    def delete_message(queue_name, msg_id, prefixed: true)
+      name = prefixed ? config.queue_name(queue_name) : queue_name
+      synchronized { @pgmq.delete(name, msg_id) }
     end
 
-    def archive_message(queue_name, msg_id)
-      full_name = config.queue_name(queue_name)
-      synchronized { @pgmq.archive(full_name, msg_id) }
-    end
-
-    def archive_from_queue(full_queue_name, msg_id)
-      synchronized { @pgmq.archive(full_queue_name, msg_id) }
+    # Archive a message. Pass prefixed: false when queue_name is already
+    # the full PGMQ queue name.
+    def archive_message(queue_name, msg_id, prefixed: true)
+      name = prefixed ? config.queue_name(queue_name) : queue_name
+      synchronized { @pgmq.archive(name, msg_id) }
     end
 
     # Batch archive — moves multiple messages to the archive table in one call.
-    # queue_name is a logical name (prefix is added).
-    def archive_batch(queue_name, msg_ids)
-      full_name = config.queue_name(queue_name)
-      synchronized { @pgmq.archive_batch(full_name, msg_ids) }
+    def archive_batch(queue_name, msg_ids, prefixed: true)
+      name = prefixed ? config.queue_name(queue_name) : queue_name
+      synchronized { @pgmq.archive_batch(name, msg_ids) }
     end
 
     # Batch delete — permanently removes multiple messages in one call.
-    # queue_name is the full PGMQ queue name (no prefix added).
-    def delete_batch_from_queue(queue_name, msg_ids)
-      synchronized { @pgmq.delete_batch(queue_name, msg_ids) }
+    def delete_batch(queue_name, msg_ids, prefixed: true)
+      name = prefixed ? config.queue_name(queue_name) : queue_name
+      synchronized { @pgmq.delete_batch(name, msg_ids) }
     end
 
-    def extend_visibility(queue_name, msg_id, vt:)
-      full_name = config.queue_name(queue_name)
-      synchronized { @pgmq.set_vt(full_name, msg_id, vt: vt) }
-    end
-
-    def set_visibility_timeout(queue_name, msg_id, vt:)
-      synchronized { @pgmq.set_vt(queue_name, msg_id, vt: vt) }
-    end
-
-    def delete_from_queue(queue_name, msg_id)
-      synchronized { @pgmq.delete(queue_name, msg_id) }
+    # Set visibility timeout. Pass prefixed: false when queue_name is already
+    # the full PGMQ queue name.
+    def set_visibility_timeout(queue_name, msg_id, vt:, prefixed: true)
+      name = prefixed ? config.queue_name(queue_name) : queue_name
+      synchronized { @pgmq.set_vt(name, msg_id, vt: vt) }
     end
 
     def transaction(&block)

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -105,11 +105,11 @@ module Pgbus
       end
 
       def retry_job(queue_name, msg_id)
-        @client.set_visibility_timeout(queue_name, msg_id.to_i, vt: 0)
+        @client.set_visibility_timeout(queue_name, msg_id.to_i, vt: 0, prefixed: false)
       end
 
       def discard_job(queue_name, msg_id)
-        @client.archive_message(queue_name, msg_id.to_i)
+        @client.archive_message(queue_name, msg_id.to_i, prefixed: false)
       end
 
       # Failed events
@@ -269,7 +269,7 @@ module Pgbus
 
       def discard_dlq_message(queue_name, msg_id)
         # queue_name here is the full DLQ name (already prefixed)
-        @client.delete_from_queue(queue_name, msg_id.to_i)
+        @client.delete_message(queue_name, msg_id.to_i, prefixed: false)
         true
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error discarding DLQ message #{msg_id}: #{e.message}" }
@@ -295,7 +295,7 @@ module Pgbus
         # Group by queue for batch delete — one call per DLQ instead of N calls
         messages.group_by { |m| m[:queue_name] }.sum do |queue_name, msgs|
           ids = msgs.map { |m| m[:msg_id].to_i }
-          @client.delete_batch_from_queue(queue_name, ids).size
+          @client.delete_batch(queue_name, ids, prefixed: false).size
         rescue StandardError => e
           Pgbus.logger.debug { "[Pgbus::Web] Error batch-discarding DLQ messages from #{queue_name}: #{e.message}" }
           0

--- a/spec/integration/queue_operations_spec.rb
+++ b/spec/integration/queue_operations_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Queue operations (integration)", :integration do
       msg_id = client.send_message("vt_test", { "extend" => true })
       client.read_batch("vt_test", qty: 1, vt: 5)
 
-      client.extend_visibility("vt_test", msg_id, vt: 60)
+      client.set_visibility_timeout("vt_test", msg_id, vt: 60)
 
       messages = client.read_batch("vt_test", qty: 1, vt: 5)
       expect(messages || []).to be_empty

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -284,18 +284,30 @@ RSpec.describe Pgbus::Client do
   end
 
   describe "#delete_message" do
-    it "deletes from the prefixed queue" do
+    it "deletes from the prefixed queue by default" do
       client.delete_message("default", 42)
 
       expect(mock_pgmq).to have_received(:delete).with("pgbus_test_default", 42)
     end
+
+    it "skips prefix when prefixed: false" do
+      client.delete_message("raw_queue", 99, prefixed: false)
+
+      expect(mock_pgmq).to have_received(:delete).with("raw_queue", 99)
+    end
   end
 
   describe "#archive_message" do
-    it "archives from the prefixed queue" do
+    it "archives from the prefixed queue by default" do
       client.archive_message("default", 7)
 
       expect(mock_pgmq).to have_received(:archive).with("pgbus_test_default", 7)
+    end
+
+    it "skips prefix when prefixed: false" do
+      client.archive_message("pgbus_test_default_p0", 42, prefixed: false)
+
+      expect(mock_pgmq).to have_received(:archive).with("pgbus_test_default_p0", 42)
     end
   end
 
@@ -307,35 +319,31 @@ RSpec.describe Pgbus::Client do
     end
   end
 
-  describe "#delete_batch_from_queue" do
-    it "deletes multiple messages using the raw queue name" do
-      client.delete_batch_from_queue("pgbus_test_default_dlq", [4, 5])
+  describe "#delete_batch" do
+    it "deletes multiple messages from the prefixed queue" do
+      client.delete_batch("default", [1, 2])
+
+      expect(mock_pgmq).to have_received(:delete_batch).with("pgbus_test_default", [1, 2])
+    end
+
+    it "skips prefix when prefixed: false" do
+      client.delete_batch("pgbus_test_default_dlq", [4, 5], prefixed: false)
 
       expect(mock_pgmq).to have_received(:delete_batch).with("pgbus_test_default_dlq", [4, 5])
     end
   end
 
-  describe "#extend_visibility" do
-    it "sets VT on the prefixed queue" do
-      client.extend_visibility("default", 5, vt: 120)
+  describe "#set_visibility_timeout" do
+    it "adds prefix by default" do
+      client.set_visibility_timeout("default", 5, vt: 120)
 
       expect(mock_pgmq).to have_received(:set_vt).with("pgbus_test_default", 5, vt: 120)
     end
-  end
 
-  describe "#set_visibility_timeout" do
-    it "passes the raw queue name directly to pgmq" do
-      client.set_visibility_timeout("raw_queue", 3, vt: 60)
+    it "skips prefix when prefixed: false" do
+      client.set_visibility_timeout("raw_queue", 3, vt: 60, prefixed: false)
 
       expect(mock_pgmq).to have_received(:set_vt).with("raw_queue", 3, vt: 60)
-    end
-  end
-
-  describe "#delete_from_queue" do
-    it "passes the raw queue name directly to pgmq" do
-      client.delete_from_queue("raw_queue", 99)
-
-      expect(mock_pgmq).to have_received(:delete).with("raw_queue", 99)
     end
   end
 
@@ -516,14 +524,6 @@ RSpec.describe Pgbus::Client do
           delay: 0
         )
       end
-    end
-  end
-
-  describe "#archive_from_queue" do
-    it "archives using the raw queue name" do
-      client.archive_from_queue("pgbus_test_default_p0", 42)
-
-      expect(mock_pgmq).to have_received(:archive).with("pgbus_test_default_p0", 42)
     end
   end
 

--- a/spec/support/pgmq_doubles.rb
+++ b/spec/support/pgmq_doubles.rb
@@ -44,7 +44,7 @@ module PgmqDoubles
         read_multi: [],
         delete_message: true,
         archive_message: true,
-        extend_visibility: nil,
+        set_visibility_timeout: nil,
         move_to_dead_letter: nil,
         metrics: nil,
         list_queues: [],
@@ -55,7 +55,7 @@ module PgmqDoubles
         transaction: nil
       )
       # Batch operations echo back the ids to mirror pgmq-ruby behavior
-      allow(client).to receive(:delete_batch_from_queue) { |_queue, ids| ids.map(&:to_s) }
+      allow(client).to receive(:delete_batch) { |_queue, ids| ids.map(&:to_s) }
       allow(client).to receive(:archive_batch) { |_queue, ids| ids.map(&:to_s) }
     end
   end


### PR DESCRIPTION
## Summary
- Replace confusing dual API with a single method per operation using `prefixed:` parameter
- `prefixed: true` (default) adds the queue prefix — the common case
- `prefixed: false` passes the raw PGMQ queue name — used by dashboard and priority queue paths
- Removes 4 methods: `archive_from_queue`, `delete_from_queue`, `delete_batch_from_queue`, `extend_visibility`
- All callers updated throughout executor, dashboard, integration specs

### New unified API:
| Method | Default | Raw queue |
|--------|---------|-----------|
| `archive_message(name, id)` | adds prefix | `prefixed: false` |
| `delete_message(name, id)` | adds prefix | `prefixed: false` |
| `archive_batch(name, ids)` | adds prefix | `prefixed: false` |
| `delete_batch(name, ids)` | adds prefix | `prefixed: false` |
| `set_visibility_timeout(name, id, vt:)` | adds prefix | `prefixed: false` |

## Test plan
- [x] New specs for `prefixed: false` paths on archive/delete/set_vt
- [x] All 659 examples pass, 0 failures
- [x] Rubocop clean

**PR 5 of 6** in the pgmq-ruby optimization series. Based on PR #31.