### PR TITLE
fix: recurring scheduler respects ensures_uniqueness locks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,6 +178,17 @@ jobs:
                 ON pgbus_job_locks (expires_at);
               CREATE INDEX IF NOT EXISTS idx_pgbus_job_locks_reaper
                 ON pgbus_job_locks (state, owner_pid);
+
+              CREATE TABLE IF NOT EXISTS pgbus_recurring_executions (
+                id BIGSERIAL PRIMARY KEY,
+                task_key VARCHAR NOT NULL,
+                run_at TIMESTAMP NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+              );
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_pgbus_recurring_executions_dedup
+                ON pgbus_recurring_executions (task_key, run_at);
+              CREATE INDEX IF NOT EXISTS idx_pgbus_recurring_executions_cleanup
+                ON pgbus_recurring_executions (run_at);
             SQL
             conn.close
           "

--- a/lib/pgbus/recurring/schedule.rb
+++ b/lib/pgbus/recurring/schedule.rb
@@ -125,7 +125,7 @@ module Pgbus
         return false unless config
         return false unless config[:strategy] == :until_executed
 
-        key = resolve_uniqueness_key(job_class, config, task)
+        key = resolve_uniqueness_key(config, task)
         return false unless key
 
         # Try to acquire the lock. If it fails, the lock is already held.
@@ -146,7 +146,7 @@ module Pgbus
 
       # Resolve the uniqueness key for a recurring task.
       # For no-argument recurring jobs, the key defaults to the class name.
-      def resolve_uniqueness_key(job_class, config, task)
+      def resolve_uniqueness_key(config, task)
         key_proc = config[:key]
         args = task.arguments || []
 
@@ -166,12 +166,12 @@ module Pgbus
         return payload unless task.class_name
 
         job_class = task.class_name.safe_constantize
-        return payload unless job_class&.respond_to?(:pgbus_uniqueness)
+        return payload unless job_class.respond_to?(:pgbus_uniqueness)
 
         config = job_class.pgbus_uniqueness
         return payload unless config
 
-        key = resolve_uniqueness_key(job_class, config, task)
+        key = resolve_uniqueness_key(config, task)
         return payload unless key
 
         payload.merge(

--- a/lib/pgbus/recurring/schedule.rb
+++ b/lib/pgbus/recurring/schedule.rb
@@ -17,9 +17,23 @@ module Pgbus
       def enqueue_task(task, run_at:)
         queue = resolve_queue(task)
 
+        # Check uniqueness lock before enqueuing. If the job class declares
+        # ensures_uniqueness, we acquire the lock here so duplicate recurring
+        # enqueues are rejected while a previous instance is still queued or running.
+        if uniqueness_locked?(task)
+          Pgbus.logger.debug do
+            "[Pgbus] Recurring task #{task.key} skipped: uniqueness lock held"
+          end
+          return
+        end
+
         RecurringExecution.record(task.key, run_at) do
           payload = build_payload(task)
           headers = build_headers(task, run_at)
+
+          # Inject uniqueness metadata into the payload so the worker knows
+          # to release the lock after execution.
+          payload = inject_uniqueness_metadata(task, payload)
 
           Pgbus.client.ensure_queue(queue)
           Pgbus.client.send_message(queue, payload, headers: headers)
@@ -96,6 +110,75 @@ module Pgbus
           "pgbus.recurring_run_at" => run_at.iso8601,
           "pgbus.recurring_schedule" => task.schedule
         }
