### PR TITLE
feat: add ActiveJob::Continuation support and update migration docs

### DIFF
--- a/docs/switch_from_sidekiq.md
+++ b/docs/switch_from_sidekiq.md
@@ -200,16 +200,17 @@ Once all Sidekiq jobs have drained and you've verified Pgbus is processing corre
 - **Event bus** -- AMQP-style topic routing for pub/sub, built into the same infrastructure
 - **LISTEN/NOTIFY** -- instant job wake-up without polling overhead
 
-## What you lose (for now)
+## Feature comparison
 
-| Sidekiq feature | Status in Pgbus |
+| Sidekiq feature | Pgbus equivalent |
 |-----------------|-----------------|
-| Batches (Pro) | `Pgbus::Batch` with on_finish/on_success/on_discard callbacks |
-| Rate limiting (Enterprise) | Planned |
+| Batches (Pro) | `Pgbus::Batch` with `on_finish` / `on_success` / `on_discard` callbacks |
 | Concurrency controls (Enterprise) | `Pgbus::Concurrency` with `limits_concurrency` DSL |
-| Unique jobs (Enterprise / `sidekiq-unique-jobs`) | Partial -- event bus has idempotency; job-level dedup planned |
-| Cron / recurring jobs (`sidekiq-cron`) | Planned |
-| Real-time metrics (Sidekiq Web) | Pgbus dashboard covers queue depth, failures, processes |
+| Unique jobs (Enterprise / `sidekiq-unique-jobs`) | `Pgbus::Uniqueness` with `until_executed` / `while_executing` strategies |
+| Cron / recurring jobs (`sidekiq-cron`) | `config/recurring.yml` with cron syntax (Fugit) |
+| Rate limiting (Enterprise) | Use `limits_concurrency` for most cases; sliding-window rate limiting not yet built |
+| Real-time metrics (Sidekiq Web) | Pgbus dashboard covers queue depth, failures, processes, recurring tasks |
+| `ActiveJob::Continuation` (Rails 8.1+) | Supported -- `stopping?` wired to worker lifecycle |
 
 ## Gotchas
 

--- a/docs/switch_from_solid_queue.md
+++ b/docs/switch_from_solid_queue.md
@@ -209,7 +209,7 @@ end
 | `limits_concurrency` | `Pgbus::Concurrency` with `limits_concurrency` DSL (add `include Pgbus::Concurrency`) |
 | `config/recurring.yml` | Supported -- same YAML format, cron + human-readable syntax via Fugit |
 | Queue pausing (`SolidQueue::Queue.pause`) | Planned |
-| Separate queue database (`connects_to`) | Supported -- `Pgbus.configure { |c| c.connects_to = { database: { writing: :pgbus } } }` |
+| Separate queue database (`connects_to`) | Supported -- `Pgbus.configure { \|c\| c.connects_to = { database: { writing: :pgbus } } }` |
 | Numeric job priorities | Supported -- configurable priority levels with per-queue subqueues |
 | `ActiveJob::Continuation` (Rails 8.1+) | Supported -- `stopping?` wired to worker lifecycle |
 

--- a/docs/switch_from_solid_queue.md
+++ b/docs/switch_from_solid_queue.md
@@ -135,10 +135,10 @@ end
 
 ## Step 5: Migrate recurring tasks
 
-If you use SolidQueue's `config/recurring.yml`:
+If you use SolidQueue's `config/recurring.yml`, Pgbus supports the same file format:
 
 ```yaml
-# Before: config/recurring.yml (SolidQueue)
+# config/recurring.yml (works with both SolidQueue and Pgbus)
 production:
   daily_cleanup:
     class: CleanupJob
@@ -150,26 +150,7 @@ production:
     args: [42, "sync"]
 ```
 
-Pgbus does not yet have built-in recurring task support. Options:
-
-1. **Use the `whenever` gem** for cron-based scheduling:
-   ```ruby
-   # config/schedule.rb (whenever gem)
-   every 1.day, at: "2:00 am" do
-     runner "CleanupJob.perform_later"
-   end
-   every :hour do
-     runner "SyncJob.perform_later(42, 'sync')"
-   end
-   ```
-
-2. **Use system cron** directly:
-   ```cron
-   0 2 * * * cd /app && bin/rails runner "CleanupJob.perform_later"
-   0 * * * * cd /app && bin/rails runner "SyncJob.perform_later(42, 'sync')"
-   ```
-
-3. Wait for Pgbus recurring task support (planned).
+Pgbus parses both human-readable (`every day at 2am`) and standard cron (`0 * * * *`) syntax via Fugit. Your existing `recurring.yml` should work without changes. Verify per-environment overrides and `args` parameter passing.
 
 ## Step 6: Replace the dashboard
 
@@ -221,25 +202,28 @@ end
 - **Event bus** -- AMQP-style pub/sub with topic routing, not available in SolidQueue.
 - **PGMQ under the hood** -- battle-tested message queue extension with visibility timeouts and atomic operations.
 
-## What you lose (for now)
+## Feature comparison
 
-| SolidQueue feature | Status in Pgbus |
+| SolidQueue feature | Pgbus equivalent |
 |--------------------|-----------------|
