### PR TITLE
feat(metrics): add queue latency and retry tracking

### DIFF
--- a/app/controllers/pgbus/api/insights_controller.rb
+++ b/app/controllers/pgbus/api/insights_controller.rb
@@ -5,12 +5,17 @@ module Pgbus
     class InsightsController < ApplicationController
       def show
         minutes = insights_minutes
-        render json: {
+        payload = {
           summary: data_source.job_stats_summary(minutes: minutes),
           throughput: data_source.job_throughput(minutes: minutes),
           status_counts: data_source.job_status_counts(minutes: minutes),
           slowest: data_source.slowest_job_classes(minutes: minutes)
         }
+        if Pgbus::JobStat.latency_columns?
+          payload[:latency_trend] = data_source.latency_trend(minutes: minutes)
+          payload[:latency_by_queue] = data_source.latency_by_queue(minutes: minutes)
+        end
+        render json: payload
       end
     end
   end

--- a/app/controllers/pgbus/insights_controller.rb
+++ b/app/controllers/pgbus/insights_controller.rb
@@ -6,6 +6,8 @@ module Pgbus
       @minutes = insights_minutes
       @summary = data_source.job_stats_summary(minutes: @minutes)
       @slowest = data_source.slowest_job_classes(minutes: @minutes)
+      @latency_by_queue = data_source.latency_by_queue(minutes: @minutes)
+      @latency_available = Pgbus::JobStat.latency_columns?
     end
   end
 end

--- a/app/frontend/pgbus/modules/charts.js
+++ b/app/frontend/pgbus/modules/charts.js
@@ -12,13 +12,14 @@ function getThemeColors() {
   };
 }
 
