### PR TITLE
feat: configurable base_controller_class for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ end
 
 When `base_controller_class` is set, all dashboard controllers inherit from that class instead of `ActionController::Base`. This is the recommended approach when mounting the dashboard inside an authenticated namespace -- your base controller's `before_action` filters, helper methods, and authentication logic apply automatically without monkey-patching.
 
+Add a "back to app" button in the dashboard nav to return to your main application:
+
+```ruby
+Pgbus.configure do |config|
+  config.return_to_app_url = "/admin"
+end
+```
+
 ## Concurrency controls
 
 Limit how many jobs with the same key can run concurrently:
@@ -635,6 +643,7 @@ The dispatcher runs archive compaction as part of its maintenance loop, deleting
 | `outbox_retention` | `86400` | Seconds to keep published outbox entries (1 day) |
 | `idempotency_ttl` | `604800` | Seconds to keep processed event records (7 days, cleaned hourly) |
 | `base_controller_class` | `"::ActionController::Base"` | Base class for dashboard controllers (string, constantized at load time) |
+| `return_to_app_url` | `nil` | URL for "back to app" button in dashboard nav (nil hides the button) |
 | `web_auth` | `nil` | Lambda for dashboard authentication |
 | `web_refresh_interval` | `5000` | Dashboard auto-refresh interval in milliseconds |
 | `web_live_updates` | `true` | Enable Turbo Frames auto-refresh on dashboard |

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ mount Pgbus::Engine => "/pgbus"
 
 The dashboard shows queues, jobs, processes, failures, dead letter messages, and event subscribers. It auto-refreshes via Turbo Frames with no WebSocket dependency.
 
-Protect it in production:
+Protect it in production with a simple auth lambda:
 
 ```ruby
 Pgbus.configure do |config|
@@ -220,6 +220,16 @@ Pgbus.configure do |config|
   }
 end
 ```
+
+Or inherit from your own authenticated controller (like mission_control-jobs):
+
+```ruby
+Pgbus.configure do |config|
+  config.base_controller_class = "Admin::BaseController"
+end
+```
+
+When `base_controller_class` is set, all dashboard controllers inherit from that class instead of `ActionController::Base`. This is the recommended approach when mounting the dashboard inside an authenticated namespace -- your base controller's `before_action` filters, helper methods, and authentication logic apply automatically without monkey-patching.
 
 ## Concurrency controls
 
@@ -624,6 +634,7 @@ The dispatcher runs archive compaction as part of its maintenance loop, deleting
 | `outbox_batch_size` | `100` | Max entries per outbox poll cycle |
 | `outbox_retention` | `86400` | Seconds to keep published outbox entries (1 day) |
 | `idempotency_ttl` | `604800` | Seconds to keep processed event records (7 days, cleaned hourly) |
+| `base_controller_class` | `"::ActionController::Base"` | Base class for dashboard controllers (string, constantized at load time) |
 | `web_auth` | `nil` | Lambda for dashboard authentication |
 | `web_refresh_interval` | `5000` | Dashboard auto-refresh interval in milliseconds |
 | `web_live_updates` | `true` | Enable Turbo Frames auto-refresh on dashboard |

--- a/app/controllers/pgbus/application_controller.rb
+++ b/app/controllers/pgbus/application_controller.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 module Pgbus
-  class ApplicationController < ActionController::Base
+  class ApplicationController < Pgbus.configuration.base_controller_class.constantize
+    # Ensure core ActionController modules are available even when the
+    # base controller is a slim subclass that may not include them all.
+    ActionController::Base::MODULES.each do |mod|
+      include mod unless self < mod
+    end
+
     include Web::Authentication
 
     protect_from_forgery with: :exception
@@ -10,7 +16,7 @@ module Pgbus
 
     layout "pgbus/application"
 
-    helper Pgbus::ApplicationHelper
+    helper Pgbus::ApplicationHelper unless self < Pgbus::ApplicationHelper
 
     # Make `pgbus` route proxy available in views (e.g. pgbus.root_path).
     # With isolate_namespace, the non-prefixed helpers (root_path) work inside

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -158,6 +158,16 @@ module Pgbus
       link_to label, path, class: css
     end
 
