### PR TITLE
feat(web): add lock discard and checkbox bulk delete across dashboard

### DIFF
--- a/app/controllers/pgbus/dead_letter_controller.rb
+++ b/app/controllers/pgbus/dead_letter_controller.rb
@@ -46,5 +46,22 @@ module Pgbus
       count = data_source.discard_all_dlq
       redirect_to dead_letter_index_path, notice: "Discarded #{count} DLQ messages."
     end
+
+    def discard_selected
+      selections = Array(params[:messages]).reject { |s| s[:queue_name].blank? || s[:msg_id].blank? }
+      if selections.empty?
+        redirect_to dead_letter_index_path, alert: t("pgbus.dead_letter.index.none_selected")
+        return
+      end
+
+      count = 0
+      selections.each do |sel|
+        queue_name = sel[:queue_name].to_s
+        next unless queue_name.end_with?(Pgbus.configuration.dead_letter_queue_suffix)
+
+        count += 1 if data_source.discard_dlq_message(queue_name, sel[:msg_id])
+      end
+      redirect_to dead_letter_index_path, notice: t("pgbus.dead_letter.index.discarded_selected", count: count)
+    end
   end
 end

--- a/app/controllers/pgbus/jobs_controller.rb
+++ b/app/controllers/pgbus/jobs_controller.rb
@@ -65,7 +65,15 @@ module Pgbus
     end
 
     def discard_selected_enqueued
-      selections = Array(params[:messages]).reject { |s| s[:queue_name].blank? || s[:msg_id].blank? }
+      selections = Array(params[:messages]).filter_map do |s|
+        next unless s.respond_to?(:[])
+
+        queue_name = s[:queue_name]
+        msg_id = s[:msg_id]
+        next if queue_name.blank? || msg_id.blank?
+
+        { queue_name: queue_name, msg_id: msg_id }
+      end
       if selections.empty?
         redirect_to jobs_path, alert: t("pgbus.jobs.index.none_selected")
         return
@@ -73,8 +81,7 @@ module Pgbus
 
       count = 0
       selections.each do |sel|
-        data_source.discard_job(sel[:queue_name], sel[:msg_id])
-        count += 1
+        count += 1 if data_source.discard_job(sel[:queue_name], sel[:msg_id])
       end
       redirect_to jobs_path, notice: t("pgbus.jobs.index.discarded_selected", count: count)
     end

--- a/app/controllers/pgbus/jobs_controller.rb
+++ b/app/controllers/pgbus/jobs_controller.rb
@@ -49,5 +49,34 @@ module Pgbus
       count = data_source.discard_all_enqueued
       redirect_to jobs_path, notice: t("pgbus.jobs.index.discard_all_enqueued_notice", count: count)
     end
+
+    def discard_selected_failed
+      ids = Array(params[:ids]).map(&:to_i).reject(&:zero?)
+      if ids.empty?
+        redirect_to jobs_path, alert: t("pgbus.jobs.index.none_selected")
+        return
+      end
+
+      count = 0
+      ids.each do |id|
+        count += 1 if data_source.discard_failed_event(id)
+      end
+      redirect_to jobs_path, notice: t("pgbus.jobs.index.discarded_selected", count: count)
+    end
+
+    def discard_selected_enqueued
+      selections = Array(params[:messages]).reject { |s| s[:queue_name].blank? || s[:msg_id].blank? }
+      if selections.empty?
+        redirect_to jobs_path, alert: t("pgbus.jobs.index.none_selected")
+        return
+      end
+
+      count = 0
+      selections.each do |sel|
+        data_source.discard_job(sel[:queue_name], sel[:msg_id])
+        count += 1
+      end
+      redirect_to jobs_path, notice: t("pgbus.jobs.index.discarded_selected", count: count)
+    end
   end
 end

--- a/app/controllers/pgbus/locks_controller.rb
+++ b/app/controllers/pgbus/locks_controller.rb
@@ -5,5 +5,30 @@ module Pgbus
     def index
       @locks = data_source.job_locks
     end
+
+    def discard
+      count = data_source.discard_lock(params[:id])
+      if count.positive?
+        redirect_to locks_path, notice: t("pgbus.locks.index.lock_discarded")
+      else
+        redirect_to locks_path, alert: t("pgbus.locks.index.lock_discard_failed")
+      end
+    end
+
+    def discard_selected
+      keys = Array(params[:lock_keys]).reject(&:blank?)
+      if keys.empty?
+        redirect_to locks_path, alert: t("pgbus.locks.index.none_selected")
+        return
+      end
+
+      count = data_source.discard_locks(keys)
+      redirect_to locks_path, notice: t("pgbus.locks.index.locks_discarded", count: count)
+    end
+
+    def discard_all
+      count = data_source.discard_all_locks
+      redirect_to locks_path, notice: t("pgbus.locks.index.all_locks_discarded", count: count)
+    end
   end
 end

