### PR TITLE
feat(web): add per-message discard/retry from any queue, fix confirm dialog

### DIFF
--- a/app/controllers/pgbus/queues_controller.rb
+++ b/app/controllers/pgbus/queues_controller.rb
@@ -33,5 +33,15 @@ module Pgbus
       data_source.resume_queue(params[:name])
       redirect_to queue_path(name: params[:name]), notice: "Queue resumed."
     end
+
+    def retry_message
+      data_source.retry_job(params[:name], params[:msg_id])
+      redirect_to queue_path(name: params[:name]), notice: t("pgbus.queues.show.message_retried")
+    end
+
+    def discard_message
+      data_source.discard_job(params[:name], params[:msg_id])
+      redirect_to queue_path(name: params[:name]), notice: t("pgbus.queues.show.message_discarded")
+    end
   end
 end

--- a/app/controllers/pgbus/queues_controller.rb
+++ b/app/controllers/pgbus/queues_controller.rb
@@ -35,13 +35,19 @@ module Pgbus
     end
 
     def retry_message
-      data_source.retry_job(params[:name], params[:msg_id])
-      redirect_to queue_path(name: params[:name]), notice: t("pgbus.queues.show.message_retried")
+      if data_source.retry_job(params[:name], params[:msg_id])
+        redirect_back fallback_location: queue_path(name: params[:name]), notice: t("pgbus.queues.show.message_retried")
+      else
+        redirect_back fallback_location: queue_path(name: params[:name]), alert: t("pgbus.queues.show.message_retry_failed")
+      end
     end
 
     def discard_message
-      data_source.discard_job(params[:name], params[:msg_id])
-      redirect_to queue_path(name: params[:name]), notice: t("pgbus.queues.show.message_discarded")
+      if data_source.discard_job(params[:name], params[:msg_id])
+        redirect_back fallback_location: queue_path(name: params[:name]), notice: t("pgbus.queues.show.message_discarded")
+      else
+        redirect_back fallback_location: queue_path(name: params[:name]), alert: t("pgbus.queues.show.message_discard_failed")
+      end
     end
   end
 end

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -140,11 +140,17 @@
       }, 5000);
     }
 
-    // Render flash toasts from <template> tags
-    document.querySelectorAll("template[data-pgbus-toast]").forEach(tpl => {
-      showToast(tpl.content.textContent.trim(), tpl.dataset.pgbusToast);
-      tpl.remove();
-    });
+    // Render flash toasts from <template> tags.
+    // Must run on turbo:load as well — module scripts only execute once,
+    // but Turbo Drive replaces the body on navigation.
+    function renderFlashToasts() {
+      document.querySelectorAll("template[data-pgbus-toast]").forEach(tpl => {
+        showToast(tpl.content.textContent.trim(), tpl.dataset.pgbusToast);
+        tpl.remove();
+      });
+    }
+    renderFlashToasts();
+    document.addEventListener("turbo:load", renderFlashToasts);
 
     <% if Pgbus.configuration.web_live_updates %>
     const interval = <%= Pgbus.configuration.web_refresh_interval %>;

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -291,10 +291,10 @@
           </div>
         </div>
       </div>
-      <div class="flex justify-end space-x-3 px-6 py-4 bg-gray-50 dark:bg-gray-900/50 rounded-b-lg">
+      <form method="dialog" class="flex justify-end space-x-3 px-6 py-4 bg-gray-50 dark:bg-gray-900/50 rounded-b-lg">
         <button value="cancel" class="rounded-md px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"><%= t("pgbus.dialogs.cancel", default: "Cancel") %></button>
         <button value="confirm" id="pgbus-confirm-btn" class="rounded-md px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500"><%= t("pgbus.dialogs.confirm", default: "Confirm") %></button>
-      </div>
+      </form>
     </dialog>
 
     <!-- Alert dialog -->
@@ -309,9 +309,9 @@
           <p class="text-sm text-gray-700 dark:text-gray-300" id="pgbus-alert-message"></p>
         </div>
       </div>
-      <div class="flex justify-end px-6 py-4 bg-gray-50 dark:bg-gray-900/50 rounded-b-lg">
+      <form method="dialog" class="flex justify-end px-6 py-4 bg-gray-50 dark:bg-gray-900/50 rounded-b-lg">
         <button value="ok" class="rounded-md px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"><%= t("pgbus.dialogs.ok", default: "OK") %></button>
-      </div>
+      </form>
     </dialog>
 
     <!-- Content -->

--- a/app/views/pgbus/jobs/_enqueued_table.html.erb
+++ b/app/views/pgbus/jobs/_enqueued_table.html.erb
@@ -61,11 +61,11 @@
                       <%= button_to t("pgbus.jobs.enqueued_table.retry"), pgbus.retry_message_queue_path(name: j[:queue_name], msg_id: j[:msg_id]),
                             method: :post,
                             class: "rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500",
-                            data: { turbo_confirm: t("pgbus.jobs.enqueued_table.retry_confirm") } %>
+                            data: { turbo_confirm: t("pgbus.jobs.enqueued_table.retry_confirm"), turbo_frame: "_top" } %>
                       <%= button_to t("pgbus.jobs.enqueued_table.discard"), pgbus.discard_message_queue_path(name: j[:queue_name], msg_id: j[:msg_id]),
                             method: :post,
                             class: "rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-500",
-                            data: { turbo_confirm: t("pgbus.jobs.enqueued_table.discard_confirm") } %>
+                            data: { turbo_confirm: t("pgbus.jobs.enqueued_table.discard_confirm"), turbo_frame: "_top" } %>
                     </div>
                   </div>
                 </details>

