### PR TITLE
fix: locale switcher, dark mode flash, and Turbo CDN issues

### DIFF
--- a/app/controllers/pgbus/application_controller.rb
+++ b/app/controllers/pgbus/application_controller.rb
@@ -51,6 +51,7 @@ module Pgbus
       @available_locales ||= Dir[Pgbus::Engine.root.join("config", "locales", "*.yml")]
                              .map { |f| File.basename(f, ".yml").to_sym }
     end
+    helper_method :available_locales
 
     def data_source
       @data_source ||= Pgbus.configuration.web_data_source || Web::DataSource.new

--- a/app/controllers/pgbus/application_controller.rb
+++ b/app/controllers/pgbus/application_controller.rb
@@ -67,9 +67,8 @@ module Pgbus
     def insights_minutes
       config = Pgbus.configuration
       default = config.insights_default_minutes.to_i
-      max = config.stats_retention.to_i / 60
       value = (params[:minutes] || default).to_i
-      value.clamp(1, [max, 1].max)
+      value.clamp(1, [default, 43_200].max)
     end
 
     def turbo_frame_request?

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -4,6 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= t("pgbus.layout.title") %></title>
+  <style>
+    /* Prevent white flash during navigation in dark mode.
+       Applied before Tailwind CDN loads so the background is correct immediately. */
+    html.dark { background-color: #030712; } /* gray-950 */
+    html.dark body { background-color: #030712; }
+  </style>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { darkMode: 'class' };
@@ -17,24 +23,17 @@
       var isDark = document.documentElement.classList.toggle('dark');
       localStorage.setItem('pgbus-dark', isDark);
     }
-    // Locale dropdown toggle
+    // Close locale dropdown when clicking outside
     document.addEventListener('click', function(e) {
-      var btn = e.target.closest('[data-action="click->dropdown#toggle"]');
-      var menu = btn && btn.parentElement.querySelector('[data-dropdown-target="menu"]');
-      // Close all menus first
-      document.querySelectorAll('[data-dropdown-target="menu"]').forEach(function(m) {
-        if (m !== menu) m.classList.add('hidden');
-      });
-      if (menu) { menu.classList.toggle('hidden'); e.stopPropagation(); }
-    });
-    document.addEventListener('click', function() {
-      document.querySelectorAll('[data-dropdown-target="menu"]').forEach(function(m) {
-        m.classList.add('hidden');
-      });
+      var switcher = document.getElementById('pgbus-locale-switcher');
+      var menu = document.getElementById('pgbus-locale-menu');
+      if (menu && switcher && !switcher.contains(e.target)) {
+        menu.classList.add('hidden');
+      }
     });
   </script>
   <script type="module">
-    import * as Turbo from "https://cdn.jsdelivr.net/npm/@hotwired/turbo@8/dist/turbo.es2017.esm.js";
+    import * as Turbo from "https://esm.sh/@hotwired/turbo@8";
 
     <% if Pgbus.configuration.web_live_updates %>
     const interval = <%= Pgbus.configuration.web_refresh_interval %>;
@@ -43,7 +42,10 @@
       function refreshFrames() {
         if (document.hidden) return;
         document.querySelectorAll("turbo-frame[data-auto-refresh]")
-          .forEach(frame => frame.reload());
+          .forEach(frame => {
+            if (!frame.src && frame.dataset.src) frame.src = frame.dataset.src;
+            if (frame.src) frame.reload();
+          });
       }
       function start() { timer = setInterval(refreshFrames, interval); }
       function stop() { clearInterval(timer); }
@@ -81,19 +83,16 @@
 
           <div class="flex items-center space-x-2">
             <!-- Locale switcher -->
-            <div class="relative" data-controller="dropdown">
-              <button type="button" data-action="click->dropdown#toggle" class="rounded-md px-2 py-1.5 text-sm text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            <div class="relative" id="pgbus-locale-switcher">
+              <button type="button" onclick="document.getElementById('pgbus-locale-menu').classList.toggle('hidden')" class="rounded-md px-2 py-1 text-sm text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                 <%= pgbus_locale_flag(I18n.locale) %> <%= I18n.locale.to_s.upcase %>
               </button>
-              <div data-dropdown-target="menu" class="hidden absolute right-0 z-50 mt-1 w-44 origin-top-right rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-black/5 dark:ring-white/10">
+              <div id="pgbus-locale-menu" class="hidden absolute right-0 z-50 mt-1 w-44 origin-top-right rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-black/5 dark:ring-white/10">
                 <div class="py-1" role="menu">
                   <% controller.send(:available_locales).sort.each do |loc| %>
-                    <%= form_tag pgbus.set_locale_path, method: :post, class: "contents" do %>
-                      <%= hidden_field_tag :locale, loc %>
-                      <button type="submit" role="menuitem" class="w-full text-left px-3 py-1.5 text-sm <%= loc == I18n.locale ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700' %>">
-                        <%= pgbus_locale_flag(loc) %> <%= pgbus_locale_name(loc) %>
-                      </button>
-                    <% end %>
+                    <a href="<%= pgbus.set_locale_path(locale: loc) %>" role="menuitem" class="block px-3 py-1 text-sm no-underline <%= loc == I18n.locale ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700' %>">
+                      <%= pgbus_locale_flag(loc) %> <%= pgbus_locale_name(loc) %>
+                    </a>
                   <% end %>
                 </div>
               </div>

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -89,7 +89,7 @@
               </button>
               <div id="pgbus-locale-menu" class="hidden absolute right-0 z-50 mt-1 w-44 origin-top-right rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-black/5 dark:ring-white/10">
                 <div class="py-1" role="menu">
-                  <% controller.send(:available_locales).sort.each do |loc| %>
+                  <% available_locales.sort.each do |loc| %>
                     <a href="<%= pgbus.set_locale_path(locale: loc) %>" role="menuitem" class="block px-3 py-1 text-sm no-underline <%= loc == I18n.locale ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700' %>">
                       <%= pgbus_locale_flag(loc) %> <%= pgbus_locale_name(loc) %>
                     </a>

--- a/app/views/pgbus/dashboard/_processes_table.html.erb
+++ b/app/views/pgbus/dashboard/_processes_table.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="dashboard-processes" data-auto-refresh src="<%= pgbus.root_path(frame: 'processes') %>">
+<turbo-frame id="dashboard-processes" data-auto-refresh data-src="<%= pgbus.root_path(frame: 'processes') %>">
   <div>
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.dashboard.processes_table.title") %></h2>
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">

--- a/app/views/pgbus/dashboard/_queues_table.html.erb
+++ b/app/views/pgbus/dashboard/_queues_table.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="dashboard-queues" data-auto-refresh src="<%= pgbus.root_path(frame: 'queues') %>">
+<turbo-frame id="dashboard-queues" data-auto-refresh data-src="<%= pgbus.root_path(frame: 'queues') %>">
   <div class="mb-8">
     <div class="flex items-center justify-between mb-3">
       <h2 class="text-lg font-semibold text-gray-900 dark:text-white"><%= t("pgbus.dashboard.queues_table.title") %></h2>

--- a/app/views/pgbus/dashboard/_recent_failures.html.erb
+++ b/app/views/pgbus/dashboard/_recent_failures.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="dashboard-failures" data-auto-refresh src="<%= pgbus.root_path(frame: 'failures') %>">
+<turbo-frame id="dashboard-failures" data-auto-refresh data-src="<%= pgbus.root_path(frame: 'failures') %>">
   <div>
     <div class="flex items-center justify-between mb-3">
       <h2 class="text-lg font-semibold text-gray-900 dark:text-white"><%= t("pgbus.dashboard.recent_failures.title") %></h2>

--- a/app/views/pgbus/dashboard/_stats_cards.html.erb
+++ b/app/views/pgbus/dashboard/_stats_cards.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="dashboard-stats" data-auto-refresh src="<%= pgbus.root_path(frame: 'stats') %>">
+<turbo-frame id="dashboard-stats" data-auto-refresh data-src="<%= pgbus.root_path(frame: 'stats') %>">
   <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-6 mb-8">
     <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
       <p class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.dashboard.stats_cards.queues") %></p>

--- a/app/views/pgbus/dead_letter/_messages_table.html.erb
+++ b/app/views/pgbus/dead_letter/_messages_table.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="dlq-messages" data-auto-refresh src="<%= pgbus.dead_letter_index_path(frame: 'list') %>">
+<turbo-frame id="dlq-messages" data-auto-refresh data-src="<%= pgbus.dead_letter_index_path(frame: 'list') %>">
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
     <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">

--- a/app/views/pgbus/jobs/_enqueued_table.html.erb
+++ b/app/views/pgbus/jobs/_enqueued_table.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="jobs-enqueued" data-auto-refresh src="<%= pgbus.jobs_path(request.query_parameters.merge(frame: 'enqueued')) %>">
+<turbo-frame id="jobs-enqueued" data-auto-refresh data-src="<%= pgbus.jobs_path(request.query_parameters.merge(frame: 'enqueued')) %>">
   <div>
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.jobs.enqueued_table.title") %></h2>
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">

--- a/app/views/pgbus/jobs/_failed_table.html.erb
+++ b/app/views/pgbus/jobs/_failed_table.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="jobs-failed" data-auto-refresh src="<%= pgbus.jobs_path(frame: 'failed') %>">
+<turbo-frame id="jobs-failed" data-auto-refresh data-src="<%= pgbus.jobs_path(frame: 'failed') %>">
   <div class="mb-8">
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.jobs.failed_table.title") %></h2>
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">

--- a/app/views/pgbus/processes/_processes_table.html.erb
+++ b/app/views/pgbus/processes/_processes_table.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="processes-list" data-auto-refresh src="<%= pgbus.processes_path(frame: 'list') %>">
+<turbo-frame id="processes-list" data-auto-refresh data-src="<%= pgbus.processes_path(frame: 'list') %>">
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
     <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">

--- a/app/views/pgbus/queues/_queues_list.html.erb
+++ b/app/views/pgbus/queues/_queues_list.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="queues-list" data-auto-refresh src="<%= pgbus.queues_path(frame: 'list') %>">
+<turbo-frame id="queues-list" data-auto-refresh data-src="<%= pgbus.queues_path(frame: 'list') %>">
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
     <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">

--- a/app/views/pgbus/recurring_tasks/_tasks_table.html.erb
+++ b/app/views/pgbus/recurring_tasks/_tasks_table.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="recurring-tasks" data-auto-refresh src="<%= pgbus.recurring_tasks_path(frame: 'recurring_tasks') %>">
+<turbo-frame id="recurring-tasks" data-auto-refresh data-src="<%= pgbus.recurring_tasks_path(frame: 'recurring_tasks') %>">
   <div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
     <% if @recurring_tasks.empty? %>
       <div class="p-8 text-center text-gray-500">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Pgbus::Engine.routes.draw do
   resources :locks, only: [:index]
   resource :insights, only: [:show], controller: "insights"
 
-  post :set_locale, to: "locale#update"
+  get :set_locale, to: "locale#update"
 
   namespace :api do
     get :stats, to: "stats#show"


### PR DESCRIPTION
## Summary
Follow-up fixes to the i18n infrastructure (PR #35):

- **Locale switcher not working**: Replaced `form_tag` POST with plain GET `<a>` links. The POST forms were failing silently due to Turbo intercepting the submission and CSRF token issues. Route changed from `post :set_locale` to `get :set_locale` (idempotent cookie setter).
- **Dark mode white flash**: Added inline `<style>` before Tailwind CDN that sets `html.dark` background to `#030712` (gray-950). Renders immediately — no waiting for external JS.
- **Turbo CDN CORS blocked**: Switched from `cdn.jsdelivr.net` (returning `text/plain` MIME type, blocked by CORS) to `esm.sh` which serves proper ES module CORS headers.
- **30d insights button**: Removed `stats_retention` ceiling clamp that silently reduced 30d to 7d when host app had lower retention. Now clamps to at least 43200 (30d).

## Test plan
- [x] All 683 examples pass, 0 failures
- [x] Rubocop clean
- [x] Locale switcher uses GET links (no CSRF/Turbo dependency)
- [x] Dark mode inline CSS matches Tailwind gray-950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dark mode to prevent a white flash on initial load.

* **Bug Fixes & Improvements**
  * Locale switching simplified to direct navigation links and a click-based toggle.
  * Auto-refresh behavior made more robust for dashboard sections (processes, queues, failures, stats, jobs, DLQ, recurring tasks).
  * Safer handling of insights time range inputs to enforce sensible minute limits.
  * Updated Turbo integration for more reliable frame loading.

* **Chores**
  * Standardized frame loading attributes across views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->