+      end
+
+      # Check if the job class has ensures_uniqueness and if its lock is currently held.
+      # Returns true if the lock is held (skip enqueue), false otherwise.
+      def uniqueness_locked?(task)
+        return false unless task.class_name
+
+        job_class = task.class_name.safe_constantize
+        return false unless job_class
+        return false unless job_class.respond_to?(:pgbus_uniqueness)
+
+        config = job_class.pgbus_uniqueness
+        return false unless config
+        return false unless config[:strategy] == :until_executed
+
+        key = resolve_uniqueness_key(job_class, config, task)
+        return false unless key
+
+        # Try to acquire the lock. If it fails, the lock is already held.
+        acquired = JobLock.acquire!(
+          key,
+          job_class: task.class_name,
+          job_id: "recurring-#{task.key}",
+          state: "queued",
+          ttl: config[:lock_ttl]
+        )
+        # If we acquired it, great — the message will be enqueued with the lock held.
+        # If not, a previous instance is still queued/running.
+        !acquired
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Uniqueness check failed for #{task.key}: #{e.message}" }
+        false # Fail open — allow enqueue if uniqueness check errors
+      end
+
+      # Resolve the uniqueness key for a recurring task.
+      # For no-argument recurring jobs, the key defaults to the class name.
+      def resolve_uniqueness_key(job_class, config, task)
+        key_proc = config[:key]
+        args = task.arguments || []
+
+        if args.empty?
+          key_proc.call
+        else
+          key_proc.call(*args)
+        end
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Could not resolve uniqueness key for #{task.key}: #{e.message}" }
+        nil
+      end
+
+      # Inject uniqueness metadata into the payload so the executor releases
+      # the lock after the job completes.
+      def inject_uniqueness_metadata(task, payload)
+        return payload unless task.class_name
+
+        job_class = task.class_name.safe_constantize
+        return payload unless job_class&.respond_to?(:pgbus_uniqueness)
+
+        config = job_class.pgbus_uniqueness
+        return payload unless config
+
+        key = resolve_uniqueness_key(job_class, config, task)
+        return payload unless key
+
+        payload.merge(
+          Pgbus::Uniqueness::METADATA_KEY => key,
+          Pgbus::Uniqueness::STRATEGY_KEY => config[:strategy].to_s,
+          Pgbus::Uniqueness::TTL_KEY => config[:lock_ttl]
+        )
       end
     end
   end

--- a/spec/integration/recurring_scheduler_uniqueness_spec.rb
+++ b/spec/integration/recurring_scheduler_uniqueness_spec.rb
@@ -29,9 +29,6 @@ RSpec.describe "Recurring scheduler uniqueness (integration)", :integration do
         "queue" => "maintenance"
       }
     }
-
-    Pgbus::RecurringExecution.delete_all
-    Pgbus::JobLock.delete_all
   end
 
   describe "first enqueue acquires lock and sends message" do

