### PR TITLE
fix(worker): evict deleted queues and periodically re-resolve wildcards

### DIFF
--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -12,11 +12,13 @@ module Pgbus
       def initialize(queues:, threads: 5, config: Pgbus.configuration,
                      single_active_consumer: false, consumer_priority: 0)
         @queues = Array(queues)
+        @wildcard = @queues.include?("*")
         @threads = threads
         @config = config
         @single_active_consumer = single_active_consumer
         @consumer_priority = consumer_priority
         @lifecycle = Lifecycle.new
+        @last_wildcard_resolve = nil
         @jobs_processed = Concurrent::AtomicFixnum.new(0)
         @jobs_failed = Concurrent::AtomicFixnum.new(0)
         @in_flight = Concurrent::AtomicFixnum.new(0)
@@ -53,6 +55,7 @@ module Pgbus
         loop do
           process_signals
           check_recycle
+          refresh_wildcard_queues
 
           break if @lifecycle.stopped?
           break if @lifecycle.draining? && @pool.queue_length.zero?
@@ -78,6 +81,8 @@ module Pgbus
         @wake_signal.notify!
         @pool.kill
       end
+
+      WILDCARD_REFRESH_INTERVAL = 30 # seconds
 
       private
 
@@ -125,7 +130,11 @@ module Pgbus
           fetch_multi(active_queues, qty)
         end
       rescue StandardError => e
-        Pgbus.logger.error { "[Pgbus] Error fetching messages: #{e.message}" }
+        if e.message.include?("does not exist") && e.message.include?("pgmq.q_")
+          evict_missing_queues(e)
+        else
+          Pgbus.logger.error { "[Pgbus] Error fetching messages: #{e.message}" }
+        end
         []
       end
 
@@ -184,9 +193,8 @@ module Pgbus
       end
 
       # Resolve "*" to all non-DLQ queues from pgmq.meta, stripping the prefix.
-      # Called once at startup. If no wildcard, this is a no-op.
       def resolve_wildcard_queues
-        return unless @queues.include?("*")
+        return unless @queues.include?("*") || @wildcard
 
         dlq_suffix = config.dead_letter_queue_suffix
         prefix = "#{config.queue_prefix}_"
@@ -201,12 +209,39 @@ module Pgbus
           Pgbus.logger.warn { "[Pgbus] Wildcard queue '*' resolved to no queues — falling back to default" }
           @queues = [config.default_queue]
         else
+          if @last_wildcard_resolve && resolved != @queues
+            Pgbus.logger.info { "[Pgbus] Wildcard queues changed: #{@queues.join(", ")} → #{resolved.join(", ")}" }
+          end
           @queues = resolved
-          Pgbus.logger.info { "[Pgbus] Wildcard queue '*' resolved to: #{@queues.join(", ")}" }
+          Pgbus.logger.info { "[Pgbus] Wildcard queue '*' resolved to: #{@queues.join(", ")}" } unless @last_wildcard_resolve
         end
+        @last_wildcard_resolve = Time.now
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Failed to resolve wildcard queues: #{e.message} — falling back to default" }
-        @queues = [config.default_queue]
+        @queues = [config.default_queue] unless @last_wildcard_resolve
+      end
+
+      # Periodically re-resolve wildcard queues to pick up new queues and
+      # drop deleted ones without requiring a worker restart.
+      def refresh_wildcard_queues
+        return unless @wildcard
+        return if @last_wildcard_resolve && (Time.now - @last_wildcard_resolve) < WILDCARD_REFRESH_INTERVAL
+
+        resolve_wildcard_queues
+      end
+
+      # When a "relation does not exist" error occurs, the queue was deleted.
+      # Extract the queue name from the error and remove it from the active list.
+      def evict_missing_queues(error)
+        prefix = "#{config.queue_prefix}_"
+        if error.message =~ /pgmq\.q_(\w+)/
+          physical_name = Regexp.last_match(1)
+          logical_name = physical_name.delete_prefix(prefix)
+          if @queues.delete(logical_name)
+            Pgbus.logger.warn { "[Pgbus] Evicted deleted queue '#{logical_name}' (#{physical_name}) from worker" }
+          end
+        end
+        Pgbus.logger.error { "[Pgbus] Queue table missing: #{error.message}" }
       end
 
       def check_recycle

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -194,7 +194,7 @@ module Pgbus
 
       # Resolve "*" to all non-DLQ queues from pgmq.meta, stripping the prefix.
       def resolve_wildcard_queues
-        return unless @queues.include?("*") || @wildcard
+        return unless @wildcard
 
         dlq_suffix = config.dead_letter_queue_suffix
         prefix = "#{config.queue_prefix}_"
@@ -215,7 +215,7 @@ module Pgbus
           @queues = resolved
           Pgbus.logger.info { "[Pgbus] Wildcard queue '*' resolved to: #{@queues.join(", ")}" } unless @last_wildcard_resolve
         end
-        @last_wildcard_resolve = Time.now
+        @last_wildcard_resolve = monotonic_now
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Failed to resolve wildcard queues: #{e.message} — falling back to default" }
         @queues = [config.default_queue] unless @last_wildcard_resolve
@@ -225,7 +225,7 @@ module Pgbus
       # drop deleted ones without requiring a worker restart.
       def refresh_wildcard_queues
         return unless @wildcard
-        return if @last_wildcard_resolve && (Time.now - @last_wildcard_resolve) < WILDCARD_REFRESH_INTERVAL
+        return if @last_wildcard_resolve && (monotonic_now - @last_wildcard_resolve) < WILDCARD_REFRESH_INTERVAL
 
         resolve_wildcard_queues
       end