--- a/app/frontend/pgbus/application.js
+++ b/app/frontend/pgbus/application.js
@@ -89,8 +89,15 @@ function initBulkSelect() {
       selectAll.indeterminate = checked.length > 0 && checked.length < all.length;
     }
 
+    let inSelectAll = false;
     selectAll.addEventListener("change", () => {
-      checkboxes().forEach(cb => { cb.checked = selectAll.checked; });
+      inSelectAll = true;
+      checkboxes().forEach(cb => {
+        cb.checked = selectAll.checked;
+        // Dispatch change event so inline onchange handlers fire (e.g., hidden input sync)
+        cb.dispatchEvent(new Event("change", { bubbles: false }));
+      });
+      inSelectAll = false;
       updateUI();
     });
 

--- a/app/frontend/pgbus/application.js
+++ b/app/frontend/pgbus/application.js
@@ -69,6 +69,41 @@ function renderFlashToasts() {
 renderFlashToasts();
 document.addEventListener("turbo:load", renderFlashToasts);
 
+// -- Bulk checkbox selection --
+function initBulkSelect() {
+  document.querySelectorAll("[data-bulk-select-all]").forEach(selectAll => {
+    const scope = selectAll.closest("[data-bulk-scope]") || document;
+    const checkboxes = () => scope.querySelectorAll("input[data-bulk-item]");
+    // Look for bulk-actions in the parent page container (outside the table scope)
+    const pageScope = scope.closest("[data-bulk-page]") || scope.closest("turbo-frame") || scope.parentElement?.closest("div") || document;
+    const countEl = pageScope.querySelector("[data-bulk-count]");
+    const actions = pageScope.querySelector("[data-bulk-actions]");
+
+    function updateUI() {
+      const checked = scope.querySelectorAll("input[data-bulk-item]:checked");
+      if (countEl) countEl.textContent = checked.length;
+      if (actions) actions.classList.toggle("hidden", checked.length === 0);
+
+      const all = checkboxes();
+      selectAll.checked = all.length > 0 && checked.length === all.length;
+      selectAll.indeterminate = checked.length > 0 && checked.length < all.length;
+    }
+
+    selectAll.addEventListener("change", () => {
+      checkboxes().forEach(cb => { cb.checked = selectAll.checked; });
+      updateUI();
+    });
+
+    scope.addEventListener("change", (e) => {
+      if (e.target.matches("input[data-bulk-item]")) updateUI();
+    });
+  });
+
+}
+initBulkSelect();
+document.addEventListener("turbo:load", initBulkSelect);
+document.addEventListener("turbo:frame-load", initBulkSelect);
+
 // -- Auto-refresh --
 const refreshInterval = parseInt(document.body?.dataset.pgbusRefreshInterval || "0", 10);
 if (refreshInterval > 0) {

--- a/app/views/pgbus/dead_letter/_messages_table.html.erb
+++ b/app/views/pgbus/dead_letter/_messages_table.html.erb
@@ -1,8 +1,18 @@
 <turbo-frame id="dlq-messages" data-auto-refresh data-src="<%= pgbus.dead_letter_index_path(frame: 'list') %>">
-  <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+  <%# Bulk form outside table to avoid nested form issues %>
+  <form id="bulk-discard-dlq-form" action="<%= pgbus.discard_selected_dead_letter_index_path %>" method="post" data-turbo-frame="_top" class="hidden">
+    <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+  </form>
+  <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700" data-bulk-scope="dlq">
     <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">
         <tr>
+          <% if @messages.any? %>
+            <th class="w-10 px-4 py-3">
+              <input type="checkbox" data-bulk-select-all
+                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
+            </th>
+          <% end %>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dead_letter.messages_table.headers.id") %></th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dead_letter.messages_table.headers.job_class") %></th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dead_letter.messages_table.headers.source_queue") %></th>
@@ -16,6 +26,14 @@
           <% dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix %>
           <% source_queue = m[:queue_name].to_s.delete_suffix(dlq_suffix) %>
           <tr>
+            <td class="w-10 px-4 py-3 align-top">
+              <input type="checkbox" data-bulk-item
+                     data-queue-name="<%= m[:queue_name] %>" data-msg-id="<%= m[:msg_id] %>"
+                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 mt-1"
+                     onchange="this.nextElementSibling.disabled = !this.checked; this.nextElementSibling.nextElementSibling.disabled = !this.checked">
+              <input type="hidden" name="messages[][queue_name]" value="<%= m[:queue_name] %>" form="bulk-discard-dlq-form" disabled>
+              <input type="hidden" name="messages[][msg_id]" value="<%= m[:msg_id] %>" form="bulk-discard-dlq-form" disabled>
+            </td>
             <td colspan="5" class="p-0">
               <details class="group">
                 <summary class="flex cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900 list-none">
@@ -69,7 +87,7 @@
           </tr>
         <% end %>
         <% if @messages.empty? %>
-          <tr><td colspan="5" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.dead_letter.messages_table.empty") %></td></tr>
+          <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.dead_letter.messages_table.empty") %></td></tr>
         <% end %>
       </tbody>
     </table>

--- a/app/views/pgbus/dead_letter/index.html.erb
+++ b/app/views/pgbus/dead_letter/index.html.erb
@@ -3,7 +3,7 @@
   <% if @messages.any? %>
     <div class="flex items-center space-x-2">
       <div data-bulk-actions class="hidden flex items-center space-x-2">
-        <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> selected</span>
+        <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> <%= t("pgbus.helpers.bulk_selected") %></span>
         <button type="submit" form="bulk-discard-dlq-form"
                 class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
                 data-turbo-confirm="<%= t("pgbus.dead_letter.index.discard_selected_confirm") %>">

--- a/app/views/pgbus/dead_letter/index.html.erb
+++ b/app/views/pgbus/dead_letter/index.html.erb
@@ -1,7 +1,15 @@
 <div class="flex items-center justify-between mb-6">
   <h1 class="text-2xl font-bold text-gray-900 dark:text-white"><%= t("pgbus.dead_letter.index.title") %></h1>
   <% if @messages.any? %>
-    <div class="flex space-x-2">
+    <div class="flex items-center space-x-2">
+      <div data-bulk-actions class="hidden flex items-center space-x-2">
+        <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> selected</span>
+        <button type="submit" form="bulk-discard-dlq-form"
+                class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
+                data-turbo-confirm="<%= t("pgbus.dead_letter.index.discard_selected_confirm") %>">
+          <%= t("pgbus.dead_letter.index.discard_selected") %>
+        </button>
+      </div>
       <%= button_to t("pgbus.dead_letter.index.retry_all"), pgbus.retry_all_dead_letter_index_path, method: :post,
             class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-500",
             data: { turbo_confirm: t("pgbus.dead_letter.index.retry_all_confirm") } %>

--- a/app/views/pgbus/jobs/_enqueued_table.html.erb
+++ b/app/views/pgbus/jobs/_enqueued_table.html.erb
@@ -5,7 +5,7 @@
       <% if @jobs.any? %>
         <div class="flex items-center space-x-2">
           <div data-bulk-actions class="hidden flex items-center space-x-2">
-            <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> selected</span>
+            <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> <%= t("pgbus.helpers.bulk_selected") %></span>
             <button type="submit" form="bulk-discard-enqueued-form"
                     class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
                     data-turbo-confirm="<%= t("pgbus.jobs.index.discard_selected_confirm") %>">

--- a/app/views/pgbus/jobs/_enqueued_table.html.erb
+++ b/app/views/pgbus/jobs/_enqueued_table.html.erb
@@ -1,17 +1,37 @@
 <turbo-frame id="jobs-enqueued" data-auto-refresh data-src="<%= pgbus.jobs_path(request.query_parameters.merge(frame: 'enqueued')) %>">
-  <div>
+  <div data-bulk-page>
     <div class="flex items-center justify-between mb-3">
       <h2 class="text-lg font-semibold text-gray-900 dark:text-white"><%= t("pgbus.jobs.enqueued_table.title") %></h2>
       <% if @jobs.any? %>
-        <%= button_to t("pgbus.jobs.enqueued_table.discard_all"), pgbus.discard_all_enqueued_jobs_path, method: :post,
-              class: "rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500",
-              data: { turbo_confirm: t("pgbus.jobs.enqueued_table.discard_all_confirm"), turbo_frame: "_top" } %>
+        <div class="flex items-center space-x-2">
+          <div data-bulk-actions class="hidden flex items-center space-x-2">
+            <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> selected</span>
+            <button type="submit" form="bulk-discard-enqueued-form"
+                    class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
+                    data-turbo-confirm="<%= t("pgbus.jobs.index.discard_selected_confirm") %>">
+              <%= t("pgbus.jobs.index.discard_selected") %>
+            </button>
+          </div>
+          <%= button_to t("pgbus.jobs.enqueued_table.discard_all"), pgbus.discard_all_enqueued_jobs_path, method: :post,
+                class: "rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500",
+                data: { turbo_confirm: t("pgbus.jobs.enqueued_table.discard_all_confirm"), turbo_frame: "_top" } %>
+        </div>
       <% end %>
     </div>
-    <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <%# Bulk form outside table to avoid nested form issues %>
+    <form id="bulk-discard-enqueued-form" action="<%= pgbus.discard_selected_enqueued_jobs_path %>" method="post" data-turbo-frame="_top" class="hidden">
+      <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+    </form>
+    <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700" data-bulk-scope="enqueued">
       <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">
           <tr>
+            <% if @jobs.any? %>
+              <th class="w-10 px-4 py-3">
+                <input type="checkbox" data-bulk-select-all
+                       class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
+              </th>
+            <% end %>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.jobs.enqueued_table.headers.id") %></th>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.jobs.enqueued_table.headers.job_class") %></th>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.jobs.enqueued_table.headers.queue") %></th>
@@ -23,6 +43,14 @@
           <% @jobs.each do |j| %>
             <% payload = pgbus_parse_message(j[:message]) %>
             <tr>
