### PR TITLE
feat(web): add Discard All for enqueued jobs with lock cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,6 +189,23 @@ jobs:
                 ON pgbus_recurring_executions (task_key, run_at);
               CREATE INDEX IF NOT EXISTS idx_pgbus_recurring_executions_cleanup
                 ON pgbus_recurring_executions (run_at);
+
+              CREATE TABLE IF NOT EXISTS pgbus_failed_events (
+                id BIGSERIAL PRIMARY KEY,
+                queue_name VARCHAR NOT NULL,
+                msg_id BIGINT,
+                payload JSONB,
+                headers JSONB,
+                error_class VARCHAR,
+                error_message TEXT,
+                backtrace TEXT,
+                retry_count INTEGER DEFAULT 0,
+                failed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+              );
+              CREATE INDEX IF NOT EXISTS idx_pgbus_failed_events_queue
+                ON pgbus_failed_events (queue_name);
+              CREATE INDEX IF NOT EXISTS idx_pgbus_failed_events_time
+                ON pgbus_failed_events (failed_at);
             SQL
             conn.close
           "

--- a/app/controllers/pgbus/jobs_controller.rb
+++ b/app/controllers/pgbus/jobs_controller.rb
@@ -44,5 +44,10 @@ module Pgbus
       count = data_source.discard_all_failed
       redirect_to jobs_path, notice: "Discarded #{count} jobs."
     end
+
+    def discard_all_enqueued
+      count = data_source.discard_all_enqueued
+      redirect_to jobs_path, notice: t("pgbus.jobs.index.discard_all_enqueued_notice", count: count)
+    end
   end
 end

--- a/app/views/pgbus/jobs/_enqueued_table.html.erb
+++ b/app/views/pgbus/jobs/_enqueued_table.html.erb
@@ -1,6 +1,13 @@
 <turbo-frame id="jobs-enqueued" data-auto-refresh data-src="<%= pgbus.jobs_path(request.query_parameters.merge(frame: 'enqueued')) %>">
   <div>
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.jobs.enqueued_table.title") %></h2>
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white"><%= t("pgbus.jobs.enqueued_table.title") %></h2>
+      <% if @jobs.any? %>
+        <%= button_to t("pgbus.jobs.enqueued_table.discard_all"), pgbus.discard_all_enqueued_jobs_path, method: :post,
+              class: "rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500",
+              data: { turbo_confirm: t("pgbus.jobs.enqueued_table.discard_all_confirm"), turbo_frame: "_top" } %>
+      <% end %>
+    </div>
     <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
       <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -30,6 +30,8 @@ module BenchStubs
       client.instance_variable_set(:@pgmq_mutex, Mutex.new)
       client.instance_variable_set(:@queues_created, Concurrent::Map.new.tap { |m| m["pgbus_bench_default"] = true })
       client.instance_variable_set(:@queue_strategy, Pgbus::QueueFactory.for(Pgbus.configuration))
+      client.instance_variable_set(:@schema_ensured, true)
+      client.instance_variable_set(:@shared_connection, false)
     end
   end
 

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -179,6 +179,8 @@ da:
         title: Job i kø
         discard: Kassér
         discard_confirm: Kassér denne besked?
+        discard_all: Kassér alle
+        discard_all_confirm: Kassér alle ventende jobs og frigiv deres låse? Dette kan ikke fortrydes.
         retry: Prøv igen
         retry_confirm: Nulstil synlighedstimeout og prøv igen?
       failed_table:
@@ -197,6 +199,7 @@ da:
       index:
         discard_all: Kassér alle
         discard_all_confirm: Kassér alle mislykkede job?
+        discard_all_enqueued_notice: Kasserede %{count} ventende jobs og frigav deres låse.
         retry_all: Forsøg alle igen
         retry_all_confirm: Forsøg alle mislykkede job igen?
         title: Job

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -179,6 +179,8 @@ de:
         title: Eingereihte Jobs
         discard: Verwerfen
         discard_confirm: Diese Nachricht verwerfen?
+        discard_all: Alle verwerfen
+        discard_all_confirm: Alle eingereihten Jobs verwerfen und ihre Sperren freigeben? Dies kann nicht rückgängig gemacht werden.
         retry: Wiederholen
         retry_confirm: Sichtbarkeits-Timeout zurücksetzen und erneut versuchen?
       failed_table:
@@ -197,6 +199,7 @@ de:
       index:
         discard_all: Alle verwerfen
         discard_all_confirm: Alle fehlgeschlagenen Jobs verwerfen?
+        discard_all_enqueued_notice: "%{count} eingereihte Jobs verworfen und Sperren freigegeben."
         retry_all: Alle wiederholen
         retry_all_confirm: Alle fehlgeschlagenen Jobs wiederholen?
         title: Jobs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,8 @@ en:
           timezone: 'Timezone:'
           visible_at: 'Visible at:'
         discard: Discard
+        discard_all: Discard All
+        discard_all_confirm: Discard all enqueued jobs and release their locks? This cannot be undone.
         discard_confirm: Discard this message?
         retry: Retry
         retry_confirm: Reset visibility timeout and retry?