+    def pgbus_mobile_nav_link(label, path)
+      active = request.path == path || (path != pgbus.root_path && request.path.start_with?(path))
+      css = if active
+              "block rounded-md px-3 py-2 text-base font-medium text-white bg-gray-800"
+            else
+              "block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:text-white hover:bg-gray-700"
+            end
+      link_to label, path, class: css
+    end
+
     LOCALE_NAMES = {
       da: "Dansk",
       de: "Deutsch",

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -9,6 +9,43 @@
        Applied before Tailwind CDN loads so the background is correct immediately. */
     html.dark { background-color: #030712; } /* gray-950 */
     html.dark body { background-color: #030712; }
+
+    /* Responsive tables: stack rows as cards on small screens */
+    @media (max-width: 1023px) {
+      .pgbus-table thead { display: none; }
+      .pgbus-table tbody tr {
+        display: block;
+        margin-bottom: 0.75rem;
+        border-radius: 0.5rem;
+        padding: 0.75rem;
+        border: 1px solid #e5e7eb;
+      }
+      html.dark .pgbus-table tbody tr { border-color: #374151; }
+      .pgbus-table tbody td {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 0.25rem 0;
+        border: none;
+        text-align: right;
+      }
+      .pgbus-table tbody td::before {
+        content: attr(data-label);
+        font-weight: 600;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        color: #6b7280;
+        text-align: left;
+        margin-right: 1rem;
+        flex-shrink: 0;
+      }
+      html.dark .pgbus-table tbody td::before { color: #9ca3af; }
+      .pgbus-table tbody td[colspan] {
+        display: block;
+        text-align: center;
+      }
+      .pgbus-table tbody td[colspan]::before { display: none; }
+    }
   </style>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -52,8 +89,10 @@
         if (document.hidden) return;
         document.querySelectorAll("turbo-frame[data-auto-refresh]")
           .forEach(frame => {
-            if (!frame.src && frame.dataset.src) frame.src = frame.dataset.src;
-            if (frame.src) frame.reload();
+            try {
+              if (!frame.src && frame.dataset.src) frame.src = frame.dataset.src;
+              if (frame.src) frame.reload();
+            } catch (_) { /* Turbo may abort in-flight fetches during navigation */ }
           });
       }
       function start() { timer = setInterval(refreshFrames, interval); }

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -62,10 +62,19 @@
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-14 items-center justify-between">
           <div class="flex items-center space-x-8">
-            <%= link_to pgbus.root_path, class: "flex items-center space-x-2" do %>
-              <span class="text-lg font-bold text-white"><%= t("pgbus.layout.brand") %></span>
-              <span class="rounded bg-gray-700 px-1.5 py-0.5 text-xs text-gray-300"><%= Pgbus::VERSION %></span>
-            <% end %>
+            <div class="flex items-center space-x-3">
+              <% if Pgbus.configuration.return_to_app_url %>
+                <a href="<%= Pgbus.configuration.return_to_app_url %>" class="rounded-md p-1.5 text-gray-400 hover:text-white hover:bg-gray-700" title="<%= t("pgbus.layout.return_to_app") %>">
+                  <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"/>
+                  </svg>
+                </a>
+              <% end %>
+              <%= link_to pgbus.root_path, class: "flex items-center space-x-2" do %>
+                <span class="text-lg font-bold text-white"><%= t("pgbus.layout.brand") %></span>
+                <span class="rounded bg-gray-700 px-1.5 py-0.5 text-xs text-gray-300"><%= Pgbus::VERSION %></span>
+              <% end %>
+            </div>
 
             <div class="flex space-x-1">
               <%= pgbus_nav_link t("pgbus.layout.nav.dashboard"), pgbus.root_path %>

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -23,6 +23,15 @@
       var isDark = document.documentElement.classList.toggle('dark');
       localStorage.setItem('pgbus-dark', isDark);
     }
+    // Mobile menu toggle
+    function toggleMobileMenu() {
+      var menu = document.getElementById('pgbus-mobile-menu');
+      var openIcon = document.getElementById('pgbus-menu-open');
+      var closeIcon = document.getElementById('pgbus-menu-close');
+      menu.classList.toggle('hidden');
+      openIcon.classList.toggle('hidden');
+      closeIcon.classList.toggle('hidden');
+    }
     // Close locale dropdown when clicking outside
     document.addEventListener('click', function(e) {
       var switcher = document.getElementById('pgbus-locale-switcher');
@@ -61,6 +70,7 @@
     <nav class="bg-gray-900 dark:bg-gray-950 border-b border-gray-800">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-14 items-center justify-between">
+          <!-- Left: brand + desktop nav -->
           <div class="flex items-center space-x-8">
             <div class="flex items-center space-x-3">
               <% if Pgbus.configuration.return_to_app_url %>
@@ -76,7 +86,8 @@
               <% end %>
             </div>
 
-            <div class="flex space-x-1">
+            <!-- Desktop nav links (hidden on small screens) -->
+            <div class="hidden lg:flex space-x-1">
               <%= pgbus_nav_link t("pgbus.layout.nav.dashboard"), pgbus.root_path %>
               <%= pgbus_nav_link t("pgbus.layout.nav.queues"), pgbus.queues_path %>
               <%= pgbus_nav_link t("pgbus.layout.nav.jobs"), pgbus.jobs_path %>
@@ -90,6 +101,7 @@
             </div>
           </div>
 
+          <!-- Right: locale, dark mode, hamburger -->
           <div class="flex items-center space-x-2">
             <!-- Locale switcher -->
             <div class="relative" id="pgbus-locale-switcher">
@@ -107,15 +119,44 @@
               </div>
             </div>
 
-          <button onclick="toggleDarkMode()" class="rounded-md p-2 text-gray-400 hover:text-white focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-900" aria-label="<%= t("pgbus.layout.toggle_dark_mode") %>">
-            <svg class="h-5 w-5 hidden dark:block" fill="currentColor" viewBox="0 0 20 20">
-              <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/>
-            </svg>
-            <svg class="h-5 w-5 block dark:hidden" fill="currentColor" viewBox="0 0 20 20">
-              <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
-            </svg>
-          </button>
+            <!-- Dark mode toggle -->
+            <button onclick="toggleDarkMode()" class="rounded-md p-2 text-gray-400 hover:text-white focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-900" aria-label="<%= t("pgbus.layout.toggle_dark_mode") %>">
+              <svg class="h-5 w-5 hidden dark:block" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/>
+              </svg>
+              <svg class="h-5 w-5 block dark:hidden" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+              </svg>
+            </button>
+
+            <!-- Mobile menu button (hidden on large screens) -->
+            <button onclick="toggleMobileMenu()" class="lg:hidden rounded-md p-2 text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="<%= t("pgbus.layout.toggle_menu") %>">
+              <!-- Hamburger icon -->
+              <svg id="pgbus-menu-open" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/>
+              </svg>
+              <!-- Close icon (hidden by default) -->
+              <svg id="pgbus-menu-close" class="hidden h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+              </svg>
+            </button>
           </div>
+        </div>
+      </div>
+
+      <!-- Mobile menu (hidden by default, shown on small screens when toggled) -->
+      <div id="pgbus-mobile-menu" class="hidden lg:hidden border-t border-gray-800">
+        <div class="space-y-1 px-3 py-3">
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.dashboard"), pgbus.root_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.queues"), pgbus.queues_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.jobs"), pgbus.jobs_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.recurring"), pgbus.recurring_tasks_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.processes"), pgbus.processes_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.events"), pgbus.events_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.dlq"), pgbus.dead_letter_index_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.outbox"), pgbus.outbox_index_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.locks"), pgbus.locks_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.insights"), pgbus.insights_path %>
         </div>
       </div>
     </nav>

--- a/app/views/pgbus/dashboard/_processes_table.html.erb
+++ b/app/views/pgbus/dashboard/_processes_table.html.erb
@@ -2,7 +2,7 @@
   <div>
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.dashboard.processes_table.title") %></h2>
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">
           <tr>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.processes_table.headers.kind") %></th>
@@ -14,10 +14,10 @@
         <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
           <% @processes.each do |p| %>
             <tr>