+              <td class="w-10 px-4 py-3 align-top">
+                <input type="checkbox" data-bulk-item
+                       data-queue-name="<%= j[:queue_name] %>" data-msg-id="<%= j[:msg_id] %>"
+                       class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 mt-1"
+                       onchange="this.nextElementSibling.disabled = !this.checked; this.nextElementSibling.nextElementSibling.disabled = !this.checked">
+                <input type="hidden" name="messages[][queue_name]" value="<%= j[:queue_name] %>" form="bulk-discard-enqueued-form" disabled>
+                <input type="hidden" name="messages[][msg_id]" value="<%= j[:msg_id] %>" form="bulk-discard-enqueued-form" disabled>
+              </td>
               <td colspan="5" class="p-0">
                 <details class="group">
                   <summary class="flex cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900 list-none">
@@ -80,7 +108,7 @@
             </tr>
           <% end %>
           <% if @jobs.empty? %>
-            <tr><td colspan="5" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.jobs.enqueued_table.empty") %></td></tr>
+            <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.jobs.enqueued_table.empty") %></td></tr>
           <% end %>
         </tbody>
       </table>

--- a/app/views/pgbus/jobs/_failed_table.html.erb
+++ b/app/views/pgbus/jobs/_failed_table.html.erb
@@ -1,10 +1,34 @@
 <turbo-frame id="jobs-failed" data-auto-refresh data-src="<%= pgbus.jobs_path(frame: 'failed') %>">