--- a/app/views/pgbus/jobs/_enqueued_table.html.erb
+++ b/app/views/pgbus/jobs/_enqueued_table.html.erb
@@ -57,6 +57,16 @@
                         <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto"><%= JSON.pretty_generate(JSON.parse(j[:headers])) rescue j[:headers] %></pre>
                       </details>
                     <% end %>
+                    <div class="flex space-x-2 mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+                      <%= button_to t("pgbus.jobs.enqueued_table.retry"), pgbus.retry_message_queue_path(name: j[:queue_name], msg_id: j[:msg_id]),
+                            method: :post,
+                            class: "rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500",
+                            data: { turbo_confirm: t("pgbus.jobs.enqueued_table.retry_confirm") } %>
+                      <%= button_to t("pgbus.jobs.enqueued_table.discard"), pgbus.discard_message_queue_path(name: j[:queue_name], msg_id: j[:msg_id]),
+                            method: :post,
+                            class: "rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-500",
+                            data: { turbo_confirm: t("pgbus.jobs.enqueued_table.discard_confirm") } %>
+                    </div>
                   </div>
                 </details>
               </td>

--- a/app/views/pgbus/queues/show.html.erb
+++ b/app/views/pgbus/queues/show.html.erb
@@ -46,6 +46,7 @@
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.reads") %></th>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.vt") %></th>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.payload") %></th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.actions") %></th>
       </tr>
     </thead>
     <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
@@ -58,10 +59,20 @@
           <td class="px-4 py-3 text-sm text-gray-600 font-mono text-xs max-w-md truncate">
             <%= pgbus_json_preview(m[:message]) %>
           </td>
+          <td class="px-4 py-3 text-sm text-right space-x-1 whitespace-nowrap">
+            <%= button_to t("pgbus.queues.show.retry"), pgbus.retry_message_queue_path(name: params[:name], msg_id: m[:msg_id]),
+                  method: :post,
+                  class: "text-xs text-indigo-600 hover:text-indigo-800 font-medium",
+                  data: { turbo_confirm: t("pgbus.queues.show.retry_confirm") } %>
+            <%= button_to t("pgbus.queues.show.discard"), pgbus.discard_message_queue_path(name: params[:name], msg_id: m[:msg_id]),
+                  method: :post,
+                  class: "text-xs text-red-600 hover:text-red-800 font-medium",
+                  data: { turbo_confirm: t("pgbus.queues.show.discard_confirm") } %>
+          </td>
         </tr>
       <% end %>
       <% if @messages.empty? %>
-        <tr><td colspan="5" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.queues.show.empty") %></td></tr>
+        <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.queues.show.empty") %></td></tr>
       <% end %>
     </tbody>
   </table>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -177,6 +177,10 @@ da:
           timezone: 'Tidszone:'
           visible_at: 'Synlig fra:'
         title: Job i kø
+        discard: Kassér
+        discard_confirm: Kassér denne besked?
+        retry: Prøv igen
+        retry_confirm: Nulstil synlighedstimeout og prøv igen?
       failed_table:
         discard: Kassér
         discard_confirm: Kassér dette job?
@@ -301,18 +305,25 @@ da:
         delete_confirm: Slet denne kø permanent? Dette kan ikke fortrydes.
         delete_queue: Slet kø
         depth: 'Dybde:'
+        discard: Kassér
+        discard_confirm: Kassér denne besked?
         empty: Køen er tom
         headers:
+          actions: Handlinger
           enqueued: Sat i kø
           id: ID
           payload: Indhold
           reads: Læsninger
           vt: VT
+        message_discarded: Besked kasseret.
+        message_retried: Beskedens synlighed nulstillet.
         pause: Pause
         pause_confirm: Pause behandling?
         purge_confirm: Rens alle beskeder?
         purge_queue: Rens kø
         resume: Genoptag
+        retry: Prøv igen
+        retry_confirm: Nulstil synlighedstimeout og prøv igen?
         total: 'Total:'
         visible: 'Synlig:'
     recurring_tasks:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -315,8 +315,10 @@ da:
           payload: Indhold
           reads: Læsninger
           vt: VT
+        message_discard_failed: Kunne ikke kassere besked.
         message_discarded: Besked kasseret.
         message_retried: Beskedens synlighed nulstillet.
+        message_retry_failed: Kunne ikke prøve besked igen.
         pause: Pause
         pause_confirm: Pause behandling?
         purge_confirm: Rens alle beskeder?

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -315,8 +315,10 @@ de:
           payload: Nutzlast
           reads: Lesevorgänge
           vt: VT
+        message_discard_failed: Nachricht konnte nicht verworfen werden.
         message_discarded: Nachricht verworfen.
         message_retried: Sichtbarkeit der Nachricht zurückgesetzt.
+        message_retry_failed: Nachricht konnte nicht wiederholt werden.
         pause: Pause
         pause_confirm: Verarbeitung pausieren?
         purge_confirm: Alle Nachrichten löschen?

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -177,6 +177,10 @@ de:
           timezone: 'Zeitzone:'
           visible_at: 'Sichtbar ab:'
         title: Eingereihte Jobs
+        discard: Verwerfen
+        discard_confirm: Diese Nachricht verwerfen?
+        retry: Wiederholen
+        retry_confirm: Sichtbarkeits-Timeout zurücksetzen und erneut versuchen?
       failed_table:
         discard: Verwerfen
         discard_confirm: Diesen Job verwerfen?
@@ -301,18 +305,25 @@ de:
         delete_confirm: Diese Warteschlange dauerhaft löschen? Dies kann nicht rückgängig gemacht werden.
         delete_queue: Warteschlange löschen
         depth: 'Tiefe:'