@@ -213,6 +215,7 @@ en:
       index:
         discard_all: Discard All
         discard_all_confirm: Discard all failed jobs?
+        discard_all_enqueued_notice: Discarded %{count} enqueued jobs and released their locks.
         retry_all: Retry All
         retry_all_confirm: Retry all failed jobs?
         title: Jobs

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -179,6 +179,8 @@ es:
         title: Trabajos en Cola
         discard: Descartar
         discard_confirm: "¿Descartar este mensaje?"
+        discard_all: Descartar todos
+        discard_all_confirm: "¿Descartar todos los trabajos en cola y liberar sus bloqueos? Esta acción no se puede deshacer."
         retry: Reintentar
         retry_confirm: "¿Restablecer tiempo de visibilidad y reintentar?"
       failed_table:
@@ -197,6 +199,7 @@ es:
       index:
         discard_all: Descartar Todo
         discard_all_confirm: "¿Descartar todos los trabajos fallidos?"
+        discard_all_enqueued_notice: Se descartaron %{count} trabajos en cola y se liberaron sus bloqueos.
         retry_all: Reintentar Todo
         retry_all_confirm: "¿Reintentar todos los trabajos fallidos?"
         title: Trabajos

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -179,6 +179,8 @@ fi:
         title: Jonotetut työt
         discard: Hylkää
         discard_confirm: Hylätä tämä viesti?
+        discard_all: Hylkää kaikki
+        discard_all_confirm: Hylkää kaikki jonossa olevat tehtävät ja vapauta lukot? Tätä ei voi perua.
         retry: Yritä uudelleen
         retry_confirm: Nollaa näkyvyysaika ja yritä uudelleen?
       failed_table:
@@ -197,6 +199,7 @@ fi:
       index:
         discard_all: Hylkää kaikki
         discard_all_confirm: Hylätäänkö kaikki epäonnistuneet työt?
+        discard_all_enqueued_notice: Hylättiin %{count} jonossa olevaa tehtävää ja vapautettiin lukot.
         retry_all: Yritä uudelleen kaikki
         retry_all_confirm: Yritetäänkö uudelleen kaikki epäonnistuneet työt?
         title: Työt

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -179,6 +179,8 @@ fr:
         title: Travaux en file d'attente
         discard: Rejeter
         discard_confirm: Rejeter ce message ?
+        discard_all: Tout supprimer
+        discard_all_confirm: Supprimer tous les travaux en file d'attente et libérer leurs verrous ? Cette action est irréversible.
         retry: Réessayer
         retry_confirm: Réinitialiser le délai de visibilité et réessayer ?
       failed_table:
@@ -197,6 +199,7 @@ fr:
       index:
         discard_all: Tout ignorer
         discard_all_confirm: Ignorer tous les travaux échoués ?
+        discard_all_enqueued_notice: "%{count} travaux en file d'attente supprimés et verrous libérés."
         retry_all: Tout réessayer
         retry_all_confirm: Réessayer tous les travaux échoués ?
         title: Travaux

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -179,6 +179,8 @@ it:
         title: Lavori in coda
         discard: Scarta
         discard_confirm: Scartare questo messaggio?
+        discard_all: Elimina tutti
+        discard_all_confirm: Eliminare tutti i lavori in coda e rilasciare i relativi blocchi? Questa azione non può essere annullata.
         retry: Riprova
         retry_confirm: Reimpostare il timeout di visibilità e riprovare?
       failed_table:
@@ -197,6 +199,7 @@ it:
       index:
         discard_all: Scarta Tutto
         discard_all_confirm: Scartare tutti i lavori falliti?
+        discard_all_enqueued_notice: Eliminati %{count} lavori in coda e rilasciati i relativi blocchi.
         retry_all: Riprova Tutto
         retry_all_confirm: Riprova tutti i lavori falliti?
         title: Lavori

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -179,8 +179,8 @@ it:
         title: Lavori in coda
         discard: Scarta
         discard_confirm: Scartare questo messaggio?
-        discard_all: Elimina tutti
-        discard_all_confirm: Eliminare tutti i lavori in coda e rilasciare i relativi blocchi? Questa azione non può essere annullata.
+        discard_all: Scarta tutti
+        discard_all_confirm: Scartare tutti i lavori in coda e rilasciare i relativi blocchi? Questa azione non può essere annullata.
         retry: Riprova
         retry_confirm: Reimpostare il timeout di visibilità e riprovare?
       failed_table:
@@ -199,7 +199,7 @@ it:
       index:
         discard_all: Scarta Tutto
         discard_all_confirm: Scartare tutti i lavori falliti?
-        discard_all_enqueued_notice: Eliminati %{count} lavori in coda e rilasciati i relativi blocchi.
+        discard_all_enqueued_notice: Scartati %{count} lavori in coda e rilasciati i relativi blocchi.
         retry_all: Riprova Tutto
         retry_all_confirm: Riprova tutti i lavori falliti?
         title: Lavori

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -179,6 +179,8 @@ ja:
         title: キューに入れられたジョブ
         discard: 破棄
         discard_confirm: このメッセージを破棄しますか？