-  <div class="mb-8">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.jobs.failed_table.title") %></h2>
-    <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+  <div class="mb-8" data-bulk-page>
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white"><%= t("pgbus.jobs.failed_table.title") %></h2>
+      <% if @failed.any? %>
+        <div class="flex items-center space-x-2">
+          <div data-bulk-actions class="hidden flex items-center space-x-2">
+            <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> selected</span>
+            <button type="submit" form="bulk-discard-failed-form"
+                    class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
+                    data-turbo-confirm="<%= t("pgbus.jobs.index.discard_selected_confirm") %>">
+              <%= t("pgbus.jobs.index.discard_selected") %>
+            </button>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <%# Bulk form outside table to avoid nested form issues %>
+    <form id="bulk-discard-failed-form" action="<%= pgbus.discard_selected_failed_jobs_path %>" method="post" data-turbo-frame="_top" class="hidden">
+      <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+    </form>
+    <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700" data-bulk-scope="failed">
       <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-900">
           <tr>
+            <% if @failed.any? %>
+              <th class="w-10 px-4 py-3">
+                <input type="checkbox" data-bulk-select-all
+                       class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
+              </th>
+            <% end %>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.jobs.failed_table.headers.id") %></th>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.jobs.failed_table.headers.queue") %></th>
             <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.jobs.failed_table.headers.error") %></th>
@@ -16,6 +40,11 @@
         <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
           <% @failed.each do |f| %>
             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
+              <td class="w-10 px-4 py-3">
+                <input type="checkbox" name="ids[]" value="<%= f["id"] %>" form="bulk-discard-failed-form"
+                       data-bulk-item
+                       class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
+              </td>
               <td data-label="ID" class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white">
                 <%= link_to f["id"], pgbus.job_path(f["id"]), class: "text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
               </td>
@@ -36,7 +65,7 @@
             </tr>
           <% end %>
           <% if @failed.empty? %>
-            <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.jobs.failed_table.empty") %></td></tr>
+            <tr><td colspan="7" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.jobs.failed_table.empty") %></td></tr>
           <% end %>
         </tbody>
       </table>

--- a/app/views/pgbus/jobs/_failed_table.html.erb
+++ b/app/views/pgbus/jobs/_failed_table.html.erb
@@ -5,7 +5,7 @@
       <% if @failed.any? %>
         <div class="flex items-center space-x-2">
           <div data-bulk-actions class="hidden flex items-center space-x-2">
-            <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> selected</span>
+            <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> <%= t("pgbus.helpers.bulk_selected") %></span>
             <button type="submit" form="bulk-discard-failed-form"
                     class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
                     data-turbo-confirm="<%= t("pgbus.jobs.index.discard_selected_confirm") %>">

--- a/app/views/pgbus/locks/index.html.erb
+++ b/app/views/pgbus/locks/index.html.erb
@@ -6,7 +6,7 @@
   <% if @locks.any? %>
     <div class="flex items-center space-x-2">
       <div data-bulk-actions class="hidden flex items-center space-x-2">
-        <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> selected</span>
+        <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> <%= t("pgbus.helpers.bulk_selected") %></span>
         <button type="submit" form="bulk-discard-locks-form"
                 class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
                 data-turbo-confirm="<%= t("pgbus.locks.index.discard_selected_confirm") %>">