+        discard: Verwerfen
+        discard_confirm: Diese Nachricht verwerfen?
         empty: Warteschlange ist leer
         headers:
+          actions: Aktionen
           enqueued: Eingereiht
           id: ID
           payload: Nutzlast
           reads: Lesevorgänge
           vt: VT
+        message_discarded: Nachricht verworfen.
+        message_retried: Sichtbarkeit der Nachricht zurückgesetzt.
         pause: Pause
         pause_confirm: Verarbeitung pausieren?
         purge_confirm: Alle Nachrichten löschen?
         purge_queue: Warteschlange bereinigen
         resume: Fortsetzen
+        retry: Wiederholen
+        retry_confirm: Sichtbarkeits-Timeout zurücksetzen und erneut versuchen?
         total: 'Insgesamt:'
         visible: 'Sichtbar:'
     recurring_tasks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,10 @@ en:
           scheduled: 'Scheduled:'
           timezone: 'Timezone:'
           visible_at: 'Visible at:'
+        discard: Discard
+        discard_confirm: Discard this message?
+        retry: Retry
+        retry_confirm: Reset visibility timeout and retry?
         title: Enqueued Jobs
       failed_table:
         discard: Discard
@@ -301,18 +305,25 @@ en:
         delete_confirm: Permanently delete this queue? This cannot be undone.
         delete_queue: Delete Queue
         depth: 'Depth:'
+        discard: Discard
+        discard_confirm: Discard this message?
         empty: Queue is empty
         headers:
+          actions: Actions
           enqueued: Enqueued
           id: ID
           payload: Payload
           reads: Reads
           vt: VT
+        message_discarded: Message discarded.
+        message_retried: Message visibility reset.
         pause: Pause
         pause_confirm: Pause processing?
         purge_confirm: Purge all messages?
         purge_queue: Purge Queue
         resume: Resume
+        retry: Retry
+        retry_confirm: Reset visibility timeout and retry?
         total: 'Total:'
         visible: 'Visible:'
     recurring_tasks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,8 +315,10 @@ en:
           payload: Payload
           reads: Reads
           vt: VT
+        message_discard_failed: Could not discard message.
         message_discarded: Message discarded.
         message_retried: Message visibility reset.
+        message_retry_failed: Could not retry message.
         pause: Pause
         pause_confirm: Pause processing?
         purge_confirm: Purge all messages?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -177,6 +177,10 @@ es:
           timezone: 'Zona horaria:'
           visible_at: 'Visible en:'
         title: Trabajos en Cola
+        discard: Descartar
+        discard_confirm: "¿Descartar este mensaje?"
+        retry: Reintentar
+        retry_confirm: "¿Restablecer tiempo de visibilidad y reintentar?"
       failed_table:
         discard: Descartar
         discard_confirm: "¿Descartar este trabajo?"
@@ -301,18 +305,25 @@ es:
         delete_confirm: "¿Eliminar permanentemente esta cola? Esto no se puede deshacer."
         delete_queue: Eliminar cola
         depth: 'Profundidad:'
+        discard: Descartar
+        discard_confirm: "¿Descartar este mensaje?"
         empty: La cola está vacía
         headers:
+          actions: Acciones
           enqueued: Encolado
           id: ID
           payload: Carga útil
           reads: Lecturas
           vt: VT
+        message_discarded: Mensaje descartado.
+        message_retried: Visibilidad del mensaje restablecida.
         pause: Pausar
         pause_confirm: "¿Pausar el procesamiento?"
         purge_confirm: "¿Purgar todos los mensajes?"
         purge_queue: Purgar cola
         resume: Reanudar
+        retry: Reintentar
+        retry_confirm: "¿Restablecer tiempo de visibilidad y reintentar?"
         total: 'Total:'
         visible: 'Visible:'
     recurring_tasks:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -315,8 +315,10 @@ es:
           payload: Carga útil
           reads: Lecturas
           vt: VT
+        message_discard_failed: No se pudo descartar el mensaje.
         message_discarded: Mensaje descartado.
         message_retried: Visibilidad del mensaje restablecida.
+        message_retry_failed: No se pudo reintentar el mensaje.
         pause: Pausar
         pause_confirm: "¿Pausar el procesamiento?"
         purge_confirm: "¿Purgar todos los mensajes?"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -177,6 +177,10 @@ fi:
           timezone: 'Aikavyöhyke:'
           visible_at: 'Näkyvissä:'
         title: Jonotetut työt
+        discard: Hylkää
+        discard_confirm: Hylätä tämä viesti?
+        retry: Yritä uudelleen
+        retry_confirm: Nollaa näkyvyysaika ja yritä uudelleen?
       failed_table:
         discard: Hylkää
         discard_confirm: Hylätäänkö tämä työ?
@@ -301,18 +305,25 @@ fi:
         delete_confirm: Poista tämä jono pysyvästi? Tätä ei voi kumota.
         delete_queue: Poista jono
         depth: 'Syvyys:'
+        discard: Hylkää
+        discard_confirm: Hylätä tämä viesti?
         empty: Jono on tyhjä
         headers:
+          actions: Toiminnot
           enqueued: Jonoon lisätty
           id: ID
           payload: Kuorma
           reads: Lukukerrat
           vt: VT
+        message_discarded: Viesti hylätty.
+        message_retried: Viestin näkyvyys nollattu.
         pause: Tauko
         pause_confirm: Keskeytetäänkö käsittely?
         purge_confirm: Tyhjennetäänkö kaikki viestit?
         purge_queue: Tyhjennä jono
         resume: Jatka
+        retry: Yritä uudelleen
+        retry_confirm: Nollaa näkyvyysaika ja yritä uudelleen?
         total: 'Yhteensä:'
         visible: 'Näkyvissä:'
     recurring_tasks:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -315,8 +315,10 @@ fi:
           payload: Kuorma
           reads: Lukukerrat
           vt: VT
