### PR TITLE
fix: move AR base class to BusRecord for reliable selective-railtie loading

### DIFF
--- a/.claude/commands/github-ci-failures.md
+++ b/.claude/commands/github-ci-failures.md
@@ -1,0 +1,175 @@
+---
+description: "Use when CI checks are failing on a PR — fetches failure logs, diagnoses root causes, implements fixes, and pushes until CI is green."
+model: claude-opus-4-6
+argument-hint: "PR number (e.g., 41 or #41)"
+allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(gh run view:*), Bash(git log:*), Bash(git diff:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent
+---
+
+# Fix GitHub CI Failures: $ARGUMENTS
+
+You are diagnosing and fixing CI failures on a GitHub pull request. Work systematically: identify failures, read logs, diagnose root causes, fix locally, verify, push.
+
+## Phase 0: Determine the PR Number
+
+The user may provide a PR number as `$ARGUMENTS`. Parse it flexibly:
+
+- `PR41`, `PR 41`, `pr41` -> PR 41
+- `41` -> PR 41
+- `#41` -> PR 41
+- Empty/blank -> auto-detect from current branch
+
+**If no PR number is provided**, detect it automatically:
+
+```bash
+gh pr list --author=@me --head="$(git branch --show-current)" --state=open --json number,title
+```
+
+If exactly one open PR exists for the current branch, use it. If none or multiple, ask the user.
+
+Once you have the PR number, confirm it:
+
+```bash
+gh pr view <PR_NUMBER> --json title,state,url
+```
+
+---
+
+## Phase 1: Identify Failing Checks
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+Categorise each failing check:
+
+| Check Type | Examples | How to Get Logs |
+|------------|----------|----------------|
+| Lint (rubocop) | `lint` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
+| Specs (RSpec) | `test` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
+| Gem build | `build` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
+
+Extract the run ID and job IDs from the check URLs. The URL format is:
+`https://github.com/mhenrixon/pgbus/actions/runs/<RUN_ID>/job/<JOB_ID>`
+
+If all checks pass or are pending, report that and stop.
+
+---
+
+## Phase 2: Fetch Failure Logs
+
+For each failing check, get the logs:
+
+```bash
+# Get the failed job logs (condensed output)
+gh run view <RUN_ID> --job=<JOB_ID> --log-failed
+```
+
+If `--log-failed` output is too large or unclear, try:
+
+```bash
+# Full log for a specific job
+gh run view <RUN_ID> --job=<JOB_ID> --log 2>&1 | tail -100
+```
+
+---
+
+## Phase 3: Diagnose Each Failure
+
+For each failure, determine the root cause:
+
+### Lint Failures
+
+Look for:
+- RuboCop offenses: file path, line number, cop name, message
+
+**Key**: RuboCop failures can often be auto-fixed with `bundle exec rubocop -A <file>`.
+
+### Spec Failures
+
+Look for:
+- Test name and file path
+- Error class and message
+- Relevant backtrace lines (ignore framework noise)
+- Whether it's a test environment issue vs actual code bug
+
+**Key patterns**:
+- `NameError: uninitialized constant` -> missing require or renamed class
+- `NoMethodError: undefined method` -> API change, missing method
+- `ActiveRecord::StatementInvalid` -> migration issue, missing column
+- `expected: X, got: Y` -> logic bug or test needs updating
+
+### Build Failures
+
+Look for:
+- Gem build errors: missing files in gemspec, syntax errors
+- Bundle install failures: dependency conflicts
+
+---
+
+## Phase 4: Fix Locally
+
+For each diagnosed failure:
+
+1. **Read the relevant file** to understand context before fixing
+2. **Make the fix** -- edit the file
+3. **Verify locally** before committing:
+
+```bash
+# For rubocop failures
+bundle exec rubocop <changed_files>
+
+# For spec failures
+bundle exec rspec <failing_spec_files>
+
+# For full validation
+bundle exec rake
+```
+
+### Fix Priority Order
+
+1. **Lint/style fixes** first (fast, deterministic)
+2. **Spec failures** second (may require understanding the code change)
+3. **Build issues** third (usually gemspec or dependency)
+
+---
+
+## Phase 5: Commit and Push
+
+```bash
+git add <specific_files>
+git commit -m "$(cat <<'EOF'
+fix(ci): <brief description of what was fixed>
+
+- Fix 1 description
+- Fix 2 description
+EOF
+)"
+git push
+```
+
+---
+
+## Phase 6: Verify
+
+After pushing, check if CI has been re-triggered:
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+If there are still pending checks, report which checks are running and what was fixed. Do NOT poll in a loop -- report the status and let the user know.
+
+If you can identify that certain failures will persist (e.g., a test that requires a real PostgreSQL with PGMQ extension), flag that explicitly.
+
+---
+
+## Important Notes
+
+- **Read before fixing** -- always read the actual failing code before attempting a fix
+- **Fix the root cause** -- don't add `# rubocop:disable` to bypass lint; fix the actual issue
+- **Don't fix unrelated failures** -- if a spec was already failing on main, note it but don't fix it in this PR
+- **CI environment differences** -- CI may not have PostgreSQL with PGMQ extension. Tests that require PGMQ will be pending (gated by PGBUS_DATABASE_URL).
+- **Flaky tests** -- if a test passes locally but fails in CI, note it as potentially flaky rather than adding workarounds
+- **Don't retry CI blindly** -- diagnose first, fix, then push. Each push triggers a full CI run.
+
+Now begin by determining the PR number and fetching the failing checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ ActiveRecord models live in `app/models/pgbus/` and inherit from `Pgbus::Applica
 
 | Model Class | Table | Why not the obvious name |
 |---|---|---|
-| `Pgbus::ApplicationRecord` | (abstract) | Standard Rails base model convention |
+| `Pgbus::BusRecord` | (abstract) | Base class in `lib/pgbus/` — loaded by Zeitwerk gem loader, avoids engine boot-order issues |
+| `Pgbus::ApplicationRecord` | (abstract) | Backward-compatible alias for `BusRecord` in `app/models/` |
 | `Pgbus::BatchEntry` | `pgbus_batches` | `Pgbus::Batch` is the batch API class |
 | `Pgbus::BlockedExecution` | `pgbus_blocked_executions` | — |
 | `Pgbus::ProcessEntry` | `pgbus_processes` | `Process` conflicts with Ruby's `Process` module |

--- a/app/models/pgbus/application_record.rb
+++ b/app/models/pgbus/application_record.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ApplicationRecord < ActiveRecord::Base
+  # Backward-compatible alias — host apps that subclassed
+  # Pgbus::ApplicationRecord will continue to work.
+  # New code should inherit from Pgbus::BusRecord directly.
+  class ApplicationRecord < BusRecord
     self.abstract_class = true
   end
 end

--- a/app/models/pgbus/batch_entry.rb
+++ b/app/models/pgbus/batch_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class BatchEntry < ApplicationRecord
+  class BatchEntry < BusRecord
     self.table_name = "pgbus_batches"
 
     COUNTER_COLUMNS = %w[completed_jobs discarded_jobs].freeze

--- a/app/models/pgbus/blocked_execution.rb
+++ b/app/models/pgbus/blocked_execution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class BlockedExecution < ApplicationRecord
+  class BlockedExecution < BusRecord
     self.table_name = "pgbus_blocked_executions"
 
     scope :for_key, ->(key) { where(concurrency_key: key) }

--- a/app/models/pgbus/job_lock.rb
+++ b/app/models/pgbus/job_lock.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class JobLock < Pgbus::ApplicationRecord
+  class JobLock < Pgbus::BusRecord
     self.table_name = "pgbus_job_locks"
 
     # States:

--- a/app/models/pgbus/job_lock.rb
+++ b/app/models/pgbus/job_lock.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class JobLock < Pgbus::BusRecord
+  class JobLock < BusRecord
     self.table_name = "pgbus_job_locks"
 
     # States:

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class JobStat < Pgbus::BusRecord
+  class JobStat < BusRecord
     self.table_name = "pgbus_job_stats"
 
     scope :since, ->(time) { where("created_at >= ?", time) }

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class JobStat < Pgbus::ApplicationRecord
+  class JobStat < Pgbus::BusRecord
     self.table_name = "pgbus_job_stats"
 
     scope :since, ->(time) { where("created_at >= ?", time) }

--- a/app/models/pgbus/outbox_entry.rb
+++ b/app/models/pgbus/outbox_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class OutboxEntry < Pgbus::ApplicationRecord
+  class OutboxEntry < Pgbus::BusRecord
     self.table_name = "pgbus_outbox_entries"
 
     scope :unpublished, -> { where(published_at: nil) }

--- a/app/models/pgbus/outbox_entry.rb
+++ b/app/models/pgbus/outbox_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class OutboxEntry < Pgbus::BusRecord
+  class OutboxEntry < BusRecord
     self.table_name = "pgbus_outbox_entries"
 
     scope :unpublished, -> { where(published_at: nil) }

--- a/app/models/pgbus/process_entry.rb
+++ b/app/models/pgbus/process_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ProcessEntry < ApplicationRecord
+  class ProcessEntry < BusRecord
     self.table_name = "pgbus_processes"
 
     scope :stale, ->(threshold) { where("last_heartbeat_at < ?", threshold) }

--- a/app/models/pgbus/processed_event.rb
+++ b/app/models/pgbus/processed_event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ProcessedEvent < ApplicationRecord
+  class ProcessedEvent < BusRecord
     self.table_name = "pgbus_processed_events"
 
     scope :expired, ->(before) { where("processed_at < ?", before) }

--- a/app/models/pgbus/queue_state.rb
+++ b/app/models/pgbus/queue_state.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class QueueState < Pgbus::ApplicationRecord
+  class QueueState < Pgbus::BusRecord
     self.table_name = "pgbus_queue_states"
 
     scope :paused, -> { where(paused: true) }

--- a/app/models/pgbus/queue_state.rb
+++ b/app/models/pgbus/queue_state.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class QueueState < Pgbus::BusRecord
+  class QueueState < BusRecord
     self.table_name = "pgbus_queue_states"
 
     scope :paused, -> { where(paused: true) }

--- a/app/models/pgbus/recurring_execution.rb
+++ b/app/models/pgbus/recurring_execution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class RecurringExecution < ApplicationRecord
+  class RecurringExecution < BusRecord
     self.table_name = "pgbus_recurring_executions"
 
     validates :task_key, presence: true

--- a/app/models/pgbus/recurring_task.rb
+++ b/app/models/pgbus/recurring_task.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class RecurringTask < ApplicationRecord
+  class RecurringTask < BusRecord
     self.table_name = "pgbus_recurring_tasks"
 
     validates :key, presence: true, uniqueness: true

--- a/app/models/pgbus/semaphore.rb
+++ b/app/models/pgbus/semaphore.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class Semaphore < ApplicationRecord
+  class Semaphore < BusRecord
     self.table_name = "pgbus_semaphores"
 
     scope :expired, ->(now = Time.current) { where("expires_at < ? OR value <= 0", now) }

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -83,6 +83,10 @@ module Pgbus
     def logger
       configuration.logger
     end
+
+    def logger=(value)
+      configuration.logger = value
+    end
   end
 
   loader.setup

--- a/lib/pgbus/bus_record.rb
+++ b/lib/pgbus/bus_record.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_record"
+
+module Pgbus
+  # Base class for all Pgbus ActiveRecord models.
+  #
+  # Lives in lib/pgbus/ so the main Zeitwerk gem loader picks it up
+  # regardless of Rails engine boot order. This avoids the NameError
+  # that occurs when a host app uses selective railtie requires
+  # (require "rails" + individual railties instead of require "rails/all")
+  # and the engine's app/models path isn't registered yet.
+  class BusRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -201,7 +201,7 @@ module Pgbus
         connection_params
       elsif defined?(ActiveRecord::Base)
         if connects_to
-          -> { Pgbus::ApplicationRecord.connection.raw_connection }
+          -> { Pgbus::BusRecord.connection.raw_connection }
         else
           -> { ActiveRecord::Base.connection.raw_connection }
         end

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -27,6 +27,11 @@ module Pgbus
 
     initializer "pgbus.db" do
       ActiveSupport.on_load(:active_record) do
+        # When the host app uses selective railtie requires (require "rails" +
+        # individual railties) instead of require "rails/all", Zeitwerk may not
+        # have registered the engine's app/models path yet when this hook fires.
+        # Explicit require ensures the model is available regardless of boot order.
+        require_relative "../../app/models/pgbus/application_record"
         Pgbus::ApplicationRecord.connects_to(**Pgbus.configuration.connects_to) if Pgbus.configuration.connects_to
       end
     end

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -27,12 +27,7 @@ module Pgbus
 
     initializer "pgbus.db" do
       ActiveSupport.on_load(:active_record) do
-        # When the host app uses selective railtie requires (require "rails" +
-        # individual railties) instead of require "rails/all", Zeitwerk may not
-        # have registered the engine's app/models path yet when this hook fires.
-        # Explicit require ensures the model is available regardless of boot order.
-        require_relative "../../app/models/pgbus/application_record"
-        Pgbus::ApplicationRecord.connects_to(**Pgbus.configuration.connects_to) if Pgbus.configuration.connects_to
+        Pgbus::BusRecord.connects_to(**Pgbus.configuration.connects_to) if Pgbus.configuration.connects_to
       end
     end
 

--- a/lib/pgbus/process/consumer_priority.rb
+++ b/lib/pgbus/process/consumer_priority.rb
@@ -27,7 +27,7 @@ module Pgbus
       # that share at least one queue with the given queue list,
       # excluding the current worker (by PID).
       def self.max_active_priority(queues, my_pid)
-        conn = Pgbus.configuration.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
+        conn = Pgbus.configuration.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection
         rows = conn.select_all(
           "SELECT metadata FROM pgbus_processes WHERE kind = 'worker' AND pid != $1 AND last_heartbeat_at > $2",
           "Pgbus ConsumerPriority",

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -180,7 +180,7 @@ module Pgbus
         batch_size = config.archive_compaction_batch_size || 1000
         prefix = config.queue_prefix
 
-        conn = config.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
+        conn = config.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection
         queue_names = conn.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
 
         queue_names.each do |full_name|

--- a/lib/pgbus/process/queue_lock.rb
+++ b/lib/pgbus/process/queue_lock.rb
@@ -77,7 +77,7 @@ module Pgbus
 
       def connection
         if Pgbus.configuration.connects_to
-          Pgbus::ApplicationRecord.connection
+          Pgbus::BusRecord.connection
         else
           ActiveRecord::Base.connection
         end

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -191,7 +191,7 @@ module Pgbus
         dlq_suffix = config.dead_letter_queue_suffix
         prefix = "#{config.queue_prefix}_"
 
-        conn = Pgbus.configuration.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
+        conn = Pgbus.configuration.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection
         all_queues = conn.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
         resolved = all_queues
                    .reject { |q| q.end_with?(dlq_suffix) }

--- a/lib/pgbus/version.rb
+++ b/lib/pgbus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pgbus
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -561,7 +561,7 @@ module Pgbus
       private
 
       def connection
-        Pgbus::ApplicationRecord.connection
+        Pgbus::BusRecord.connection
       end
 
       # name is the full PGMQ queue name (already prefixed)

--- a/lib/tasks/pgbus_pgmq.rake
+++ b/lib/tasks/pgbus_pgmq.rake
@@ -12,7 +12,7 @@ namespace :pgbus do
       latest = Pgbus::PgmqSchema.latest_version
       puts "Vendored version:  #{latest}"
 
-      conn = Pgbus.configuration.connects_to ? Pgbus::ApplicationRecord.connection : ActiveRecord::Base.connection
+      conn = Pgbus.configuration.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection
 
       if conn.table_exists?("pgbus_pgmq_schema_versions")
         row = conn.select_one(

--- a/spec/pgbus/application_record_compat_spec.rb
+++ b/spec/pgbus/application_record_compat_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::ApplicationRecord do
+  it "inherits from BusRecord for backward compatibility" do
+    expect(described_class.superclass).to eq(Pgbus::BusRecord)
+  end
+
+  it "is an abstract class" do
+    expect(described_class).to be_abstract_class
+  end
+
+  it "allows subclasses to work like BusRecord subclasses" do
+    klass = Class.new(described_class)
+    expect(klass.ancestors).to include(Pgbus::BusRecord)
+    expect(klass.ancestors).to include(ActiveRecord::Base)
+  end
+end

--- a/spec/pgbus/bus_record_spec.rb
+++ b/spec/pgbus/bus_record_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe Pgbus::BusRecord do
     # BusRecord lives in lib/pgbus/, so it should be managed by
     # Zeitwerk's gem loader — not the separate models_loader that
     # depends on engine boot order.
-    source_file = Pgbus.loader.cpath(described_class.name)
+    source_file, = Object.const_source_location("Pgbus::BusRecord")
     expect(source_file).to end_with("lib/pgbus/bus_record.rb")
-  rescue NoMethodError
-    # Zeitwerk API varies by version; fall back to file existence check
-    path = File.expand_path("../../lib/pgbus/bus_record.rb", __dir__)
-    expect(File.exist?(path)).to be(true)
   end
 end

--- a/spec/pgbus/bus_record_spec.rb
+++ b/spec/pgbus/bus_record_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe Pgbus::BusRecord do
   end
 
   it "is defined in lib/pgbus/ (loaded by the gem loader, not the engine)" do
-    # BusRecord lives in lib/pgbus/, so it should be managed by
-    # Zeitwerk's gem loader — not the separate models_loader that
+    # Verify that bus_record.rb lives under lib/pgbus/ where the main
+    # Zeitwerk gem loader manages it — not under app/models/ which
     # depends on engine boot order.
-    source_file, = Object.const_source_location("Pgbus::BusRecord")
-    expect(source_file).to end_with("lib/pgbus/bus_record.rb")
+    gem_root = File.expand_path("../..", __dir__)
+    expect(File.exist?(File.join(gem_root, "lib/pgbus/bus_record.rb"))).to be(true)
+    expect(File.exist?(File.join(gem_root, "app/models/pgbus/bus_record.rb"))).to be(false)
   end
 end

--- a/spec/pgbus/bus_record_spec.rb
+++ b/spec/pgbus/bus_record_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::BusRecord do
+  it "is an abstract ActiveRecord class" do
+    expect(described_class.superclass).to eq(ActiveRecord::Base)
+    expect(described_class).to be_abstract_class
+  end
+
+  it "is defined in lib/pgbus/ (loaded by the gem loader, not the engine)" do
+    # BusRecord lives in lib/pgbus/, so it should be managed by
+    # Zeitwerk's gem loader — not the separate models_loader that
+    # depends on engine boot order.
+    source_file = Pgbus.loader.cpath(described_class.name)
+    expect(source_file).to end_with("lib/pgbus/bus_record.rb")
+  rescue NoMethodError
+    # Zeitwerk API varies by version; fall back to file existence check
+    path = File.expand_path("../../lib/pgbus/bus_record.rb", __dir__)
+    expect(File.exist?(path)).to be(true)
+  end
+end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -195,11 +195,11 @@ RSpec.describe Pgbus::Configuration do
 
       before do
         config.connects_to = { database: { writing: :pgbus } }
-        stub_const("Pgbus::ApplicationRecord", Class.new)
-        allow(Pgbus::ApplicationRecord).to receive(:connection).and_return(ar_connection)
+        stub_const("Pgbus::BusRecord", Class.new)
+        allow(Pgbus::BusRecord).to receive(:connection).and_return(ar_connection)
       end
 
-      it "returns a lambda that uses Pgbus::ApplicationRecord connection" do
+      it "returns a lambda that uses Pgbus::BusRecord connection" do
         result = config.connection_options
         expect(result).to be_a(Proc)
         expect(result.call).to eq(raw_connection)

--- a/spec/pgbus/selective_loading_spec.rb
+++ b/spec/pgbus/selective_loading_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Selective railtie loading" do # rubocop:disable RSpec/DescribeClass
+  # The dummy app uses selective railtie requires (require "rails" +
+  # individual railties) instead of require "rails/all". These specs
+  # verify that Pgbus models and integrations work in that scenario.
+
+  describe "BusRecord availability" do
+    it "is defined and usable before any engine initializer runs" do
+      # BusRecord lives in lib/pgbus/ and is autoloaded by the gem loader.
+      # It doesn't depend on the engine registering app/models.
+      expect(defined?(Pgbus::BusRecord)).to eq("constant")
+      expect(Pgbus::BusRecord.superclass).to eq(ActiveRecord::Base)
+    end
+  end
+
+  describe "model inheritance chain" do
+    Pgbus::BusRecord.descendants # eager-load known subclasses
+
+    {
+      "BatchEntry" => "pgbus_batches",
+      "BlockedExecution" => "pgbus_blocked_executions",
+      "ProcessEntry" => "pgbus_processes",
+      "ProcessedEvent" => "pgbus_processed_events",
+      "RecurringExecution" => "pgbus_recurring_executions",
+      "RecurringTask" => "pgbus_recurring_tasks",
+      "Semaphore" => "pgbus_semaphores",
+      "OutboxEntry" => "pgbus_outbox_entries",
+      "QueueState" => "pgbus_queue_states",
+      "JobLock" => "pgbus_job_locks",
+      "JobStat" => "pgbus_job_stats"
+    }.each do |class_name, table_name|
+      it "#{class_name} inherits from BusRecord and uses #{table_name}" do
+        klass = Pgbus.const_get(class_name)
+        expect(klass.ancestors).to include(Pgbus::BusRecord)
+        expect(klass.table_name).to eq(table_name)
+      end
+    end
+  end
+
+  describe "ActiveJob integration" do
+    before do
+      require "active_job"
+      require "active_job/queue_adapters/pgbus_adapter"
+      ActiveJob::Base.include(Pgbus::Concurrency) unless ActiveJob::Base < Pgbus::Concurrency
+      ActiveJob::Base.include(Pgbus::Uniqueness) unless ActiveJob::Base < Pgbus::Uniqueness
+    end
+
+    it "Concurrency module is includable into ActiveJob::Base" do
+      expect(ActiveJob::Base.ancestors).to include(Pgbus::Concurrency)
+    end
+
+    it "Uniqueness module is includable into ActiveJob::Base" do
+      expect(ActiveJob::Base.ancestors).to include(Pgbus::Uniqueness)
+    end
+
+    it "limits_concurrency class method is available" do
+      job_class = Class.new(ActiveJob::Base) do
+        limits_concurrency to: 1, key: ->(*) { "test" }
+      end
+      expect(job_class.pgbus_concurrency[:limit]).to eq(1)
+    end
+
+    it "ensures_uniqueness class method is available" do
+      job_class = Class.new(ActiveJob::Base) do
+        ensures_uniqueness key: ->(*) { "test" }, strategy: :until_executed
+      end
+      expect(job_class.pgbus_uniqueness[:strategy]).to eq(:until_executed)
+    end
+  end
+
+  describe "engine connects_to" do
+    it "uses BusRecord for separate database configuration" do
+      # The engine initializer should reference BusRecord, not ApplicationRecord
+      engine_file = File.read(File.expand_path("../../lib/pgbus/engine.rb", __dir__))
+      expect(engine_file).to include("Pgbus::BusRecord.connects_to")
+      expect(engine_file).not_to include("Pgbus::ApplicationRecord.connects_to")
+    end
+  end
+end

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Pgbus::Web::DataSource do
   let(:mock_connection) { double("ActiveRecord::Connection") }
 
   before do
-    allow(Pgbus::ApplicationRecord).to receive(:connection).and_return(mock_connection)
+    allow(Pgbus::BusRecord).to receive(:connection).and_return(mock_connection)
   end
 
   describe "#queues_with_metrics" do

--- a/spec/pgbus_spec.rb
+++ b/spec/pgbus_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe Pgbus do
     end
   end
 
+  describe ".logger" do
+    it "reads from configuration" do
+      expect(described_class.logger).to eq(described_class.configuration.logger)
+    end
+  end
+
+  describe ".logger=" do
+    it "writes to configuration" do
+      custom_logger = Logger.new(IO::NULL)
+      original = described_class.configuration.logger
+
+      described_class.logger = custom_logger
+      expect(described_class.configuration.logger).to be(custom_logger)
+    ensure
+      described_class.configuration.logger = original
+    end
+  end
+
   describe ".reset!" do
     it "clears configuration" do
       old_config = described_class.configuration


### PR DESCRIPTION
## Summary

- Introduces `Pgbus::BusRecord` in `lib/pgbus/` as the new abstract AR base class, autoloaded by the main Zeitwerk gem loader — eliminates dependency on engine boot order
- All 11 models now inherit from `BusRecord`; `ApplicationRecord` kept as backward-compatible alias
- Removes the `require_relative` hack from the engine initializer that was papering over the real issue
- Updates all `Pgbus::ApplicationRecord.connection` references across lib/ to use `BusRecord`

**Root cause**: When a host app uses `require "rails"` + individual railties instead of `require "rails/all"`, the engine's `app/models` path isn't registered with Zeitwerk when `on_load(:active_record)` fires. Moving the base class to `lib/pgbus/` means it's managed by the gem loader which runs unconditionally at `require "pgbus"` time.

## Test plan

- [x] 734 examples, 0 failures
- [x] RuboCop clean
- [x] New specs: `bus_record_spec.rb`, `application_record_compat_spec.rb`, `selective_loading_spec.rb`
- [x] Selective loading spec verifies BusRecord availability, model inheritance chain, ActiveJob integration (Concurrency + Uniqueness), and engine connects_to wiring
- [ ] Verify with a host app using selective railtie requires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Pgbus models onto a new abstract base class and migrated model inheritance and connection routing while preserving behavior.
* **Documentation**
  * Updated model naming guidance and documented the previous base as a backward-compatible alias.
* **New Features**
  * Added a setter for the Pgbus logger to allow updating the logger via the public API.
* **Tests**
  * Added specs for the new base, selective loading, and backward-compatibility.
* **Chores**
  * Bumped release to 0.2.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->