--- a/app/views/pgbus/locks/index.html.erb
+++ b/app/views/pgbus/locks/index.html.erb
@@ -1,23 +1,59 @@
-<div class="mb-6">
-  <h1 class="text-2xl font-bold text-gray-900 dark:text-white"><%= t("pgbus.locks.index.title") %></h1>
-  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.description") %></p>
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white"><%= t("pgbus.locks.index.title") %></h1>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.description") %></p>
+  </div>
+  <% if @locks.any? %>
+    <div class="flex items-center space-x-2">
+      <div data-bulk-actions class="hidden flex items-center space-x-2">
+        <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> selected</span>
+        <button type="submit" form="bulk-discard-locks-form"
+                class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
+                data-turbo-confirm="<%= t("pgbus.locks.index.discard_selected_confirm") %>">
+          <%= t("pgbus.locks.index.discard_selected") %>
+        </button>
+      </div>
+      <%= button_to t("pgbus.locks.index.discard_all"), pgbus.discard_all_locks_path, method: :post,
+            class: "rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500",
+            data: { turbo_confirm: t("pgbus.locks.index.discard_all_confirm") } %>
+    </div>
+  <% end %>
 </div>
 
-<div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+<%# Bulk form lives outside the table to avoid nested form issues with button_to %>
+<form id="bulk-discard-locks-form" action="<%= pgbus.discard_selected_locks_path %>" method="post" data-turbo-frame="_top" class="hidden">
+  <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+</form>
+
+<div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700" data-bulk-scope="locks">
   <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
     <thead class="bg-gray-50 dark:bg-gray-900">
       <tr>
+        <% if @locks.any? %>
+          <th class="w-10 px-4 py-3">
+            <input type="checkbox" data-bulk-select-all
+                   class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
+          </th>
+        <% end %>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.headers.lock_key") %></th>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.headers.job_class") %></th>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.headers.state") %></th>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.headers.owner") %></th>
         <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.headers.age") %></th>
         <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.locks.index.headers.expires") %></th>
+        <% if @locks.any? %>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"></th>
+        <% end %>
       </tr>
     </thead>
     <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
       <% @locks.each do |lock| %>
         <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+          <td class="w-10 px-4 py-3">
+            <input type="checkbox" name="lock_keys[]" value="<%= lock[:lock_key] %>"
+                   form="bulk-discard-locks-form" data-bulk-item
+                   class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
+          </td>
           <td data-label="Lock Key" class="px-4 py-3 text-sm font-mono text-gray-700 dark:text-gray-300 max-w-xs truncate"><%= lock[:lock_key] %></td>
           <td data-label="Job Class" class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300"><%= lock[:job_class] %></td>
           <td data-label="State" class="px-4 py-3 text-sm">
@@ -34,7 +70,7 @@
                 <span class="text-xs text-gray-400 dark:text-gray-500">@<%= lock[:owner_hostname] %></span>
               <% end %>
             <% else %>
-              <span class="text-gray-400 dark:text-gray-500">—</span>
+              <span class="text-gray-400 dark:text-gray-500">&mdash;</span>
             <% end %>
           </td>
           <td data-label="Age" class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400">
@@ -43,10 +79,16 @@
             <% end %>
           </td>
           <td data-label="Expires" class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400"><%= pgbus_time_ago_future(lock[:expires_at]) %></td>
+          <td class="px-4 py-3 text-sm text-right">
+            <%= button_to t("pgbus.locks.index.discard"), pgbus.discard_lock_path(lock[:lock_key]),
+                  method: :post,
+                  class: "text-xs text-red-600 hover:text-red-800 font-medium",
+                  data: { turbo_confirm: t("pgbus.locks.index.discard_confirm"), turbo_frame: "_top" } %>
+          </td>
         </tr>
       <% end %>
       <% if @locks.empty? %>
-        <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500"><%= t("pgbus.locks.index.empty") %></td></tr>
+        <tr><td colspan="8" class="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500"><%= t("pgbus.locks.index.empty") %></td></tr>
       <% end %>
     </tbody>
   </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,10 @@ en:
       index:
         discard_all: Discard All
         discard_all_confirm: Permanently discard all DLQ messages?
+        discard_selected: Discard Selected
+        discard_selected_confirm: Discard selected DLQ messages?
+        discarded_selected: Discarded %{count} DLQ messages.
+        none_selected: No messages selected.
         retry_all: Retry All
         retry_all_confirm: Retry all DLQ messages?
         title: Dead Letter Queue
@@ -216,6 +220,10 @@ en:
         discard_all: Discard All
         discard_all_confirm: Discard all failed jobs?
         discard_all_enqueued_notice: Discarded %{count} enqueued jobs and released their locks.
+        discard_selected: Discard Selected
+        discard_selected_confirm: Discard selected items?
+        discarded_selected: Discarded %{count} selected items.
+        none_selected: No items selected.
         retry_all: Retry All
         retry_all_confirm: Retry all failed jobs?
         title: Jobs