-let throughputChart, statusChart;
+let throughputChart, statusChart, latencyChart;
 
 export function renderCharts(data, i18n) {
   const t = getThemeColors();
 
   if (throughputChart) throughputChart.destroy();
   if (statusChart) statusChart.destroy();
+  if (latencyChart) latencyChart.destroy();
 
   const throughputData = data.throughput.map(p => ({
     x: new Date(p.time).getTime(),
@@ -63,6 +64,32 @@ export function renderCharts(data, i18n) {
   } else {
     const el = document.querySelector("#status-chart");
     if (el) el.innerHTML = `<p class="text-center text-sm text-gray-400 dark:text-gray-500 pt-24">${i18n.noData || "No data"}</p>`;
+  }
+
+  // Latency chart (only if data is available)
+  const latencyEl = document.querySelector("#latency-chart");
+  if (latencyEl && data.latency_trend && data.latency_trend.length > 0) {
+    const avgData = data.latency_trend.map(p => ({ x: new Date(p.time).getTime(), y: p.avg_ms }));
+    const p95Data = data.latency_trend.map(p => ({ x: new Date(p.time).getTime(), y: p.p95_ms }));
+
+    latencyChart = new ApexCharts(latencyEl, {
+      series: [
+        { name: i18n.latencyAvg || "Avg", data: avgData },
+        { name: i18n.latencyP95 || "P95", data: p95Data },
+      ],
+      chart: { type: "line", height: 280, toolbar: { show: false }, background: "transparent", foreColor: t.text },
+      stroke: { curve: "smooth", width: [2, 2], dashArray: [0, 5] },
+      colors: ["#6366f1", "#f59e0b"],
+      xaxis: { type: "datetime", labels: { style: { colors: t.text } } },
+      yaxis: { labels: { style: { colors: t.text }, formatter: v => Math.round(v) + "ms" } },
+      grid: { borderColor: t.grid },
+      tooltip: { theme: t.tooltip },
+      dataLabels: { enabled: false },
+      legend: { position: "top", labels: { colors: t.text } },
+    });
+    latencyChart.render();
+  } else if (latencyEl) {
+    latencyEl.innerHTML = `<p class="text-center text-sm text-gray-400 dark:text-gray-500 pt-24">${i18n.noData || "No data"}</p>`;
   }
 }
 

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -10,15 +10,19 @@ module Pgbus
     scope :dead_lettered, -> { where(status: "dead_lettered") }
 
     # Record a job execution stat. Called by the executor after each job.
-    def self.record!(job_class:, queue_name:, status:, duration_ms:)
+    def self.record!(job_class:, queue_name:, status:, duration_ms:, enqueue_latency_ms: nil, retry_count: 0)
       return unless table_exists?
 
-      create!(
+      attrs = {
         job_class: job_class,
         queue_name: queue_name,
         status: status,
         duration_ms: duration_ms
-      )
+      }
+      attrs[:enqueue_latency_ms] = enqueue_latency_ms if latency_columns?
+      attrs[:retry_count] = retry_count if latency_columns?
+
+      create!(attrs)
     rescue StandardError => e
       Pgbus.logger.debug { "[Pgbus] Failed to record job stat: #{e.message}" }
     end
@@ -32,6 +36,15 @@ module Pgbus
       @table_exists = connection.table_exists?(table_name)
     rescue StandardError
       @table_exists = false
+    end
+
+    # Memoized — checks if the latency migration has been applied.
+    def self.latency_columns?
+      return @latency_columns if defined?(@latency_columns)
+
+      @latency_columns = table_exists? && column_names.include?("enqueue_latency_ms")
+    rescue StandardError
+      @latency_columns = false
     end
 
     # Throughput: jobs per minute bucketed by minute for the last N minutes
@@ -67,16 +80,30 @@ module Pgbus
 
     # Single-query aggregate summary using conditional counts.
     def self.summary(minutes: 60)
-      row = since(minutes.minutes.ago).pick(
-        Arel.sql("COUNT(*)"),
-        Arel.sql("COUNT(*) FILTER (WHERE status = 'success')"),
-        Arel.sql("COUNT(*) FILTER (WHERE status = 'failed')"),
-        Arel.sql("COUNT(*) FILTER (WHERE status = 'dead_lettered')"),
-        Arel.sql("ROUND(AVG(duration_ms)::numeric, 1)"),
-        Arel.sql("MAX(duration_ms)")
-      )
+      cols = [
+        "COUNT(*)",
+        "COUNT(*) FILTER (WHERE status = 'success')",
+        "COUNT(*) FILTER (WHERE status = 'failed')",
+        "COUNT(*) FILTER (WHERE status = 'dead_lettered')",
+        "ROUND(AVG(duration_ms)::numeric, 1)",
+        "MAX(duration_ms)"
+      ]
+      if latency_columns?
+        cols.push(
+          "ROUND(AVG(enqueue_latency_ms) FILTER (WHERE enqueue_latency_ms IS NOT NULL)::numeric, 1)",
+          "PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY enqueue_latency_ms) " \
+          "FILTER (WHERE enqueue_latency_ms IS NOT NULL)",
+          "PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY enqueue_latency_ms) " \
+          "FILTER (WHERE enqueue_latency_ms IS NOT NULL)",
+          "PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY enqueue_latency_ms) " \
+          "FILTER (WHERE enqueue_latency_ms IS NOT NULL)",
+          "ROUND(AVG(retry_count) FILTER (WHERE retry_count IS NOT NULL)::numeric, 2)"
+        )
+      end
 
-      {
+      row = since(minutes.minutes.ago).pick(*cols.map { |c| Arel.sql(c) })
+
+      result = {
         total: row[0].to_i,
         success: row[1].to_i,
         failed: row[2].to_i,
@@ -84,6 +111,51 @@ module Pgbus
         avg_duration_ms: row[4]&.to_f || 0,
         max_duration_ms: row[5].to_i
       }
+
+      if latency_columns?
+        result.merge!(
+          avg_latency_ms: row[6]&.to_f || 0,
+          p50_latency_ms: row[7]&.to_f || 0,
+          p95_latency_ms: row[8]&.to_f || 0,
+          p99_latency_ms: row[9]&.to_f || 0,
+          avg_retries: row[10]&.to_f || 0
+        )
+      end
+
+      result
+    end
+
+    # Latency trend: average enqueue latency per minute bucketed
+    def self.latency_trend(minutes: 60)
+      return [] unless latency_columns?
+
+      since(minutes.minutes.ago)
+        .where.not(enqueue_latency_ms: nil)
+        .group("date_trunc('minute', created_at)")
+        .order(Arel.sql("date_trunc('minute', created_at)"))
+        .pluck(
+          Arel.sql("date_trunc('minute', created_at)"),
+          Arel.sql("ROUND(AVG(enqueue_latency_ms))"),
+          Arel.sql("ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY enqueue_latency_ms))")
+        )
+        .map { |time, avg, p95| { time: time, avg_ms: avg.to_i, p95_ms: p95.to_i } }
+    end
+
+    # Average latency by queue
+    def self.avg_latency_by_queue(minutes: 60)
+      return {} unless latency_columns?
+
+      since(minutes.minutes.ago)
+        .where.not(enqueue_latency_ms: nil)
+        .group(:queue_name)
+        .order(Arel.sql("AVG(enqueue_latency_ms) DESC"))
+        .pluck(
+          :queue_name,
+          Arel.sql("ROUND(AVG(enqueue_latency_ms))"),
+          Arel.sql("ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY enqueue_latency_ms))"),
+          Arel.sql("COUNT(*)")
+        )
+        .map { |q, avg, p95, count| { queue_name: q, avg_ms: avg.to_i, p95_ms: p95.to_i, count: count.to_i } }
     end
 
     # Cleanup old stats

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -143,7 +143,7 @@ module Pgbus
 
     # Average latency by queue
     def self.avg_latency_by_queue(minutes: 60)
-      return {} unless latency_columns?
+      return [] unless latency_columns?
 
       since(minutes.minutes.ago)
         .where.not(enqueue_latency_ms: nil)

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -182,9 +182,8 @@
     .then(data => { chartData = data; renderCharts(data, i18n); })
     .catch(err => {
       const msg = '<p class="text-center text-sm text-gray-400 dark:text-gray-500 pt-24">' + i18n.failedToLoad + "</p>";
-      const el1 = document.querySelector("#throughput-chart");
-      const el2 = document.querySelector("#status-chart");
-      if (el1) el1.innerHTML = msg;
-      if (el2) el2.innerHTML = msg;
+      document.querySelectorAll("#throughput-chart, #status-chart, #latency-chart").forEach(el => {
+        el.innerHTML = msg;
+      });
     });
 </script>

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -51,6 +51,32 @@
   </div>
 </div>
 
+<% if @latency_available %>
+<!-- Latency summary cards -->
+<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5 mb-8">
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.summary.avg_latency") %></dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_ms_duration(@summary[:avg_latency_ms]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.summary.p50_latency") %></dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_ms_duration(@summary[:p50_latency_ms]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.summary.p95_latency") %></dt>
+    <dd class="mt-1 text-2xl font-semibold text-yellow-600 dark:text-yellow-400"><%= pgbus_ms_duration(@summary[:p95_latency_ms]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.summary.p99_latency") %></dt>
+    <dd class="mt-1 text-2xl font-semibold text-orange-600 dark:text-orange-400"><%= pgbus_ms_duration(@summary[:p99_latency_ms]) %></dd>
+  </div>
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.summary.avg_retries") %></dt>
+    <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= @summary[:avg_retries]&.round(2) || 0 %></dd>
+  </div>
+</div>
+<% end %>
+
 <!-- Charts -->
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
   <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
@@ -62,6 +88,46 @@
     <div id="status-chart" style="height: 280px;"></div>
   </div>
 </div>
+
+<% if @latency_available %>
+<!-- Latency chart -->
+<div class="grid grid-cols-1 gap-6 mb-8">
+  <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4"><%= t("pgbus.insights.show.charts.latency") %></h3>
+    <div id="latency-chart" style="height: 280px;"></div>
+  </div>
+</div>
+
+<!-- Latency by queue -->
+<div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700 mb-8">
+  <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300"><%= t("pgbus.insights.show.latency_by_queue.title") %></h3>
+  </div>
+  <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <thead class="bg-gray-50 dark:bg-gray-900">
+      <tr>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.latency_by_queue.headers.queue") %></th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.latency_by_queue.headers.count") %></th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.latency_by_queue.headers.avg") %></th>
+        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.latency_by_queue.headers.p95") %></th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+      <% @latency_by_queue.each do |row| %>
+        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+          <td data-label="Queue" class="px-4 py-3 text-sm font-medium text-gray-700 dark:text-gray-300"><%= row[:queue_name] %></td>
+          <td data-label="Count" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_number(row[:count]) %></td>
+          <td data-label="Avg" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:avg_ms]) %></td>
+          <td data-label="P95" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:p95_ms]) %></td>
+        </tr>
+      <% end %>
+      <% if @latency_by_queue.empty? %>
+        <tr><td colspan="4" class="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500"><%= t("pgbus.insights.show.latency_by_queue.empty") %></td></tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<% end %>
 
 <!-- Slowest job classes -->
 <div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