--- a/spec/integration/recurring_scheduler_uniqueness_spec.rb
+++ b/spec/integration/recurring_scheduler_uniqueness_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Recurring scheduler uniqueness (integration)", :integration do
+  let(:config) { Pgbus.configuration }
+  let(:schedule) { Pgbus::Recurring::Schedule.new(config: config) }
+  let(:run_at) { Time.utc(2026, 4, 1, 2, 0, 0) }
+
+  let(:unique_job_class) do
+    Class.new do
+      include Pgbus::Uniqueness
+
+      def self.name
+        "UniqueRecurringJob"
+      end
+
+      ensures_uniqueness strategy: :until_executed, lock_ttl: 3600
+    end
+  end
+
+  before do
+    stub_const("UniqueRecurringJob", unique_job_class)
+
+    config.recurring_tasks = {
+      "unique_cleanup" => {
+        "class" => "UniqueRecurringJob",
+        "schedule" => "0 2 * * *",
+        "queue" => "maintenance"
+      }
+    }
+
+    Pgbus::RecurringExecution.delete_all
+    Pgbus::JobLock.delete_all
+  end
+
+  describe "first enqueue acquires lock and sends message" do
+    it "creates a job lock row and enqueues the message" do
+      task = schedule.tasks.first
+
+      schedule.enqueue_task(task, run_at: run_at)
+
+      # Lock should exist in the database
+      lock = Pgbus::JobLock.find_by(lock_key: "UniqueRecurringJob")
+      expect(lock).to be_present
+      expect(lock.state).to eq("queued")
+      expect(lock.job_class).to eq("UniqueRecurringJob")
+      expect(lock.job_id).to eq("recurring-unique_cleanup")
+
+      # Message should be in the queue
+      messages = Pgbus.client.read_batch("maintenance", qty: 10)
+      expect(messages.size).to eq(1)
+
+      payload = JSON.parse(messages.first.message)
+      expect(payload["job_class"]).to eq("UniqueRecurringJob")
+      expect(payload[Pgbus::Uniqueness::METADATA_KEY]).to eq("UniqueRecurringJob")
+      expect(payload[Pgbus::Uniqueness::STRATEGY_KEY]).to eq("until_executed")
+      expect(payload[Pgbus::Uniqueness::TTL_KEY]).to eq(3600)
+    end
+  end
+
+  describe "duplicate enqueue is rejected when lock is held" do
+    it "skips the second enqueue while the first lock is active" do
+      task = schedule.tasks.first
+
+      # First enqueue — should succeed
+      schedule.enqueue_task(task, run_at: run_at)
+
+      # Second enqueue with a different run_at — should be skipped due to lock
+      second_run_at = Time.utc(2026, 4, 2, 2, 0, 0)
+      schedule.enqueue_task(task, run_at: second_run_at)
+
+      # Only one message should be in the queue
+      messages = Pgbus.client.read_batch("maintenance", qty: 10)
+      expect(messages.size).to eq(1)
+
+      # Only one lock should exist
+      locks = Pgbus::JobLock.where(lock_key: "UniqueRecurringJob")
+      expect(locks.count).to eq(1)
+    end
+  end
+
+  describe "enqueue succeeds after lock is released" do
+    it "allows a new enqueue once the previous lock is gone" do
+      task = schedule.tasks.first
+
+      # First enqueue
+      schedule.enqueue_task(task, run_at: run_at)
+
+      # Simulate job completion — release the lock
+      Pgbus::JobLock.release!("UniqueRecurringJob")
+
+      # Second enqueue should now succeed
+      second_run_at = Time.utc(2026, 4, 2, 2, 0, 0)
+      schedule.enqueue_task(task, run_at: second_run_at)
+
+      # Two messages should be in the queue (first is invisible due to VT, read again)
+      # Read with VT=0 to see all
+      messages = Pgbus.client.read_batch("maintenance", qty: 10, vt: 0)
+      expect(messages.size).to eq(2)
+
+      # New lock should exist
+      lock = Pgbus::JobLock.find_by(lock_key: "UniqueRecurringJob")
+      expect(lock).to be_present
+    end
+  end
+
+  describe "expired lock is cleaned up on next acquire" do
+    it "replaces an expired lock and enqueues successfully" do
+      task = schedule.tasks.first
+
+      # Manually create an expired lock (TTL in the past)
+      Pgbus::JobLock.acquire!(
+        "UniqueRecurringJob",
+        job_class: "UniqueRecurringJob",
+        job_id: "old-run",
+        state: "executing",
+        ttl: -1
+      )
+
+      # Enqueue should succeed because acquire! cleans up expired locks first
+      schedule.enqueue_task(task, run_at: run_at)
+
+      messages = Pgbus.client.read_batch("maintenance", qty: 10)
+      expect(messages.size).to eq(1)
+
+      lock = Pgbus::JobLock.find_by(lock_key: "UniqueRecurringJob")
+      expect(lock.job_id).to eq("recurring-unique_cleanup")
+      expect(lock.state).to eq("queued")
+    end
+  end
+
+  describe "non-unique job class is not affected" do
+    let(:plain_schedule) do
+      plain_job = Class.new do
+        def self.name
+          "PlainRecurringJob"
+        end
+      end
+      stub_const("PlainRecurringJob", plain_job)
+
+      config.recurring_tasks = {
+        "plain_task" => {
+          "class" => "PlainRecurringJob",
+          "schedule" => "0 3 * * *",
+          "queue" => "default"
+        }
+      }
+
+      Pgbus::Recurring::Schedule.new(config: config)
+    end
+
+    it "enqueues without acquiring a lock" do
+      task = plain_schedule.tasks.first
+      plain_schedule.enqueue_task(task, run_at: run_at)
+
+      expect(Pgbus::JobLock.count).to eq(0)
+
+      messages = Pgbus.client.read_batch("default", qty: 10)
+      expect(messages.size).to eq(1)
+
+      payload = JSON.parse(messages.first.message)
+      expect(payload).not_to have_key(Pgbus::Uniqueness::METADATA_KEY)
+    end
+  end
+
+  describe "uniqueness metadata in payload" do
+    it "includes lock key, strategy, and TTL for downstream executor" do
+      task = schedule.tasks.first
+
+      schedule.enqueue_task(task, run_at: run_at)
+
+      messages = Pgbus.client.read_batch("maintenance", qty: 1)
+      payload = JSON.parse(messages.first.message)
+
+      expect(payload[Pgbus::Uniqueness::METADATA_KEY]).to eq("UniqueRecurringJob")
+      expect(payload[Pgbus::Uniqueness::STRATEGY_KEY]).to eq("until_executed")
+      expect(payload[Pgbus::Uniqueness::TTL_KEY]).to eq(3600)
+    end
+  end
+
+  describe "concurrent scheduler ticks" do
+    it "only one tick wins the lock when racing" do
+      results = Concurrent::Array.new
+      barrier = Concurrent::CyclicBarrier.new(5)
+
+      threads = 5.times.map do |i|
+        Thread.new do
+          # Each thread gets its own schedule instance to avoid shared state
+          thread_schedule = Pgbus::Recurring::Schedule.new(config: config)
+          thread_task = thread_schedule.tasks.first
+          thread_run_at = Time.utc(2026, 4, 1, 2, 0, i)
+
+          barrier.wait
+          thread_schedule.enqueue_task(thread_task, run_at: thread_run_at)
+          results << :done
+        end
+      end
+
+      threads.each(&:join)
+
+      # Only one lock should exist
+      locks = Pgbus::JobLock.where(lock_key: "UniqueRecurringJob")
+      expect(locks.count).to eq(1)
+
+      # Only one message should have been enqueued
+      messages = Pgbus.client.read_batch("maintenance", qty: 10, vt: 0)
+      expect(messages.size).to eq(1)
+    end
+  end
+end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -64,7 +64,7 @@ end
 
 def cleanup_tables
   conn = ActiveRecord::Base.connection