@@ -253,7 +261,14 @@ en:
       toggle_menu: Toggle menu
     locks:
       index:
+        all_locks_discarded: Discarded %{count} locks.
         description: Active uniqueness locks preventing duplicate job execution
+        discard: Discard
+        discard_all: Discard All
+        discard_all_confirm: Permanently discard all locks? This may allow duplicate job execution.
+        discard_confirm: Discard this lock? The associated job may be enqueued again.
+        discard_selected: Discard Selected
+        discard_selected_confirm: Discard selected locks?
         empty: No active locks
         executing: Executing
         headers:
@@ -263,6 +278,10 @@ en:
           lock_key: Lock Key
           owner: Owner
           state: State
+        lock_discard_failed: Could not discard lock.
+        lock_discarded: Lock discarded.
+        locks_discarded: Discarded %{count} locks.
+        none_selected: No locks selected.
         queued: Queued
         title: Job Locks
     outbox:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,7 @@ en:
         not_found: Event not found
         title: Event %{event_id}
     helpers:
+      bulk_selected: selected
       paused_badge: Paused
       queue_badge:
         dlq: DLQ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Pgbus::Engine.routes.draw do
       post :retry_all
       post :discard_all
       post :discard_all_enqueued
+      post :discard_selected_failed
+      post :discard_selected_enqueued
     end
   end
 
@@ -48,11 +50,20 @@ Pgbus::Engine.routes.draw do
     collection do
       post :retry_all
       post :discard_all
+      post :discard_selected
     end
   end
 
   resources :outbox, only: [:index], controller: "outbox"
-  resources :locks, only: [:index]
+  resources :locks, only: [:index] do
+    member do
+      post :discard
+    end
+    collection do
+      post :discard_selected
+      post :discard_all
+    end
+  end
   resource :insights, only: [:show], controller: "insights"
 
   get :set_locale, to: "locale#update"

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -533,6 +533,30 @@ module Pgbus
         []
       end
 
+      # Lock management
+      def discard_lock(lock_key)
+        JobLock.where(lock_key: lock_key).delete_all
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error discarding lock #{lock_key}: #{e.message}" }
+        0
+      end
+
+      def discard_locks(lock_keys)
+        return 0 if lock_keys.empty?
+
+        JobLock.where(lock_key: lock_keys).delete_all
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error discarding locks: #{e.message}" }
+        0
+      end
+
+      def discard_all_locks
+        JobLock.delete_all
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error discarding all locks: #{e.message}" }
+        0
+      end
+
       # Job locks
       def job_locks
         JobLock.order(locked_at: :desc).limit(100).map do |lock|

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -306,4 +306,59 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(Pgbus::JobLock).to have_received(:where).with(lock_key: ["k1"])
     end
   end
+
+  describe "#discard_lock" do
+    it "deletes the lock by key" do
+      allow(Pgbus::JobLock).to receive(:where).and_return(double(delete_all: 1))
+
+      result = data_source.discard_lock("import-42")
+
+      expect(result).to eq(1)
+      expect(Pgbus::JobLock).to have_received(:where).with(lock_key: "import-42")
+    end
+
+    it "returns 0 on error" do
+      allow(Pgbus::JobLock).to receive(:where).and_raise(StandardError)
+
+      expect(data_source.discard_lock("import-42")).to eq(0)
+    end
+  end
+
+  describe "#discard_locks" do
+    it "deletes multiple locks by keys" do
+      allow(Pgbus::JobLock).to receive(:where).and_return(double(delete_all: 3))
+
+      result = data_source.discard_locks(%w[k1 k2 k3])
+
+      expect(result).to eq(3)
+      expect(Pgbus::JobLock).to have_received(:where).with(lock_key: %w[k1 k2 k3])
+    end
+
+    it "returns 0 for empty array" do
+      expect(data_source.discard_locks([])).to eq(0)
+    end
+
+    it "returns 0 on error" do
+      allow(Pgbus::JobLock).to receive(:where).and_raise(StandardError)
+
+      expect(data_source.discard_locks(%w[k1])).to eq(0)
+    end
+  end
+
+  describe "#discard_all_locks" do
+    it "deletes all locks" do
+      allow(Pgbus::JobLock).to receive(:delete_all).and_return(5)
+
+      result = data_source.discard_all_locks
+
+      expect(result).to eq(5)
+      expect(Pgbus::JobLock).to have_received(:delete_all)
+    end
+
+    it "returns 0 on error" do
+      allow(Pgbus::JobLock).to receive(:delete_all).and_raise(StandardError)
+
+      expect(data_source.discard_all_locks).to eq(0)
+    end
+  end
 end

--- a/spec/system/dead_letter_spec.rb
+++ b/spec/system/dead_letter_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe "Dead Letter Queue", type: :system do
       expect(page).to have_button("Discard")
     end
 