-| `limits_concurrency` | `Pgbus::Concurrency` with `limits_concurrency` DSL |
-| `config/recurring.yml` | Planned |
+| `limits_concurrency` | `Pgbus::Concurrency` with `limits_concurrency` DSL (add `include Pgbus::Concurrency`) |
+| `config/recurring.yml` | Supported -- same YAML format, cron + human-readable syntax via Fugit |
 | Queue pausing (`SolidQueue::Queue.pause`) | Planned |
-| Separate queue database | Not planned (PGMQ lives in your primary DB) |
-| Numeric job priorities | PGMQ reads in FIFO order per queue; use separate queues for priority |
+| Separate queue database (`connects_to`) | Supported -- `Pgbus.configure { |c| c.connects_to = { database: { writing: :pgbus } } }` |
+| Numeric job priorities | Supported -- configurable priority levels with per-queue subqueues |
+| `ActiveJob::Continuation` (Rails 8.1+) | Supported -- `stopping?` wired to worker lifecycle |
 
 ## Gotchas
 
 1. **PgBouncer**: If you run PgBouncer in transaction mode, LISTEN/NOTIFY won't work. Use session mode or direct connections for Pgbus worker processes. This also applies to PGMQ's `FOR UPDATE SKIP LOCKED`.
 
-2. **Separate queue database**: SolidQueue supports `connects_to` for a dedicated queue DB. Pgbus requires PGMQ in the same database it connects to. If you need isolation, use a separate PostgreSQL database with PGMQ installed and configure `Pgbus.configuration.database_url`.
+2. **Separate queue database**: Both SolidQueue and Pgbus support `connects_to` for a dedicated queue DB. PGMQ must be installed in whichever database Pgbus connects to.
 
 3. **Queue naming**: SolidQueue uses bare queue names (`default`). Pgbus prefixes all queues (`pgbus_default`). Your `queue_as :default` declarations work unchanged -- the prefix is applied automatically.
 
