### PR TITLE
fix(web): fix queue purge double-prefix, add delete queue and show page pause/resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ pgbus help      # Show help
 The dashboard is a mountable Rails engine at `/pgbus` with:
 
 - **Overview** -- queue depths, enqueued count, active processes, failure count, throughput rate
-- **Queues** -- per-queue metrics, purge/pause/resume actions
+- **Queues** -- per-queue metrics, purge/pause/resume/delete actions
 - **Jobs** -- enqueued and failed jobs, retry/discard actions
 - **Dead letter** -- DLQ messages with retry/discard, bulk actions
 - **Processes** -- active workers/dispatcher/consumers with heartbeat status
@@ -716,7 +716,17 @@ The dashboard is a mountable Rails engine at `/pgbus` with:
 - **Locks** -- active job uniqueness locks with state (queued/executing), owner PID@hostname, age
 - **Insights** -- throughput chart (jobs/min), status distribution donut, slowest job classes table
 
-All tables use Turbo Frames for periodic auto-refresh without page reloads.
+All tables use Turbo Frames for periodic auto-refresh without page reloads. Destructive actions use styled confirmation dialogs (not browser `confirm()`), and flash messages appear as auto-dismissing toast notifications.
+
+### Queue management
+
+The queues page lets you manage PGMQ queues directly:
+
+- **Purge** -- removes all messages from the queue (the queue itself remains)
+- **Delete** -- permanently drops the queue from PGMQ (removes the queue table and metadata)
+- **Pause / Resume** -- pauses or resumes job processing for a queue
+
+All destructive actions require confirmation. Pause/resume and delete are available on both the queue index and detail pages.
 
 ### Dark mode
 

--- a/app/controllers/pgbus/queues_controller.rb
+++ b/app/controllers/pgbus/queues_controller.rb
@@ -10,12 +10,18 @@ module Pgbus
       @queue = data_source.queue_detail(params[:name])
       redirect_to queues_path, alert: "Queue not found." and return unless @queue
 
+      @paused = data_source.queue_paused?(params[:name])
       @messages = data_source.jobs(queue_name: params[:name], page: page_param, per_page: per_page)
     end
 
     def purge
       data_source.purge_queue(params[:name])
       redirect_to queue_path(name: params[:name]), notice: "Queue purged."
+    end
+
+    def destroy
+      data_source.drop_queue(params[:name])
+      redirect_to queues_path, notice: t("pgbus.queues.destroy.success", name: params[:name])
     end
 
     def pause

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -81,6 +81,71 @@
   <script type="module">
     import * as Turbo from "https://esm.sh/@hotwired/turbo@8";
 