+        message_discard_failed: Viestiä ei voitu hylätä.
         message_discarded: Viesti hylätty.
         message_retried: Viestin näkyvyys nollattu.
+        message_retry_failed: Viestiä ei voitu yrittää uudelleen.
         pause: Tauko
         pause_confirm: Keskeytetäänkö käsittely?
         purge_confirm: Tyhjennetäänkö kaikki viestit?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -177,6 +177,10 @@ fr:
           timezone: 'Fuseau horaire :'
           visible_at: 'Visible à :'
         title: Travaux en file d'attente
+        discard: Rejeter
+        discard_confirm: Rejeter ce message ?
+        retry: Réessayer
+        retry_confirm: Réinitialiser le délai de visibilité et réessayer ?
       failed_table:
         discard: Ignorer
         discard_confirm: Ignorer ce travail ?
@@ -301,18 +305,25 @@ fr:
         delete_confirm: Supprimer définitivement cette file d'attente ? Cette action est irréversible.
         delete_queue: Supprimer la file d'attente
         depth: 'Profondeur :'
+        discard: Rejeter
+        discard_confirm: Rejeter ce message ?
         empty: La file d'attente est vide
         headers:
+          actions: Actions
           enqueued: Enregistré
           id: ID
           payload: Charge utile
           reads: Lectures
           vt: VT
+        message_discarded: Message rejeté.
+        message_retried: Visibilité du message réinitialisée.
         pause: Pause
         pause_confirm: Mettre en pause le traitement ?
         purge_confirm: Purger tous les messages ?
         purge_queue: Purger la file d'attente
         resume: Reprendre
+        retry: Réessayer
+        retry_confirm: Réinitialiser le délai de visibilité et réessayer ?
         total: 'Total :'
         visible: 'Visible :'
     recurring_tasks:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -315,8 +315,10 @@ fr:
           payload: Charge utile
           reads: Lectures
           vt: VT
+        message_discard_failed: Impossible de rejeter le message.
         message_discarded: Message rejeté.
         message_retried: Visibilité du message réinitialisée.
+        message_retry_failed: Impossible de réessayer le message.
         pause: Pause
         pause_confirm: Mettre en pause le traitement ?
         purge_confirm: Purger tous les messages ?

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -177,6 +177,10 @@ it:
           timezone: 'Fuso orario:'
           visible_at: 'Visibile alle:'
         title: Lavori in coda
+        discard: Scarta
+        discard_confirm: Scartare questo messaggio?
+        retry: Riprova
+        retry_confirm: Reimpostare il timeout di visibilità e riprovare?
       failed_table:
         discard: Scarta
         discard_confirm: Scartare questo lavoro?
@@ -301,18 +305,25 @@ it:
         delete_confirm: Eliminare permanentemente questa coda? Questa azione non può essere annullata.
         delete_queue: Elimina coda
         depth: 'Profondità:'
+        discard: Scarta
+        discard_confirm: Scartare questo messaggio?
         empty: La coda è vuota
         headers:
+          actions: Azioni
           enqueued: In coda
           id: ID
           payload: Carico utile
           reads: Letture
           vt: VT
+        message_discarded: Messaggio scartato.
+        message_retried: Visibilità del messaggio reimpostata.
         pause: Pausa
         pause_confirm: Mettere in pausa l'elaborazione?
         purge_confirm: Eliminare tutti i messaggi?
         purge_queue: Pulisci coda
         resume: Riprendi
+        retry: Riprova
+        retry_confirm: Reimpostare il timeout di visibilità e riprovare?
         total: 'Totale:'
         visible: 'Visibile:'
     recurring_tasks:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -315,8 +315,10 @@ it:
           payload: Carico utile
           reads: Letture
           vt: VT
+        message_discard_failed: Impossibile scartare il messaggio.
         message_discarded: Messaggio scartato.
         message_retried: Visibilità del messaggio reimpostata.
+        message_retry_failed: Impossibile riprovare il messaggio.
         pause: Pausa
         pause_confirm: Mettere in pausa l'elaborazione?
         purge_confirm: Eliminare tutti i messaggi?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -315,8 +315,10 @@ ja:
           payload: ペイロード
           reads: 読み取り回数
           vt: VT
+        message_discard_failed: メッセージを破棄できませんでした。
         message_discarded: メッセージを破棄しました。
         message_retried: メッセージの可視性をリセットしました。
+        message_retry_failed: メッセージをリトライできませんでした。
         pause: 一時停止
         pause_confirm: 処理を一時停止しますか？
         purge_confirm: すべてのメッセージを削除しますか？

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -177,6 +177,10 @@ ja:
           timezone: タイムゾーン：
           visible_at: 表示可能日時：
         title: キューに入れられたジョブ
+        discard: 破棄
+        discard_confirm: このメッセージを破棄しますか？
+        retry: リトライ
+        retry_confirm: 可視性タイムアウトをリセットしてリトライしますか？
       failed_table:
         discard: 破棄
         discard_confirm: このジョブを破棄しますか？
@@ -301,18 +305,25 @@ ja:
         delete_confirm: このキューを完全に削除しますか？この操作は取り消せません。
         delete_queue: キューを削除
         depth: 深さ：
+        discard: 破棄
+        discard_confirm: このメッセージを破棄しますか？
         empty: キューは空です
         headers:
+          actions: アクション
           enqueued: エンキュー済み
           id: ID
           payload: ペイロード
           reads: 読み取り回数
           vt: VT