+    it "shows checkboxes for DLQ messages" do
+      visit "/pgbus/dlq"
+
+      expect(page).to have_css("input[data-bulk-item]", count: 1)
+      expect(page).to have_css("input[data-bulk-select-all]")
+    end
+
     it "retry DLQ message: no confirm, shows toast" do
       visit "/pgbus/dlq"
 

--- a/spec/system/jobs_spec.rb
+++ b/spec/system/jobs_spec.rb
@@ -45,6 +45,40 @@ RSpec.describe "Jobs", type: :system do
       expect(page).to have_button("Retry", minimum: 2)
       expect(page).to have_button("Discard", minimum: 2)
     end
+
+    it "shows checkboxes for each failed job" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-failed") do
+        expect(page).to have_css("input[data-bulk-item]", count: 2)
+        expect(page).to have_css("input[data-bulk-select-all]")
+      end
+    end
+
+    it "select all checkbox toggles all failed job checkboxes" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-failed") do
+        find("input[data-bulk-select-all]").check
+
+        expect(all("input[data-bulk-item]")).to all(be_checked)
+      end
+    end
+
+    it "bulk select and discard selected failed jobs" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-failed") do
+        find("input[data-bulk-select-all]").click
+        expect(page).to have_css("input[data-bulk-item]:checked", count: 2)
+      end
+
+      expect(page).to have_button("Discard Selected")
+      click_button "Discard Selected", match: :first
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Discarded 2 selected")
+    end
   end
 
   context "with enqueued jobs" do
@@ -76,6 +110,15 @@ RSpec.describe "Jobs", type: :system do
 
       within("turbo-frame#jobs-enqueued") do
         expect(page).to have_button("Discard All")
+      end
+    end
+
+    it "shows checkboxes for enqueued jobs" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-enqueued") do
+        expect(page).to have_css("input[data-bulk-item]", count: 1)
+        expect(page).to have_css("input[data-bulk-select-all]")
       end
     end
 

--- a/spec/system/jobs_spec.rb
+++ b/spec/system/jobs_spec.rb
@@ -122,6 +122,21 @@ RSpec.describe "Jobs", type: :system do
       end
     end
 
+    it "bulk select and discard selected enqueued jobs" do
+      visit "/pgbus/jobs"
+
+      within("turbo-frame#jobs-enqueued") do
+        find("input[data-bulk-select-all]").click
+        expect(page).to have_css("input[data-bulk-item]:checked", count: 1)
+      end
+
+      expect(page).to have_button("Discard Selected")
+      click_button "Discard Selected", match: :first
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Discarded 1 selected")
+    end
+
     it "discard all enqueued: confirm and redirects with toast" do
       visit "/pgbus/jobs"
 

--- a/spec/system/locks_spec.rb
+++ b/spec/system/locks_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe "Locks", type: :system do
+  it "shows empty state" do
+    visit "/pgbus/locks"
+
+    expect(page).to have_css("h1", text: "Job Locks")
+    expect(page).to have_text("No active locks")
+  end
+
+  context "with locks" do
+    before do
+      @stub_data_source.locks_list = [
+        { lock_key: "import-42", job_class: "ImportJob", job_id: "j1",
+          state: "executing", owner_pid: 12_345, owner_hostname: "worker-1",
+          locked_at: Time.now.utc, expires_at: (Time.now.utc + 3600),
+          age_seconds: 120 },
+        { lock_key: "export-99", job_class: "ExportJob", job_id: "j2",
+          state: "queued", owner_pid: nil, owner_hostname: nil,
+          locked_at: Time.now.utc, expires_at: (Time.now.utc + 7200),
+          age_seconds: 60 }
+      ]
+    end
+
+    it "displays locks with details" do
+      visit "/pgbus/locks"
+
+      expect(page).to have_text("import-42")
+      expect(page).to have_text("export-99")
+      expect(page).to have_text("ImportJob")
+      expect(page).to have_text("ExportJob")
+      expect(page).to have_text("Executing")
+      expect(page).to have_text("Queued")
+    end
+
+    it "shows per-lock discard buttons" do
+      visit "/pgbus/locks"
+
+      expect(page).to have_button("Discard", minimum: 2)
+    end
+
+    it "shows Discard All button" do
+      visit "/pgbus/locks"
+
+      expect(page).to have_button("Discard All")
+    end
+
+    it "shows checkboxes for each lock" do
+      visit "/pgbus/locks"
+
+      expect(page).to have_css("input[data-bulk-item]", count: 2)
+      expect(page).to have_css("input[data-bulk-select-all]")
+    end
+
+    it "discard single lock: confirm and shows toast" do
+      visit "/pgbus/locks"
+
+      # Click the first per-row Discard button (inside button_to forms)
+      within("tbody") do
+        all("tr").first.click_button("Discard")
+      end
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Lock discarded")
+      expect(@stub_data_source).to be_called(:discard_lock)
+    end
+
+    it "discard all locks: confirm and shows toast" do
+      visit "/pgbus/locks"
+
+      click_button "Discard All"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Discarded")
+      expect(@stub_data_source).to be_called(:discard_all_locks)
+    end
+
+    it "bulk select and discard selected locks" do
+      visit "/pgbus/locks"
+
+      # Initially the "Discard Selected" button is hidden
+      expect(page).not_to have_button("Discard Selected", visible: :visible)
+
+      # Check individual checkboxes
+      all("input[data-bulk-item]").each(&:check)
+
+      # Now the "Discard Selected" button should appear
+      expect(page).to have_button("Discard Selected", visible: :visible)
+
+      click_button "Discard Selected"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("Discarded")
+      expect(@stub_data_source).to be_called(:discard_locks)
+    end
+
+    it "select all checkbox toggles all items" do
+      visit "/pgbus/locks"
+
+      find("input[data-bulk-select-all]").check
+
+      expect(all("input[data-bulk-item]")).to all(be_checked)
+
+      find("input[data-bulk-select-all]").uncheck
+
+      all("input[data-bulk-item]").each do |cb|
+        expect(cb).not_to be_checked
+      end
+    end
+  end
+
+  context "without locks" do
+    it "does not show action buttons" do
+      visit "/pgbus/locks"
+
+      expect(page).not_to have_button("Discard All")
+      expect(page).not_to have_button("Discard Selected")
+      expect(page).not_to have_css("input[data-bulk-select-all]")
+    end
+  end
+end

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -5,7 +5,7 @@ module Pgbus
     class StubDataSource
       attr_accessor :stats, :queues, :processes_list, :failed_events_list,
                     :dlq_messages_list, :events_list, :subscribers_list, :jobs_list,
