### PR TITLE
fix(i18n): intersect pgbus locales with host app available_locales

### DIFF
--- a/app/controllers/pgbus/application_controller.rb
+++ b/app/controllers/pgbus/application_controller.rb
@@ -57,8 +57,11 @@ module Pgbus
     end
 
     def available_locales
-      @available_locales ||= Dir[Pgbus::Engine.root.join("config", "locales", "*.yml")]
-                             .map { |f| File.basename(f, ".yml").to_sym }
+      @available_locales ||= begin
+        pgbus_locales = Dir[Pgbus::Engine.root.join("config", "locales", "*.yml")]
+                        .map { |f| File.basename(f, ".yml").to_sym }
+        pgbus_locales & I18n.available_locales
+      end
     end
     helper_method :available_locales
 

--- a/spec/pgbus/web/locale_spec.rb
+++ b/spec/pgbus/web/locale_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe Pgbus::ApplicationController do
       it "only includes locales available in both pgbus and the host app" do
         expect(available_locales).to contain_exactly(:en, :de)
       end
-
-      it "excludes pgbus locales not available in the host app" do
-        expect(available_locales).not_to include(:pt, :fr, :ja)
-      end
     end
 
     context "when host app has all pgbus locales available" do

--- a/spec/pgbus/web/locale_spec.rb
+++ b/spec/pgbus/web/locale_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Pgbus::ApplicationController do
+  # Pgbus ships these locale files
+  let(:pgbus_shipped_locales) { %i[da de en es fi fr it ja nb nl pt sv] }
+
+  describe "#available_locales" do
+    subject(:available_locales) { controller.send(:available_locales) }
+
+    let(:controller) do
+      ctrl = described_class.allocate
+      ctrl.instance_variable_set(:@available_locales, nil)
+      ctrl
+    end
+
+    context "when host app enforces available_locales (default Rails behavior)" do
+      before do
+        allow(I18n).to receive(:available_locales).and_return(%i[en de])
+      end
+
+      it "only includes locales available in both pgbus and the host app" do
+        expect(available_locales).to contain_exactly(:en, :de)
+      end
+
+      it "excludes pgbus locales not available in the host app" do
+        expect(available_locales).not_to include(:pt, :fr, :ja)
+      end
+    end
+
+    context "when host app has all pgbus locales available" do
+      before do
+        allow(I18n).to receive(:available_locales).and_return(pgbus_shipped_locales)
+      end
+
+      it "includes all pgbus locales" do
+        expect(available_locales).to match_array(pgbus_shipped_locales)
+      end
+    end
+
+    context "when host app has locales pgbus doesn't ship" do
+      before do
+        allow(I18n).to receive(:available_locales).and_return(%i[en de zh kr])
+      end
+
+      it "only includes the intersection" do
+        expect(available_locales).to contain_exactly(:en, :de)
+      end
+    end
+  end
+end

--- a/spec/pgbus/web/locale_spec.rb
+++ b/spec/pgbus/web/locale_spec.rb
@@ -48,5 +48,15 @@ RSpec.describe Pgbus::ApplicationController do
         expect(available_locales).to contain_exactly(:en, :de)
       end
     end
+
+    context "when host app has no available locales" do
+      before do
+        allow(I18n).to receive(:available_locales).and_return([])
+      end
+
+      it "returns an empty array" do
+        expect(available_locales).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Pgbus dashboard's `available_locales` now returns the **intersection** of pgbus-shipped locales and `I18n.available_locales`, preventing `I18n::InvalidLocale` errors when the host app restricts available locales
- The locale switcher UI automatically shows only locales valid for both pgbus and the host application

## Root cause
The `available_locales` method scanned pgbus's `config/locales/*.yml` directory and returned all 12 shipped locales. When `I18n.enforce_available_locales` is `true` (Rails default), setting a locale the host app doesn't support (e.g. `pt`) raises `I18n::InvalidLocale`.

## Fix
One-line change: `pgbus_locales & I18n.available_locales` — intersects pgbus's locale files with the host app's configured locales.

## Test plan
- [x] Host app with `I18n.available_locales = [:en, :de]` — only `:en, :de` returned
- [x] Host app with all pgbus locales — all 12 returned  
- [x] Host app with extra locales pgbus doesn't ship (`:zh`) — only intersection returned
- [x] `bundle exec rubocop` passes
- [x] `bundle exec rspec` passes (716 examples, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Locale selection now only exposes locales that are both bundled with the system and registered in the application's locale configuration, preventing unexpected or unsupported locales from appearing.

* **Tests**
  * Added test coverage to validate locale filtering across scenarios (host-restricted locales, full shipped set, unsupported host locales, and no host locales) to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->