-  %w[pgbus_semaphores pgbus_blocked_executions pgbus_job_locks pgbus_processes].each do |table|
+  %w[pgbus_semaphores pgbus_blocked_executions pgbus_job_locks pgbus_processes pgbus_recurring_executions].each do |table|
     conn.execute("DELETE FROM #{table}")
   end
 rescue StandardError => e

--- a/spec/pgbus/recurring/schedule_spec.rb
+++ b/spec/pgbus/recurring/schedule_spec.rb
@@ -142,6 +142,121 @@ RSpec.describe Pgbus::Recurring::Schedule do
     end
   end
 
+  describe "uniqueness integration" do
+    let(:schedule) { described_class.new(config: config) }
+    let(:task) { schedule.tasks.first }
+    let(:run_at) { Time.utc(2026, 3, 31, 2, 0, 0) }
+
+    before do
+      allow(Pgbus::RecurringExecution).to receive(:record).and_yield
+    end
+
+    context "when job class has ensures_uniqueness" do
+      let(:unique_job_class) do
+        Class.new(ActiveJob::Base) do
+          include Pgbus::Uniqueness
+
+          self.queue_adapter = :pgbus
+
+          def self.name
+            "CleanupJob"
+          end
+
+          ensures_uniqueness strategy: :until_executed, on_conflict: :discard
+        end
+      end
+
+      before do
+        stub_const("CleanupJob", unique_job_class)
+      end
+
+      it "skips enqueue when uniqueness lock is already held" do
+        # Acquire the lock manually (simulating a previous enqueue still running)
+        Pgbus::JobLock.acquire!(
+          "CleanupJob",
+          job_class: "CleanupJob",
+          job_id: "previous-run",
+          state: "executing",
+          ttl: 86_400
+        )
+
+        schedule.enqueue_task(task, run_at: run_at)
+
+        expect(mock_client).not_to have_received(:send_message)
+      end
+
+      it "enqueues and acquires lock when no lock is held" do
+        schedule.enqueue_task(task, run_at: run_at)
+
+        expect(mock_client).to have_received(:send_message)
+        lock = Pgbus::JobLock.find_by(lock_key: "CleanupJob")
+        expect(lock).to be_present
+        expect(lock.state).to eq("queued")
+      end
+
+      it "injects uniqueness metadata into the payload" do
+        schedule.enqueue_task(task, run_at: run_at)
+
+        expect(mock_client).to have_received(:send_message).with(
+          anything,
+          hash_including(
+            Pgbus::Uniqueness::METADATA_KEY => "CleanupJob",
+            Pgbus::Uniqueness::STRATEGY_KEY => "until_executed"
+          ),
+          headers: anything
+        )
+      end
+    end
+
+    context "when job class does not have ensures_uniqueness" do
+      before do
+        plain_job = Class.new(ActiveJob::Base) do
+          def self.name
+            "CleanupJob"
+          end
+        end
+        stub_const("CleanupJob", plain_job)
+      end
+
+      it "enqueues without checking locks" do
+        schedule.enqueue_task(task, run_at: run_at)
+
+        expect(mock_client).to have_received(:send_message)
+      end
+
+      it "does not inject uniqueness metadata" do
+        schedule.enqueue_task(task, run_at: run_at)
+
+        expect(mock_client).to have_received(:send_message).with(
+          anything,
+          hash_not_including(Pgbus::Uniqueness::METADATA_KEY),
+          headers: anything
+        )
+      end
+    end
+
+    context "when job class cannot be constantized" do
+      before do
+        config.recurring_tasks = {
+          "missing_class" => {
+            "class" => "NonexistentJob",
+            "schedule" => "0 * * * *"
+          }
+        }
+      end
+
+      it "enqueues without uniqueness check (fail open)" do
+        schedule_with_missing = described_class.new(config: config)
+        task_missing = schedule_with_missing.tasks.first
+        allow(Pgbus::RecurringExecution).to receive(:record).and_yield
+
+        schedule_with_missing.enqueue_task(task_missing, run_at: run_at)
+
+        expect(mock_client).to have_received(:send_message)
+      end
+    end
+  end
+
   describe "#build_payload" do
     let(:schedule) { described_class.new(config: config) }
 