@@ -100,6 +166,8 @@
     seriesName: "<%= j(t("pgbus.insights.show.charts.series_name")) %>",
     noData: "<%= j(t("pgbus.insights.show.charts.no_data")) %>",
     failedToLoad: "<%= j(t("pgbus.insights.show.charts.failed_to_load")) %>",
+    latencyAvg: "<%= j(t("pgbus.insights.show.charts.latency_avg")) %>",
+    latencyP95: "<%= j(t("pgbus.insights.show.charts.latency_p95")) %>",
   };
 
   let chartData = null;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,11 +128,22 @@ en:
       show:
         charts:
           failed_to_load: Failed to load chart data
+          latency: Queue Latency (ms)
+          latency_avg: Avg
+          latency_p95: P95
           no_data: No data yet
           series_name: Jobs/min
           status_distribution: Status Distribution
           throughput: Throughput (jobs/min)
         description_html: Job performance metrics for the last %{range}
+        latency_by_queue:
+          empty: No latency data yet
+          headers:
+            avg: Avg (ms)
+            count: Count
+            p95: P95 (ms)
+            queue: Queue
+          title: Latency by Queue
         slowest:
           empty: No job stats yet
           headers:
@@ -143,9 +154,14 @@ en:
           title: Slowest Job Classes (avg duration)
         summary:
           avg_duration: Avg Duration