@@ -321,6 +321,10 @@ module Pgbus
         @heartbeat&.stop
         restore_signals
         Pgbus.logger.info { "[Pgbus] Worker stopped. Processed: #{@jobs_processed.value}, Failed: #{@jobs_failed.value}" }
+      end
+
+      def monotonic_now
+        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       end
     end
   end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -131,6 +131,28 @@ RSpec.describe Pgbus::Process::Worker do
         expect(worker.send(:fetch_messages, 5)).to eq([])
       end
     end
+
+    context "when a queue table is missing (deleted queue)" do
+      let(:prefix) { worker.config.queue_prefix }
+      let(:error_message) do
+        "Database connection error: ERROR:  relation \"pgmq.q_#{prefix}_stale_queue\" does not exist"
+      end
+
+      before do
+        worker.instance_variable_set(:@queues, %w[default stale_queue])
+        allow(mock_client).to receive(:read_multi)
+          .and_raise(StandardError, error_message)
+      end
+
+      it "evicts the deleted queue from the worker queue list" do
+        worker.send(:fetch_messages, 5)
+        expect(worker.queues).to eq(%w[default])
+      end
+
+      it "returns an empty array" do
+        expect(worker.send(:fetch_messages, 5)).to eq([])
+      end
+    end
   end
 
   describe "prefetch flow control" do
@@ -302,6 +324,44 @@ RSpec.describe Pgbus::Process::Worker do
 
     it "exposes single_active_consumer in stats" do
       expect(worker.stats[:single_active_consumer]).to be true
+    end
+  end
+
+  describe "#refresh_wildcard_queues (private)" do
+    let(:worker) { described_class.new(queues: %w[*], threads: 5) }
+    let(:prefix) { worker.config.queue_prefix }
+    let(:conn) { double("connection") }
+
+    before do
+      allow(ActiveRecord::Base).to receive(:connection).and_return(conn)
+    end
+
+    it "is a no-op for non-wildcard workers" do
+      static_worker = described_class.new(queues: %w[default], threads: 5)
+      static_worker.send(:refresh_wildcard_queues)
+      expect(static_worker.queues).to eq(%w[default])
+    end
+
+    it "re-resolves when enough time has passed" do
+      allow(conn).to receive(:select_values).and_return(["#{prefix}_default", "#{prefix}_events"])
+      worker.send(:resolve_wildcard_queues)
+      expect(worker.queues).to eq(%w[default events])
+
+      # Simulate time passing and queues changing
+      worker.instance_variable_set(:@last_wildcard_resolve, Time.now - 60)
+      allow(conn).to receive(:select_values).and_return(["#{prefix}_default"])
+      worker.send(:refresh_wildcard_queues)
+      expect(worker.queues).to eq(%w[default])
+    end
+
+    it "skips re-resolve when interval has not elapsed" do
+      allow(conn).to receive(:select_values).and_return(["#{prefix}_default"])
+      worker.send(:resolve_wildcard_queues)
+
+      # Try to refresh immediately — should be a no-op
+      worker.send(:refresh_wildcard_queues)
+      # Only called once (the initial resolve)
+      expect(conn).to have_received(:select_values).once
     end
   end
 

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe Pgbus::Process::Worker do
       expect(worker.queues).to eq(%w[default events])
 
       # Simulate time passing and queues changing
-      worker.instance_variable_set(:@last_wildcard_resolve, Time.now - 60)
+      worker.instance_variable_set(:@last_wildcard_resolve, Process.clock_gettime(Process::CLOCK_MONOTONIC) - 60)
       allow(conn).to receive(:select_values).and_return(["#{prefix}_default"])
       worker.send(:refresh_wildcard_queues)
       expect(worker.queues).to eq(%w[default])


### PR DESCRIPTION
## Summary
Fixes the error spam when a queue is deleted from the dashboard while a wildcard worker is running.

**Root cause**: Wildcard workers (`queues: ["*"]`) resolve queue names from `pgmq.meta` at startup and cache the list. When a queue is deleted via the dashboard (PGMQ `drop_queue`), the worker keeps trying to read from the now-deleted table every poll interval, producing `relation "pgmq.q_..." does not exist` errors forever.

**Fixes**:
- **Evict deleted queues**: When `fetch_messages` hits a "does not exist" error, extract the queue name and remove it from the worker's active queue list. One log line, no more spam.
- **Periodic re-resolve**: Wildcard workers now re-resolve their queue list from `pgmq.meta` every 30 seconds, picking up new queues and dropping deleted ones without requiring a restart. Changes are logged for observability.

**Not a recurring task issue**: The recurring tasks in the user's app don't specify a queue (they use nil/default), so they enqueue correctly. The double-prefixed queue (`pgbus_pgbus_default`) was a leftover from the original purge bug (fixed in PR #43). The wildcard worker found it in `pgmq.meta`, stripped one prefix, and the client added another — producing the error.

## Test plan
- [x] Worker evicts queue from list on "does not exist" error
- [x] Worker returns empty array after eviction (no crash)
- [x] Wildcard re-resolve picks up queue changes
- [x] Re-resolve skips when interval hasn't elapsed
- [x] Non-wildcard workers ignore refresh entirely
- [x] Full suite: 786 examples, 0 failures
- [x] RuboCop clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker now periodically refreshes wildcard queue configurations dynamically.

* **Bug Fixes**
  * Worker gracefully detects and removes deleted queue tables from active processing.

* **Tests**
  * Added test coverage for wildcard queue refresh behavior and deleted queue handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->