+        discard_all: すべて破棄
+        discard_all_confirm: キュー内のすべてのジョブを破棄し、ロックを解放しますか？この操作は元に戻せません。
         retry: リトライ
         retry_confirm: 可視性タイムアウトをリセットしてリトライしますか？
       failed_table:
@@ -197,6 +199,7 @@ ja:
       index:
         discard_all: すべて破棄
         discard_all_confirm: すべての失敗したジョブを破棄しますか？
+        discard_all_enqueued_notice: "%{count}件のキュー内ジョブを破棄し、ロックを解放しました。"
         retry_all: すべてリトライ
         retry_all_confirm: すべての失敗したジョブをリトライしますか？
         title: ジョブ

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -179,6 +179,8 @@ nb:
         title: Kølagte jobber
         discard: Forkast
         discard_confirm: Forkaste denne meldingen?
+        discard_all: Forkast alle
+        discard_all_confirm: Forkast alle køede jobber og frigi låsene? Dette kan ikke angres.
         retry: Prøv igjen
         retry_confirm: Tilbakestill synlighetstidsavbrudd og prøv igjen?
       failed_table:
@@ -197,6 +199,7 @@ nb:
       index:
         discard_all: Forkast alle
         discard_all_confirm: Forkast alle mislykkede jobber?
+        discard_all_enqueued_notice: Forkastet %{count} køede jobber og frigitt låsene.
         retry_all: Prøv alle på nytt
         retry_all_confirm: Prøv alle mislykkede jobber på nytt?
         title: Jobber

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -179,6 +179,8 @@ nl:
         title: Taken in de wachtrij
         discard: Verwerpen
         discard_confirm: Dit bericht verwerpen?
+        discard_all: Alles verwijderen
+        discard_all_confirm: Alle taken in de wachtrij verwijderen en hun vergrendelingen vrijgeven? Dit kan niet ongedaan worden gemaakt.
         retry: Opnieuw proberen
         retry_confirm: Zichtbaarheidstimeout resetten en opnieuw proberen?
       failed_table:
@@ -197,6 +199,7 @@ nl:
       index:
         discard_all: Alles Verwijderen
         discard_all_confirm: Alle mislukte taken verwijderen?
+        discard_all_enqueued_notice: "%{count} taken in de wachtrij verwijderd en vergrendelingen vrijgegeven."
         retry_all: Alles Opnieuw Proberen
         retry_all_confirm: Alle mislukte taken opnieuw proberen?
         title: Taken

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -179,6 +179,8 @@ pt:
         title: Trabalhos Enfileirados
         discard: Descartar
         discard_confirm: Descartar esta mensagem?
+        discard_all: Descartar todos
+        discard_all_confirm: Descartar todos os trabalhos na fila e liberar seus bloqueios? Esta ação não pode ser desfeita.
         retry: Tentar novamente
         retry_confirm: Redefinir tempo de visibilidade e tentar novamente?
       failed_table:
@@ -197,6 +199,7 @@ pt:
       index:
         discard_all: Descartar Todos
         discard_all_confirm: Descartar todos os trabalhos falhados?
+        discard_all_enqueued_notice: Descartados %{count} trabalhos na fila e bloqueios liberados.
         retry_all: Tentar Novamente Todos
         retry_all_confirm: Tentar novamente todos os trabalhos falhados?
         title: Trabalhos

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -179,6 +179,8 @@ sv:
         title: Köade jobb
         discard: Kassera
         discard_confirm: Kassera detta meddelande?
+        discard_all: Kassera alla
+        discard_all_confirm: Kassera alla köade jobb och frigör deras lås? Detta kan inte ångras.
         retry: Försök igen
         retry_confirm: Återställ synlighetstimeout och försök igen?
       failed_table:
@@ -197,6 +199,7 @@ sv:
       index:
         discard_all: Kassera alla
         discard_all_confirm: Kassera alla misslyckade jobb?
+        discard_all_enqueued_notice: Kasserade %{count} köade jobb och frigjorde deras lås.
         retry_all: Försök igen alla
         retry_all_confirm: Försök igen alla misslyckade jobb?
         title: Jobb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Pgbus::Engine.routes.draw do
     collection do
       post :retry_all
       post :discard_all
+      post :discard_all_enqueued
     end
   end
 

--- a/lib/pgbus/recurring/schedule.rb
+++ b/lib/pgbus/recurring/schedule.rb
@@ -162,6 +162,8 @@ module Pgbus
 
       # Inject uniqueness metadata into the payload so the executor releases
       # the lock after the job completes.
+      # Only inject for :until_executed strategy — :while_executing locks are
+      # acquired at execution time by the executor, not by the scheduler.
       def inject_uniqueness_metadata(task, payload)
         return payload unless task.class_name
 
@@ -170,6 +172,7 @@ module Pgbus
 
         config = job_class.pgbus_uniqueness
         return payload unless config
+        return payload unless config[:strategy] == :until_executed
 
         key = resolve_uniqueness_key(config, task)
         return payload unless key

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -113,7 +113,29 @@ module Pgbus
       end
 
       def discard_job(queue_name, msg_id)
+        release_lock_for_message(queue_name, msg_id)
         @client.archive_message(queue_name, msg_id.to_i, prefixed: false)