+          avg_latency: Avg Latency
+          avg_retries: Avg Retries
           dead_lettered: Dead Lettered
           failed: Failed
           max_duration: Max Duration
+          p50_latency: P50 Latency
+          p95_latency: P95 Latency
+          p99_latency: P99 Latency
           succeeded: Succeeded
           total_jobs: Total Jobs
         time_ranges:

--- a/lib/generators/pgbus/add_job_stats_latency_generator.rb
+++ b/lib/generators/pgbus/add_job_stats_latency_generator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class AddJobStatsLatencyGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Add enqueue latency and retry count columns to pgbus_job_stats"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
+      def create_migration_file
+        if separate_database?
+          migration_template "add_job_stats_latency.rb.erb",
+                             "db/pgbus_migrate/add_pgbus_job_stats_latency.rb"
+        else
+          migration_template "add_job_stats_latency.rb.erb",
+                             "db/migrate/add_pgbus_job_stats_latency.rb"
+        end
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus job stats latency columns installed!", :green
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
+        say "  2. Queue latency and retry metrics are now tracked automatically"
+        say "  3. View latency insights at /pgbus/insights"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/templates/add_job_stats_latency.rb.erb
+++ b/lib/generators/pgbus/templates/add_job_stats_latency.rb.erb
@@ -1,6 +1,6 @@
 class AddPgbusJobStatsLatency < ActiveRecord::Migration<%= migration_version %>
   def change
-    add_column :pgbus_job_stats, :enqueue_latency_ms, :integer
+    add_column :pgbus_job_stats, :enqueue_latency_ms, :bigint
     add_column :pgbus_job_stats, :retry_count, :integer, default: 0
 
     add_index :pgbus_job_stats, [:queue_name, :created_at],

--- a/lib/generators/pgbus/templates/add_job_stats_latency.rb.erb
+++ b/lib/generators/pgbus/templates/add_job_stats_latency.rb.erb
@@ -1,0 +1,9 @@
+class AddPgbusJobStatsLatency < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_column :pgbus_job_stats, :enqueue_latency_ms, :integer
+    add_column :pgbus_job_stats, :retry_count, :integer, default: 0
+
+    add_index :pgbus_job_stats, [:queue_name, :created_at],
+      name: "idx_pgbus_job_stats_queue_time"
+  end
+end

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -20,7 +20,7 @@ module Pgbus
           signal_concurrency(payload)
           signal_batch_discarded(payload)
           Uniqueness.release_lock(Uniqueness.extract_key(payload))
-          record_stat(payload, queue_name, "dead_lettered", execution_start)
+          record_stat(payload, queue_name, "dead_lettered", execution_start, message: message)
           return :dead_lettered
         end
 
@@ -56,12 +56,12 @@ module Pgbus
         end
 
         instrument("pgbus.job_completed", queue: queue_name, job_class: job_class)