-4. **`ActionMailer::MailDeliveryJob`**: This can bypass the application-level adapter setting in some Rails versions. If mailer jobs don't appear in Pgbus, add to `ApplicationMailer`:
+4. **Uniqueness**: SolidQueue has no built-in uniqueness. If you need it, add `include Pgbus::Uniqueness` with `ensures_uniqueness strategy: :until_executed` or `:while_executing`.
+
+5. **`ActionMailer::MailDeliveryJob`**: This can bypass the application-level adapter setting in some Rails versions. If mailer jobs don't appear in Pgbus, add to `ApplicationMailer`:
    ```ruby
    class ApplicationMailer < ActionMailer::Base
      self.deliver_later_queue_name = :mailers

--- a/lib/active_job/queue_adapters/pgbus_adapter.rb
+++ b/lib/active_job/queue_adapters/pgbus_adapter.rb
@@ -19,6 +19,13 @@ module ActiveJob
         true
       end
 
+      # Called by ActiveJob::Continuation (Rails 8.1+) at each checkpoint.
+      # When true, continuable jobs save their cursor and re-enqueue
+      # themselves so the worker can shut down gracefully.
+      def stopping?
+        Pgbus.stopping
+      end
+
       private
 
       def adapter

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -12,11 +12,15 @@ module Pgbus
   class JobNotUnique < Error; end
   class SchemaNotReady < Error; end
 
-  # Process-global flag set by Worker#graceful_shutdown so the adapter
-  # can report stopping? to ActiveJob::Continuation (Rails 8.1+).
-  mattr_accessor :stopping, default: false
-
   class << self
+    # Process-global flag set by Worker#graceful_shutdown so the adapter
+    # can report stopping? to ActiveJob::Continuation (Rails 8.1+).
+    attr_writer :stopping
+
+    def stopping
+      @stopping || false
+    end
+
     def loader
       @loader ||= begin
         loader = Zeitwerk::Loader.for_gem

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -12,6 +12,10 @@ module Pgbus
   class JobNotUnique < Error; end
   class SchemaNotReady < Error; end
 
+  # Process-global flag set by Worker#graceful_shutdown so the adapter
+  # can report stopping? to ActiveJob::Continuation (Rails 8.1+).
+  mattr_accessor :stopping, default: false
+
   class << self
     def loader
       @loader ||= begin

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -66,12 +66,14 @@ module Pgbus
 
       def graceful_shutdown
         Pgbus.logger.info { "[Pgbus] Worker shutting down gracefully..." }
+        Pgbus.stopping = true
         @lifecycle.transition_to(:draining)
         @wake_signal.notify!
       end
 
       def immediate_shutdown
         Pgbus.logger.warn { "[Pgbus] Worker shutting down immediately!" }
+        Pgbus.stopping = true
         @lifecycle.transition_to!(:stopped)
         @wake_signal.notify!
         @pool.kill
@@ -210,6 +212,7 @@ module Pgbus
       def check_recycle
         return unless @lifecycle.running? && recycle_needed?
 
+        Pgbus.stopping = true
         @lifecycle.transition_to(:draining)
         @wake_signal.notify!
       end

--- a/spec/pgbus/active_job/pgbus_adapter_spec.rb
+++ b/spec/pgbus/active_job/pgbus_adapter_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe "ActiveJob::QueueAdapters::PgbusAdapter" do
   describe "#stopping?" do
     let(:adapter) { ActiveJob::QueueAdapters::PgbusAdapter.new }
 
+    around do |example|
+      original = Pgbus.stopping
+      Pgbus.stopping = false
+      example.run
+    ensure
+      Pgbus.stopping = original
+    end
+
     it "responds to stopping?" do
       expect(adapter).to respond_to(:stopping?)
     end
@@ -43,8 +51,6 @@ RSpec.describe "ActiveJob::QueueAdapters::PgbusAdapter" do
     it "returns true when Pgbus.stopping is set" do
       Pgbus.stopping = true
       expect(adapter.stopping?).to be true
-    ensure
-      Pgbus.stopping = false
     end
 
     it "returns false after Pgbus.stopping is cleared" do

--- a/spec/pgbus/active_job/pgbus_adapter_spec.rb
+++ b/spec/pgbus/active_job/pgbus_adapter_spec.rb
@@ -28,4 +28,29 @@ RSpec.describe "ActiveJob::QueueAdapters::PgbusAdapter" do
     adapter = ActiveJob::QueueAdapters::PgbusAdapter.new
     expect(adapter).to respond_to(:enqueue_all)
   end
+
+  describe "#stopping?" do
+    let(:adapter) { ActiveJob::QueueAdapters::PgbusAdapter.new }
+
+    it "responds to stopping?" do
+      expect(adapter).to respond_to(:stopping?)
+    end
+
+    it "returns false by default" do
+      expect(adapter.stopping?).to be false
+    end
+
+    it "returns true when Pgbus.stopping is set" do
+      Pgbus.stopping = true
+      expect(adapter.stopping?).to be true
+    ensure
+      Pgbus.stopping = false
+    end
+
+    it "returns false after Pgbus.stopping is cleared" do
+      Pgbus.stopping = true
+      Pgbus.stopping = false
+      expect(adapter.stopping?).to be false
+    end
+  end
 end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -36,19 +36,31 @@ RSpec.describe Pgbus::Process::Worker do
   end
 
   describe "#graceful_shutdown" do
+    before { worker.instance_variable_get(:@lifecycle).transition_to!(:running) }
+    after { Pgbus.stopping = false }
+
     it "transitions to draining state" do
-      worker.instance_variable_get(:@lifecycle).transition_to!(:running)
       worker.graceful_shutdown
       expect(worker.instance_variable_get(:@lifecycle).state).to eq(:draining)
+    end
+
+    it "sets Pgbus.stopping for ActiveJob::Continuation support" do
+      expect { worker.graceful_shutdown }.to change(Pgbus, :stopping).from(false).to(true)
     end
   end
 
   describe "#immediate_shutdown" do
+    before { worker.instance_variable_get(:@lifecycle).transition_to!(:running) }
+    after { Pgbus.stopping = false }
+
     it "transitions to stopped state and kills the pool" do
-      worker.instance_variable_get(:@lifecycle).transition_to!(:running)
       worker.immediate_shutdown
       expect(worker.instance_variable_get(:@lifecycle).state).to eq(:stopped)
       expect(pool).to have_received(:kill)
+    end
+
+    it "sets Pgbus.stopping for ActiveJob::Continuation support" do
+      expect { worker.immediate_shutdown }.to change(Pgbus, :stopping).from(false).to(true)
     end
   end
 


### PR DESCRIPTION
## Summary
- Add `stopping?` to `PgbusAdapter` for Rails 8.1 `ActiveJob::Continuation` support — continuable jobs can now checkpoint and re-enqueue during graceful shutdown/recycling
- Set `Pgbus.stopping` flag in worker's `graceful_shutdown`, `immediate_shutdown`, and `check_recycle` paths
- Fix migration docs that listed implemented features as "Planned" (recurring tasks, uniqueness, priorities, separate DB)

## Changes

### Code
- `lib/pgbus.rb` — `mattr_accessor :stopping` process-global flag
- `lib/active_job/queue_adapters/pgbus_adapter.rb` — `stopping?` reads the flag
- `lib/pgbus/process/worker.rb` — sets flag on all drain/stop transitions

### Docs
- `docs/switch_from_sidekiq.md` — replaced "What you lose" with accurate feature comparison
- `docs/switch_from_solid_queue.md` — recurring tasks, separate DB, priorities, uniqueness all marked as supported

## Test plan
- [x] 6 new specs (4 adapter, 2 worker) covering `stopping?` behavior
- [x] Full suite passes (712 examples, 0 failures)
- [x] Rubocop clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guides with feature-comparison tables mapping Sidekiq/Solid Queue features to Pgbus equivalents; clarified recurring job config, uniqueness, concurrency, priorities, and gotchas.

* **New Features**
  * Added a global stopping flag and ActiveJob::Continuation support so continuable jobs can observe shutdown and persist/re-enqueue checkpoints.

* **Tests**
  * Added/expanded tests verifying the stopping behavior and shutdown lifecycle integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->