-                    :paused_queues
+                    :paused_queues, :locks_list
       attr_reader :calls
 
       def initialize
@@ -18,6 +18,7 @@ module Pgbus
         @subscribers_list = []
         @jobs_list = []
         @paused_queues = []
+        @locks_list = []
         @calls = Hash.new { |h, k| h[k] = [] }
       end
 
@@ -35,6 +36,7 @@ module Pgbus
       def processed_event(id) = @events_list.find { |e| e["id"].to_s == id.to_s }
       def registered_subscribers = @subscribers_list
       def jobs(queue_name: nil, page: 1, per_page: 25) = @jobs_list
+      def job_locks = @locks_list
       def queue_paused?(name) = @paused_queues.include?(name)
 
       def purge_queue(name)          = record(:purge_queue, name)
@@ -53,6 +55,9 @@ module Pgbus
       def retry_all_dlq              = record(:retry_all_dlq) && @dlq_messages_list.size
       def discard_all_dlq            = record(:discard_all_dlq) && @dlq_messages_list.size
       def replay_event(event)        = record(:replay_event, event)
+      def discard_lock(key)          = record(:discard_lock, key) && 1
+      def discard_locks(keys)        = record(:discard_locks, keys) && keys.size
+      def discard_all_locks          = record(:discard_all_locks) && @locks_list.size
 
       def called?(method_name) = @calls.key?(method_name)
 


### PR DESCRIPTION
## Summary
- Add discard individual/selected/all locks from the web dashboard Locks page
- Add checkbox-based bulk selection with "Discard Selected" to failed jobs, enqueued jobs, and DLQ messages tables
- Select-all checkbox with count display and indeterminate state
- All bulk forms use HTML `form=` attribute pattern to avoid nested form issues with Turbo

## Changes
- **LocksController**: `discard`, `discard_selected`, `discard_all` actions
- **JobsController**: `discard_selected_failed`, `discard_selected_enqueued` actions
- **DeadLetterController**: `discard_selected` action
- **DataSource**: `discard_lock`, `discard_locks`, `discard_all_locks` methods
- **Views**: checkbox columns, select-all header checkbox, bulk action bar with count
- **JS**: bulk select-all/count/visibility logic in application.js
- **Routes**: new collection/member routes for all bulk operations
- **i18n**: English translations for all new UI elements

## Test plan
- [x] 76 system tests pass (Playwright browser tests)
- [x] 26 data source unit tests pass
- [x] RuboCop clean (204 files, 0 offenses)
- [x] Lock discard: single, bulk selected, all
- [x] Failed jobs: checkbox select, bulk discard selected
- [x] Enqueued jobs: checkbox select, bulk discard selected
- [x] DLQ messages: checkbox select, bulk discard selected
- [x] Select-all checkbox toggles all items
- [x] Empty state hides action buttons and checkboxes
- [x] Confirm dialogs for destructive actions
- [x] Toast notifications after actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk discard actions for Dead Letter Queue messages, failed jobs, and enqueued jobs with multi-select checkboxes, select-all control, and real-time selection counter
  * Lock management UI: discard single locks, discard selected locks, or discard all locks
  * Localized confirmation prompts and success/none-selected notices for bulk actions
  * Frontend behavior to drive bulk selection and action visibility

* **Tests**
  * New system and unit tests covering bulk-selection UI, discard flows, and lock-discard helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->