### PR TITLE
fix(web): polish bulk select — dedup listeners, a11y labels, pluralized notices

### DIFF
--- a/app/frontend/pgbus/application.js
+++ b/app/frontend/pgbus/application.js
@@ -72,6 +72,9 @@ document.addEventListener("turbo:load", renderFlashToasts);
 // -- Bulk checkbox selection --
 function initBulkSelect() {
   document.querySelectorAll("[data-bulk-select-all]").forEach(selectAll => {
+    if (selectAll.dataset.bulkInitialized === "true") return;
+    selectAll.dataset.bulkInitialized = "true";
+
     const scope = selectAll.closest("[data-bulk-scope]") || document;
     const checkboxes = () => scope.querySelectorAll("input[data-bulk-item]");
     // Look for bulk-actions in the parent page container (outside the table scope)

--- a/app/views/pgbus/dead_letter/_messages_table.html.erb
+++ b/app/views/pgbus/dead_letter/_messages_table.html.erb
@@ -10,6 +10,7 @@
           <% if @messages.any? %>
             <th class="w-10 px-4 py-3">
               <input type="checkbox" data-bulk-select-all
+                     aria-label="<%= t("pgbus.helpers.bulk_select_all") %>"
                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
             </th>
           <% end %>
@@ -28,6 +29,7 @@
           <tr>
             <td class="w-10 px-4 py-3 align-top">
               <input type="checkbox" data-bulk-item
+                     aria-label="<%= t("pgbus.helpers.bulk_select_row", id: m[:msg_id]) %>"
                      data-queue-name="<%= m[:queue_name] %>" data-msg-id="<%= m[:msg_id] %>"
                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 mt-1"
                      onchange="this.nextElementSibling.disabled = !this.checked; this.nextElementSibling.nextElementSibling.disabled = !this.checked">

--- a/app/views/pgbus/jobs/_enqueued_table.html.erb
+++ b/app/views/pgbus/jobs/_enqueued_table.html.erb
@@ -29,6 +29,7 @@
             <% if @jobs.any? %>
               <th class="w-10 px-4 py-3">
                 <input type="checkbox" data-bulk-select-all
+                       aria-label="<%= t("pgbus.helpers.bulk_select_all") %>"
                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
               </th>
             <% end %>
@@ -45,6 +46,7 @@
             <tr>
               <td class="w-10 px-4 py-3 align-top">
                 <input type="checkbox" data-bulk-item
+                       aria-label="<%= t("pgbus.helpers.bulk_select_row", id: j[:msg_id]) %>"
                        data-queue-name="<%= j[:queue_name] %>" data-msg-id="<%= j[:msg_id] %>"
                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 mt-1"
                        onchange="this.nextElementSibling.disabled = !this.checked; this.nextElementSibling.nextElementSibling.disabled = !this.checked">

--- a/app/views/pgbus/jobs/_failed_table.html.erb
+++ b/app/views/pgbus/jobs/_failed_table.html.erb
@@ -26,6 +26,7 @@
             <% if @failed.any? %>
               <th class="w-10 px-4 py-3">
                 <input type="checkbox" data-bulk-select-all
+                       aria-label="<%= t("pgbus.helpers.bulk_select_all") %>"
                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
               </th>
             <% end %>
@@ -42,6 +43,7 @@
             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
               <td class="w-10 px-4 py-3">
                 <input type="checkbox" name="ids[]" value="<%= f["id"] %>" form="bulk-discard-failed-form"
+                       aria-label="<%= t("pgbus.helpers.bulk_select_row", id: f["id"]) %>"
                        data-bulk-item
                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
               </td>

--- a/app/views/pgbus/locks/index.html.erb
+++ b/app/views/pgbus/locks/index.html.erb
@@ -32,6 +32,7 @@
         <% if @locks.any? %>
           <th class="w-10 px-4 py-3">
             <input type="checkbox" data-bulk-select-all
+                   aria-label="<%= t("pgbus.helpers.bulk_select_all") %>"
                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
           </th>
         <% end %>
@@ -51,6 +52,7 @@
         <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
           <td class="w-10 px-4 py-3">
             <input type="checkbox" name="lock_keys[]" value="<%= lock[:lock_key] %>"
+                   aria-label="<%= t("pgbus.helpers.bulk_select_row", id: lock[:lock_key]) %>"
                    form="bulk-discard-locks-form" data-bulk-item
                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
           </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,7 +46,9 @@ en:
         discard_all_confirm: Permanently discard all DLQ messages?
         discard_selected: Discard Selected
         discard_selected_confirm: Discard selected DLQ messages?
-        discarded_selected: Discarded %{count} DLQ messages.
+        discarded_selected:
+          one: Discarded 1 DLQ message.
+          other: Discarded %{count} DLQ messages.
         none_selected: No messages selected.
         retry_all: Retry All
         retry_all_confirm: Retry all DLQ messages?
@@ -118,6 +120,8 @@ en:
         not_found: Event not found
         title: Event %{event_id}
     helpers:
+      bulk_select_all: Select all
+      bulk_select_row: Select %{id}
       bulk_selected: selected
       paused_badge: Paused
       queue_badge:
@@ -223,7 +227,9 @@ en:
         discard_all_enqueued_notice: Discarded %{count} enqueued jobs and released their locks.
         discard_selected: Discard Selected
         discard_selected_confirm: Discard selected items?
-        discarded_selected: Discarded %{count} selected items.
+        discarded_selected:
+          one: Discarded 1 selected item.
+          other: Discarded %{count} selected items.
         none_selected: No items selected.
         retry_all: Retry All
         retry_all_confirm: Retry all failed jobs?
@@ -262,7 +268,9 @@ en:
       toggle_menu: Toggle menu
     locks:
       index:
-        all_locks_discarded: Discarded %{count} locks.
+        all_locks_discarded:
+          one: Discarded 1 lock.
+          other: Discarded %{count} locks.
         description: Active uniqueness locks preventing duplicate job execution
         discard: Discard
         discard_all: Discard All
@@ -281,7 +289,9 @@ en:
           state: State
         lock_discard_failed: Could not discard lock.
         lock_discarded: Lock discarded.
-        locks_discarded: Discarded %{count} locks.
+        locks_discarded:
+          one: Discarded 1 lock.
+          other: Discarded %{count} locks.
         none_selected: No locks selected.
         queued: Queued
         title: Job Locks


### PR DESCRIPTION
## Summary

Follow-up to #57 addressing post-merge CodeRabbit review feedback:

- **Dedup event listeners**: Guard `initBulkSelect()` with `data-bulk-initialized` so `turbo:frame-load` auto-refresh doesn't accumulate duplicate `change` handlers
- **Accessibility**: Add `aria-label` to all select-all and per-row bulk checkboxes (locks, failed jobs, enqueued jobs, DLQ) via `t("pgbus.helpers.bulk_select_all")` / `t("pgbus.helpers.bulk_select_row")`
- **Pluralized notices**: Convert count-based flash strings to `one`/`other` variants so "Discarded 1 lock." reads correctly instead of "Discarded 1 locks."

## Test plan
- [x] 103 specs pass (76 system + 27 unit)
- [x] RuboCop clean
- [x] All bulk select/discard system tests green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility labels to bulk selection checkboxes across all tables for improved screen reader support.

* **Improvements**
  * Enhanced pluralization of status messages for better grammatical accuracy.
  * Improved stability of bulk selection functionality to prevent duplicate initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->