+        message_discarded: メッセージを破棄しました。
+        message_retried: メッセージの可視性をリセットしました。
         pause: 一時停止
         pause_confirm: 処理を一時停止しますか？
         purge_confirm: すべてのメッセージを削除しますか？
         purge_queue: キューをパージ
         resume: 再開
+        retry: リトライ
+        retry_confirm: 可視性タイムアウトをリセットしてリトライしますか？
         total: 合計：
         visible: 表示中：
     recurring_tasks:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -315,8 +315,10 @@ nb:
           payload: Innhold
           reads: Lesninger
           vt: VT
+        message_discard_failed: Kunne ikke forkaste meldingen.
         message_discarded: Melding forkastet.
         message_retried: Meldingens synlighet tilbakestilt.
+        message_retry_failed: Kunne ikke prøve meldingen igjen.
         pause: Pause
         pause_confirm: Pause behandling?
         purge_confirm: Rens alle meldinger?

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -177,6 +177,10 @@ nb:
           timezone: 'Tidssone:'
           visible_at: 'Synlig fra:'
         title: Kølagte jobber
+        discard: Forkast
+        discard_confirm: Forkaste denne meldingen?
+        retry: Prøv igjen
+        retry_confirm: Tilbakestill synlighetstidsavbrudd og prøv igjen?
       failed_table:
         discard: Forkast
         discard_confirm: Forkast denne jobben?
@@ -301,18 +305,25 @@ nb:
         delete_confirm: Slette denne køen permanent? Dette kan ikke angres.
         delete_queue: Slett kø
         depth: 'Dybde:'
+        discard: Forkast
+        discard_confirm: Forkaste denne meldingen?
         empty: Køen er tom
         headers:
+          actions: Handlinger
           enqueued: I kø
           id: ID
           payload: Innhold
           reads: Lesninger
           vt: VT
+        message_discarded: Melding forkastet.
+        message_retried: Meldingens synlighet tilbakestilt.
         pause: Pause
         pause_confirm: Pause behandling?
         purge_confirm: Rens alle meldinger?
         purge_queue: Rens kø
         resume: Gjenoppta
+        retry: Prøv igjen
+        retry_confirm: Tilbakestill synlighetstidsavbrudd og prøv igjen?
         total: 'Totalt:'
         visible: 'Synlig:'
     recurring_tasks:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -177,6 +177,10 @@ nl:
           timezone: 'Tijdzone:'
           visible_at: 'Zichtbaar op:'
         title: Taken in de wachtrij
+        discard: Verwerpen
+        discard_confirm: Dit bericht verwerpen?
+        retry: Opnieuw proberen
+        retry_confirm: Zichtbaarheidstimeout resetten en opnieuw proberen?
       failed_table:
         discard: Verwijderen
         discard_confirm: Deze taak verwijderen?
@@ -301,18 +305,25 @@ nl:
         delete_confirm: Deze wachtrij permanent verwijderen? Dit kan niet ongedaan worden gemaakt.
         delete_queue: Wachtrij verwijderen
         depth: 'Diepte:'
+        discard: Verwerpen
+        discard_confirm: Dit bericht verwerpen?
         empty: Wachtrij is leeg
         headers:
+          actions: Acties
           enqueued: In de wachtrij geplaatst
           id: ID
           payload: Inhoud
           reads: Lezingen
           vt: VT
+        message_discarded: Bericht verworpen.
+        message_retried: Zichtbaarheid van bericht gereset.
         pause: Pauzeren
         pause_confirm: Verwerking pauzeren?
         purge_confirm: Alle berichten verwijderen?
         purge_queue: Wachtrij opschonen
         resume: Hervatten
+        retry: Opnieuw proberen
+        retry_confirm: Zichtbaarheidstimeout resetten en opnieuw proberen?
         total: 'Totaal:'
         visible: 'Zichtbaar:'
     recurring_tasks:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -315,8 +315,10 @@ nl:
           payload: Inhoud
           reads: Lezingen
           vt: VT
+        message_discard_failed: Kon bericht niet verwerpen.
         message_discarded: Bericht verworpen.
         message_retried: Zichtbaarheid van bericht gereset.
+        message_retry_failed: Kon bericht niet opnieuw proberen.
         pause: Pauzeren
         pause_confirm: Verwerking pauzeren?
         purge_confirm: Alle berichten verwijderen?

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -177,6 +177,10 @@ pt:
           timezone: 'Fuso horário:'
           visible_at: 'Visível em:'
         title: Trabalhos Enfileirados
+        discard: Descartar
+        discard_confirm: Descartar esta mensagem?
+        retry: Tentar novamente
+        retry_confirm: Redefinir tempo de visibilidade e tentar novamente?
       failed_table:
         discard: Descartar
         discard_confirm: Descartar este trabalho?
@@ -301,18 +305,25 @@ pt:
         delete_confirm: Excluir permanentemente esta fila? Esta ação não pode ser desfeita.
         delete_queue: Excluir fila
         depth: 'Profundidade:'
+        discard: Descartar
+        discard_confirm: Descartar esta mensagem?
         empty: Fila está vazia
         headers:
+          actions: Ações
           enqueued: Enfileirado
           id: ID
           payload: Carga útil
           reads: Leituras
           vt: VT
+        message_discarded: Mensagem descartada.
+        message_retried: Visibilidade da mensagem redefinida.
         pause: Pausar
         pause_confirm: Pausar processamento?
         purge_confirm: Limpar todas as mensagens?
         purge_queue: Limpar fila
         resume: Retomar
+        retry: Tentar novamente
+        retry_confirm: Redefinir tempo de visibilidade e tentar novamente?
         total: 'Total:'
         visible: 'Visível:'
     recurring_tasks:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -315,8 +315,10 @@ pt:
           payload: Carga útil
           reads: Leituras
           vt: VT