-        record_stat(payload, queue_name, "success", execution_start)
+        record_stat(payload, queue_name, "success", execution_start, message: message)
         :success
       rescue StandardError => e
         handle_failure(message, queue_name, e)
         instrument("pgbus.job_failed", queue: queue_name, job_class: payload&.dig("job_class"), error: e.class.name)
-        record_stat(payload, queue_name, "failed", execution_start)
+        record_stat(payload, queue_name, "failed", execution_start, message: message)
         # Don't signal concurrency on transient failure — the job will be retried.
         # Semaphore is released only on success or dead-lettering.
         :failed
@@ -91,18 +91,35 @@ module Pgbus
         ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       end
 
-      def record_stat(payload, queue_name, status, start_time)
+      def record_stat(payload, queue_name, status, start_time, message: nil)
         return unless config.stats_enabled
 
         duration_ms = ((monotonic_now - start_time) * 1000).round
+        enqueue_latency_ms = compute_enqueue_latency(message)
+        retry_count = message ? [message.read_ct.to_i - 1, 0].max : 0
+
         JobStat.record!(
           job_class: payload&.dig("job_class") || "unknown",
           queue_name: queue_name,
           status: status,
-          duration_ms: duration_ms
+          duration_ms: duration_ms,
+          enqueue_latency_ms: enqueue_latency_ms,
+          retry_count: retry_count
         )
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus] Stat recording failed: #{e.message}" }
+      end
+
+      def compute_enqueue_latency(message)
+        return unless message
+
+        enqueued_at_str = message.enqueued_at
+        return unless enqueued_at_str
+
+        enqueued_at = Time.parse(enqueued_at_str.to_s)
+        ((Time.now.utc - enqueued_at) * 1000).round
+      rescue ArgumentError, TypeError
+        nil
       end
 
       def handle_failure(_message, _queue_name, error)

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 module Pgbus
   module ActiveJob
     class Executor
@@ -117,7 +119,7 @@ module Pgbus
         return unless enqueued_at_str
 
         enqueued_at = Time.parse(enqueued_at_str.to_s)
-        ((Time.now.utc - enqueued_at) * 1000).round
+        [((Time.now.utc - enqueued_at) * 1000).round, 0].max
       rescue ArgumentError, TypeError
         nil
       end

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -552,6 +552,20 @@ module Pgbus
         []
       end
 
+      def latency_trend(minutes: 60)
+        JobStat.latency_trend(minutes: minutes)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching latency trend: #{e.message}" }
+        []
+      end
+
+      def latency_by_queue(minutes: 60)
+        JobStat.avg_latency_by_queue(minutes: minutes)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching latency by queue: #{e.message}" }
+        []
+      end
+
       # Subscriber registry
       def registered_subscribers
         EventBus::Registry.instance.subscribers.map do |s|

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -192,20 +192,23 @@ RSpec.describe Pgbus::ActiveJob::Executor do
     end
 
     context "with job stat recording" do
-      let(:message) { build_message_double(msg_id: 1, message: message_json, read_ct: 1) }
+      let(:enqueued_at) { (Time.now.utc - 0.5).iso8601(6) } # 500ms ago
+      let(:message) { build_message_double(msg_id: 1, message: message_json, read_ct: 1, enqueued_at: enqueued_at) }
 
-      it "records a success stat after successful execution" do
+      it "records a success stat with enqueue latency and retry count" do
         executor.execute(message, queue_name)
 
         expect(Pgbus::JobStat).to have_received(:record!).with(
           job_class: "TestJob",
           queue_name: queue_name,
           status: "success",
-          duration_ms: an_instance_of(Integer)
+          duration_ms: an_instance_of(Integer),
+          enqueue_latency_ms: a_value >= 400,
+          retry_count: 0
         )
       end
 
-      it "records a failed stat when job raises" do
+      it "records a failed stat with enqueue latency" do
         allow(job_double).to receive(:perform_now).and_raise(StandardError, "boom")
 
         executor.execute(message, queue_name)
@@ -214,12 +217,17 @@ RSpec.describe Pgbus::ActiveJob::Executor do
           job_class: "TestJob",
           queue_name: queue_name,
           status: "failed",
-          duration_ms: an_instance_of(Integer)
+          duration_ms: an_instance_of(Integer),
+          enqueue_latency_ms: a_value >= 400,
+          retry_count: 0
         )
       end
 