--- a/spec/pgbus/recurring/schedule_spec.rb
+++ b/spec/pgbus/recurring/schedule_spec.rb
@@ -146,17 +146,18 @@ RSpec.describe Pgbus::Recurring::Schedule do
     let(:schedule) { described_class.new(config: config) }
     let(:task) { schedule.tasks.first }
     let(:run_at) { Time.utc(2026, 3, 31, 2, 0, 0) }
+    let(:job_lock_class) { stub_const("Pgbus::JobLock", Class.new) }
 
     before do
       allow(Pgbus::RecurringExecution).to receive(:record).and_yield
+      job_lock_class
+      allow(Pgbus::JobLock).to receive_messages(acquire!: true, release!: 1, locked?: false)
     end
 
     context "when job class has ensures_uniqueness" do
       let(:unique_job_class) do
-        Class.new(ActiveJob::Base) do
+        Class.new do
           include Pgbus::Uniqueness
-
-          self.queue_adapter = :pgbus
 
           def self.name
             "CleanupJob"
@@ -171,30 +172,38 @@ RSpec.describe Pgbus::Recurring::Schedule do
       end
 
       it "skips enqueue when uniqueness lock is already held" do
-        # Acquire the lock manually (simulating a previous enqueue still running)
-        Pgbus::JobLock.acquire!(
-          "CleanupJob",
-          job_class: "CleanupJob",
-          job_id: "previous-run",
-          state: "executing",
-          ttl: 86_400
-        )
+        allow(Pgbus::JobLock).to receive(:acquire!).and_return(false)
 
         schedule.enqueue_task(task, run_at: run_at)
 
         expect(mock_client).not_to have_received(:send_message)