+        message_discard_failed: Não foi possível descartar a mensagem.
         message_discarded: Mensagem descartada.
         message_retried: Visibilidade da mensagem redefinida.
+        message_retry_failed: Não foi possível tentar novamente a mensagem.
         pause: Pausar
         pause_confirm: Pausar processamento?
         purge_confirm: Limpar todas as mensagens?

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -177,6 +177,10 @@ sv:
           timezone: 'Tidszon:'
           visible_at: 'Synlig vid:'
         title: Köade jobb
+        discard: Kassera
+        discard_confirm: Kassera detta meddelande?
+        retry: Försök igen
+        retry_confirm: Återställ synlighetstimeout och försök igen?
       failed_table:
         discard: Kassera
         discard_confirm: Kassera detta jobb?
@@ -301,18 +305,25 @@ sv:
         delete_confirm: Ta bort denna kö permanent? Detta kan inte ångras.
         delete_queue: Ta bort kö
         depth: 'Djup:'
+        discard: Kassera
+        discard_confirm: Kassera detta meddelande?
         empty: Kön är tom
         headers:
+          actions: Åtgärder
           enqueued: Inlagd
           id: ID
           payload: Innehåll
           reads: Läsningar
           vt: VT
+        message_discarded: Meddelande kasserat.
+        message_retried: Meddelandets synlighet återställd.
         pause: Pausa
         pause_confirm: Pausa bearbetning?
         purge_confirm: Rensa alla meddelanden?
         purge_queue: Rensa kö
         resume: Återuppta
+        retry: Försök igen
+        retry_confirm: Återställ synlighetstimeout och försök igen?
         total: 'Totalt:'
         visible: 'Synliga:'
     recurring_tasks:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -315,8 +315,10 @@ sv:
           payload: Innehåll
           reads: Läsningar
           vt: VT
+        message_discard_failed: Kunde inte kassera meddelandet.
         message_discarded: Meddelande kasserat.
         message_retried: Meddelandets synlighet återställd.
+        message_retry_failed: Kunde inte försöka igen med meddelandet.
         pause: Pausa
         pause_confirm: Pausa bearbetning?
         purge_confirm: Rensa alla meddelanden?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Pgbus::Engine.routes.draw do
       post :purge
       post :pause
       post :resume
+      post :retry_message
+      post :discard_message
     end
   end
 

--- a/spec/system/dead_letter_spec.rb
+++ b/spec/system/dead_letter_spec.rb
@@ -39,5 +39,46 @@ RSpec.describe "Dead Letter Queue", type: :system do
       expect(page).to have_button("Retry")
       expect(page).to have_button("Discard")
     end
+
+    it "retry DLQ message: no confirm, shows toast" do
+      visit "/pgbus/dlq"
+
+      find("details summary").click
+      click_button "Retry"
+
+      expect(page).to have_toast("re-enqueued")
+      expect(@stub_data_source).to be_called(:retry_dlq_message)
+    end
+
+    it "discard DLQ message: confirm and shows toast" do
+      visit "/pgbus/dlq"
+
+      find("details summary").click
+      click_button "Discard"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("discarded")
+      expect(@stub_data_source).to be_called(:discard_dlq_message)
+    end
+
+    it "retry all: confirm and shows toast" do
+      visit "/pgbus/dlq"
+
+      click_button "Retry All"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Re-enqueued")
+      expect(@stub_data_source).to be_called(:retry_all_dlq)
+    end
+
+    it "discard all: confirm and shows toast" do
+      visit "/pgbus/dlq"
+
+      click_button "Discard All"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Discarded")
+      expect(@stub_data_source).to be_called(:discard_all_dlq)
+    end
   end
 end

--- a/spec/system/jobs_spec.rb
+++ b/spec/system/jobs_spec.rb
@@ -61,5 +61,15 @@ RSpec.describe "Jobs", type: :system do
       expect(page).to have_text("42")
       expect(page).to have_text("TestJob")
     end
+
+    it "shows discard and retry buttons in expanded row" do
+      visit "/pgbus/jobs"
+
+      # Expand the details row
+      find("details summary").click
+
+      expect(page).to have_button("Discard")
+      expect(page).to have_button("Retry")
+    end
   end
 end

--- a/spec/system/jobs_spec.rb
+++ b/spec/system/jobs_spec.rb
@@ -65,11 +65,61 @@ RSpec.describe "Jobs", type: :system do
     it "shows discard and retry buttons in expanded row" do
       visit "/pgbus/jobs"
 
-      # Expand the details row
       find("details summary").click
 
       expect(page).to have_button("Discard")
       expect(page).to have_button("Retry")
+    end
+
+    it "discard enqueued job: confirm and redirects with toast" do
+      visit "/pgbus/jobs"
+
+      find("details summary").click
+      click_button "Discard"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Message discarded")
+      expect(@stub_data_source).to be_called(:discard_job)
+    end
+
+    it "retry enqueued job: confirm and redirects with toast" do
+      visit "/pgbus/jobs"
+
+      find("details summary").click
+      click_button "Retry"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Message visibility reset")
+      expect(@stub_data_source).to be_called(:retry_job)
+    end
+  end
+
+  describe "failed job actions" do
+    before do
+      @stub_data_source.failed_events_list = [
+        { "id" => 1, "queue_name" => "pgbus_default", "error_class" => "ArgumentError",
+          "error_message" => "bad args", "retry_count" => 3,
+          "failed_at" => Time.now.utc.iso8601 }
+      ]
+    end
+
+    it "retry failed job: no confirm needed, shows toast" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-failed") { click_button "Retry", match: :first }
+
+      expect(page).to have_toast("re-enqueued")
+      expect(@stub_data_source).to be_called(:retry_failed_event)
+    end
+
+    it "discard failed job: confirm and shows toast" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-failed") { click_button "Discard", match: :first }
+      accept_confirm_dialog
+
+      expect(page).to have_toast("discarded")
+      expect(@stub_data_source).to be_called(:discard_failed_event)
     end
   end
 end