+      end
+
+      def discard_all_enqueued
+        dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix
+        queues = queues_with_metrics.reject { |q| q[:name].end_with?(dlq_suffix) }
+        total = 0
+
+        queues.each do |q|
+          messages = query_queue_messages_raw(q[:name], 10_000, 0)
+          next if messages.empty?
+
+          release_locks_for_messages(messages)
+
+          ids = messages.map { |m| m[:msg_id].to_i }
+          @client.archive_batch(q[:name], ids, prefixed: false)
+          total += ids.size
+        rescue StandardError => e
+          Pgbus.logger.debug { "[Pgbus::Web] Error discarding enqueued messages from #{q[:name]}: #{e.message}" }
+        end
+
+        total
       end
 
       # Failed events
@@ -170,6 +192,9 @@ module Pgbus
       end
 
       def discard_failed_event(id)
+        event = failed_event(id)
+        release_lock_for_payload(event["payload"]) if event
+
         connection.exec_delete(
           "DELETE FROM pgbus_failed_events WHERE id = $1", "Pgbus Delete Failed Event", [id.to_i]
         )
@@ -207,6 +232,8 @@ module Pgbus
       end
 
       def discard_all_failed
+        release_locks_for_failed_events
+
         result = connection.execute("DELETE FROM pgbus_failed_events")
         result.cmd_tuples
       rescue StandardError => e
@@ -273,6 +300,7 @@ module Pgbus
 
       def discard_dlq_message(queue_name, msg_id)
         # queue_name here is the full DLQ name (already prefixed)
+        release_lock_for_message(queue_name, msg_id)
         @client.delete_message(queue_name, msg_id.to_i, prefixed: false)
         true
       rescue StandardError => e
@@ -295,6 +323,8 @@ module Pgbus
       def discard_all_dlq
         messages = dlq_messages(page: 1, per_page: 1000)
         return 0 if messages.empty?
+
+        release_locks_for_messages(messages)
 
         # Group by queue for batch delete — one call per DLQ instead of N calls
         messages.group_by { |m| m[:queue_name] }.sum do |queue_name, msgs|
@@ -732,6 +762,69 @@ module Pgbus
       rescue JSON::ParserError => e
         Pgbus.logger.debug { "[Pgbus::Web] Invalid recurring task arguments JSON: #{e.message}" }
         []
+      end
+
+      # --- Lock cleanup helpers ---
+
+      # Extract uniqueness key from a queue message and release its lock.
+      def release_lock_for_message(queue_name, msg_id)
+        row = connection.select_one(
+          "SELECT * FROM pgmq.q_#{sanitize_name(queue_name)} WHERE msg_id = $1",
+          "Pgbus Job Detail",
+          [msg_id.to_i]
+        )
+        return unless row
+
+        release_lock_for_payload(row["message"])
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error releasing lock for message #{msg_id}: #{e.message}" }
+      end
+
+      # Extract uniqueness key from a JSON payload string and release its lock.
+      def release_lock_for_payload(payload_str)
+        return unless payload_str
+
+        payload = payload_str.is_a?(String) ? JSON.parse(payload_str) : payload_str
+        key = payload[Uniqueness::METADATA_KEY]
+        JobLock.release!(key) if key
+      rescue JSON::ParserError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error parsing payload for lock release: #{e.message}" }
+      end
+
+      # Extract uniqueness keys from a collection of formatted messages and
+      # release all associated locks in a single query.
+      def release_locks_for_messages(messages)
+        keys = messages.filter_map do |m|
+          payload = m[:message]
+          next unless payload
+
+          parsed = payload.is_a?(String) ? JSON.parse(payload) : payload
+          parsed[Uniqueness::METADATA_KEY]
+        rescue JSON::ParserError
+          nil
+        end
+
+        JobLock.where(lock_key: keys).delete_all if keys.any?
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error releasing locks for messages: #{e.message}" }
+      end
+
+      # Collect uniqueness keys from all failed events and release their locks.
+      def release_locks_for_failed_events
+        rows = connection.select_all(
+          "SELECT payload FROM pgbus_failed_events", "Pgbus Collect Failed Keys"
+        )
+
+        keys = rows.to_a.filter_map do |row|
+          payload = JSON.parse(row["payload"])
+          payload[Uniqueness::METADATA_KEY]
+        rescue JSON::ParserError
+          nil
+        end
+
+        JobLock.where(lock_key: keys).delete_all if keys.any?
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error releasing locks for failed events: #{e.message}" }
       end
     end
   end