-              <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white"><%= p[:kind] %></td>
-              <td class="px-4 py-3 text-sm text-gray-500"><%= p[:hostname] %></td>
-              <td class="px-4 py-3 text-sm text-gray-500"><%= p[:pid] %></td>
-              <td class="px-4 py-3 text-sm"><%= pgbus_status_badge(p[:healthy]) %></td>
+              <td data-label="Kind" class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white"><%= p[:kind] %></td>
+              <td data-label="Host" class="px-4 py-3 text-sm text-gray-500"><%= p[:hostname] %></td>
+              <td data-label="PID" class="px-4 py-3 text-sm text-gray-500"><%= p[:pid] %></td>
+              <td data-label="Status" class="px-4 py-3 text-sm"><%= pgbus_status_badge(p[:healthy]) %></td>
             </tr>
           <% end %>
           <% if @processes.empty? %>

--- a/app/views/pgbus/dashboard/_queues_table.html.erb
+++ b/app/views/pgbus/dashboard/_queues_table.html.erb
@@ -6,7 +6,7 @@
     </div>
 
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">
           <tr>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.queues_table.headers.queue") %></th>
@@ -19,14 +19,14 @@
         <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
           <% @queues.each do |q| %>
             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-              <td class="px-4 py-3 text-sm">
+              <td data-label="Queue" class="px-4 py-3 text-sm">
                 <%= link_to q[:name], pgbus.queue_path(name: q[:name]), class: "font-medium text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
                 <%= pgbus_queue_badge(q[:name]) %>
               </td>
-              <td class="px-4 py-3 text-sm text-right text-gray-700"><%= pgbus_number(q[:queue_length]) %></td>
-              <td class="px-4 py-3 text-sm text-right text-gray-700"><%= pgbus_number(q[:queue_visible_length]) %></td>
-              <td class="px-4 py-3 text-sm text-right text-gray-500"><%= q[:oldest_msg_age_sec] || "—" %></td>
-              <td class="px-4 py-3 text-sm text-right text-gray-500"><%= pgbus_number(q[:total_messages]) %></td>
+              <td data-label="Depth" class="px-4 py-3 text-sm text-right text-gray-700"><%= pgbus_number(q[:queue_length]) %></td>
+              <td data-label="Visible" class="px-4 py-3 text-sm text-right text-gray-700"><%= pgbus_number(q[:queue_visible_length]) %></td>
+              <td data-label="Oldest" class="px-4 py-3 text-sm text-right text-gray-500"><%= q[:oldest_msg_age_sec] || "—" %></td>
+              <td data-label="Total" class="px-4 py-3 text-sm text-right text-gray-500"><%= pgbus_number(q[:total_messages]) %></td>
             </tr>
           <% end %>
           <% if @queues.empty? %>

--- a/app/views/pgbus/dashboard/_recent_failures.html.erb
+++ b/app/views/pgbus/dashboard/_recent_failures.html.erb
@@ -7,7 +7,7 @@
       <% end %>
     </div>
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">
           <tr>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.recent_failures.headers.queue") %></th>
@@ -18,9 +18,9 @@
         <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
           <% @recent_failures.each do |f| %>
             <tr>
-              <td class="px-4 py-3 text-sm text-gray-700"><%= f["queue_name"] %></td>
-              <td class="px-4 py-3 text-sm text-red-600 truncate max-w-xs"><%= f["error_class"] %>: <%= truncate(f["error_message"].to_s, length: 60) %></td>
-              <td class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(f["failed_at"]) %></td>
+              <td data-label="Queue" class="px-4 py-3 text-sm text-gray-700"><%= f["queue_name"] %></td>
+              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 truncate max-w-xs"><%= f["error_class"] %>: <%= truncate(f["error_message"].to_s, length: 60) %></td>
+              <td data-label="Time" class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(f["failed_at"]) %></td>
             </tr>
           <% end %>
           <% if @recent_failures.empty? %>

--- a/app/views/pgbus/dead_letter/_messages_table.html.erb
+++ b/app/views/pgbus/dead_letter/_messages_table.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="dlq-messages" data-auto-refresh data-src="<%= pgbus.dead_letter_index_path(frame: 'list') %>">
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">
         <tr>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dead_letter.messages_table.headers.id") %></th>

--- a/app/views/pgbus/events/index.html.erb
+++ b/app/views/pgbus/events/index.html.erb
@@ -4,7 +4,7 @@
 <div class="mb-8">
   <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.events.index.subscribers_title") %></h2>
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">
         <tr>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.events.index.subscribers_headers.pattern") %></th>
@@ -15,9 +15,9 @@
       <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
         <% @subscribers.each do |s| %>
           <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-            <td class="px-4 py-3 text-sm font-mono text-indigo-600"><%= s[:pattern] %></td>
-            <td class="px-4 py-3 text-sm text-gray-900 dark:text-white"><%= s[:handler_class] %></td>
-            <td class="px-4 py-3 text-sm text-gray-500"><%= s[:queue_name] %></td>
+            <td data-label="Pattern" class="px-4 py-3 text-sm font-mono text-indigo-600"><%= s[:pattern] %></td>
+            <td data-label="Handler" class="px-4 py-3 text-sm text-gray-900 dark:text-white"><%= s[:handler_class] %></td>
+            <td data-label="Queue" class="px-4 py-3 text-sm text-gray-500"><%= s[:queue_name] %></td>
           </tr>
         <% end %>
         <% if @subscribers.empty? %>
@@ -32,7 +32,7 @@
 <div>
   <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.events.index.processed_title") %></h2>
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">
         <tr>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.events.index.processed_headers.event_id") %></th>
@@ -43,9 +43,9 @@
       <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
         <% @events.each do |e| %>
           <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-            <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white"><%= e["event_id"] %></td>
-            <td class="px-4 py-3 text-sm text-gray-700"><%= e["handler_class"] %></td>
-            <td class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(e["processed_at"]) %></td>
+            <td data-label="Event ID" class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white"><%= e["event_id"] %></td>
+            <td data-label="Handler" class="px-4 py-3 text-sm text-gray-700"><%= e["handler_class"] %></td>
+            <td data-label="Processed At" class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(e["processed_at"]) %></td>
           </tr>
         <% end %>
         <% if @events.empty? %>

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -68,7 +68,7 @@
   <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
     <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300"><%= t("pgbus.insights.show.slowest.title") %></h3>
   </div>