--- a/spec/system/queues_spec.rb
+++ b/spec/system/queues_spec.rb
@@ -99,5 +99,18 @@ RSpec.describe "Queues", type: :system do
       expect(page).to have_text("42")
       expect(page).to have_text("3") # read_ct
     end
+
+    it "shows discard and retry buttons for each message" do
+      @stub_data_source.jobs_list = [
+        { msg_id: 42, queue_name: "pgbus_default", read_ct: 0,
+          enqueued_at: Time.now.utc.iso8601, vt: Time.now.utc.iso8601,
+          message: '{"job_class":"TestJob"}' }
+      ]
+
+      visit "/pgbus/queues/pgbus_default"
+
+      expect(page).to have_button("Discard", count: 1)
+      expect(page).to have_button("Retry", count: 1)
+    end
   end
 end

--- a/spec/system/queues_spec.rb
+++ b/spec/system/queues_spec.rb
@@ -113,4 +113,89 @@ RSpec.describe "Queues", type: :system do
       expect(page).to have_button("Retry", count: 1)
     end
   end
+
+  describe "queue actions" do
+    it "purge: confirm dialog accepts and shows toast" do
+      visit "/pgbus/queues/pgbus_default"
+
+      click_button "Purge Queue"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Queue purged")
+      expect(@stub_data_source).to be_called(:purge_queue)
+    end
+
+    it "purge: cancel dialog does not purge" do
+      visit "/pgbus/queues/pgbus_default"
+
+      click_button "Purge Queue"
+      dismiss_confirm_dialog
+
+      # Still on show page, no toast, no call
+      expect(page).to have_css("h1", text: "pgbus_default")
+      expect(@stub_data_source).not_to be_called(:purge_queue)
+    end
+
+    it "delete: confirm dialog deletes and redirects to index" do
+      visit "/pgbus/queues/pgbus_default"
+
+      click_button "Delete Queue"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("deleted")
+      expect(page).to have_css("h1", text: "Queues")
+      expect(@stub_data_source).to be_called(:drop_queue)
+    end
+
+    it "pause: confirm dialog pauses and shows toast" do
+      visit "/pgbus/queues/pgbus_default"
+
+      click_button "Pause"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Queue paused")
+      expect(@stub_data_source).to be_called(:pause_queue)
+    end
+
+    it "resume: no confirm needed, shows toast" do
+      @stub_data_source.paused_queues = ["pgbus_default"]
+
+      visit "/pgbus/queues/pgbus_default"
+
+      click_button "Resume"
+
+      expect(page).to have_toast("Queue resumed")
+      expect(@stub_data_source).to be_called(:resume_queue)
+    end
+
+    context "with messages" do
+      before do
+        @stub_data_source.jobs_list = [
+          { msg_id: 42, queue_name: "pgbus_default", read_ct: 0,
+            enqueued_at: Time.now.utc.iso8601, vt: Time.now.utc.iso8601,
+            message: '{"job_class":"TestJob"}' }
+        ]
+      end
+
+      it "discard message: confirm and shows toast" do
+        visit "/pgbus/queues/pgbus_default"
+
+        within("tr", text: "42") { click_button "Discard" }
+        accept_confirm_dialog
+
+        expect(page).to have_toast("Message discarded")
+        expect(@stub_data_source).to be_called(:discard_job)
+      end
+
+      it "retry message: confirm and shows toast" do
+        visit "/pgbus/queues/pgbus_default"
+
+        within("tr", text: "42") { click_button "Retry" }
+        accept_confirm_dialog
+
+        expect(page).to have_toast("Message visibility reset")
+        expect(@stub_data_source).to be_called(:retry_job)
+      end
+    end
+  end
 end

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -38,6 +38,8 @@ module Pgbus
       def queue_paused?(name) = @paused_queues.include?(name)
       def pause_queue(_name, reason: nil) = true
       def resume_queue(_name) = true
+      def retry_job(_queue_name, _msg_id) = true
+      def discard_job(_queue_name, _msg_id) = true
       def retry_failed_event(_id) = true
       def discard_failed_event(_id) = true
       def retry_all_failed = @failed_events_list.size

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -6,6 +6,7 @@ module Pgbus
       attr_accessor :stats, :queues, :processes_list, :failed_events_list,
                     :dlq_messages_list, :events_list, :subscribers_list, :jobs_list,
                     :paused_queues
+      attr_reader :calls
 
       def initialize
         @stats = default_stats
@@ -17,6 +18,7 @@ module Pgbus
         @subscribers_list = []
         @jobs_list = []
         @paused_queues = []
+        @calls = Hash.new { |h, k| h[k] = [] }
       end
 
       def summary_stats = @stats
@@ -33,24 +35,32 @@ module Pgbus
       def processed_event(id) = @events_list.find { |e| e["id"].to_s == id.to_s }
       def registered_subscribers = @subscribers_list
       def jobs(queue_name: nil, page: 1, per_page: 25) = @jobs_list
-      def purge_queue(_name) = true
-      def drop_queue(_name) = true
       def queue_paused?(name) = @paused_queues.include?(name)