--- a/spec/integration/dashboard_discard_locks_spec.rb
+++ b/spec/integration/dashboard_discard_locks_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Dashboard discard operations clear locks (integration)", :integration do
+  let(:client) { Pgbus.client }
+  let(:data_source) { Pgbus::Web::DataSource.new(client: client) }
+  let(:queue_name) { "default" }
+  let(:full_queue) { Pgbus.configuration.queue_name(queue_name) }
+
+  before do
+    Pgbus::JobLock.delete_all
+    client.ensure_queue(queue_name)
+  end
+
+  describe "#discard_job clears associated lock" do
+    it "releases the uniqueness lock when archiving a single enqueued message" do
+      # Enqueue a message with uniqueness metadata
+      payload = {
+        "job_class" => "ImportJob",
+        "arguments" => [42],
+        Pgbus::Uniqueness::METADATA_KEY => "import-42",
+        Pgbus::Uniqueness::STRATEGY_KEY => "until_executed",
+        Pgbus::Uniqueness::TTL_KEY => 86_400
+      }
+      client.send_message(queue_name, payload)
+
+      # Simulate the lock that was acquired at enqueue time
+      Pgbus::JobLock.acquire!("import-42", job_class: "ImportJob", job_id: "j1", ttl: 86_400)
+      expect(Pgbus::JobLock.locked?("import-42")).to be true
+
+      # Read message to get msg_id
+      msg = client.read_batch(queue_name, qty: 1, vt: 0).first
+
+      # Discard via dashboard
+      data_source.discard_job(full_queue, msg.msg_id)
+
+      # Lock should be released
+      expect(Pgbus::JobLock.locked?("import-42")).to be false
+    end
+
+    it "does nothing for messages without uniqueness metadata" do
+      payload = { "job_class" => "PlainJob", "arguments" => [] }
+      client.send_message(queue_name, payload)
+
+      msg = client.read_batch(queue_name, qty: 1, vt: 0).first
+
+      expect { data_source.discard_job(full_queue, msg.msg_id) }.not_to raise_error
+    end
+  end
+
+  describe "#discard_all_enqueued clears all associated locks" do
+    it "archives all messages from all queues and releases their locks" do
+      # Enqueue messages with uniqueness locks
+      3.times do |i|
+        payload = {
+          "job_class" => "ImportJob",
+          "arguments" => [i],
+          Pgbus::Uniqueness::METADATA_KEY => "import-#{i}",
+          Pgbus::Uniqueness::STRATEGY_KEY => "until_executed",
+          Pgbus::Uniqueness::TTL_KEY => 86_400
+        }
+        client.send_message(queue_name, payload)
+        Pgbus::JobLock.acquire!("import-#{i}", job_class: "ImportJob", job_id: "j#{i}", ttl: 86_400)
+      end
+
+      expect(Pgbus::JobLock.count).to eq(3)
+
+      count = data_source.discard_all_enqueued
+      expect(count).to eq(3)
+
+      # All locks should be released
+      expect(Pgbus::JobLock.count).to eq(0)
+
+      # Queue should be empty
+      messages = client.read_batch(queue_name, qty: 10, vt: 0)
+      expect(messages).to be_empty
+    end
+
+    it "returns 0 when no messages exist" do
+      count = data_source.discard_all_enqueued
+      expect(count).to eq(0)
+    end
+
+    it "only clears locks for discarded messages, not unrelated locks" do
+      # Enqueue one message with a lock
+      payload = {
+        "job_class" => "ImportJob",
+        "arguments" => [1],
+        Pgbus::Uniqueness::METADATA_KEY => "import-1",
+        Pgbus::Uniqueness::STRATEGY_KEY => "until_executed",
+        Pgbus::Uniqueness::TTL_KEY => 86_400
+      }
+      client.send_message(queue_name, payload)
+      Pgbus::JobLock.acquire!("import-1", job_class: "ImportJob", job_id: "j1", ttl: 86_400)
+
+      # Create an unrelated lock (e.g., from a different system)
+      Pgbus::JobLock.acquire!("unrelated-lock", job_class: "OtherJob", job_id: "j99", ttl: 86_400)
+
+      data_source.discard_all_enqueued
+
+      # The enqueued message's lock should be cleared
+      expect(Pgbus::JobLock.locked?("import-1")).to be false
+      # The unrelated lock should remain
+      expect(Pgbus::JobLock.locked?("unrelated-lock")).to be true
+    end
+  end
+
+  describe "#discard_failed_event clears associated lock" do
+    before do
+      ActiveRecord::Base.connection.execute(<<~SQL)
+        INSERT INTO pgbus_failed_events (queue_name, payload, headers, error_class, error_message, failed_at)
+        VALUES ('#{full_queue}',
+                '{"job_class":"FailedJob","arguments":[1],"pgbus_uniqueness_key":"failed-1","pgbus_uniqueness_strategy":"until_executed"}',
+                '{}', 'RuntimeError', 'boom', NOW())
+      SQL
+    end
+
+    it "releases the lock when discarding a failed event" do
+      Pgbus::JobLock.acquire!("failed-1", job_class: "FailedJob", job_id: "j1", ttl: 86_400)
+      expect(Pgbus::JobLock.locked?("failed-1")).to be true
+
+      event = data_source.failed_events.first
+      data_source.discard_failed_event(event["id"])
+
+      expect(Pgbus::JobLock.locked?("failed-1")).to be false
+    end
+  end
+
+  describe "#discard_all_failed clears associated locks" do
+    before do
+      3.times do |i|
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          INSERT INTO pgbus_failed_events (queue_name, payload, headers, error_class, error_message, failed_at)
+          VALUES ('#{full_queue}',
+                  '{"job_class":"FailedJob","arguments":[#{i}],"pgbus_uniqueness_key":"failed-#{i}","pgbus_uniqueness_strategy":"until_executed"}',
+                  '{}', 'RuntimeError', 'boom #{i}', NOW())
+        SQL
+        Pgbus::JobLock.acquire!("failed-#{i}", job_class: "FailedJob", job_id: "j#{i}", ttl: 86_400)
+      end
+    end
+
+    it "releases all locks for discarded failed events" do
+      expect(Pgbus::JobLock.count).to eq(3)
+
+      data_source.discard_all_failed
+
+      expect(Pgbus::JobLock.count).to eq(0)
+    end
+  end
+
+  describe "#discard_dlq_message clears associated lock" do
+    let(:dlq_name) { Pgbus.configuration.dead_letter_queue_name(queue_name) }
+    let(:full_dlq) { dlq_name }
+
+    before do
+      client.ensure_dead_letter_queue(queue_name)
+    end
+
+    it "releases the lock when discarding a DLQ message" do
+      # Send a message directly to the DLQ
+      payload = {
+        "job_class" => "DlqJob",
+        "arguments" => [1],
+        Pgbus::Uniqueness::METADATA_KEY => "dlq-1",
+        Pgbus::Uniqueness::STRATEGY_KEY => "until_executed",
+        Pgbus::Uniqueness::TTL_KEY => 86_400
+      }
+      ActiveRecord::Base.connection.execute(
+        "INSERT INTO pgmq.q_#{full_dlq} (vt, message) VALUES (NOW(), '#{JSON.generate(payload)}')"
+      )
+
+      Pgbus::JobLock.acquire!("dlq-1", job_class: "DlqJob", job_id: "j1", ttl: 86_400)
+      expect(Pgbus::JobLock.locked?("dlq-1")).to be true
+
+      msg = ActiveRecord::Base.connection.select_one("SELECT msg_id FROM pgmq.q_#{full_dlq} LIMIT 1")
+      data_source.discard_dlq_message(full_dlq, msg["msg_id"])
+
+      expect(Pgbus::JobLock.locked?("dlq-1")).to be false
+    end
+  end
+
+  describe "#discard_all_dlq clears associated locks" do
+    let(:dlq_name) { Pgbus.configuration.dead_letter_queue_name(queue_name) }
+    let(:full_dlq) { dlq_name }
+
+    before do
+      client.ensure_dead_letter_queue(queue_name)
+    end
+
+    it "releases all locks for discarded DLQ messages" do
+      3.times do |i|
+        payload = {
+          "job_class" => "DlqJob",
+          "arguments" => [i],
+          Pgbus::Uniqueness::METADATA_KEY => "dlq-#{i}",
+          Pgbus::Uniqueness::STRATEGY_KEY => "until_executed",
+          Pgbus::Uniqueness::TTL_KEY => 86_400
+        }
+        ActiveRecord::Base.connection.execute(
+          "INSERT INTO pgmq.q_#{full_dlq} (vt, message) VALUES (NOW(), '#{JSON.generate(payload)}')"
+        )
+        Pgbus::JobLock.acquire!("dlq-#{i}", job_class: "DlqJob", job_id: "j#{i}", ttl: 86_400)
+      end
+
+      expect(Pgbus::JobLock.count).to eq(3)
+
+      data_source.discard_all_dlq
+
+      expect(Pgbus::JobLock.count).to eq(0)
+    end
+  end
+end

