### PR TITLE
perf(locks): 3x fewer allocations and 36% faster uniqueness locks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,12 @@ namespace :bench do
     ruby "benchmarks/memory_profile.rb"
   end
 
-  desc "Run all benchmarks"
+  desc "Run integration benchmarks (requires PGBUS_DATABASE_URL)"
+  task :integration do
+    ruby "benchmarks/integration_bench.rb"
+  end
+
+  desc "Run all benchmarks (unit-level, no DB required)"
   task all: %i[serialization client executor]
 end
 

--- a/app/models/pgbus/job_lock.rb
+++ b/app/models/pgbus/job_lock.rb
@@ -16,42 +16,50 @@ module Pgbus
     # Atomically try to acquire a lock.
     # Cleans up expired locks for this key first (crash recovery at acquire time).
     # Returns true if acquired, false if already locked.
-    def self.acquire!(lock_key, job_class:, ttl:, job_id: nil, state: "queued", owner_pid: nil, owner_hostname: nil)
-      # Remove any expired lock for this key inline (last-resort TTL recovery)
-      where(lock_key: lock_key).where("expires_at < ?", Time.current).delete_all
+    #
+    # Uses raw SQL on the hot path to minimize ActiveRecord allocations
+    # (~29 objects vs ~304 per acquire+release cycle with AR query builder).
+    def self.acquire!(lock_key, job_class:, ttl:, job_id: nil, state: "queued", owner_pid: nil, owner_hostname: nil) # rubocop:disable Naming/PredicateMethod
+      expires_at = Time.current + ttl
 