+        expect(Pgbus::JobLock).to have_received(:acquire!).with(
+          "CleanupJob",
+          job_class: "CleanupJob",
+          job_id: "recurring-daily_cleanup",
+          state: "queued",
+          ttl: anything
+        )
       end
 
       it "enqueues and acquires lock when no lock is held" do
+        allow(Pgbus::JobLock).to receive(:acquire!).and_return(true)
+
         schedule.enqueue_task(task, run_at: run_at)
 
         expect(mock_client).to have_received(:send_message)
-        lock = Pgbus::JobLock.find_by(lock_key: "CleanupJob")
-        expect(lock).to be_present
-        expect(lock.state).to eq("queued")
+        expect(Pgbus::JobLock).to have_received(:acquire!).with(
+          "CleanupJob",
+          job_class: "CleanupJob",
+          job_id: "recurring-daily_cleanup",
+          state: "queued",
+          ttl: anything
+        )
       end
 
       it "injects uniqueness metadata into the payload" do
+        allow(Pgbus::JobLock).to receive(:acquire!).and_return(true)
+
         schedule.enqueue_task(task, run_at: run_at)
 
         expect(mock_client).to have_received(:send_message).with(
@@ -210,7 +219,7 @@ RSpec.describe Pgbus::Recurring::Schedule do
 
     context "when job class does not have ensures_uniqueness" do
       before do
-        plain_job = Class.new(ActiveJob::Base) do
+        plain_job = Class.new do
           def self.name
             "CleanupJob"
           end


### PR DESCRIPTION
## Problem

The recurring scheduler uses `Pgbus.client.send_message` directly, bypassing ActiveJob. This means `ensures_uniqueness strategy: :until_executed` locks were never checked when enqueuing recurring tasks. The scheduler would enqueue a new instance every tick (every minute) even while a previous instance was still queued or running, causing unbounded queue growth.

Discovered on Zazu staging: `FetchTransactionsJob` and `ExecuteScheduledTransfersJob` accumulated dozens of duplicate entries in the queue because:
1. Scheduler enqueues every minute
2. Workers process slowly (FetchTransactionsJob takes ~8 min)
3. No uniqueness check at enqueue time
4. All duplicates have READS: 0 — workers weren't picking them up fast enough

## Fix

The scheduler now checks `ensures_uniqueness` before enqueuing:

1. **Lock check** — if the job class has `pgbus_uniqueness` with `:until_executed`, try to acquire the lock
2. **Skip if locked** — if a previous instance holds the lock, skip this enqueue
3. **Metadata injection** — inject uniqueness metadata into the raw PGMQ payload so the worker releases the lock after execution
4. **Fail open** — if the uniqueness check errors, allow the enqueue (preserves existing behavior)

## Test plan

- [x] Added specs for uniqueness integration in schedule_spec.rb
- [ ] Run full spec suite
- [ ] Deploy to staging and verify queue depth stays at 0-1 per job class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recurring tasks with uniqueness constraints now prevent duplicate execution when a lock is already held, improving task reliability.

* **Tests**
  * Added comprehensive test coverage for recurring task uniqueness behavior during scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->