--- a/spec/integration/recurring_scheduler_while_executing_spec.rb
+++ b/spec/integration/recurring_scheduler_while_executing_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+RSpec.describe "Recurring scheduler with :while_executing strategy (integration)", :integration do
+  let(:config) { Pgbus.configuration }
+  let(:schedule) { Pgbus::Recurring::Schedule.new(config: config) }
+  let(:run_at) { Time.utc(2026, 4, 1, 2, 0, 0) }
+
+  let(:while_executing_job_class) do
+    Class.new do
+      include Pgbus::Uniqueness
+
+      def self.name
+        "WhileExecutingJob"
+      end
+
+      ensures_uniqueness strategy: :while_executing, lock_ttl: 3600
+    end
+  end
+
+  before do
+    stub_const("WhileExecutingJob", while_executing_job_class)
+
+    config.recurring_tasks = {
+      "while_exec_task" => {
+        "class" => "WhileExecutingJob",
+        "schedule" => "*/5 * * * *",
+        "queue" => "default"
+      }
+    }
+  end
+
+  describe "scheduler does not acquire locks for :while_executing jobs" do
+    it "enqueues without creating a job lock" do
+      task = schedule.tasks.first
+
+      schedule.enqueue_task(task, run_at: run_at)
+
+      # No lock should exist — :while_executing locks are only acquired at execution time
+      expect(Pgbus::JobLock.count).to eq(0)
+
+      # Message should be in the queue
+      messages = Pgbus.client.read_batch("default", qty: 10)
+      expect(messages.size).to eq(1)
+
+      payload = JSON.parse(messages.first.message)
+      expect(payload["job_class"]).to eq("WhileExecutingJob")
+    end
+
+    it "does not inject uniqueness metadata into the payload" do
+      task = schedule.tasks.first
+
+      schedule.enqueue_task(task, run_at: run_at)
+
+      messages = Pgbus.client.read_batch("default", qty: 1)
+      payload = JSON.parse(messages.first.message)
+
+      # while_executing strategy should NOT have uniqueness metadata injected
+      # by the scheduler — the executor handles lock acquisition at runtime
+      expect(payload).not_to have_key(Pgbus::Uniqueness::METADATA_KEY)
+      expect(payload).not_to have_key(Pgbus::Uniqueness::STRATEGY_KEY)
+      expect(payload).not_to have_key(Pgbus::Uniqueness::TTL_KEY)
+    end
+
+    it "allows multiple enqueues since no lock prevents it" do
+      task = schedule.tasks.first
+
+      schedule.enqueue_task(task, run_at: run_at)
+      schedule.enqueue_task(task, run_at: Time.utc(2026, 4, 1, 2, 5, 0))
+
+      messages = Pgbus.client.read_batch("default", qty: 10, vt: 0)
+      expect(messages.size).to eq(2)
+
+      expect(Pgbus::JobLock.count).to eq(0)
+    end
+  end
+end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -65,7 +65,11 @@ end
 
 def cleanup_tables
   conn = ActiveRecord::Base.connection
