### PR TITLE
fix: ensure ApplicationRecord is loadable with selective railtie requires

### DIFF
--- a/app/controllers/pgbus/application_controller.rb
+++ b/app/controllers/pgbus/application_controller.rb
@@ -57,8 +57,11 @@ module Pgbus
     end
 
     def available_locales
-      @available_locales ||= Dir[Pgbus::Engine.root.join("config", "locales", "*.yml")]
-                             .map { |f| File.basename(f, ".yml").to_sym }
+      @available_locales ||= begin
+        pgbus_locales = Dir[Pgbus::Engine.root.join("config", "locales", "*.yml")]
+                        .map { |f| File.basename(f, ".yml").to_sym }
+        pgbus_locales & I18n.available_locales
+      end
     end
     helper_method :available_locales
 

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -27,6 +27,11 @@ module Pgbus
 
     initializer "pgbus.db" do
       ActiveSupport.on_load(:active_record) do
+        # When the host app uses selective railtie requires (require "rails" +
+        # individual railties) instead of require "rails/all", Zeitwerk may not
+        # have registered the engine's app/models path yet when this hook fires.
+        # Explicit require ensures the model is available regardless of boot order.
+        require_relative "../../app/models/pgbus/application_record"
         Pgbus::ApplicationRecord.connects_to(**Pgbus.configuration.connects_to) if Pgbus.configuration.connects_to
       end
     end

--- a/lib/pgbus/version.rb
+++ b/lib/pgbus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pgbus
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/spec/pgbus/web/locale_spec.rb
+++ b/spec/pgbus/web/locale_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe Pgbus::ApplicationController do
       it "only includes locales available in both pgbus and the host app" do
         expect(available_locales).to contain_exactly(:en, :de)
       end
-
-      it "excludes pgbus locales not available in the host app" do
-        expect(available_locales).not_to include(:pt, :fr, :ja)
-      end
     end
 
     context "when host app has all pgbus locales available" do

--- a/spec/pgbus/web/locale_spec.rb
+++ b/spec/pgbus/web/locale_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Pgbus::ApplicationController do
+  # Pgbus ships these locale files
+  let(:pgbus_shipped_locales) { %i[da de en es fi fr it ja nb nl pt sv] }
+
+  describe "#available_locales" do
+    subject(:available_locales) { controller.send(:available_locales) }
+
+    let(:controller) do
+      ctrl = described_class.allocate
+      ctrl.instance_variable_set(:@available_locales, nil)
+      ctrl
+    end
+
+    context "when host app enforces available_locales (default Rails behavior)" do
+      before do
+        allow(I18n).to receive(:available_locales).and_return(%i[en de])
+      end
+
+      it "only includes locales available in both pgbus and the host app" do
+        expect(available_locales).to contain_exactly(:en, :de)
+      end
+
+      it "excludes pgbus locales not available in the host app" do
+        expect(available_locales).not_to include(:pt, :fr, :ja)
+      end
+    end
+
+    context "when host app has all pgbus locales available" do
+      before do
+        allow(I18n).to receive(:available_locales).and_return(pgbus_shipped_locales)
+      end
+
+      it "includes all pgbus locales" do
+        expect(available_locales).to match_array(pgbus_shipped_locales)
+      end
+    end
+
+    context "when host app has locales pgbus doesn't ship" do
+      before do
+        allow(I18n).to receive(:available_locales).and_return(%i[en de zh kr])
+      end
+
+      it "only includes the intersection" do
+        expect(available_locales).to contain_exactly(:en, :de)
+      end
+    end
+  end
+end

--- a/spec/pgbus/web/locale_spec.rb
+++ b/spec/pgbus/web/locale_spec.rb
@@ -48,5 +48,15 @@ RSpec.describe Pgbus::ApplicationController do
         expect(available_locales).to contain_exactly(:en, :de)
       end
     end
+
+    context "when host app has no available locales" do
+      before do
+        allow(I18n).to receive(:available_locales).and_return([])
+      end
+
+      it "returns an empty array" do
+        expect(available_locales).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

When the host app uses `require "rails"` + individual railties instead of `require "rails/all"`, Zeitwerk may not have registered the engine's `app/models` path when the `on_load(:active_record)` hook fires. This causes:

```
uninitialized constant Pgbus::ApplicationRecord (NameError)
```

**Root cause**: The `pgbus.release_models_loader` initializer tears down the gem's own Zeitwerk loader (correct), but when the host app uses selective requires, Rails hasn't set up engine autoload paths yet by the time `on_load(:active_record)` fires. With `require "rails/all"`, everything loads in one shot so the timing works out.

**Fix**: Add `require_relative` for the model in the `pgbus.db` initializer, ensuring it's available regardless of boot order.

Discovered while migrating [Zazu](https://github.com/getzazu/app) from Solid Queue to pgbus.

## Test plan

- [x] Cosmos (uses `require "rails/all"`) — still boots fine
- [x] Zazu (uses selective railties) — now boots without NameError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed locale handling to only include locales supported by both the engine and your application's I18n configuration, preventing potential mismatches
  * Resolved initialization issues that could occur in certain Rails application loading scenarios

* **Tests**
  * Added comprehensive test coverage for locale filtering behavior across multiple configurations

* **Chores**
  * Version bump to 0.2.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->