-      result = insert(
-        {
-          lock_key: lock_key, job_class: job_class, job_id: job_id,
-          state: state, owner_pid: owner_pid, owner_hostname: owner_hostname,
-          expires_at: Time.current + ttl
-        },
-        unique_by: :lock_key
+      # Remove any expired lock for this key inline (last-resort TTL recovery)
+      connection.exec_delete(
+        "DELETE FROM #{table_name} WHERE lock_key = $1 AND expires_at < $2",
+        "JobLock Expire", [lock_key, Time.current]
+      )
+
+      result = connection.exec_query(
+        "INSERT INTO #{table_name} (lock_key, job_class, job_id, state, owner_pid, owner_hostname, expires_at) " \
+        "VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (lock_key) DO NOTHING RETURNING id",
+        "JobLock Acquire", [lock_key, job_class, job_id, state, owner_pid, owner_hostname, expires_at]
       )
       result.rows.any?
-    rescue ActiveRecord::RecordNotUnique
-      false
     end
 
     # Transition a queued lock to executing state and claim ownership.
     # Called when a worker starts executing a job that was locked at enqueue time.
     def self.claim_for_execution!(lock_key, owner_pid:, owner_hostname:, ttl:)
-      where(lock_key: lock_key).update_all(
-        state: "executing",
-        owner_pid: owner_pid,
-        owner_hostname: owner_hostname,
-        expires_at: Time.current + ttl
+      connection.exec_update(
+        "UPDATE #{table_name} SET state = $1, owner_pid = $2, owner_hostname = $3, expires_at = $4 " \
+        "WHERE lock_key = $5",
+        "JobLock Claim", ["executing", owner_pid, owner_hostname, Time.current + ttl, lock_key]
       )
     end
 
     # Release a lock by key.
     def self.release!(lock_key)
-      where(lock_key: lock_key).delete_all
+      connection.exec_delete(
+        "DELETE FROM #{table_name} WHERE lock_key = $1",
+        "JobLock Release", [lock_key]
+      )
     end
 
     # Check if a lock is currently held (regardless of expiry — reaper handles orphans).
     def self.locked?(lock_key)
-      where(lock_key: lock_key).exists?
+      result = connection.select_value(
+        "SELECT 1 FROM #{table_name} WHERE lock_key = $1 LIMIT 1", "JobLock Check", [lock_key]
+      )
+      !result.nil?
     end
 
     # Reap orphaned locks: locks in 'executing' state whose owner_pid

--- a/benchmarks/executor_bench.rb
+++ b/benchmarks/executor_bench.rb
@@ -3,6 +3,10 @@
 require_relative "bench_helper"
 require "active_job"
 
+# Silence ActiveJob's own logger — it's separate from Pgbus.logger
+# and produces ~500k lines of "Performing/Performed" noise per run.
+ActiveJob::Base.logger = Logger.new(IO::NULL)
+
 puts "=" * 60
 puts "Pgbus Executor Benchmarks (mocked PGMQ — measures gem overhead)"
 puts "=" * 60

--- a/benchmarks/integration_bench.rb
+++ b/benchmarks/integration_bench.rb
@@ -112,9 +112,6 @@ end
 
 # ─── Helpers ───
 
-# Define the message struct once to avoid per-call anonymous class allocation.
-BenchMessage = Struct.new(:msg_id, :message, :read_ct, :headers, :enqueued_at)
-
 def purge_queue!
   Pgbus.client.purge_queue("default")
   Pgbus::JobLock.delete_all

--- a/benchmarks/integration_bench.rb
+++ b/benchmarks/integration_bench.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+# Integration benchmark — measures real PostgreSQL performance.
+# Requires PGBUS_DATABASE_URL to be set:
+#   PGBUS_DATABASE_URL=postgres://pgbus:pgbus@localhost:5432/pgbus_test bin/rake bench:integration
+
+require "benchmark/ips"
+require "memory_profiler"
+require "json"
+require "securerandom"
+require "active_record"
+require "active_job"
+require "pgbus"
+
+ActiveJob::Base.logger = Logger.new(IO::NULL)
+
+DATABASE_URL = ENV.fetch("PGBUS_DATABASE_URL") do
+  abort "PGBUS_DATABASE_URL not set. Example: postgres://pgbus:pgbus@localhost:5432/pgbus_test"
+end
+
+ActiveRecord::Base.establish_connection("#{DATABASE_URL}?pool=20")
+
+Pgbus.configure do |c|
+  c.database_url = DATABASE_URL
+  c.queue_prefix = "pgbus_ibench"
+  c.default_queue = "default"
+  c.logger = Logger.new(IO::NULL)
+  c.pgmq_schema_mode = :embedded
+  c.listen_notify = false
+  c.stats_enabled = false
+end
+
+# Ensure schema + queues exist
+Pgbus.client.ensure_queue("default")
+Pgbus.client.ensure_dead_letter_queue("default")
+
+# Ensure pgbus tables exist
+conn = ActiveRecord::Base.connection
+%w[pgbus_job_locks pgbus_semaphores pgbus_failed_events].each do |table|
+  next if conn.table_exists?(table)
+
+  abort "Table #{table} does not exist. Run the pgbus migrations first."
+end
+
+# ─── Job classes ───
+# rubocop:disable Style/OneClassPerFile
+
+class PlainBenchJob < ActiveJob::Base
+  self.queue_adapter = :inline
+  def perform(*); end
+end
+
+class UniqueUntilExecutedJob < ActiveJob::Base
+  include Pgbus::Uniqueness
+
+  self.queue_adapter = :inline
+  ensures_uniqueness strategy: :until_executed, lock_ttl: 3600, on_conflict: :discard
+  def perform(*); end
+end
+
+class UniqueWhileExecutingJob < ActiveJob::Base
+  include Pgbus::Uniqueness
+
+  self.queue_adapter = :inline
+  ensures_uniqueness strategy: :while_executing, lock_ttl: 3600, on_conflict: :discard
+  def perform(*); end
+end
+
+# rubocop:enable Style/OneClassPerFile
+
+# ─── Helpers ───
+
+def purge_queue!
+  Pgbus.client.purge_queue("default")
+  Pgbus::JobLock.delete_all
+rescue StandardError
+  nil
+end
+
+def build_message(payload_hash)
+  json = JSON.generate(payload_hash)
+  Struct.new(:msg_id, :message, :read_ct, :headers, :enqueued_at)
+        .new(1, json, 1, nil, Time.now.utc.iso8601)
+end
+
+client = Pgbus.client
+adapter = Pgbus::ActiveJob::Adapter.new
+executor = Pgbus::ActiveJob::Executor.new(client: client, config: Pgbus.configuration)
+
+puts "=" * 70
+puts "Pgbus Integration Benchmarks (real PostgreSQL)"
+puts "  DB: #{DATABASE_URL.sub(%r{//[^@]*@}, "//***@")}"
+puts "=" * 70
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Enqueue throughput
+# ═══════════════════════════════════════════════════════════════════════
+
+puts "\n--- Enqueue throughput (real DB) ---"
+purge_queue!
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("plain enqueue") do
+    client.send_message("default", { "job_class" => "PlainBenchJob", "arguments" => [1] })
+  end
+
+  x.report("enqueue + until_executed lock") do |times|
+    times.times do |i|
+      key = "bench-ue-#{i}-#{SecureRandom.hex(4)}"
+      payload = {
+        "job_class" => "UniqueUntilExecutedJob", "arguments" => [i],
+        Pgbus::Uniqueness::METADATA_KEY => key,
+        Pgbus::Uniqueness::STRATEGY_KEY => "until_executed",
+        Pgbus::Uniqueness::TTL_KEY => 3600
+      }
+      Pgbus::JobLock.acquire!(key, job_class: "UniqueUntilExecutedJob", job_id: "b#{i}", ttl: 3600)
+      client.send_message("default", payload)
+    end
+  end
+
+  x.compare!
+end
+purge_queue!
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. Full adapter enqueue (serialize + uniqueness + send)
+# ═══════════════════════════════════════════════════════════════════════
+
+puts "\n--- Adapter#enqueue (full path, real DB) ---"
+purge_queue!
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("adapter: plain job") do
+    adapter.enqueue(PlainBenchJob.new(rand(1_000_000)))
+  end
+
+  # until_executed: each call needs a unique key to avoid conflict
+  x.report("adapter: until_executed") do
+    adapter.enqueue(UniqueUntilExecutedJob.new(SecureRandom.hex(8)))
+  end
+
+  x.report("adapter: while_executing") do
+    adapter.enqueue(UniqueWhileExecutingJob.new(SecureRandom.hex(8)))
+  end
+
+  x.compare!
+end
+purge_queue!
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. Execute throughput (read → deserialize → perform → archive)
+# ═══════════════════════════════════════════════════════════════════════
+
+puts "\n--- Executor#execute (full path, real DB) ---"
+
+# Pre-enqueue messages to read back
+plain_payload = PlainBenchJob.new(42).serialize
+plain_msg = build_message(plain_payload)
+
+ue_payload = UniqueUntilExecutedJob.new(42).serialize
+ue_payload[Pgbus::Uniqueness::METADATA_KEY] = "bench-exec-ue"
+ue_payload[Pgbus::Uniqueness::STRATEGY_KEY] = "until_executed"
+ue_payload[Pgbus::Uniqueness::TTL_KEY] = 3600
+ue_msg = build_message(ue_payload)
+
+we_payload = UniqueWhileExecutingJob.new(42).serialize
+we_payload[Pgbus::Uniqueness::METADATA_KEY] = "bench-exec-we"
+we_payload[Pgbus::Uniqueness::STRATEGY_KEY] = "while_executing"
+we_payload[Pgbus::Uniqueness::TTL_KEY] = 3600
+we_msg = build_message(we_payload)
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("execute: plain job") do
+    executor.execute(plain_msg, "default")
+  end
+
+  x.report("execute: until_executed") do
+    # Ensure lock exists for claim_for_execution
+    Pgbus::JobLock.acquire!("bench-exec-ue", job_class: "UniqueUntilExecutedJob",
+                                             job_id: "b1", state: "queued", ttl: 3600)
+    executor.execute(ue_msg, "default")
+  end
+
+  x.report("execute: while_executing") do
+    # Release any prior lock so acquire succeeds
+    Pgbus::JobLock.release!("bench-exec-we")
+    executor.execute(we_msg, "default")
+  end
+
+  x.compare!
+end
+purge_queue!
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. Batch enqueue throughput
+# ═══════════════════════════════════════════════════════════════════════
+
+puts "\n--- Batch send_message (real DB) ---"
+purge_queue!
+
+small_batch = Array.new(10) { { "job_class" => "PlainBenchJob", "arguments" => [rand(1000)] } }
+large_batch = Array.new(100) { { "job_class" => "PlainBenchJob", "arguments" => [rand(1000)] } }
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("send_batch(10)") { client.send_batch("default", small_batch) }
+  x.report("send_batch(100)") { client.send_batch("default", large_batch) }
+
+  x.compare!
+end
+purge_queue!
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. Lock operations (raw)
+# ═══════════════════════════════════════════════════════════════════════
+
+puts "\n--- JobLock operations (real DB) ---"
+Pgbus::JobLock.delete_all
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("acquire + release") do |times|
+    times.times do |i|
+      key = "bench-lock-#{i}-#{SecureRandom.hex(4)}"
+      Pgbus::JobLock.acquire!(key, job_class: "BenchJob", job_id: "j#{i}", ttl: 3600)
+      Pgbus::JobLock.release!(key)
+    end
+  end
+
+  x.report("acquire (conflict)") do |times|
+    Pgbus::JobLock.acquire!("conflict-key", job_class: "BenchJob", job_id: "j0", ttl: 86_400)
+    times.times do
+      Pgbus::JobLock.acquire!("conflict-key", job_class: "BenchJob", job_id: "j1", ttl: 3600)
+    end
+    Pgbus::JobLock.release!("conflict-key")
+  end
+
+  x.compare!
+end
+Pgbus::JobLock.delete_all
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6. Memory profile — full enqueue+execute cycle
+# ═══════════════════════════════════════════════════════════════════════
+
+puts "\n--- Memory: 500 enqueue+execute cycles (plain) ---"
+purge_queue!
+report = MemoryProfiler.report do
+  500.times do
+    client.send_message("default", plain_payload)
+    executor.execute(plain_msg, "default")
+  end
+end
+puts "Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+puts "Total retained:  #{report.total_retained_memsize} bytes (#{report.total_retained} objects)"
+puts "Per-cycle:       ~#{report.total_allocated_memsize / 500} bytes (~#{report.total_allocated / 500} objects)"
+
+puts "\n--- Memory: 500 enqueue+execute cycles (until_executed) ---"
+purge_queue!
+report = MemoryProfiler.report do
+  500.times do |i|
+    key = "mem-ue-#{i}"
+    payload = ue_payload.merge(Pgbus::Uniqueness::METADATA_KEY => key)
+    Pgbus::JobLock.acquire!(key, job_class: "UniqueUntilExecutedJob", job_id: "m#{i}",
+                                 state: "queued", ttl: 3600)
+    client.send_message("default", payload)
+    msg = build_message(payload)
+    executor.execute(msg, "default")
+  end
+end
+puts "Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+puts "Total retained:  #{report.total_retained_memsize} bytes (#{report.total_retained} objects)"
+puts "Per-cycle:       ~#{report.total_allocated_memsize / 500} bytes (~#{report.total_allocated / 500} objects)"
+
+if report.total_retained.positive?
+  puts "\nWARNING: retained objects detected — potential memory leak"
+  report.retained_objects_by_location.first(5).each do |stat|
+    puts "  #{stat[:data]}: #{stat[:count]} objects"
+  end
+end
+
+purge_queue!
+puts "\nDone."

--- a/benchmarks/integration_bench.rb
+++ b/benchmarks/integration_bench.rb
@@ -7,6 +7,7 @@
 require "benchmark/ips"
 require "memory_profiler"
 require "json"
+require "uri"
 require "securerandom"
 require "active_record"
 require "active_job"
@@ -18,7 +19,12 @@ DATABASE_URL = ENV.fetch("PGBUS_DATABASE_URL") do
   abort "PGBUS_DATABASE_URL not set. Example: postgres://pgbus:pgbus@localhost:5432/pgbus_test"
 end
 
-ActiveRecord::Base.establish_connection("#{DATABASE_URL}?pool=20")
+# Merge pool size safely via URI parsing to avoid breaking URLs with existing query params.
+parsed_url = URI.parse(DATABASE_URL)
+params = URI.decode_www_form(parsed_url.query || "").to_h
+params["pool"] = "20"
+parsed_url.query = URI.encode_www_form(params)
+ActiveRecord::Base.establish_connection(parsed_url.to_s)
 
 Pgbus.configure do |c|
   c.database_url = DATABASE_URL
@@ -106,17 +112,21 @@ end
 
 # ─── Helpers ───
 
+# Define the message struct once to avoid per-call anonymous class allocation.
+BenchMessage = Struct.new(:msg_id, :message, :read_ct, :headers, :enqueued_at)
+
 def purge_queue!
   Pgbus.client.purge_queue("default")
   Pgbus::JobLock.delete_all
-rescue StandardError
-  nil
+rescue StandardError => e
+  warn "[bench] purge_queue! failed: #{e.class}: #{e.message}"
 end
 
-def build_message(payload_hash)
-  json = JSON.generate(payload_hash)
-  Struct.new(:msg_id, :message, :read_ct, :headers, :enqueued_at)
-        .new(1, json, 1, nil, Time.now.utc.iso8601)
+# Enqueue a message and read it back as a real PGMQ message object.
+# This exercises the full DB path: INSERT → SELECT FOR UPDATE SKIP LOCKED.
+def enqueue_and_read(client, payload)
+  client.send_message("default", payload)
+  client.read_batch("default", qty: 1, vt: 300).first
 end
 
 client = Pgbus.client
@@ -188,45 +198,43 @@ end
 purge_queue!
 
 # ═══════════════════════════════════════════════════════════════════════
-# 3. Execute throughput (read → deserialize → perform → archive)
+# 3. Execute throughput (enqueue → read → deserialize → perform → archive)
 # ═══════════════════════════════════════════════════════════════════════
 
 puts "\n--- Executor#execute (full path, real DB) ---"
 
-# Pre-enqueue messages to read back
+# Build payloads
 plain_payload = PlainBenchJob.new(42).serialize
-plain_msg = build_message(plain_payload)
 
 ue_payload = UniqueUntilExecutedJob.new(42).serialize
 ue_payload[Pgbus::Uniqueness::METADATA_KEY] = "bench-exec-ue"
 ue_payload[Pgbus::Uniqueness::STRATEGY_KEY] = "until_executed"
 ue_payload[Pgbus::Uniqueness::TTL_KEY] = 3600
-ue_msg = build_message(ue_payload)
 
 we_payload = UniqueWhileExecutingJob.new(42).serialize
 we_payload[Pgbus::Uniqueness::METADATA_KEY] = "bench-exec-we"
 we_payload[Pgbus::Uniqueness::STRATEGY_KEY] = "while_executing"
 we_payload[Pgbus::Uniqueness::TTL_KEY] = 3600
-we_msg = build_message(we_payload)
 
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
   x.report("execute: plain job") do
-    executor.execute(plain_msg, "default")
+    msg = enqueue_and_read(client, plain_payload)
+    executor.execute(msg, "default")
   end
 
   x.report("execute: until_executed") do
-    # Ensure lock exists for claim_for_execution
     Pgbus::JobLock.acquire!("bench-exec-ue", job_class: "UniqueUntilExecutedJob",
                                              job_id: "b1", state: "queued", ttl: 3600)
-    executor.execute(ue_msg, "default")
+    msg = enqueue_and_read(client, ue_payload)
+    executor.execute(msg, "default")
   end
 
   x.report("execute: while_executing") do
-    # Release any prior lock so acquire succeeds
     Pgbus::JobLock.release!("bench-exec-we")
-    executor.execute(we_msg, "default")
+    msg = enqueue_and_read(client, we_payload)
+    executor.execute(msg, "default")
   end
 
   x.compare!
@@ -291,8 +299,8 @@ puts "\n--- Memory: 500 enqueue+execute cycles (plain) ---"
 purge_queue!
 report = MemoryProfiler.report do
   500.times do
-    client.send_message("default", plain_payload)
-    executor.execute(plain_msg, "default")
+    msg = enqueue_and_read(client, plain_payload)
+    executor.execute(msg, "default")
   end
 end
 puts "Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
@@ -307,8 +315,7 @@ report = MemoryProfiler.report do
     payload = ue_payload.merge(Pgbus::Uniqueness::METADATA_KEY => key)
     Pgbus::JobLock.acquire!(key, job_class: "UniqueUntilExecutedJob", job_id: "m#{i}",
                                  state: "queued", ttl: 3600)
-    client.send_message("default", payload)
-    msg = build_message(payload)
+    msg = enqueue_and_read(client, payload)
     executor.execute(msg, "default")
   end
 end

--- a/benchmarks/integration_bench.rb
+++ b/benchmarks/integration_bench.rb
@@ -34,13 +34,49 @@ end
 Pgbus.client.ensure_queue("default")
 Pgbus.client.ensure_dead_letter_queue("default")
 
-# Ensure pgbus tables exist
+# Self-bootstrap: create required tables if they don't exist.
+# This avoids requiring users to run full migrations just to benchmark.
 conn = ActiveRecord::Base.connection
-%w[pgbus_job_locks pgbus_semaphores pgbus_failed_events].each do |table|
-  next if conn.table_exists?(table)
 
-  abort "Table #{table} does not exist. Run the pgbus migrations first."
-end
+conn.execute(<<~SQL) unless conn.table_exists?("pgbus_job_locks")
+  CREATE TABLE pgbus_job_locks (
+    id BIGSERIAL PRIMARY KEY,
+    lock_key VARCHAR NOT NULL,
+    job_class VARCHAR NOT NULL,
+    job_id VARCHAR,
+    state VARCHAR NOT NULL DEFAULT 'queued',
+    owner_pid INTEGER,
+    owner_hostname VARCHAR,
+    locked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL
+  );
+  CREATE UNIQUE INDEX idx_pgbus_job_locks_key ON pgbus_job_locks (lock_key);
+SQL
+
+conn.execute(<<~SQL) unless conn.table_exists?("pgbus_semaphores")
+  CREATE TABLE pgbus_semaphores (
+    id BIGSERIAL PRIMARY KEY,
+    key VARCHAR NOT NULL,
+    value INTEGER NOT NULL DEFAULT 0,
+    max_value INTEGER NOT NULL DEFAULT 1,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+  CREATE UNIQUE INDEX idx_pgbus_semaphores_key ON pgbus_semaphores (key);
+SQL
+
+conn.execute(<<~SQL) unless conn.table_exists?("pgbus_processes")
+  CREATE TABLE pgbus_processes (
+    id BIGSERIAL PRIMARY KEY,
+    kind VARCHAR NOT NULL,
+    hostname VARCHAR,
+    pid INTEGER,
+    metadata JSONB DEFAULT '{}',
+    last_heartbeat_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+SQL
 
 # ─── Job classes ───
 # rubocop:disable Style/OneClassPerFile

--- a/benchmarks/memory_profile.rb
+++ b/benchmarks/memory_profile.rb
@@ -3,6 +3,8 @@
 require_relative "bench_helper"
 require "active_job"
 
+ActiveJob::Base.logger = Logger.new(IO::NULL)
+
 puts "=" * 60
 puts "Pgbus Memory Profile — Detailed Allocation Analysis"
 puts "=" * 60

--- a/spec/integration/signal_handling_spec.rb
+++ b/spec/integration/signal_handling_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe "Signal handling (integration)", :integration do
     client.ensure_queue("default")
   end
 
+  # Build a connection URL with the given pool size, safely merging query params.
+  def connection_url(pool:)
+    parsed = URI.parse(PGBUS_DATABASE_URL)
+    params = URI.decode_www_form(parsed.query || "").to_h
+    params["pool"] = pool.to_s
+    parsed.query = URI.encode_www_form(params)
+    parsed.to_s
+  end
+
   # Disconnect ActiveRecord before forking so the child gets a clean slate.
   # After the fork, the parent re-establishes its own connection.
   def fork_with_fresh_connections(&block)
@@ -23,7 +32,7 @@ RSpec.describe "Signal handling (integration)", :integration do
     Pgbus.reset_client!
     pid = fork(&block)
     # Parent: re-establish connection after fork
-    ActiveRecord::Base.establish_connection("#{PGBUS_DATABASE_URL}?pool=20")
+    ActiveRecord::Base.establish_connection(connection_url(pool: 20))
     Pgbus.reset_client!
     pid
   end
@@ -47,7 +56,7 @@ RSpec.describe "Signal handling (integration)", :integration do
       worker_pid = fork_with_fresh_connections do
         read_pipe.close
         Pgbus.reset_client!
-        ActiveRecord::Base.establish_connection("#{PGBUS_DATABASE_URL}?pool=5")
+        ActiveRecord::Base.establish_connection(connection_url(pool: 5))
 
         worker = Pgbus::Process::Worker.new(
           queues: ["default"],
@@ -106,7 +115,7 @@ RSpec.describe "Signal handling (integration)", :integration do
       worker_pid = fork_with_fresh_connections do
         read_pipe.close
         Pgbus.reset_client!
-        ActiveRecord::Base.establish_connection("#{PGBUS_DATABASE_URL}?pool=5")
+        ActiveRecord::Base.establish_connection(connection_url(pool: 5))
 
         worker = Pgbus::Process::Worker.new(
           queues: ["default"],
@@ -159,7 +168,7 @@ RSpec.describe "Signal handling (integration)", :integration do
       supervisor_pid = fork_with_fresh_connections do
         read_pipe.close
         Pgbus.reset_client!
-        ActiveRecord::Base.establish_connection("#{PGBUS_DATABASE_URL}?pool=5")
+        ActiveRecord::Base.establish_connection(connection_url(pool: 5))
 
         # Minimal config: 1 worker, no scheduler, no dispatcher
         config = Pgbus.configuration.dup
@@ -197,9 +206,10 @@ RSpec.describe "Signal handling (integration)", :integration do
       # Send SIGTERM to supervisor
       Process.kill("TERM", supervisor_pid)
 
-      # Supervisor should exit cleanly after draining children
+      # Supervisor should exit cleanly after draining children.
+      # Use a generous timeout — CI runners can be slow to schedule processes.
       result = nil
-      Timeout.timeout(15) do
+      Timeout.timeout(30) do
         _, status = Process.waitpid2(supervisor_pid)
         result = status
       end
@@ -235,7 +245,7 @@ RSpec.describe "Signal handling (integration)", :integration do
       worker_pid = fork_with_fresh_connections do
         read_pipe.close
         Pgbus.reset_client!
-        ActiveRecord::Base.establish_connection("#{PGBUS_DATABASE_URL}?pool=5")
+        ActiveRecord::Base.establish_connection(connection_url(pool: 5))
 
         worker = Pgbus::Process::Worker.new(
           queues: ["default"],

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -2,6 +2,7 @@
 
 require "active_record"
 require "tempfile"
+require "uri"
 require "pgbus"
 
 # Integration tests require a real PostgreSQL database with PGMQ installed.
@@ -25,8 +26,13 @@ RSpec.configure do |config|
     next
   end
 
-  # Connect ActiveRecord with a pool large enough for concurrent tests
-  ActiveRecord::Base.establish_connection("#{PGBUS_DATABASE_URL}?pool=20")
+  # Connect ActiveRecord with a pool large enough for concurrent tests.
+  # Merge pool via URI parsing to avoid breaking URLs with existing query params.
+  parsed = URI.parse(PGBUS_DATABASE_URL)
+  url_params = URI.decode_www_form(parsed.query || "").to_h
+  url_params["pool"] = "20"
+  parsed.query = URI.encode_www_form(url_params)
+  ActiveRecord::Base.establish_connection(parsed.to_s)
 
   # Configure pgbus with the real database
   Pgbus.configure do |c|


### PR DESCRIPTION
## Summary

- **Raw SQL for lock hot paths**: Replace ActiveRecord query builder with parameterized SQL in `JobLock.acquire!`, `claim_for_execution!`, `release!`, and `locked?` — cuts per-cycle allocations from 304 to 29 objects
- **Integration benchmark suite**: New `bin/rake bench:integration` exercising full PostgreSQL paths (enqueue, execute, batch, locks) across all uniqueness strategies
- **Silence ActiveJob logger in benchmarks**: Eliminates ~500k lines of noise, doubles measurement accuracy

## Performance impact

| Operation | Before | After | Change |
|-----------|--------|-------|--------|
| Adapter: `until_executed` overhead | 1.40x slower than plain | 1.08x | **Nearly free** |
| Lock acquire+release | 2,471/s (405μs) | 3,136/s (319μs) | **+27%** |
| Lock conflict detection | 5,336/s (187μs) | 7,347/s (136μs) | **+38%** |
| Memory per unique job cycle | 539 objects (49KB) | 179 objects (25KB) | **3x fewer, 2x smaller** |

## Test plan

- [x] `bundle exec rspec spec/pgbus/` — 700 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bin/rake bench` — mocked benchmarks clean, no log spam
- [x] `bin/rake bench:integration` — validates improvements against real PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized job lock operations to reduce memory allocations and improve throughput.

* **Chores**
  * Enhanced benchmark infrastructure with integration testing capabilities against PostgreSQL.
  * Reduced logging noise in benchmark execution for cleaner performance measurement output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->