-  %w[pgbus_semaphores pgbus_blocked_executions pgbus_job_locks pgbus_processes pgbus_recurring_executions].each do |table|
+  tables = %w[
+    pgbus_semaphores pgbus_blocked_executions pgbus_job_locks
+    pgbus_processes pgbus_recurring_executions pgbus_failed_events
+  ]
+  tables.each do |table|
     conn.execute("DELETE FROM #{table}")
   end
 rescue StandardError => e

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -186,4 +186,124 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(data_source.toggle_recurring_task(99)).to be false
     end
   end
+
+  describe "#discard_job" do
+    it "archives the message and releases the uniqueness lock" do
+      allow(mock_client).to receive(:archive_message)
+
+      # Mock reading the message to extract uniqueness key
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Job Detail", [42])
+        .and_return({
+                      "msg_id" => 42, "read_ct" => 0,
+                      "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
+                      "message" => '{"job_class":"ImportJob","pgbus_uniqueness_key":"import-42"}',
+                      "headers" => nil, "last_read_at" => nil
+                    })
+
+      allow(Pgbus::JobLock).to receive(:release!)
+
+      data_source.discard_job("pgbus_default", 42)
+
+      expect(mock_client).to have_received(:archive_message).with("pgbus_default", 42, prefixed: false)
+      expect(Pgbus::JobLock).to have_received(:release!).with("import-42")
+    end
+
+    it "does not release lock when message has no uniqueness key" do
+      allow(mock_client).to receive(:archive_message)
+
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Job Detail", [42])
+        .and_return({
+                      "msg_id" => 42, "read_ct" => 0,
+                      "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
+                      "message" => '{"job_class":"PlainJob"}',
+                      "headers" => nil, "last_read_at" => nil
+                    })
+
+      allow(Pgbus::JobLock).to receive(:release!)
+
+      data_source.discard_job("pgbus_default", 42)
+
+      expect(Pgbus::JobLock).not_to have_received(:release!)
+    end
+  end
+
+  describe "#discard_failed_event" do
+    it "deletes the event and releases the uniqueness lock" do
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Failed Event", [1])
+        .and_return({
+                      "id" => 1,
+                      "payload" => '{"job_class":"FailedJob","pgbus_uniqueness_key":"failed-1"}'
+                    })
+
+      allow(mock_connection).to receive(:exec_delete)
+      allow(Pgbus::JobLock).to receive(:release!)
+
+      data_source.discard_failed_event(1)
+
+      expect(mock_connection).to have_received(:exec_delete)
+      expect(Pgbus::JobLock).to have_received(:release!).with("failed-1")
+    end
+  end
+
+  describe "#discard_all_failed" do
+    it "collects uniqueness keys before deleting and releases locks" do
+      allow(mock_connection).to receive(:select_all)
+        .with("SELECT payload FROM pgbus_failed_events", "Pgbus Collect Failed Keys")
+        .and_return([
+                      { "payload" => '{"pgbus_uniqueness_key":"k1"}' },
+                      { "payload" => '{"pgbus_uniqueness_key":"k2"}' },
+                      { "payload" => '{"job_class":"PlainJob"}' }
+                    ])
+
+      result_double = double("result", cmd_tuples: 3)
+      allow(mock_connection).to receive(:execute)
+        .with("DELETE FROM pgbus_failed_events")
+        .and_return(result_double)
+
+      allow(Pgbus::JobLock).to receive(:where).and_return(double(delete_all: 2))
+
+      count = data_source.discard_all_failed
+
+      expect(count).to eq(3)
+      expect(Pgbus::JobLock).to have_received(:where).with(lock_key: %w[k1 k2])
+    end
+  end
+
+  describe "#discard_all_enqueued" do
+    before do
+      allow(mock_connection).to receive(:select_values).and_return(["pgbus_default"])
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Queue Metrics")
+        .and_return({
+                      "queue_length" => 2, "queue_visible_length" => 2,
+                      "oldest_msg_age_sec" => nil, "newest_msg_age_sec" => nil,
+                      "total_messages" => 10
+                    })
+
+      allow(mock_connection).to receive(:select_all)
+        .with(anything, "Pgbus Queue Messages", anything)
+        .and_return([
+                      { "msg_id" => 1, "read_ct" => 0, "enqueued_at" => Time.now.to_s,
+                        "vt" => Time.now.to_s, "last_read_at" => nil, "headers" => nil,
+                        "message" => '{"job_class":"ImportJob","pgbus_uniqueness_key":"k1"}' },
+                      { "msg_id" => 2, "read_ct" => 0, "enqueued_at" => Time.now.to_s,
+                        "vt" => Time.now.to_s, "last_read_at" => nil, "headers" => nil,
+                        "message" => '{"job_class":"PlainJob"}' }
+                    ])
+
+      allow(mock_client).to receive(:archive_batch).and_return([1, 2])
+      allow(Pgbus::JobLock).to receive(:where).and_return(double(delete_all: 1))
+    end
+
+    it "archives all messages from non-DLQ queues and releases locks" do
+      count = data_source.discard_all_enqueued
+
+      expect(count).to eq(2)
+      expect(mock_client).to have_received(:archive_batch).with("pgbus_default", [1, 2], prefixed: false)
+      expect(Pgbus::JobLock).to have_received(:where).with(lock_key: ["k1"])
+    end
+  end
 end