-      it "records a dead_lettered stat for DLQ routing" do
-        dlq_message = build_message_double(msg_id: 99, message: message_json, read_ct: config.max_retries + 1)
+      it "records a dead_lettered stat with retry count from read_ct" do
+        dlq_message = build_message_double(
+          msg_id: 99, message: message_json,
+          read_ct: config.max_retries + 1, enqueued_at: enqueued_at
+        )
 
         executor.execute(dlq_message, queue_name)
 
@@ -227,7 +235,19 @@ RSpec.describe Pgbus::ActiveJob::Executor do
           job_class: "TestJob",
           queue_name: queue_name,
           status: "dead_lettered",
-          duration_ms: an_instance_of(Integer)
+          duration_ms: an_instance_of(Integer),
+          enqueue_latency_ms: a_value >= 400,
+          retry_count: config.max_retries
+        )
+      end
+
+      it "sets retry_count to read_ct minus 1 (first read is not a retry)" do
+        retry_message = build_message_double(msg_id: 50, message: message_json, read_ct: 3, enqueued_at: enqueued_at)
+
+        executor.execute(retry_message, queue_name)
+
+        expect(Pgbus::JobStat).to have_received(:record!).with(
+          hash_including(retry_count: 2)
         )
       end
 
@@ -239,6 +259,26 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         expect(Pgbus::JobStat).not_to have_received(:record!)
       ensure
         config.stats_enabled = true
+      end
+
+      it "handles nil enqueued_at gracefully" do
+        nil_enqueued = build_message_double(msg_id: 60, message: message_json, read_ct: 1, enqueued_at: nil)
+
+        executor.execute(nil_enqueued, queue_name)
+
+        expect(Pgbus::JobStat).to have_received(:record!).with(
+          hash_including(enqueue_latency_ms: nil)
+        )
+      end
+
+      it "handles malformed enqueued_at gracefully" do
+        bad_enqueued = build_message_double(msg_id: 61, message: message_json, read_ct: 1, enqueued_at: "not-a-date")
+
+        executor.execute(bad_enqueued, queue_name)
+
+        expect(Pgbus::JobStat).to have_received(:record!).with(
+          hash_including(enqueue_latency_ms: nil)
+        )
       end
     end
   end

--- a/spec/pgbus/job_stat_spec.rb
+++ b/spec/pgbus/job_stat_spec.rb
@@ -8,20 +8,50 @@ RSpec.describe Pgbus::JobStat do
   end
 
   describe ".record!" do
-    it "creates a stat record" do
-      described_class.record!(
-        job_class: "TestJob",
-        queue_name: "default",
-        status: "success",
-        duration_ms: 42
-      )
+    context "without latency columns" do
+      before { allow(described_class).to receive(:latency_columns?).and_return(false) }
 
-      expect(described_class).to have_received(:create!).with(
-        job_class: "TestJob",
-        queue_name: "default",
-        status: "success",
-        duration_ms: 42
-      )
+      it "creates a stat record without latency fields" do
+        described_class.record!(
+          job_class: "TestJob",
+          queue_name: "default",
+          status: "success",
+          duration_ms: 42,
+          enqueue_latency_ms: 150,
+          retry_count: 1
+        )
+
+        expect(described_class).to have_received(:create!).with(
+          job_class: "TestJob",
+          queue_name: "default",
+          status: "success",
+          duration_ms: 42
+        )
+      end
+    end
+
+    context "with latency columns" do
+      before { allow(described_class).to receive(:latency_columns?).and_return(true) }
+
+      it "creates a stat record with latency fields" do
+        described_class.record!(
+          job_class: "TestJob",
+          queue_name: "default",
+          status: "success",
+          duration_ms: 42,
+          enqueue_latency_ms: 150,
+          retry_count: 2
+        )
+
+        expect(described_class).to have_received(:create!).with(
+          job_class: "TestJob",
+          queue_name: "default",
+          status: "success",
+          duration_ms: 42,
+          enqueue_latency_ms: 150,
+          retry_count: 2
+        )
+      end
     end
 
     it "skips when table does not exist" do
@@ -38,6 +68,29 @@ RSpec.describe Pgbus::JobStat do
       expect do
         described_class.record!(job_class: "X", queue_name: "q", status: "s", duration_ms: 0)
       end.not_to raise_error