+    // -- Custom confirm dialog (replaces browser confirm) --
+    Turbo.config.forms.confirm = (message, element) => {
+      const dialog = document.getElementById("pgbus-confirm-dialog");
+      const messageEl = document.getElementById("pgbus-confirm-message");
+      const titleEl = document.getElementById("pgbus-confirm-title");
+      const confirmBtn = document.getElementById("pgbus-confirm-btn");
+      const iconEl = document.getElementById("pgbus-confirm-icon");
+
+      // Detect action type from the element
+      const turboMethod = element.getAttribute("data-turbo-method");
+      const isDelete = turboMethod === "delete";
+
+      // Set title based on action
+      titleEl.textContent = isDelete ? "<%= t("pgbus.dialogs.delete_title", default: "Delete") %>" : "<%= t("pgbus.dialogs.confirm_title", default: "Are you sure?") %>";
+      messageEl.textContent = message;
+
+      // Style confirm button based on action severity
+      confirmBtn.className = "rounded-md px-4 py-2 text-sm font-medium text-white focus:outline-none focus:ring-2";
+      if (isDelete) {
+        confirmBtn.classList.add("bg-red-600", "hover:bg-red-500", "focus:ring-red-500");
+        confirmBtn.textContent = "<%= t("pgbus.dialogs.delete", default: "Delete") %>";
+        iconEl.className = "flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-red-100 dark:bg-red-900/30";
+      } else {
+        confirmBtn.classList.add("bg-yellow-500", "hover:bg-yellow-400", "focus:ring-yellow-500");
+        confirmBtn.textContent = "<%= t("pgbus.dialogs.confirm", default: "Confirm") %>";
+        iconEl.className = "flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-yellow-100 dark:bg-yellow-900/30";
+      }
+
+      dialog.showModal();
+
+      return new Promise((resolve) => {
+        dialog.addEventListener("close", () => {
+          resolve(dialog.returnValue === "confirm");
+        }, { once: true });
+      });
+    };
+
+    // -- Toast notifications --
+    function showToast(message, type = "success") {
+      const container = document.getElementById("pgbus-toast-container");
+      const toast = document.createElement("div");
+
+      const colors = {
+        success: "bg-green-50 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-800",
+        error: "bg-red-50 dark:bg-red-900/30 text-red-800 dark:text-red-300 border-red-200 dark:border-red-800",
+        info: "bg-blue-50 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border-blue-200 dark:border-blue-800",
+      };
+
+      toast.className = `rounded-md border p-3 text-sm shadow-lg transition-all duration-300 ${colors[type] || colors.info}`;
+      toast.textContent = message;
+      container.appendChild(toast);
+
+      setTimeout(() => {
+        toast.style.opacity = "0";
+        toast.style.transform = "translateX(100%)";
+        setTimeout(() => toast.remove(), 300);
+      }, 5000);
+    }
+
+    // Render flash toasts from <template> tags
+    document.querySelectorAll("template[data-pgbus-toast]").forEach(tpl => {
+      showToast(tpl.content.textContent.trim(), tpl.dataset.pgbusToast);
+      tpl.remove();
+    });
+
     <% if Pgbus.configuration.web_live_updates %>
     const interval = <%= Pgbus.configuration.web_refresh_interval %>;
     if (interval > 0) {
@@ -200,21 +265,54 @@
       </div>
     </nav>
 
-    <!-- Flash messages -->
+    <!-- Toast container (fixed top-right) -->
+    <div id="pgbus-toast-container" class="fixed top-4 right-4 z-[100] flex flex-col space-y-2 max-w-sm"></div>
+
+    <!-- Flash messages rendered as toasts -->
     <% if notice %>
-      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 mt-4">
-        <div class="rounded-md bg-green-50 dark:bg-green-900/30 p-3">
-          <p class="text-sm text-green-800 dark:text-green-300"><%= notice %></p>
-        </div>
-      </div>
+      <template data-pgbus-toast="success"><%= notice %></template>
     <% end %>
     <% if alert %>
-      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 mt-4">
-        <div class="rounded-md bg-red-50 dark:bg-red-900/30 p-3">
-          <p class="text-sm text-red-800 dark:text-red-300"><%= alert %></p>
+      <template data-pgbus-toast="error"><%= alert %></template>
+    <% end %>
+
+    <!-- Confirm dialog -->
+    <dialog id="pgbus-confirm-dialog" class="rounded-lg shadow-xl bg-white dark:bg-gray-800 p-0 backdrop:bg-gray-900/50 max-w-md w-full">
+      <div class="p-6">
+        <div class="flex items-start space-x-4">
+          <div id="pgbus-confirm-icon" class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-red-100 dark:bg-red-900/30">
+            <svg class="h-6 w-6 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/>
+            </svg>
+          </div>
+          <div class="flex-1">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white" id="pgbus-confirm-title"></h3>
+            <p class="mt-2 text-sm text-gray-600 dark:text-gray-300" id="pgbus-confirm-message"></p>
+          </div>
         </div>
       </div>
-    <% end %>
+      <div class="flex justify-end space-x-3 px-6 py-4 bg-gray-50 dark:bg-gray-900/50 rounded-b-lg">
+        <button value="cancel" class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"><%= t("pgbus.dialogs.cancel", default: "Cancel") %></button>
+        <button value="confirm" id="pgbus-confirm-btn" class="rounded-md px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500"><%= t("pgbus.dialogs.confirm", default: "Confirm") %></button>
+      </div>
+    </dialog>
+
+    <!-- Alert dialog -->
+    <dialog id="pgbus-alert-dialog" class="rounded-lg shadow-xl bg-white dark:bg-gray-800 p-0 backdrop:bg-gray-900/50 max-w-md w-full">
+      <div class="p-6">
+        <div class="flex items-start space-x-4">
+          <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-900/30">
+            <svg class="h-6 w-6 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"/>
+            </svg>
+          </div>
+          <p class="text-sm text-gray-700 dark:text-gray-300" id="pgbus-alert-message"></p>
+        </div>
+      </div>
+      <div class="flex justify-end px-6 py-4 bg-gray-50 dark:bg-gray-900/50 rounded-b-lg">
+        <button value="ok" class="rounded-md px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"><%= t("pgbus.dialogs.ok", default: "OK") %></button>
+      </div>
+    </dialog>
 
     <!-- Content -->
     <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">

--- a/app/views/pgbus/queues/_queues_list.html.erb
+++ b/app/views/pgbus/queues/_queues_list.html.erb
@@ -43,6 +43,10 @@
                     method: :post,
                     class: "text-xs text-red-600 hover:text-red-800 font-medium",
                     data: { turbo_confirm: t("pgbus.queues.queues_list.purge_confirm", name: q[:name]), turbo_frame: "_top" } %>
+              <%= button_to t("pgbus.queues.queues_list.delete"), pgbus.queue_path(name: q[:name]),
+                    method: :delete,
+                    class: "text-xs text-red-600 hover:text-red-800 font-medium",
+                    data: { turbo_confirm: t("pgbus.queues.queues_list.delete_confirm", name: q[:name]), turbo_frame: "_top" } %>
             </td>
           </tr>
         <% end %>

--- a/app/views/pgbus/queues/show.html.erb
+++ b/app/views/pgbus/queues/show.html.erb
@@ -1,6 +1,11 @@
 <div class="flex items-center justify-between mb-6">
   <div>
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white"><%= @queue&.dig(:name) || params[:name] %></h1>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+      <%= @queue&.dig(:name) || params[:name] %>
+      <% if @paused %>
+        <span class="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800"><%= t("pgbus.queues.queues_list.paused") %></span>
+      <% end %>
+    </h1>
     <% if @queue %>
       <p class="text-sm text-gray-500 mt-1">
         <%= t("pgbus.queues.show.depth") %> <span class="font-mono"><%= @queue[:queue_length] %></span> |
@@ -10,10 +15,24 @@
     <% end %>
   </div>
   <div class="flex space-x-2">
+    <% if @paused %>
+      <%= button_to t("pgbus.queues.show.resume"), pgbus.resume_queue_path(name: params[:name]),
+            method: :post,
+            class: "rounded-md bg-green-600 px-3 py-2 text-sm font-medium text-white hover:bg-green-500" %>
+    <% else %>
+      <%= button_to t("pgbus.queues.show.pause"), pgbus.pause_queue_path(name: params[:name]),
+            method: :post,
+            class: "rounded-md bg-yellow-500 px-3 py-2 text-sm font-medium text-white hover:bg-yellow-400",
+            data: { turbo_confirm: t("pgbus.queues.show.pause_confirm") } %>
+    <% end %>
     <%= button_to t("pgbus.queues.show.purge_queue"), pgbus.purge_queue_path(name: params[:name]),
           method: :post,
           class: "rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500",
           data: { turbo_confirm: t("pgbus.queues.show.purge_confirm") } %>
+    <%= button_to t("pgbus.queues.show.delete_queue"), pgbus.queue_path(name: params[:name]),
+          method: :delete,
+          class: "rounded-md bg-red-800 px-3 py-2 text-sm font-medium text-white hover:bg-red-700",
+          data: { turbo_confirm: t("pgbus.queues.show.delete_confirm") } %>
   </div>
 </div>
 

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -280,13 +280,19 @@ da:
           queue: Kø
           total_ever: Total nogensinde
           visible: Synlig
+        delete: Slet
+        delete_confirm: Slet køen %{name} permanent? Dette kan ikke fortrydes.
         pause: Pause
         pause_confirm: Pause behandling i %{name}?
         paused: Pauset
         purge: Rens
         purge_confirm: Rens alle beskeder fra %{name}?
         resume: Genoptag
+      destroy:
+        success: Køen %{name} slettet.
       show:
+        delete_confirm: Slet denne kø permanent? Dette kan ikke fortrydes.
+        delete_queue: Slet kø
         depth: 'Dybde:'
         empty: Køen er tom
         headers:
@@ -295,8 +301,11 @@ da:
           payload: Indhold
           reads: Læsninger
           vt: VT
+        pause: Pause
+        pause_confirm: Pause behandling?
         purge_confirm: Rens alle beskeder?
         purge_queue: Rens kø
+        resume: Genoptag
         total: 'Total:'
         visible: 'Synlig:'
     recurring_tasks:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,6 +1,13 @@
 ---
 da:
   pgbus:
+    dialogs:
+      cancel: Annuller
+      confirm: Bekræft
+      confirm_title: Er du sikker?
+      delete: Slet
+      delete_title: Slet
+      ok: OK
     dashboard:
       processes_table:
         empty: Ingen processer kører

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,13 @@
 ---
 de:
   pgbus:
+    dialogs:
+      cancel: Abbrechen
+      confirm: Bestätigen
+      confirm_title: Sind Sie sicher?
+      delete: Löschen
+      delete_title: Löschen
+      ok: OK
     dashboard:
       processes_table:
         empty: Keine Prozesse laufen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -280,13 +280,19 @@ de:
           queue: Warteschlange
           total_ever: Insgesamt jemals
           visible: Sichtbar
+        delete: Löschen
+        delete_confirm: Warteschlange %{name} dauerhaft löschen? Dies kann nicht rückgängig gemacht werden.
         pause: Pause
         pause_confirm: Verarbeitung für %{name} pausieren?
         paused: Pausiert
         purge: Bereinigen
         purge_confirm: Alle Nachrichten von %{name} löschen?
         resume: Fortsetzen
+      destroy:
+        success: Warteschlange %{name} gelöscht.
       show:
+        delete_confirm: Diese Warteschlange dauerhaft löschen? Dies kann nicht rückgängig gemacht werden.
+        delete_queue: Warteschlange löschen
         depth: 'Tiefe:'
         empty: Warteschlange ist leer
         headers:
@@ -295,8 +301,11 @@ de:
           payload: Nutzlast
           reads: Lesevorgänge
           vt: VT
+        pause: Pause
+        pause_confirm: Verarbeitung pausieren?
         purge_confirm: Alle Nachrichten löschen?
         purge_queue: Warteschlange bereinigen
+        resume: Fortsetzen
         total: 'Insgesamt:'
         visible: 'Sichtbar:'
     recurring_tasks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,13 @@
 ---
 en:
   pgbus:
+    dialogs:
+      cancel: Cancel
+      confirm: Confirm
+      confirm_title: Are you sure?
+      delete: Delete
+      delete_title: Delete
+      ok: OK
     dashboard:
       processes_table:
         empty: No processes running

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,13 +280,19 @@ en:
           queue: Queue
           total_ever: Total Ever
           visible: Visible
+        delete: Delete
+        delete_confirm: Permanently delete queue %{name}? This cannot be undone.
         pause: Pause
         pause_confirm: Pause processing for %{name}?
         paused: Paused
         purge: Purge
         purge_confirm: Purge all messages from %{name}?
         resume: Resume
+      destroy:
+        success: Queue %{name} deleted.
       show:
+        delete_confirm: Permanently delete this queue? This cannot be undone.
+        delete_queue: Delete Queue
         depth: 'Depth:'
         empty: Queue is empty
         headers:
@@ -295,8 +301,11 @@ en:
           payload: Payload
           reads: Reads
           vt: VT
+        pause: Pause
+        pause_confirm: Pause processing?
         purge_confirm: Purge all messages?
         purge_queue: Purge Queue
+        resume: Resume
         total: 'Total:'
         visible: 'Visible:'
     recurring_tasks:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -280,13 +280,19 @@ es:
           queue: Cola
           total_ever: Total acumulado
           visible: Visible
+        delete: Eliminar
+        delete_confirm: "¿Eliminar permanentemente la cola %{name}? Esto no se puede deshacer."
         pause: Pausar
         pause_confirm: "¿Pausar el procesamiento de %{name}?"
         paused: Pausado
         purge: Purgar
         purge_confirm: "¿Purgar todos los mensajes de %{name}?"
         resume: Reanudar
+      destroy:
+        success: Cola %{name} eliminada.
       show:
+        delete_confirm: "¿Eliminar permanentemente esta cola? Esto no se puede deshacer."
+        delete_queue: Eliminar cola
         depth: 'Profundidad:'
         empty: La cola está vacía
         headers:
@@ -295,8 +301,11 @@ es:
           payload: Carga útil
           reads: Lecturas
           vt: VT
+        pause: Pausar
+        pause_confirm: "¿Pausar el procesamiento?"
         purge_confirm: "¿Purgar todos los mensajes?"
         purge_queue: Purgar cola
+        resume: Reanudar
         total: 'Total:'
         visible: 'Visible:'
     recurring_tasks:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,13 @@
 ---
 es:
   pgbus:
+    dialogs:
+      cancel: Cancelar
+      confirm: Confirmar
+      confirm_title: "¿Estás seguro?"
+      delete: Eliminar
+      delete_title: Eliminar
+      ok: Aceptar
     dashboard:
       processes_table:
         empty: No hay procesos en ejecución

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -280,13 +280,19 @@ fi:
           queue: Jono
           total_ever: Yhteensä koskaan
           visible: Näkyvissä
+        delete: Poista
+        delete_confirm: Poista jono %{name} pysyvästi? Tätä ei voi kumota.
         pause: Tauko
         pause_confirm: Keskeytä käsittely %{name} ajan?
         paused: Keskeytetty
         purge: Tyhjennä
         purge_confirm: Tyhjennä kaikki viestit %{name}:sta?
         resume: Jatka
+      destroy:
+        success: Jono %{name} poistettu.
       show:
+        delete_confirm: Poista tämä jono pysyvästi? Tätä ei voi kumota.
+        delete_queue: Poista jono
         depth: 'Syvyys:'
         empty: Jono on tyhjä
         headers:
@@ -295,8 +301,11 @@ fi:
           payload: Kuorma
           reads: Lukukerrat
           vt: VT
+        pause: Tauko
+        pause_confirm: Keskeytetäänkö käsittely?
         purge_confirm: Tyhjennetäänkö kaikki viestit?
         purge_queue: Tyhjennä jono
+        resume: Jatka
         total: 'Yhteensä:'
         visible: 'Näkyvissä:'
     recurring_tasks:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,6 +1,13 @@
 ---
 fi:
   pgbus:
+    dialogs:
+      cancel: Peruuta
+      confirm: Vahvista
+      confirm_title: Oletko varma?
+      delete: Poista
+      delete_title: Poista
+      ok: OK
     dashboard:
       processes_table:
         empty: Ei käynnissä olevia prosesseja

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -280,13 +280,19 @@ fr:
           queue: File d'attente
           total_ever: Total jamais
           visible: Visible
+        delete: Supprimer
+        delete_confirm: Supprimer définitivement la file d'attente %{name} ? Cette action est irréversible.
         pause: Pause
         pause_confirm: Mettre en pause le traitement pour %{name} ?
         paused: En pause
         purge: Purger
         purge_confirm: Purger tous les messages de %{name} ?
         resume: Reprendre
+      destroy:
+        success: File d'attente %{name} supprimée.
       show:
+        delete_confirm: Supprimer définitivement cette file d'attente ? Cette action est irréversible.
+        delete_queue: Supprimer la file d'attente
         depth: 'Profondeur :'
         empty: La file d'attente est vide
         headers:
@@ -295,8 +301,11 @@ fr:
           payload: Charge utile
           reads: Lectures
           vt: VT
+        pause: Pause
+        pause_confirm: Mettre en pause le traitement ?
         purge_confirm: Purger tous les messages ?
         purge_queue: Purger la file d'attente
+        resume: Reprendre
         total: 'Total :'
         visible: 'Visible :'
     recurring_tasks:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,6 +1,13 @@
 ---
 fr:
   pgbus:
+    dialogs:
+      cancel: Annuler
+      confirm: Confirmer
+      confirm_title: "Êtes-vous sûr ?"
+      delete: Supprimer
+      delete_title: Supprimer
+      ok: OK
     dashboard:
       processes_table:
         empty: Aucun processus en cours d'exécution

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -280,13 +280,19 @@ it:
           queue: Coda
           total_ever: Totale mai
           visible: Visibile
+        delete: Elimina
+        delete_confirm: Eliminare permanentemente la coda %{name}? Questa azione non può essere annullata.
         pause: Pausa
         pause_confirm: Mettere in pausa l'elaborazione per %{name}?
         paused: In pausa
         purge: Pulisci
         purge_confirm: Eliminare tutti i messaggi da %{name}?
         resume: Riprendi
+      destroy:
+        success: Coda %{name} eliminata.
       show:
+        delete_confirm: Eliminare permanentemente questa coda? Questa azione non può essere annullata.
+        delete_queue: Elimina coda
         depth: 'Profondità:'
         empty: La coda è vuota
         headers:
@@ -295,8 +301,11 @@ it:
           payload: Carico utile
           reads: Letture
           vt: VT
+        pause: Pausa
+        pause_confirm: Mettere in pausa l'elaborazione?
         purge_confirm: Eliminare tutti i messaggi?
         purge_queue: Pulisci coda
+        resume: Riprendi
         total: 'Totale:'
         visible: 'Visibile:'
     recurring_tasks:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,6 +1,13 @@
 ---
 it:
   pgbus:
+    dialogs:
+      cancel: Annulla
+      confirm: Conferma
+      confirm_title: Sei sicuro?
+      delete: Elimina
+      delete_title: Elimina
+      ok: OK
     dashboard:
       processes_table:
         empty: Nessun processo in esecuzione

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -280,13 +280,19 @@ ja:
           queue: キュー
           total_ever: 合計数
           visible: 表示中
+        delete: 削除
+        delete_confirm: キュー %{name} を完全に削除しますか？この操作は取り消せません。
         pause: 一時停止
         pause_confirm: "%{name} の処理を一時停止しますか？"
         paused: 一時停止中
         purge: パージ
         purge_confirm: "%{name} からすべてのメッセージを削除しますか？"
         resume: 再開
+      destroy:
+        success: キュー %{name} を削除しました。
       show:
+        delete_confirm: このキューを完全に削除しますか？この操作は取り消せません。
+        delete_queue: キューを削除
         depth: 深さ：
         empty: キューは空です
         headers:
@@ -295,8 +301,11 @@ ja:
           payload: ペイロード
           reads: 読み取り回数
           vt: VT
+        pause: 一時停止
+        pause_confirm: 処理を一時停止しますか？
         purge_confirm: すべてのメッセージを削除しますか？
         purge_queue: キューをパージ
+        resume: 再開
         total: 合計：
         visible: 表示中：
     recurring_tasks:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,13 @@
 ---
 ja:
   pgbus:
+    dialogs:
+      cancel: キャンセル
+      confirm: 確認
+      confirm_title: よろしいですか？
+      delete: 削除
+      delete_title: 削除
+      ok: OK
     dashboard:
       processes_table:
         empty: 実行中のプロセスはありません

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -280,13 +280,19 @@ nb:
           queue: Kø
           total_ever: Totalt noensinne
           visible: Synlig
+        delete: Slett
+        delete_confirm: Slette køen %{name} permanent? Dette kan ikke angres.
         pause: Pause
         pause_confirm: Pause behandling for %{name}?
         paused: Pauset
         purge: Rens
         purge_confirm: Rens alle meldinger fra %{name}?
         resume: Gjenoppta
+      destroy:
+        success: Køen %{name} slettet.
       show:
+        delete_confirm: Slette denne køen permanent? Dette kan ikke angres.
+        delete_queue: Slett kø
         depth: 'Dybde:'
         empty: Køen er tom
         headers:
@@ -295,8 +301,11 @@ nb:
           payload: Innhold
           reads: Lesninger
           vt: VT
+        pause: Pause
+        pause_confirm: Pause behandling?
         purge_confirm: Rens alle meldinger?
         purge_queue: Rens kø
+        resume: Gjenoppta
         total: 'Totalt:'
         visible: 'Synlig:'
     recurring_tasks:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -1,6 +1,13 @@
 ---
 nb:
   pgbus:
+    dialogs:
+      cancel: Avbryt
+      confirm: Bekreft
+      confirm_title: Er du sikker?
+      delete: Slett
+      delete_title: Slett
+      ok: OK
     dashboard:
       processes_table:
         empty: Ingen prosesser kjører

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -280,13 +280,19 @@ nl:
           queue: Wachtrij
           total_ever: Totaal ooit
           visible: Zichtbaar
+        delete: Verwijderen
+        delete_confirm: Wachtrij %{name} permanent verwijderen? Dit kan niet ongedaan worden gemaakt.
         pause: Pauzeren
         pause_confirm: Verwerking pauzeren voor %{name}?
         paused: Gepauzeerd
         purge: Opschonen
         purge_confirm: Alle berichten verwijderen uit %{name}?
         resume: Hervatten
+      destroy:
+        success: Wachtrij %{name} verwijderd.
       show:
+        delete_confirm: Deze wachtrij permanent verwijderen? Dit kan niet ongedaan worden gemaakt.
+        delete_queue: Wachtrij verwijderen
         depth: 'Diepte:'
         empty: Wachtrij is leeg
         headers:
@@ -295,8 +301,11 @@ nl:
           payload: Inhoud
           reads: Lezingen
           vt: VT
+        pause: Pauzeren
+        pause_confirm: Verwerking pauzeren?
         purge_confirm: Alle berichten verwijderen?
         purge_queue: Wachtrij opschonen
+        resume: Hervatten
         total: 'Totaal:'
         visible: 'Zichtbaar:'
     recurring_tasks:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,6 +1,13 @@
 ---
 nl:
   pgbus:
+    dialogs:
+      cancel: Annuleren
+      confirm: Bevestigen
+      confirm_title: Weet u het zeker?
+      delete: Verwijderen
+      delete_title: Verwijderen
+      ok: OK
     dashboard:
       processes_table:
         empty: Geen processen actief

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,6 +1,13 @@
 ---
 pt:
   pgbus:
+    dialogs:
+      cancel: Cancelar
+      confirm: Confirmar
+      confirm_title: Tem certeza?
+      delete: Excluir
+      delete_title: Excluir
+      ok: OK
     dashboard:
       processes_table:
         empty: Nenhum processo em execução

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -280,13 +280,19 @@ pt:
           queue: Fila
           total_ever: Total de todos os tempos
           visible: Visível
+        delete: Excluir
+        delete_confirm: Excluir permanentemente a fila %{name}? Esta ação não pode ser desfeita.
         pause: Pausar
         pause_confirm: Pausar processamento por %{name}?
         paused: Pausado
         purge: Limpar
         purge_confirm: Limpar todas as mensagens de %{name}?
         resume: Retomar
+      destroy:
+        success: Fila %{name} excluída.
       show:
+        delete_confirm: Excluir permanentemente esta fila? Esta ação não pode ser desfeita.
+        delete_queue: Excluir fila
         depth: 'Profundidade:'
         empty: Fila está vazia
         headers:
@@ -295,8 +301,11 @@ pt:
           payload: Carga útil
           reads: Leituras
           vt: VT
+        pause: Pausar
+        pause_confirm: Pausar processamento?
         purge_confirm: Limpar todas as mensagens?
         purge_queue: Limpar fila
+        resume: Retomar
         total: 'Total:'
         visible: 'Visível:'
     recurring_tasks:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,6 +1,13 @@
 ---
 sv:
   pgbus:
+    dialogs:
+      cancel: Avbryt
+      confirm: Bekräfta
+      confirm_title: Är du säker?
+      delete: Ta bort
+      delete_title: Ta bort
+      ok: OK
     dashboard:
       processes_table:
         empty: Inga processer körs

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -280,13 +280,19 @@ sv:
           queue: Kö
           total_ever: Totalt någonsin
           visible: Synliga
+        delete: Ta bort
+        delete_confirm: Ta bort kön %{name} permanent? Detta kan inte ångras.
         pause: Pausa
         pause_confirm: Pausa bearbetning för %{name}?
         paused: Pausad
         purge: Rensa
         purge_confirm: Rensa alla meddelanden från %{name}?
         resume: Återuppta
+      destroy:
+        success: Kön %{name} borttagen.
       show:
+        delete_confirm: Ta bort denna kö permanent? Detta kan inte ångras.
+        delete_queue: Ta bort kö
         depth: 'Djup:'
         empty: Kön är tom
         headers:
@@ -295,8 +301,11 @@ sv:
           payload: Innehåll
           reads: Läsningar
           vt: VT
+        pause: Pausa
+        pause_confirm: Pausa bearbetning?
         purge_confirm: Rensa alla meddelanden?
         purge_queue: Rensa kö
+        resume: Återuppta
         total: 'Totalt:'
         visible: 'Synliga:'
     recurring_tasks:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Pgbus::Engine.routes.draw do
   root to: "dashboard#show"
 
-  resources :queues, only: %i[index show], param: :name do
+  resources :queues, only: %i[index show destroy], param: :name do
     member do
       post :purge
       post :pause

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -215,6 +215,13 @@ module Pgbus
       synchronized { @pgmq.purge_queue(name) }
     end
 
+    def drop_queue(queue_name, prefixed: true)
+      name = prefixed ? config.queue_name(queue_name) : queue_name
+      result = synchronized { @pgmq.drop_queue(name) }
+      @queues_created.delete(name)
+      result
+    end
+
     def purge_archive(queue_name, older_than:, batch_size: 1000)
       full_name = config.queue_name(queue_name)
       sanitized = QueueNameValidator.sanitize!(full_name)

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -210,8 +210,9 @@ module Pgbus
       synchronized { @pgmq.list_queues }
     end
 
-    def purge_queue(queue_name)
-      synchronized { @pgmq.purge_queue(config.queue_name(queue_name)) }
+    def purge_queue(queue_name, prefixed: true)
+      name = prefixed ? config.queue_name(queue_name) : queue_name
+      synchronized { @pgmq.purge_queue(name) }
     end
 
     def purge_archive(queue_name, older_than:, batch_size: 1000)

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -60,6 +60,10 @@ module Pgbus
         @client.purge_queue(name, prefixed: false)
       end
 
+      def drop_queue(name)
+        @client.drop_queue(name, prefixed: false)
+      end
+
       def pause_queue(name, reason: nil)
         QueueState.pause!(logical_queue_name(name), reason: reason)
       rescue StandardError => e

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -57,7 +57,7 @@ module Pgbus
       end
 
       def purge_queue(name)
-        @client.purge_queue(name)
+        @client.purge_queue(name, prefixed: false)
       end
 
       def pause_queue(name, reason: nil)

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -423,6 +423,12 @@ RSpec.describe Pgbus::Client do
 
       expect(mock_pgmq).to have_received(:purge_queue).with("pgbus_test_default")
     end
+
+    it "skips prefixing when prefixed: false" do
+      client.purge_queue("pgbus_test_default", prefixed: false)
+
+      expect(mock_pgmq).to have_received(:purge_queue).with("pgbus_test_default")
+    end
   end
 
   describe "#purge_archive" do

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -431,6 +431,28 @@ RSpec.describe Pgbus::Client do
     end
   end
 
+  describe "#drop_queue" do
+    it "drops the prefixed queue" do
+      client.drop_queue("default")
+
+      expect(mock_pgmq).to have_received(:drop_queue).with("pgbus_test_default")
+    end
+
+    it "skips prefixing when prefixed: false" do
+      client.drop_queue("pgbus_test_default", prefixed: false)
+
+      expect(mock_pgmq).to have_received(:drop_queue).with("pgbus_test_default")
+    end
+
+    it "removes the queue from the created cache" do
+      client.ensure_queue("default")
+      client.drop_queue("default")
+
+      # Verify the queue is no longer in the cache
+      expect(client.instance_variable_get(:@queues_created)["pgbus_test_default"]).to be_nil
+    end
+  end
+
   describe "#purge_archive" do
     let(:conn) { double("conn") }
     let(:result) { double("result", cmd_tuples: 50) }

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe Pgbus::Web::DataSource do
     end
   end
 
+  describe "#purge_queue" do
+    it "passes the queue name directly without re-prefixing" do
+      allow(mock_client).to receive(:purge_queue)
+
+      data_source.purge_queue("pgbus_default")
+
+      expect(mock_client).to have_received(:purge_queue).with("pgbus_default", prefixed: false)
+    end
+  end
+
   describe "#registered_subscribers" do
     it "returns subscriber info from registry" do
       handler_class = Class.new(Pgbus::EventBus::Handler)

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -100,6 +100,16 @@ RSpec.describe Pgbus::Web::DataSource do
     end
   end
 
+  describe "#drop_queue" do
+    it "passes the queue name directly without re-prefixing" do
+      allow(mock_client).to receive(:drop_queue)
+
+      data_source.drop_queue("pgbus_default")
+
+      expect(mock_client).to have_received(:drop_queue).with("pgbus_default", prefixed: false)
+    end
+  end
+
   describe "#registered_subscribers" do
     it "returns subscriber info from registry" do
       handler_class = Class.new(Pgbus::EventBus::Handler)

--- a/spec/support/pgmq_doubles.rb
+++ b/spec/support/pgmq_doubles.rb
@@ -19,6 +19,7 @@ module PgmqDoubles
         metrics_all: [],
         list_queues: [],
         purge_queue: nil,
+        drop_queue: true,
         bind_topic: nil,
         produce_topic: nil,
         close: nil
@@ -49,6 +50,7 @@ module PgmqDoubles
         metrics: nil,
         list_queues: [],
         purge_queue: nil,
+        drop_queue: true,
         bind_topic: nil,
         publish_to_topic: nil,
         close: nil,

--- a/spec/system/queues_spec.rb
+++ b/spec/system/queues_spec.rb
@@ -3,26 +3,101 @@
 require "system_helper"
 
 RSpec.describe "Queues", type: :system do
-  it "lists all queues with metrics" do
-    visit "/pgbus/queues"
+  describe "index page" do
+    it "lists all queues with metrics" do
+      visit "/pgbus/queues"
 
-    expect(page).to have_css("h1", text: "Queues")
-    expect(page).to have_text("pgbus_default")
-    expect(page).to have_text("pgbus_default_dlq")
-    expect(page).to have_text("500") # total_messages
+      expect(page).to have_css("h1", text: "Queues")
+      expect(page).to have_text("pgbus_default")
+      expect(page).to have_text("pgbus_default_dlq")
+      expect(page).to have_text("500") # total_messages
+    end
+
+    it "shows purge and delete buttons for each queue" do
+      visit "/pgbus/queues"
+
+      expect(page).to have_button("Purge", count: 2)
+      expect(page).to have_button("Delete", count: 2)
+    end
+
+    it "shows pause button for unpaused queues" do
+      visit "/pgbus/queues"
+
+      expect(page).to have_button("Pause", count: 2)
+      expect(page).not_to have_button("Resume")
+    end
+
+    it "shows resume button for paused queues" do
+      @stub_data_source.queues = [
+        { name: "pgbus_default", queue_length: 10, queue_visible_length: 8,
+          oldest_msg_age_sec: 120, newest_msg_age_sec: 5, total_messages: 500, paused: true }
+      ]
+
+      visit "/pgbus/queues"
+
+      expect(page).to have_button("Resume", count: 1)
+      expect(page).to have_text("Paused")
+    end
+
+    it "shows empty state when no queues" do
+      @stub_data_source.queues = []
+
+      visit "/pgbus/queues"
+
+      expect(page).to have_text("No queues found")
+    end
   end
 
-  it "shows purge button for each queue" do
-    visit "/pgbus/queues"
+  describe "show page" do
+    it "displays queue name and metrics" do
+      visit "/pgbus/queues/pgbus_default"
 
-    expect(page).to have_button("Purge", count: 2)
-  end
+      expect(page).to have_css("h1", text: "pgbus_default")
+      expect(page).to have_text("Depth:")
+      expect(page).to have_text("10")
+    end
 
-  it "shows empty state when no queues" do
-    @stub_data_source.queues = []
+    it "shows purge and delete buttons" do
+      visit "/pgbus/queues/pgbus_default"
 
-    visit "/pgbus/queues"
+      expect(page).to have_button("Purge Queue")
+      expect(page).to have_button("Delete Queue")
+    end
 
-    expect(page).to have_text("No queues found")
+    it "shows pause button when queue is not paused" do
+      visit "/pgbus/queues/pgbus_default"
+
+      expect(page).to have_button("Pause")
+      expect(page).not_to have_button("Resume")
+    end
+
+    it "shows resume button and paused badge when queue is paused" do
+      @stub_data_source.paused_queues = ["pgbus_default"]
+
+      visit "/pgbus/queues/pgbus_default"
+
+      expect(page).to have_button("Resume")
+      expect(page).not_to have_button("Pause")
+      expect(page).to have_text("Paused")
+    end
+
+    it "shows empty state when queue has no messages" do
+      visit "/pgbus/queues/pgbus_default"
+
+      expect(page).to have_text("Queue is empty")
+    end
+
+    it "displays messages when present" do
+      @stub_data_source.jobs_list = [
+        { msg_id: 42, queue_name: "pgbus_default", read_ct: 3,
+          enqueued_at: Time.now.utc.iso8601, vt: Time.now.utc.iso8601,
+          message: '{"job_class":"TestJob"}' }
+      ]
+
+      visit "/pgbus/queues/pgbus_default"
+
+      expect(page).to have_text("42")
+      expect(page).to have_text("3") # read_ct
+    end
   end
 end

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -4,7 +4,8 @@ module Pgbus
   module Test
     class StubDataSource
       attr_accessor :stats, :queues, :processes_list, :failed_events_list,
-                    :dlq_messages_list, :events_list, :subscribers_list, :jobs_list
+                    :dlq_messages_list, :events_list, :subscribers_list, :jobs_list,
+                    :paused_queues
 
       def initialize
         @stats = default_stats
@@ -15,6 +16,7 @@ module Pgbus
         @events_list = []
         @subscribers_list = []
         @jobs_list = []
+        @paused_queues = []
       end
 
       def summary_stats = @stats
@@ -33,7 +35,7 @@ module Pgbus
       def jobs(queue_name: nil, page: 1, per_page: 25) = @jobs_list
       def purge_queue(_name) = true
       def drop_queue(_name) = true
-      def queue_paused?(_name) = false
+      def queue_paused?(name) = @paused_queues.include?(name)
       def pause_queue(_name, reason: nil) = true
       def resume_queue(_name) = true
       def retry_failed_event(_id) = true

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -32,6 +32,10 @@ module Pgbus
       def registered_subscribers = @subscribers_list
       def jobs(queue_name: nil, page: 1, per_page: 25) = @jobs_list
       def purge_queue(_name) = true
+      def drop_queue(_name) = true
+      def queue_paused?(_name) = false
+      def pause_queue(_name, reason: nil) = true
+      def resume_queue(_name) = true
       def retry_failed_event(_id) = true
       def discard_failed_event(_id) = true
       def retry_all_failed = @failed_events_list.size

--- a/spec/system/turbo_frames_spec.rb
+++ b/spec/system/turbo_frames_spec.rb
@@ -43,4 +43,17 @@ RSpec.describe "Turbo Frames", type: :system do
     expect(page).to have_css("turbo-frame#dashboard-stats")
     expect(page).not_to have_css("nav")
   end
+
+  it "has custom confirm dialog element" do
+    visit "/pgbus"
+
+    expect(page).to have_css("dialog#pgbus-confirm-dialog", visible: :hidden)
+    expect(page).to have_css("dialog#pgbus-alert-dialog", visible: :hidden)
+  end
+
+  it "has toast container" do
+    visit "/pgbus"
+
+    expect(page).to have_css("#pgbus-toast-container")
+  end
 end


### PR DESCRIPTION
## Summary
- **Fix double-prefix bug**: Dashboard purge was looking for `pgmq.q_pgbus_pgbus_pgbus_default` instead of `pgmq.q_pgbus_pgbus_default` because `DataSource#purge_queue` passed already-prefixed names to `Client#purge_queue` which added the prefix again
- **Add queue delete**: New destroy action with confirmation dialog on both index and show pages, calling PGMQ's `drop_queue` to permanently remove queues (including stale double-prefixed ones)
- **Add pause/resume to show page**: Queue show page now has pause/resume buttons and a paused badge, matching the index page
- **Custom Turbo confirm dialogs**: Replace native `window.confirm()` with styled `<dialog>`-based modals with dark mode support, adaptive button colors (red for delete, yellow for others), and localized labels
- **Toast notifications**: Flash messages now render as auto-dismissing toast notifications (top-right corner) instead of static banners
- **i18n**: All new keys translated across 12 locales
- **README**: Documented queue management actions and custom dialog UX

## Test plan
- [x] `Client#purge_queue` with `prefixed: false` skips prefix
- [x] `Client#drop_queue` drops queue and clears internal cache
- [x] `Client#drop_queue` with `prefixed: false` skips prefix
- [x] `DataSource#purge_queue` passes `prefixed: false` to client
- [x] `DataSource#drop_queue` passes `prefixed: false` to client
- [x] System: index page shows purge, delete, pause buttons
- [x] System: index page shows resume button for paused queues
- [x] System: show page shows purge, delete, pause buttons
- [x] System: show page shows resume + paused badge when paused
- [x] System: show page displays queue messages
- [x] System: confirm dialog and toast container elements present
- [x] Full suite: 764 examples, 0 failures
- [x] RuboCop clean