--- a/spec/system/jobs_spec.rb
+++ b/spec/system/jobs_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe "Jobs", type: :system do
       expect(page).to have_button("Retry")
     end
 
+    it "shows Discard All button for enqueued jobs" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-enqueued") do
+        expect(page).to have_button("Discard All")
+      end
+    end
+
+    it "discard all enqueued: confirm and redirects with toast" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-enqueued") { click_button "Discard All" }
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Discarded")
+      expect(@stub_data_source).to be_called(:discard_all_enqueued)
+    end
+
     it "discard enqueued job: confirm and redirects with toast" do
       visit "/pgbus/jobs"
 

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -47,6 +47,7 @@ module Pgbus
       def discard_failed_event(id)   = record(:discard_failed_event, id)
       def retry_all_failed           = record(:retry_all_failed) && @failed_events_list.size
       def discard_all_failed         = record(:discard_all_failed) && @failed_events_list.size
+      def discard_all_enqueued       = record(:discard_all_enqueued) && @jobs_list.size
       def retry_dlq_message(queue_name, msg_id) = record(:retry_dlq_message, queue_name, msg_id)
       def discard_dlq_message(queue_name, msg_id) = record(:discard_dlq_message, queue_name, msg_id)
       def retry_all_dlq              = record(:retry_all_dlq) && @dlq_messages_list.size


### PR DESCRIPTION
## Summary

- **Discard All for enqueued jobs**: New bulk action button in the Jobs page that archives all enqueued messages across all non-DLQ queues and releases their uniqueness locks
- **Lock cleanup on all discard operations**: Single and bulk discard actions (jobs, failed events, DLQ) now automatically release associated `pgbus_job_locks`, preventing stale locks from blocking new job scheduling
- **Recurring scheduler fix**: `while_executing` strategy jobs are now freely schedulable — the scheduler no longer injects uniqueness metadata or checks locks for this strategy (only `until_executed` acquires locks at enqueue time)

### What was wrong

1. Discarding jobs from the dashboard (individually or in bulk) did NOT release their uniqueness locks, causing stale locks that prevented new recurring job scheduling
2. There was no "Discard All" button for enqueued jobs — users had to click one at a time
3. The recurring scheduler injected uniqueness metadata for ALL strategies, but `while_executing` locks should only be acquired at execution time by the worker

### What changed

| Area | Change |
|------|--------|
| `DataSource` | `discard_job`, `discard_failed_event`, `discard_all_failed`, `discard_dlq_message`, `discard_all_dlq` now release locks |
| `DataSource` | New `discard_all_enqueued` method with batch archive + lock release |
| `JobsController` | New `discard_all_enqueued` action |
| Routes | New `POST /jobs/discard_all_enqueued` |
| View | "Discard All" button in enqueued jobs section with confirmation dialog |
| `Recurring::Schedule` | `inject_uniqueness_metadata` skips `:while_executing` strategy |
| Locales | Full i18n support (12 languages) |

## Test plan

- [x] Unit tests: `discard_job`, `discard_failed_event`, `discard_all_failed`, `discard_all_enqueued` (all pass)
- [x] Integration tests: lock cleanup on discard, `while_executing` scheduler behavior
- [x] System tests: new "Discard All" button renders and triggers correctly
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rspec` — 717 examples, 0 failures (excluding pre-existing i18n scanner issue)
- [ ] Manual test on staging: bulk discard enqueued jobs, verify locks are cleared
- [ ] Manual test: verify `while_executing` recurring tasks can be freely scheduled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Discard All" bulk action for enqueued jobs with confirmation and server-side handling.
  * Discard operations now clean up associated job locks when items are removed.

* **Localization**
  * Added translations for the bulk discard UI in 12 languages (DA, DE, EN, ES, FI, FR, IT, JA, NB, NL, PT, SV).

* **Tests**
  * Added system and integration specs covering discard flows and lock cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->