+    end
+  end
+
+  describe ".latency_columns?" do
+    before { described_class.remove_instance_variable(:@latency_columns) if described_class.instance_variable_defined?(:@latency_columns) }
+
+    it "returns false when table does not exist" do
+      allow(described_class).to receive(:table_exists?).and_return(false)
+      expect(described_class.latency_columns?).to be false
+    end
+  end
+
+  describe ".latency_trend" do
+    it "returns empty array when latency columns are not available" do
+      allow(described_class).to receive(:latency_columns?).and_return(false)
+      expect(described_class.latency_trend).to eq([])
+    end
+  end
+
+  describe ".avg_latency_by_queue" do
+    it "returns empty hash when latency columns are not available" do
+      allow(described_class).to receive(:latency_columns?).and_return(false)
+      expect(described_class.avg_latency_by_queue).to eq({})
     end
   end
 end

--- a/spec/pgbus/job_stat_spec.rb
+++ b/spec/pgbus/job_stat_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe Pgbus::JobStat do
   end
 
   describe ".avg_latency_by_queue" do
-    it "returns empty hash when latency columns are not available" do
+    it "returns empty array when latency columns are not available" do
       allow(described_class).to receive(:latency_columns?).and_return(false)
-      expect(described_class.avg_latency_by_queue).to eq({})
+      expect(described_class.avg_latency_by_queue).to eq([])
     end
   end
 end

--- a/spec/support/pgmq_doubles.rb
+++ b/spec/support/pgmq_doubles.rb
@@ -62,8 +62,10 @@ module PgmqDoubles
     end
   end
 
-  def build_message_double(msg_id: 1, message: "{}", read_ct: 0, headers: nil)
-    double("PGMQ::Message", msg_id: msg_id, message: message, read_ct: read_ct, headers: headers)
+  def build_message_double(msg_id: 1, message: "{}", read_ct: 0, headers: nil, enqueued_at: :default)
+    enqueued_at = Time.now.utc.iso8601(6) if enqueued_at == :default
+    double("PGMQ::Message", msg_id: msg_id, message: message, read_ct: read_ct,
+                            headers: headers, enqueued_at: enqueued_at)
   end
 
   def build_job_double(job_class: "TestJob", queue_name: "default", job_id: SecureRandom.uuid)


### PR DESCRIPTION
## Summary

- Track **enqueue-to-read latency** (time a message spends waiting in the queue before being picked up)
- Track **retry count** per job execution (derived from PGMQ's `read_ct`)
- Add **P50/P95/P99 latency percentiles** to the insights summary
- Add **latency trend chart** (avg + P95 over time) to the dashboard
- Add **latency-by-queue table** showing per-queue latency breakdown
- Inspired by [Sidekiq's metrics approach](https://www.mikeperham.com/2022/10/27/sidekiq-7.0-metrics/) but adapted for PGMQ

### How it works

The PGMQ message already carries an `enqueued_at` timestamp set by PostgreSQL when the message is produced. At execution time, the Executor calculates:
- `enqueue_latency_ms = (Time.now - message.enqueued_at) * 1000`
- `retry_count = message.read_ct - 1` (first read is not a retry)

These are stored in two new nullable columns on `pgbus_job_stats`.

### Migration

```bash
rails generate pgbus:add_job_stats_latency
rails db:migrate
```

### Fully backwards compatible

- New columns are nullable — existing rows unaffected
- All latency features gated behind `JobStat.latency_columns?`
- Works without the migration (just doesn't show latency data)
- No changes to PGMQ schema

## Test plan

- [x] `bundle exec rspec` — 805 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] Executor correctly captures latency from `enqueued_at`
- [x] Handles nil and malformed `enqueued_at` gracefully
- [x] `retry_count` = `read_ct - 1`, minimum 0
- [x] `record!` omits latency columns when migration not applied
- [x] `latency_trend` and `avg_latency_by_queue` return `[]`/`{}` without migration
- [ ] Manual: run migration and verify latency data appears in dashboard
- [ ] Manual: verify latency chart renders with ApexCharts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added job latency tracking (enqueue latency and retry counts), latency summary cards, latency-by-queue table, and a Latency Trend chart.
  * Generator to add latency columns/migration for existing deployments.
  * UI now conditionally shows latency UI and localized labels; charts show empty-state messaging when no latency data.

* **Tests**
  * Added/updated tests covering enqueue-latency, retry-count behavior and latency-related query methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->