### PR TITLE
feat(dashboard): configurable insights time range with 30-day default

### DIFF
--- a/app/controllers/pgbus/api/insights_controller.rb
+++ b/app/controllers/pgbus/api/insights_controller.rb
@@ -4,7 +4,7 @@ module Pgbus
   module Api
     class InsightsController < ApplicationController
       def show
-        minutes = (params[:minutes] || Pgbus.configuration.insights_default_minutes).to_i
+        minutes = insights_minutes
         render json: {
           summary: data_source.job_stats_summary(minutes: minutes),
           throughput: data_source.job_throughput(minutes: minutes),

--- a/app/controllers/pgbus/api/insights_controller.rb
+++ b/app/controllers/pgbus/api/insights_controller.rb
@@ -4,11 +4,12 @@ module Pgbus
   module Api
     class InsightsController < ApplicationController
       def show
+        minutes = (params[:minutes] || Pgbus.configuration.insights_default_minutes).to_i
         render json: {
-          summary: data_source.job_stats_summary,
-          throughput: data_source.job_throughput,
-          status_counts: data_source.job_status_counts,
-          slowest: data_source.slowest_job_classes
+          summary: data_source.job_stats_summary(minutes: minutes),
+          throughput: data_source.job_throughput(minutes: minutes),
+          status_counts: data_source.job_status_counts(minutes: minutes),
+          slowest: data_source.slowest_job_classes(minutes: minutes)
         }
       end
     end

--- a/app/controllers/pgbus/application_controller.rb
+++ b/app/controllers/pgbus/application_controller.rb
@@ -32,6 +32,14 @@ module Pgbus
       Pgbus.configuration.web_per_page
     end
 
+    def insights_minutes
+      config = Pgbus.configuration
+      default = config.insights_default_minutes.to_i
+      max = config.stats_retention.to_i / 60
+      value = (params[:minutes] || default).to_i
+      value.clamp(1, [max, 1].max)
+    end
+
     def turbo_frame_request?
       request.headers["Turbo-Frame"].present? || params[:frame].present?
     end

--- a/app/controllers/pgbus/insights_controller.rb
+++ b/app/controllers/pgbus/insights_controller.rb
@@ -3,7 +3,7 @@
 module Pgbus
   class InsightsController < ApplicationController
     def show
-      @minutes = (params[:minutes] || Pgbus.configuration.insights_default_minutes).to_i
+      @minutes = insights_minutes
       @summary = data_source.job_stats_summary(minutes: @minutes)
       @slowest = data_source.slowest_job_classes(minutes: @minutes)
     end

--- a/app/controllers/pgbus/insights_controller.rb
+++ b/app/controllers/pgbus/insights_controller.rb
@@ -3,8 +3,9 @@
 module Pgbus
   class InsightsController < ApplicationController
     def show
-      @summary = data_source.job_stats_summary
-      @slowest = data_source.slowest_job_classes
+      @minutes = (params[:minutes] || Pgbus.configuration.insights_default_minutes).to_i
+      @summary = data_source.job_stats_summary(minutes: @minutes)
+      @slowest = data_source.slowest_job_classes(minutes: @minutes)
     end
   end
 end

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -133,25 +133,13 @@ module Pgbus
 
     def pgbus_time_range_label(minutes)
       minutes = [minutes.to_i, 1].max
-      if minutes < 60
-        minutes == 1 ? "1 minute" : "#{minutes} minutes"
-      elsif minutes < 1440 || (minutes <= 1440 && (minutes % 60).zero?)
-        hours = minutes / 60
-        remainder = minutes % 60
-        if remainder.zero?
-          hours == 1 ? "1 hour" : "#{hours} hours"
-        else
-          "#{minutes} minutes"
-        end
+
+      if minutes > 1440 && (minutes % 1440).zero?
+        pgbus_pluralize_unit(minutes / 1440, "day")
+      elsif minutes >= 60 && (minutes % 60).zero?
+        pgbus_pluralize_unit(minutes / 60, "hour")
       else
-        days = minutes / 1440
-        remainder = minutes % 1440
-        if remainder.zero?
-          days == 1 ? "1 day" : "#{days} days"
-        else
-          hours = minutes / 60
-          hours == 1 ? "1 hour" : "#{hours} hours"
-        end
+        pgbus_pluralize_unit(minutes, "minute")
       end
     end
 
@@ -163,6 +151,12 @@ module Pgbus
               "rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-700"
             end
       link_to label, path, class: css
+    end
+
+    private
+
+    def pgbus_pluralize_unit(count, unit)
+      count == 1 ? "1 #{unit}" : "#{count} #{unit}s"
     end
   end
 end

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -132,9 +132,9 @@ module Pgbus
     end
 
     def pgbus_time_range_label(minutes)
-      minutes = minutes.to_i
+      minutes = [minutes.to_i, 1].max
       if minutes < 60
-        "#{minutes} minutes"
+        minutes == 1 ? "1 minute" : "#{minutes} minutes"
       elsif minutes <= 1440
         hours = minutes / 60
         hours == 1 ? "1 hour" : "#{hours} hours"

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -131,6 +131,19 @@ module Pgbus
       end
     end
 
+    def pgbus_time_range_label(minutes)
+      minutes = minutes.to_i
+      if minutes < 60
+        "#{minutes} minutes"
+      elsif minutes <= 1440
+        hours = minutes / 60
+        hours == 1 ? "1 hour" : "#{hours} hours"
+      else
+        days = minutes / 1440
+        days == 1 ? "1 day" : "#{days} days"
+      end
+    end
+
     def pgbus_nav_link(label, path)
       active = request.path == path || (path != pgbus.root_path && request.path.start_with?(path))
       css = if active

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -135,12 +135,23 @@ module Pgbus
       minutes = [minutes.to_i, 1].max
       if minutes < 60
         minutes == 1 ? "1 minute" : "#{minutes} minutes"
-      elsif minutes <= 1440
+      elsif minutes < 1440 || (minutes <= 1440 && (minutes % 60).zero?)
         hours = minutes / 60
-        hours == 1 ? "1 hour" : "#{hours} hours"
+        remainder = minutes % 60
+        if remainder.zero?
+          hours == 1 ? "1 hour" : "#{hours} hours"
+        else
+          "#{minutes} minutes"
+        end
       else
         days = minutes / 1440
-        days == 1 ? "1 day" : "#{days} days"
+        remainder = minutes % 1440
+        if remainder.zero?
+          days == 1 ? "1 day" : "#{days} days"
+        else
+          hours = minutes / 60
+          hours == 1 ? "1 hour" : "#{hours} hours"
+        end
       end
     end
 

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -3,13 +3,9 @@
     <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Insights</h1>
     <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Job performance metrics for the last <%= pgbus_time_range_label(@minutes) %></p>
   </div>
-  <nav class="inline-flex rounded-lg shadow-sm" role="group">
-    <% [
-      ["1h", 60],
-      ["24h", 1440],
-      ["7d", 10_080],
-      ["30d", 43_200],
-    ].each_with_index do |(label, mins), i| %>
+  <nav class="inline-flex rounded-lg shadow-sm" role="group" aria-label="Time range">
+    <% ranges = [["1h", 60], ["24h", 1440], ["7d", 10_080], ["30d", 43_200]] %>
+    <% ranges.each_with_index do |(label, mins), i| %>
       <%
         active = @minutes == mins
         base = "px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 focus:z-10 focus:outline-none"
@@ -18,7 +14,7 @@
           "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
         rounded = case i
                   when 0 then "rounded-l-lg"
-                  when 3 then "rounded-r-lg"
+                  when ranges.length - 1 then "rounded-r-lg"
                   else "-ml-px"
                   end
       %>

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -1,6 +1,30 @@
-<div class="mb-6">
-  <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Insights</h1>
-  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Job performance metrics for the last hour</p>
+<div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Insights</h1>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Job performance metrics for the last <%= pgbus_time_range_label(@minutes) %></p>
+  </div>
+  <nav class="inline-flex rounded-lg shadow-sm" role="group">
+    <% [
+      ["1h", 60],
+      ["24h", 1440],
+      ["7d", 10_080],
+      ["30d", 43_200],
+    ].each_with_index do |(label, mins), i| %>
+      <%
+        active = @minutes == mins
+        base = "px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 focus:z-10 focus:outline-none"
+        colors = active ?
+          "bg-indigo-600 text-white border-indigo-600 dark:border-indigo-500" :
+          "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+        rounded = case i
+                  when 0 then "rounded-l-lg"
+                  when 3 then "rounded-r-lg"
+                  else "-ml-px"
+                  end
+      %>
+      <%= link_to label, pgbus.insights_path(minutes: mins), class: "#{base} #{colors} #{rounded}" %>
+    <% end %>
+  </nav>
 </div>
 
 <!-- Summary cards -->
@@ -143,7 +167,7 @@
 
   // Fetch data and render
   let chartData = null;
-  fetch('<%= pgbus.api_insights_path %>')
+  fetch('<%= pgbus.api_insights_path(minutes: @minutes) %>')
     .then(r => r.json())
     .then(data => { chartData = data; renderCharts(data); })
     .catch(() => {

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -184,6 +184,10 @@ module Pgbus
         raise ArgumentError, "priority_levels must be an integer between 1 and 10"
       end
 
+      unless insights_default_minutes.is_a?(Numeric) && insights_default_minutes.positive?
+        raise ArgumentError, "insights_default_minutes must be > 0"
+      end
+
       self
     end
 

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -63,7 +63,8 @@ module Pgbus
     attr_accessor :stats_retention, :stats_enabled
 
     # Web dashboard
-    attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source
+    attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source,
+                  :insights_default_minutes
 
     def initialize
       @database_url = nil
@@ -124,7 +125,7 @@ module Pgbus
       @recurring_execution_retention = 7 * 24 * 3600 # 7 days
 
       @stats_enabled = true
-      @stats_retention = 7 * 24 * 3600 # 7 days
+      @stats_retention = 30 * 24 * 3600 # 30 days
 
       @connects_to = nil
 
@@ -133,6 +134,7 @@ module Pgbus
       @web_per_page = 25
       @web_live_updates = true
       @web_data_source = nil
+      @insights_default_minutes = 30 * 24 * 60 # 30 days
     end
 
     def queue_name(name)

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -184,8 +184,8 @@ module Pgbus
         raise ArgumentError, "priority_levels must be an integer between 1 and 10"
       end
 
-      unless insights_default_minutes.is_a?(Numeric) && insights_default_minutes.positive?
-        raise ArgumentError, "insights_default_minutes must be > 0"
+      unless insights_default_minutes.is_a?(Integer) && insights_default_minutes.positive?
+        raise ArgumentError, "insights_default_minutes must be a positive integer"
       end
 
       self

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -165,6 +165,11 @@ RSpec.describe Pgbus::Configuration do
       config.insights_default_minutes = -1
       expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
     end
+
+    it "rejects fractional insights_default_minutes" do
+      config.insights_default_minutes = 90.5
+      expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
+    end
   end
 
   describe "#connection_options" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -62,9 +62,13 @@ RSpec.describe Pgbus::Configuration do
       expect(config.archive_compaction_batch_size).to eq(1000)
     end
 
-    it "has stats enabled by default" do
+    it "has stats enabled with 30 day retention by default" do
       expect(config.stats_enabled).to be true
-      expect(config.stats_retention).to eq(7 * 24 * 3600)
+      expect(config.stats_retention).to eq(30 * 24 * 3600)
+    end
+
+    it "has insights_default_minutes of 30 days" do
+      expect(config.insights_default_minutes).to eq(30 * 24 * 60)
     end
 
     it "has outbox disabled by default" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -155,6 +155,16 @@ RSpec.describe Pgbus::Configuration do
       config.priority_levels = 3
       expect { config.validate! }.not_to raise_error
     end
+
+    it "rejects non-positive insights_default_minutes" do
+      config.insights_default_minutes = 0
+      expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
+    end
+
+    it "rejects negative insights_default_minutes" do
+      config.insights_default_minutes = -1
+      expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
+    end
   end
 
   describe "#connection_options" do

--- a/spec/pgbus/helpers/application_helper_spec.rb
+++ b/spec/pgbus/helpers/application_helper_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe Pgbus::ApplicationHelper do
     it "clamps negative to 1 minute" do
       expect(helper.pgbus_time_range_label(-5)).to eq("1 minute")
     end
+
+    it "keeps non-divisible hour values as minutes" do
+      expect(helper.pgbus_time_range_label(90)).to eq("90 minutes")
+    end
+
+    it "keeps non-divisible day values as hours" do
+      expect(helper.pgbus_time_range_label(1500)).to eq("25 hours")
+    end
   end
 
   describe "#pgbus_json_preview" do

--- a/spec/pgbus/helpers/application_helper_spec.rb
+++ b/spec/pgbus/helpers/application_helper_spec.rb
@@ -127,6 +127,18 @@ RSpec.describe Pgbus::ApplicationHelper do
     it "returns minutes for sub-hour ranges" do
       expect(helper.pgbus_time_range_label(15)).to eq("15 minutes")
     end
+
+    it "returns singular minute for 1" do
+      expect(helper.pgbus_time_range_label(1)).to eq("1 minute")
+    end
+
+    it "clamps zero to 1 minute" do
+      expect(helper.pgbus_time_range_label(0)).to eq("1 minute")
+    end
+
+    it "clamps negative to 1 minute" do
+      expect(helper.pgbus_time_range_label(-5)).to eq("1 minute")
+    end
   end
 
   describe "#pgbus_json_preview" do

--- a/spec/pgbus/helpers/application_helper_spec.rb
+++ b/spec/pgbus/helpers/application_helper_spec.rb
@@ -147,6 +147,10 @@ RSpec.describe Pgbus::ApplicationHelper do
     it "keeps non-divisible day values as hours" do
       expect(helper.pgbus_time_range_label(1500)).to eq("25 hours")
     end
+
+    it "falls back to minutes for values not divisible by 60 above a day" do
+      expect(helper.pgbus_time_range_label(1530)).to eq("1530 minutes")
+    end
   end
 
   describe "#pgbus_json_preview" do

--- a/spec/pgbus/helpers/application_helper_spec.rb
+++ b/spec/pgbus/helpers/application_helper_spec.rb
@@ -103,6 +103,32 @@ RSpec.describe Pgbus::ApplicationHelper do
     end
   end
 
+  describe "#pgbus_time_range_label" do
+    it "returns '1 hour' for 60 minutes" do
+      expect(helper.pgbus_time_range_label(60)).to eq("1 hour")
+    end
+
+    it "returns '24 hours' for 1440 minutes" do
+      expect(helper.pgbus_time_range_label(1440)).to eq("24 hours")
+    end
+
+    it "returns '7 days' for 10080 minutes" do
+      expect(helper.pgbus_time_range_label(10_080)).to eq("7 days")
+    end
+
+    it "returns '30 days' for 43200 minutes" do
+      expect(helper.pgbus_time_range_label(43_200)).to eq("30 days")
+    end
+
+    it "returns hours for sub-day ranges" do
+      expect(helper.pgbus_time_range_label(360)).to eq("6 hours")
+    end
+
+    it "returns minutes for sub-hour ranges" do
+      expect(helper.pgbus_time_range_label(15)).to eq("15 minutes")
+    end
+  end
+
   describe "#pgbus_json_preview" do
     it "returns dash for nil" do
       expect(helper.pgbus_json_preview(nil)).to eq("—")


### PR DESCRIPTION
## Summary
- Add time range selector (1h, 24h, 7d, 30d) to the Insights dashboard
- Change default view from 1 hour to 30 days, matching AppSignal-style history
- `stats_retention` default bumped from 7 days to 30 days
- New `insights_default_minutes` config option for consumers to override default
- Both HTML and API controllers accept `?minutes=` query param
- New `pgbus_time_range_label` helper for human-readable range labels
- View subtitle and API fetch dynamically reflect selected range

## Test plan
- [x] Config spec: `insights_default_minutes` defaults to 43200
- [x] Config spec: `stats_retention` defaults to 30 days
- [x] Helper spec: `pgbus_time_range_label` for minutes, hours, days
- [x] All 670 examples pass, 0 failures
- [x] Rubocop clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time-range selector on the insights dashboard (1h, 24h, 7d, 30d) with dynamic, human-readable labels; charts and stats load for the selected range.

* **Improvements**
  * Insights requests now honor the selected time range so all data views reflect the chosen window.
  * Input clamping enforces a 1–maximum sensible range for time selections.

* **Chores**
  * Increased default data retention to 30 days and added a configurable default insights window.

* **Tests**
  * Added tests for time-range labeling, validation, and new defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->