-  <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+  <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
     <thead class="bg-gray-50 dark:bg-gray-900">
       <tr>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.slowest.headers.job_class") %></th>
@@ -80,10 +80,10 @@
     <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
       <% @slowest.each do |row| %>
         <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-          <td class="px-4 py-3 text-sm font-medium text-gray-700 dark:text-gray-300"><%= row[:job_class] %></td>
-          <td class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_number(row[:count]) %></td>
-          <td class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:avg_ms]) %></td>
-          <td class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:max_ms]) %></td>
+          <td data-label="Job Class" class="px-4 py-3 text-sm font-medium text-gray-700 dark:text-gray-300"><%= row[:job_class] %></td>
+          <td data-label="Count" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_number(row[:count]) %></td>
+          <td data-label="Avg" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:avg_ms]) %></td>
+          <td data-label="Max" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:max_ms]) %></td>
         </tr>
       <% end %>
       <% if @slowest.empty? %>
@@ -95,12 +95,14 @@
 
 <script src="https://cdn.jsdelivr.net/npm/apexcharts@4"></script>
 <script>
-  let throughputChart, statusChart;
+(function() {
+  // IIFE prevents "redeclaration of let" when Turbo re-executes on navigation
+  var throughputChart, statusChart;
 
   function getThemeColors() {
-    const isDark = document.documentElement.classList.contains('dark');
+    var isDark = document.documentElement.classList.contains('dark');
     return {
-      isDark,
+      isDark: isDark,
       text: isDark ? '#9ca3af' : '#6b7280',
       grid: isDark ? '#374151' : '#e5e7eb',
       tooltip: isDark ? 'dark' : 'light',
@@ -109,16 +111,14 @@
   }
 
   function renderCharts(data) {
-    const t = getThemeColors();
+    var t = getThemeColors();
 
-    // Destroy existing charts before re-rendering
     if (throughputChart) throughputChart.destroy();
     if (statusChart) statusChart.destroy();
 
-    // Throughput chart
-    const throughputData = data.throughput.map(p => ({
-      x: new Date(p.time).getTime(), y: p.count
-    }));
+    var throughputData = data.throughput.map(function(p) {
+      return { x: new Date(p.time).getTime(), y: p.count };
+    });
 
     throughputChart = new ApexCharts(document.querySelector('#throughput-chart'), {
       series: [{ name: '<%= j(t("pgbus.insights.show.charts.series_name")) %>', data: throughputData }],
@@ -134,10 +134,9 @@
     });
     throughputChart.render();
 
-    // Status distribution chart
-    const statusLabels = Object.keys(data.status_counts);
-    const statusValues = Object.values(data.status_counts);
-    const statusColors = statusLabels.map(s => {
+    var statusLabels = Object.keys(data.status_counts);
+    var statusValues = Object.values(data.status_counts);
+    var statusColors = statusLabels.map(function(s) {
       if (s === 'success') return '#10b981';
       if (s === 'failed') return '#ef4444';
       if (s === 'dead_lettered') return '#f97316';
@@ -161,21 +160,24 @@
     }
   }
 
-  // Fetch data and render
-  let chartData = null;
+  var chartData = null;
   fetch('<%= pgbus.api_insights_path(minutes: @minutes) %>')
-    .then(r => r.json())
-    .then(data => { chartData = data; renderCharts(data); })
-    .catch(() => {
-      const msg = '<p class="text-center text-sm text-gray-400 dark:text-gray-500 pt-24"><%= j(t("pgbus.insights.show.charts.failed_to_load")) %></p>';
-      document.querySelector('#throughput-chart').innerHTML = msg;
-      document.querySelector('#status-chart').innerHTML = msg;
+    .then(function(r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    })
+    .then(function(data) { chartData = data; renderCharts(data); })
+    .catch(function(err) {
+      if (err.name === 'AbortError') return;
+      var msg = '<p class="text-center text-sm text-gray-400 dark:text-gray-500 pt-24"><%= j(t("pgbus.insights.show.charts.failed_to_load")) %></p>';
+      var el1 = document.querySelector('#throughput-chart');
+      var el2 = document.querySelector('#status-chart');
+      if (el1) el1.innerHTML = msg;
+      if (el2) el2.innerHTML = msg;
     });
 
-  // Re-render charts when dark mode toggles.
-  // Listen for class changes on <html> instead of wrapping the toggle function,
-  // so it works regardless of script loading order.
   new MutationObserver(function() {
     if (chartData) renderCharts(chartData);
   }).observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+})();
 </script>

--- a/app/views/pgbus/jobs/_enqueued_table.html.erb
+++ b/app/views/pgbus/jobs/_enqueued_table.html.erb
@@ -2,7 +2,7 @@
   <div>
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.jobs.enqueued_table.title") %></h2>
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">
           <tr>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.jobs.enqueued_table.headers.id") %></th>

--- a/app/views/pgbus/jobs/_failed_table.html.erb
+++ b/app/views/pgbus/jobs/_failed_table.html.erb
@@ -2,7 +2,7 @@
   <div class="mb-8">
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.jobs.failed_table.title") %></h2>
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">
           <tr>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.jobs.failed_table.headers.id") %></th>
@@ -16,16 +16,16 @@
         <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
           <% @failed.each do |f| %>
             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-              <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white">
+              <td data-label="ID" class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white">
                 <%= link_to f["id"], pgbus.job_path(f["id"]), class: "text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
               </td>
-              <td class="px-4 py-3 text-sm text-gray-700"><%= f["queue_name"] %></td>
-              <td class="px-4 py-3 text-sm text-red-600 max-w-sm truncate">
+              <td data-label="Queue" class="px-4 py-3 text-sm text-gray-700"><%= f["queue_name"] %></td>
+              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 max-w-sm truncate">
                 <span class="font-medium"><%= f["error_class"] %></span>: <%= truncate(f["error_message"].to_s, length: 80) %>
               </td>
-              <td class="px-4 py-3 text-sm text-gray-500"><%= f["retry_count"] %></td>
-              <td class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(f["failed_at"]) %></td>
-              <td class="px-4 py-3 text-sm text-right space-x-2">
+              <td data-label="Retries" class="px-4 py-3 text-sm text-gray-500"><%= f["retry_count"] %></td>
+              <td data-label="Failed" class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(f["failed_at"]) %></td>
+              <td data-label="Actions" class="px-4 py-3 text-sm text-right space-x-2">
                 <%= button_to t("pgbus.jobs.failed_table.retry"), pgbus.retry_job_path(f["id"]), method: :post,
                       class: "text-xs text-indigo-600 hover:text-indigo-800 font-medium",
                       data: { turbo_frame: "_top" } %>

--- a/app/views/pgbus/locks/index.html.erb
+++ b/app/views/pgbus/locks/index.html.erb
@@ -4,7 +4,7 @@
 </div>
 
 <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-  <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+  <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
     <thead class="bg-gray-50 dark:bg-gray-900">
       <tr>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.headers.lock_key") %></th>
@@ -18,16 +18,16 @@
     <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
       <% @locks.each do |lock| %>
         <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-          <td class="px-4 py-3 text-sm font-mono text-gray-700 dark:text-gray-300 max-w-xs truncate"><%= lock[:lock_key] %></td>
-          <td class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300"><%= lock[:job_class] %></td>
-          <td class="px-4 py-3 text-sm">
+          <td data-label="Lock Key" class="px-4 py-3 text-sm font-mono text-gray-700 dark:text-gray-300 max-w-xs truncate"><%= lock[:lock_key] %></td>
+          <td data-label="Job Class" class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300"><%= lock[:job_class] %></td>
+          <td data-label="State" class="px-4 py-3 text-sm">
             <% if lock[:state] == "executing" %>
               <span class="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900/50 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300"><%= t("pgbus.locks.index.executing") %></span>
             <% else %>
               <span class="inline-flex items-center rounded-full bg-yellow-100 dark:bg-yellow-900/50 px-2.5 py-0.5 text-xs font-medium text-yellow-800 dark:text-yellow-300"><%= t("pgbus.locks.index.queued") %></span>
             <% end %>
           </td>
-          <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+          <td data-label="Owner" class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
             <% if lock[:owner_pid] %>
               <span class="font-mono"><%= lock[:owner_pid] %></span>
               <% if lock[:owner_hostname] %>
@@ -37,12 +37,12 @@
               <span class="text-gray-400 dark:text-gray-500">—</span>
             <% end %>
           </td>
-          <td class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400">
+          <td data-label="Age" class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400">
             <% if lock[:age_seconds] %>
               <%= pgbus_duration(lock[:age_seconds]) %>
             <% end %>
           </td>
-          <td class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400"><%= pgbus_time_ago_future(lock[:expires_at]) %></td>
+          <td data-label="Expires" class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400"><%= pgbus_time_ago_future(lock[:expires_at]) %></td>
         </tr>
       <% end %>
       <% if @locks.empty? %>

--- a/app/views/pgbus/outbox/index.html.erb
+++ b/app/views/pgbus/outbox/index.html.erb
@@ -19,7 +19,7 @@
 </div>
 
 <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-  <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+  <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
     <thead class="bg-gray-50 dark:bg-gray-900">
       <tr>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.outbox.index.headers.id") %></th>
@@ -33,18 +33,18 @@
     <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
       <% @entries.each do |entry| %>
         <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-          <td class="px-4 py-3 text-sm font-mono text-gray-700"><%= entry.id %></td>
-          <td class="px-4 py-3 text-sm text-gray-700"><%= entry.routing_key || entry.queue_name %></td>
-          <td class="px-4 py-3 text-sm text-gray-500 max-w-xs truncate"><%= pgbus_json_preview(entry.payload) %></td>
-          <td class="px-4 py-3 text-sm text-right text-gray-500"><%= entry.priority %></td>
-          <td class="px-4 py-3 text-sm text-right">
+          <td data-label="ID" class="px-4 py-3 text-sm font-mono text-gray-700"><%= entry.id %></td>
+          <td data-label="Routing Key" class="px-4 py-3 text-sm text-gray-700"><%= entry.routing_key || entry.queue_name %></td>
+          <td data-label="Payload" class="px-4 py-3 text-sm text-gray-500 max-w-xs truncate"><%= pgbus_json_preview(entry.payload) %></td>
+          <td data-label="Priority" class="px-4 py-3 text-sm text-right text-gray-500"><%= entry.priority %></td>
+          <td data-label="Status" class="px-4 py-3 text-sm text-right">
             <% if entry.published_at %>
               <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800"><%= t("pgbus.outbox.index.published") %></span>
             <% else %>
               <span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800"><%= t("pgbus.outbox.index.pending") %></span>
             <% end %>
           </td>
-          <td class="px-4 py-3 text-sm text-right text-gray-500"><%= pgbus_time_ago(entry.created_at) %></td>
+          <td data-label="Created" class="px-4 py-3 text-sm text-right text-gray-500"><%= pgbus_time_ago(entry.created_at) %></td>
         </tr>
       <% end %>
       <% if @entries.empty? %>

--- a/app/views/pgbus/processes/_processes_table.html.erb
+++ b/app/views/pgbus/processes/_processes_table.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="processes-list" data-auto-refresh data-src="<%= pgbus.processes_path(frame: 'list') %>">
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">
         <tr>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.processes.processes_table.headers.kind") %></th>
@@ -14,12 +14,12 @@
       <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
         <% @processes.each do |p| %>
           <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-            <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white"><%= p[:kind] %></td>
-            <td class="px-4 py-3 text-sm text-gray-700"><%= p[:hostname] %></td>
-            <td class="px-4 py-3 text-sm font-mono text-gray-700"><%= p[:pid] %></td>
-            <td class="px-4 py-3 text-sm"><%= pgbus_status_badge(p[:healthy]) %></td>
-            <td class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(p[:last_heartbeat_at]) %></td>
-            <td class="px-4 py-3 text-sm text-gray-500 font-mono text-xs max-w-xs truncate">
+            <td data-label="Kind" class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white"><%= p[:kind] %></td>
+            <td data-label="Host" class="px-4 py-3 text-sm text-gray-700"><%= p[:hostname] %></td>
+            <td data-label="PID" class="px-4 py-3 text-sm font-mono text-gray-700"><%= p[:pid] %></td>
+            <td data-label="Status" class="px-4 py-3 text-sm"><%= pgbus_status_badge(p[:healthy]) %></td>
+            <td data-label="Last Heartbeat" class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(p[:last_heartbeat_at]) %></td>
+            <td data-label="Metadata" class="px-4 py-3 text-sm text-gray-500 font-mono text-xs max-w-xs truncate">
               <% if p[:metadata].is_a?(Hash) %>
                 <% p[:metadata].each do |k, v| %>
                   <span class="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs mr-1"><%= k %>: <%= v %></span>

--- a/app/views/pgbus/queues/_queues_list.html.erb
+++ b/app/views/pgbus/queues/_queues_list.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="queues-list" data-auto-refresh data-src="<%= pgbus.queues_path(frame: 'list') %>">
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">
         <tr>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.queues_list.headers.queue") %></th>
@@ -15,19 +15,19 @@
       <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
         <% @queues.each do |q| %>
           <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-            <td class="px-4 py-3 text-sm">
+            <td data-label="Queue" class="px-4 py-3 text-sm">
               <%= link_to q[:name], pgbus.queue_path(name: q[:name]), class: "font-medium text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
               <%= pgbus_queue_badge(q[:name]) %>
               <% if q[:paused] %>
                 <span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800"><%= t("pgbus.queues.queues_list.paused") %></span>
               <% end %>
             </td>
-            <td class="px-4 py-3 text-sm text-right font-mono text-gray-700"><%= pgbus_number(q[:queue_length]) %></td>
-            <td class="px-4 py-3 text-sm text-right font-mono text-gray-700"><%= pgbus_number(q[:queue_visible_length]) %></td>
-            <td class="px-4 py-3 text-sm text-right text-gray-500"><%= q[:oldest_msg_age_sec] || "—" %></td>
-            <td class="px-4 py-3 text-sm text-right text-gray-500"><%= q[:newest_msg_age_sec] || "—" %></td>
-            <td class="px-4 py-3 text-sm text-right text-gray-500"><%= pgbus_number(q[:total_messages]) %></td>
-            <td class="px-4 py-3 text-sm text-right space-x-2">
+            <td data-label="Depth" class="px-4 py-3 text-sm text-right font-mono text-gray-700"><%= pgbus_number(q[:queue_length]) %></td>
+            <td data-label="Visible" class="px-4 py-3 text-sm text-right font-mono text-gray-700"><%= pgbus_number(q[:queue_visible_length]) %></td>
+            <td data-label="Oldest" class="px-4 py-3 text-sm text-right text-gray-500"><%= q[:oldest_msg_age_sec] || "—" %></td>
+            <td data-label="Newest" class="px-4 py-3 text-sm text-right text-gray-500"><%= q[:newest_msg_age_sec] || "—" %></td>
+            <td data-label="Total" class="px-4 py-3 text-sm text-right text-gray-500"><%= pgbus_number(q[:total_messages]) %></td>
+            <td data-label="Actions" class="px-4 py-3 text-sm text-right space-x-2">
               <% if q[:paused] %>
                 <%= button_to t("pgbus.queues.queues_list.resume"), pgbus.resume_queue_path(name: q[:name]),
                       method: :post,

--- a/app/views/pgbus/recurring_tasks/_tasks_table.html.erb
+++ b/app/views/pgbus/recurring_tasks/_tasks_table.html.erb
@@ -6,7 +6,7 @@
         <p class="mt-1 text-sm"><%= t("pgbus.recurring_tasks.tasks_table.empty_hint") %></p>
       </div>
     <% else %>
-      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">
           <tr>
             <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase"><%= t("pgbus.recurring_tasks.tasks_table.headers.task") %></th>
@@ -21,7 +21,7 @@
         <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
           <% @recurring_tasks.each do |task| %>
             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-              <td class="px-4 py-3">
+              <td data-label="Task" class="px-4 py-3">
                 <div>
                   <%= link_to task[:key], pgbus.recurring_task_path(task[:id]),
                       class: "text-sm font-medium text-blue-600 hover:text-blue-800" %>
@@ -31,26 +31,26 @@
                   <div class="text-xs text-gray-400 mt-0.5"><%= task[:description] %></div>
                 <% end %>
               </td>
-              <td class="px-4 py-3">
+              <td data-label="Schedule" class="px-4 py-3">
                 <div class="text-sm text-gray-900 dark:text-white"><%= task[:schedule] %></div>
                 <% if task[:human_schedule] && task[:human_schedule] != task[:schedule] %>
                   <div class="text-xs text-gray-400"><%= task[:human_schedule] %></div>
                 <% end %>
               </td>
-              <td class="px-4 py-3 text-sm text-gray-600">
+              <td data-label="Queue" class="px-4 py-3 text-sm text-gray-600">
                 <%= task[:queue_name] || t("pgbus.recurring_tasks.tasks_table.default_queue") %>
               </td>
-              <td class="px-4 py-3 text-sm text-gray-600">
+              <td data-label="Last Run" class="px-4 py-3 text-sm text-gray-600">
                 <%= task[:last_run_at] ? pgbus_time_ago(task[:last_run_at]) : t("pgbus.recurring_tasks.tasks_table.never") %>
               </td>
-              <td class="px-4 py-3 text-sm text-gray-600">
+              <td data-label="Next Run" class="px-4 py-3 text-sm text-gray-600">
                 <% if task[:enabled] && task[:next_run_at] %>
                   <%= pgbus_time_ago_future(task[:next_run_at]) %>
                 <% else %>
                   <span class="text-gray-400">—</span>
                 <% end %>
               </td>
-              <td class="px-4 py-3">
+              <td data-label="Status" class="px-4 py-3">
                 <% if task[:enabled] %>
                   <%= pgbus_recurring_health_badge(task) %>
                 <% else %>
@@ -59,7 +59,7 @@
                   </span>
                 <% end %>
               </td>
-              <td class="px-4 py-3 text-right space-x-1">
+              <td data-label="Actions" class="px-4 py-3 text-right space-x-1">
                 <%= button_to task[:enabled] ? t("pgbus.recurring_tasks.tasks_table.disable") : t("pgbus.recurring_tasks.tasks_table.enable"),
                     pgbus.toggle_recurring_task_path(task[:id]),
                     class: "inline-flex items-center rounded px-2 py-1 text-xs font-medium " \

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -220,6 +220,7 @@ da:
       return_to_app: Tilbage til app
       title: Pgbus Dashboard
       toggle_dark_mode: Skift til mørk tilstand
+      toggle_menu: Skift menu
     locks:
       index:
         description: Aktive unikke låse forhindrer duplikeret jobudførelse

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -217,6 +217,7 @@ da:
         processes: Processer
         queues: Køer
         recurring: Gentagende
+      return_to_app: Tilbage til app
       title: Pgbus Dashboard
       toggle_dark_mode: Skift til mørk tilstand
     locks:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -217,6 +217,7 @@ de:
         processes: Prozesse
         queues: Warteschlangen
         recurring: Wiederkehrend
+      return_to_app: Zurück zur App
       title: Pgbus Dashboard
       toggle_dark_mode: Dunkelmodus umschalten
     locks:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -220,6 +220,7 @@ de:
       return_to_app: Zurück zur App
       title: Pgbus Dashboard
       toggle_dark_mode: Dunkelmodus umschalten
+      toggle_menu: Menü umschalten
     locks:
       index:
         description: Aktive Einzigartigkeitssperren verhindern doppelte Auftragserstellung

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -217,6 +217,7 @@ en:
         processes: Processes
         queues: Queues
         recurring: Recurring
+      return_to_app: Back to app
       title: Pgbus Dashboard
       toggle_dark_mode: Toggle dark mode
     locks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,7 @@ en:
       return_to_app: Back to app
       title: Pgbus Dashboard
       toggle_dark_mode: Toggle dark mode
+      toggle_menu: Toggle menu
     locks:
       index:
         description: Active uniqueness locks preventing duplicate job execution

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -220,6 +220,7 @@ es:
       return_to_app: Volver a la app
       title: Panel de Pgbus
       toggle_dark_mode: Alternar modo oscuro
+      toggle_menu: Alternar menú
     locks:
       index:
         description: Bloqueos de unicidad activos que impiden la ejecución duplicada del trabajo

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -217,6 +217,7 @@ es:
         processes: Procesos
         queues: Colas
         recurring: Recurrente
+      return_to_app: Volver a la app
       title: Panel de Pgbus
       toggle_dark_mode: Alternar modo oscuro
     locks:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -217,6 +217,7 @@ fi:
         processes: Prosessit
         queues: Jonot
         recurring: Toistuva
+      return_to_app: Takaisin sovellukseen
       title: Pgbus-hallintapaneeli
       toggle_dark_mode: Vaihda tumma tila
     locks:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -220,6 +220,7 @@ fi:
       return_to_app: Takaisin sovellukseen
       title: Pgbus-hallintapaneeli
       toggle_dark_mode: Vaihda tumma tila
+      toggle_menu: Vaihda valikko
     locks:
       index:
         description: Aktiiviset ainutlaatuisuuden lukot estävät päällekkäisen työn suorittamisen

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -217,6 +217,7 @@ fr:
         processes: Processus
         queues: Files d'attente
         recurring: Récurrent
+      return_to_app: Retour à l'application
       title: Tableau de bord Pgbus
       toggle_dark_mode: Basculer en mode sombre
     locks:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -220,6 +220,7 @@ fr:
       return_to_app: Retour à l'application
       title: Tableau de bord Pgbus
       toggle_dark_mode: Basculer en mode sombre
+      toggle_menu: Basculer le menu
     locks:
       index:
         description: Verrous d'unicité actifs empêchant l'exécution de travaux en double

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -220,6 +220,7 @@ it:
       return_to_app: Torna all'app
       title: Cruscotto Pgbus
       toggle_dark_mode: Attiva/disattiva modalità scura
+      toggle_menu: Attiva/disattiva menu
     locks:
       index:
         description: Blocchi di unicità attivi che impediscono l'esecuzione duplicata del lavoro

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -217,6 +217,7 @@ it:
         processes: Processi
         queues: Code
         recurring: Ricorrente
+      return_to_app: Torna all'app
       title: Cruscotto Pgbus
       toggle_dark_mode: Attiva/disattiva modalità scura
     locks:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -220,6 +220,7 @@ ja:
       return_to_app: アプリに戻る
       title: Pgbus ダッシュボード
       toggle_dark_mode: ダークモード切替
+      toggle_menu: メニュー切替
     locks:
       index:
         description: 重複ジョブ実行を防ぐアクティブなユニークロック

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -217,6 +217,7 @@ ja:
         processes: プロセス
         queues: キュー
         recurring: 定期実行
+      return_to_app: アプリに戻る
       title: Pgbus ダッシュボード
       toggle_dark_mode: ダークモード切替
     locks:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -217,6 +217,7 @@ nb:
         processes: Prosesser
         queues: Køer
         recurring: Gjentakende
+      return_to_app: Tilbake til appen
       title: Pgbus-dashbord
       toggle_dark_mode: Bytt til mørk modus
     locks:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -220,6 +220,7 @@ nb:
       return_to_app: Tilbake til appen
       title: Pgbus-dashbord
       toggle_dark_mode: Bytt til mørk modus
+      toggle_menu: Veksle meny
     locks:
       index:
         description: Aktive unike låser som forhindrer duplisert jobbkjøring

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -220,6 +220,7 @@ nl:
       return_to_app: Terug naar app
       title: Pgbus Dashboard
       toggle_dark_mode: Donkere modus schakelen
+      toggle_menu: Menu wisselen
     locks:
       index:
         description: Actieve uniekheidsvergrendelingen voorkomen dubbele taakuitvoering

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -217,6 +217,7 @@ nl:
         processes: Processen
         queues: Wachtrijen
         recurring: Terugkerend
+      return_to_app: Terug naar app
       title: Pgbus Dashboard
       toggle_dark_mode: Donkere modus schakelen
     locks:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -217,6 +217,7 @@ pt:
         processes: Processos
         queues: Filas
         recurring: Recorrente
+      return_to_app: Voltar ao aplicativo
       title: Painel Pgbus
       toggle_dark_mode: Alternar modo escuro
     locks:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -220,6 +220,7 @@ pt:
       return_to_app: Voltar ao aplicativo
       title: Painel Pgbus
       toggle_dark_mode: Alternar modo escuro
+      toggle_menu: Alternar menu
     locks:
       index:
         description: Bloqueios de exclusividade ativos impedindo a execução duplicada do trabalho

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -217,6 +217,7 @@ sv:
         processes: Processer
         queues: Köer
         recurring: Återkommande
+      return_to_app: Tillbaka till appen
       title: Pgbus-instrumentpanel
       toggle_dark_mode: Växla mörkt läge
     locks:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -220,6 +220,7 @@ sv:
       return_to_app: Tillbaka till appen
       title: Pgbus-instrumentpanel
       toggle_dark_mode: Växla mörkt läge
+      toggle_menu: Växla meny
     locks:
       index:
         description: Aktiva unika lås som förhindrar duplicerad jobbexekvering

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -64,7 +64,7 @@ module Pgbus
 
     # Web dashboard
     attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source,
-                  :insights_default_minutes, :base_controller_class
+                  :insights_default_minutes, :base_controller_class, :return_to_app_url
 
     def initialize
       @database_url = nil
@@ -137,6 +137,7 @@ module Pgbus
       @web_data_source = nil
       @insights_default_minutes = 30 * 24 * 60 # 30 days
       @base_controller_class = "::ActionController::Base"
+      @return_to_app_url = nil
     end
 
     def queue_name(name)

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -64,7 +64,7 @@ module Pgbus
 
     # Web dashboard
     attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source,
-                  :insights_default_minutes
+                  :insights_default_minutes, :base_controller_class
 
     def initialize
       @database_url = nil
@@ -136,6 +136,7 @@ module Pgbus
       @web_live_updates = true
       @web_data_source = nil
       @insights_default_minutes = 30 * 24 * 60 # 30 days
+      @base_controller_class = "::ActionController::Base"
     end
 
     def queue_name(name)

--- a/spec/pgbus/base_controller_class_spec.rb
+++ b/spec/pgbus/base_controller_class_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "base_controller_class configuration" do # rubocop:disable RSpec/DescribeClass
+  describe "default" do
+    it "defaults to ::ActionController::Base" do
+      config = Pgbus::Configuration.new
+      expect(config.base_controller_class).to eq("::ActionController::Base")
+    end
+  end
+
+  describe "custom value" do
+    it "accepts a string class name" do
+      config = Pgbus::Configuration.new
+      config.base_controller_class = "Admin::BaseController"
+      expect(config.base_controller_class).to eq("Admin::BaseController")
+    end
+  end
+
+  describe "Pgbus.base_controller_class" do
+    it "delegates to configuration" do
+      expect(Pgbus.configuration.base_controller_class).to eq("::ActionController::Base")
+    end
+  end
+end

--- a/spec/pgbus/return_to_app_spec.rb
+++ b/spec/pgbus/return_to_app_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "return_to_app_url configuration" do # rubocop:disable RSpec/DescribeClass
+  describe "default" do
+    it "defaults to nil" do
+      config = Pgbus::Configuration.new
+      expect(config.return_to_app_url).to be_nil
+    end
+  end
+
+  describe "custom value" do
+    it "accepts a string URL" do
+      config = Pgbus::Configuration.new
+      config.return_to_app_url = "/admin"
+      expect(config.return_to_app_url).to eq("/admin")
+    end
+
+    it "accepts a full URL" do
+      config = Pgbus::Configuration.new
+      config.return_to_app_url = "https://example.com/admin"
+      expect(config.return_to_app_url).to eq("https://example.com/admin")
+    end
+  end
+end

--- a/spec/pgbus/web/application_controller_spec.rb
+++ b/spec/pgbus/web/application_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_controller"
+require "active_support"
+
+RSpec.describe "Pgbus::ApplicationController base class" do # rubocop:disable RSpec/DescribeClass
+  describe "with default configuration" do
+    it "resolves to ActionController::Base" do
+      expect(Pgbus.configuration.base_controller_class).to eq("::ActionController::Base")
+      expect("::ActionController::Base".constantize).to eq(ActionController::Base)
+    end
+  end
+
+  describe "with custom base_controller_class" do
+    let(:custom_base) do
+      Class.new(ActionController::Base) do
+        def self.name
+          "TestAdminController"
+        end
+      end
+    end
+
+    before do
+      stub_const("TestAdminController", custom_base)
+      @original = Pgbus.configuration.base_controller_class
+      Pgbus.configuration.base_controller_class = "TestAdminController"
+    end
+
+    after do
+      Pgbus.configuration.base_controller_class = @original # rubocop:disable RSpec/InstanceVariable
+    end
+
+    it "allows constantizing the configured class" do
+      klass = Pgbus.configuration.base_controller_class.constantize
+      expect(klass).to eq(TestAdminController)
+      expect(klass.superclass).to eq(ActionController::Base)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `base_controller_class` config option (default: `"::ActionController::Base"`)
- `Pgbus::ApplicationController` inherits from the configured class via `.constantize`
- ActionController::Base modules are conditionally included for compatibility
- Follows the same pattern as `mission_control-jobs`

**Before** (monkey-patching required):
```ruby
Rails.application.config.after_initialize do
  Pgbus::ApplicationController.class_eval do
    before_action :authenticate_staff!
    # ... lots of auth code
  end
end
```

**After**:
```ruby
Pgbus.configure do |config|
  config.base_controller_class = "Admin::BaseController"
end
```

## Test plan

- [x] Config defaults to `"::ActionController::Base"`
- [x] Config accepts custom string class name
- [x] Custom base class resolves via `.constantize`
- [x] 745 examples, 0 failures
- [x] RuboCop clean
- [ ] Verify with host app using custom base controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable base controller option for dashboard integration.
  * Added optional “Back to app” link in the dashboard navigation (configurable; hidden when unset).

* **Documentation**
  * Updated README with the new configuration options and examples.

* **Localization**
  * Added translations for the “return to app” label in multiple languages.

* **Tests**
  * Added specs covering both new configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->