-      def pause_queue(_name, reason: nil) = true
-      def resume_queue(_name) = true
-      def retry_job(_queue_name, _msg_id) = true
-      def discard_job(_queue_name, _msg_id) = true
-      def retry_failed_event(_id) = true
-      def discard_failed_event(_id) = true
-      def retry_all_failed = @failed_events_list.size
-      def discard_all_failed = @failed_events_list.size
-      def retry_dlq_message(_queue_name, _msg_id) = true
-      def discard_dlq_message(_queue_name, _msg_id) = true
-      def retry_all_dlq = @dlq_messages_list.size
-      def discard_all_dlq = @dlq_messages_list.size
-      def replay_event(_event) = true
+
+      def purge_queue(name)          = record(:purge_queue, name)
+      def drop_queue(name)           = record(:drop_queue, name)
+      def pause_queue(name, reason: nil) = record(:pause_queue, name, reason)
+      def resume_queue(name) = record(:resume_queue, name)
+      def retry_job(queue_name, msg_id)   = record(:retry_job, queue_name, msg_id)
+      def discard_job(queue_name, msg_id) = record(:discard_job, queue_name, msg_id)
+      def retry_failed_event(id)     = record(:retry_failed_event, id)
+      def discard_failed_event(id)   = record(:discard_failed_event, id)
+      def retry_all_failed           = record(:retry_all_failed) && @failed_events_list.size
+      def discard_all_failed         = record(:discard_all_failed) && @failed_events_list.size
+      def retry_dlq_message(queue_name, msg_id) = record(:retry_dlq_message, queue_name, msg_id)
+      def discard_dlq_message(queue_name, msg_id) = record(:discard_dlq_message, queue_name, msg_id)
+      def retry_all_dlq              = record(:retry_all_dlq) && @dlq_messages_list.size
+      def discard_all_dlq            = record(:discard_all_dlq) && @dlq_messages_list.size
+      def replay_event(event)        = record(:replay_event, event)
+
+      def called?(method_name) = @calls.key?(method_name)
 
       private
+
+      def record(method_name, *args)
+        @calls[method_name] << args
+        true
+      end
 
       def default_stats
         { total_queues: 2, total_depth: 15, total_visible: 12,

--- a/spec/system/support/dialog_helpers.rb
+++ b/spec/system/support/dialog_helpers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DialogHelpers
+  # Accept the custom <dialog>-based confirm by clicking the Confirm/Delete button.
+  def accept_confirm_dialog
+    dialog = find("dialog#pgbus-confirm-dialog", visible: true)
+    dialog.find("button[value='confirm']").click
+  end
+
+  # Dismiss the custom <dialog>-based confirm by clicking Cancel.
+  def dismiss_confirm_dialog
+    dialog = find("dialog#pgbus-confirm-dialog", visible: true)
+    dialog.find("button[value='cancel']").click
+  end
+
+  # Wait for a toast notification with the given text.
+  def have_toast(text)
+    have_css("#pgbus-toast-container", text: text)
+  end
+end
+
+RSpec.configure do |config|
+  config.include DialogHelpers, type: :system
+end


### PR DESCRIPTION
## Summary
- **Per-message discard/retry from any queue**: Users can now selectively remove or retry individual messages from any queue — the last major gap vs Sidekiq
  - Queue show page: each message row has Retry and Discard buttons with confirm dialogs
  - Jobs enqueued table: expanded rows now have Retry and Discard buttons
  - Routes: `POST /queues/:name/retry_message?msg_id=X` and `POST /queues/:name/discard_message?msg_id=X`
- **Fix confirm dialog**: Wrap buttons in `<form method="dialog">` so clicking Cancel/Confirm actually closes the dialog
- **Fix flash toasts on Turbo Drive navigation**: Module scripts only execute once — added `turbo:load` listener to render flash toasts after Turbo navigations
- **Fix enqueued table turbo frame escape**: Added `turbo_frame: "_top"` to enqueued table buttons to break out of the frame on redirect
- **Comprehensive interaction system tests**: 59 system tests now covering actual clicking, confirming, canceling, and toast verification across all dashboard actions
- **StubDataSource upgraded**: Tracks method calls for assertion (`called?(:purge_queue)`)
- **DialogHelpers module**: `accept_confirm_dialog`, `dismiss_confirm_dialog`, `have_toast` for interacting with the custom `<dialog>` element in tests
- **i18n**: All new keys translated across 12 locales

## Test plan (59 system tests, 781 total)
### Queue actions (confirmed by clicking dialog)
- [x] Purge queue + confirm → toast "Queue purged"
- [x] Purge queue + cancel → no action, stays on page
- [x] Delete queue + confirm → redirect to index, toast "deleted"
- [x] Pause queue + confirm → toast "Queue paused"
- [x] Resume queue (no confirm) → toast "Queue resumed"
- [x] Discard message + confirm → toast "Message discarded"
- [x] Retry message + confirm → toast "Message visibility reset"

### Jobs actions
- [x] Discard enqueued job + confirm → toast
- [x] Retry enqueued job + confirm → toast
- [x] Retry failed job (no confirm) → toast "re-enqueued"
- [x] Discard failed job + confirm → toast "discarded"

### DLQ actions
- [x] Retry DLQ message (no confirm) → toast "re-enqueued"
- [x] Discard DLQ message + confirm → toast "discarded"
- [x] Retry All + confirm → toast
- [x] Discard All + confirm → toast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-message Retry and Discard actions added to job rows and queue detail pages, with confirmation and success toasts.
  * New routes/back-end hooks to perform retry/discard operations.

* **UI**
  * Toast rendering improved to persist across Turbo page loads.
  * Dialog actions now use native dialog form semantics for confirm/cancel behavior.

* **Localization**
  * UI strings added for retry/discard workflows in 12 languages.

* **Tests**
  * System tests covering message retry/discard and related dialogs/toasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->