### PR TITLE
fix: stat buffer silently fails when latency columns missing

### DIFF
--- a/lib/pgbus/stat_buffer.rb
+++ b/lib/pgbus/stat_buffer.rb
@@ -82,6 +82,8 @@ module Pgbus
     rescue ActiveRecord::StatementInvalid, ActiveModel::UnknownAttributeError => e
       # Column doesn't exist — fall back to base columns only
       if e.message.include?("enqueue_latency_ms") || e.message.include?("retry_count")
+        Pgbus.logger.warn { "[Pgbus] Latency columns missing — recording stats without latency data" } unless @degraded_warned
+        @degraded_warned = true
         base_rows = entries.map do |entry|
           { job_class: entry[:job_class], queue_name: entry[:queue_name],
             status: entry[:status], duration_ms: entry[:duration_ms] }

--- a/lib/pgbus/stat_buffer.rb
+++ b/lib/pgbus/stat_buffer.rb
@@ -88,7 +88,11 @@ module Pgbus
           { job_class: entry[:job_class], queue_name: entry[:queue_name],
             status: entry[:status], duration_ms: entry[:duration_ms] }
         end
-        JobStat.insert_all(base_rows)
+        begin
+          JobStat.insert_all(base_rows)
+        rescue StandardError => fallback_error
+          Pgbus.logger.warn { "[Pgbus] Stat buffer fallback flush failed: #{fallback_error.message}" }
+        end
       else
         Pgbus.logger.warn { "[Pgbus] Stat buffer flush failed: #{e.message}" }
       end

--- a/lib/pgbus/stat_buffer.rb
+++ b/lib/pgbus/stat_buffer.rb
@@ -68,21 +68,30 @@ module Pgbus
     def write_to_database(entries)
       return unless JobStat.table_exists?
 
-      columns = %i[job_class queue_name status duration_ms]
-      columns.push(:enqueue_latency_ms, :retry_count) if JobStat.latency_columns?
-
+      # Always attempt all 6 columns. If the latency migration hasn't
+      # run, the first flush will fail, and we fall back to base columns.
+      # This avoids relying on the memoized latency_columns? flag which
+      # can be stuck at false if evaluated before the connection is ready.
       rows = entries.map do |e|
-        row = [e[:job_class], e[:queue_name], e[:status], e[:duration_ms]]
-        row.push(e[:enqueue_latency_ms], e[:retry_count]) if JobStat.latency_columns?
-        row
+        { job_class: e[:job_class], queue_name: e[:queue_name],
+          status: e[:status], duration_ms: e[:duration_ms],
+          enqueue_latency_ms: e[:enqueue_latency_ms], retry_count: e[:retry_count] }
       end
 
-      JobStat.insert_all(
-        rows.map { |row| columns.zip(row).to_h },
-        record_timestamps: true
-      )
+      JobStat.insert_all(rows)
+    rescue ActiveRecord::StatementInvalid, ActiveModel::UnknownAttributeError => e
+      # Column doesn't exist — fall back to base columns only
+      if e.message.include?("enqueue_latency_ms") || e.message.include?("retry_count")
+        base_rows = entries.map do |entry|
+          { job_class: entry[:job_class], queue_name: entry[:queue_name],
+            status: entry[:status], duration_ms: entry[:duration_ms] }
+        end
+        JobStat.insert_all(base_rows)
+      else
+        Pgbus.logger.warn { "[Pgbus] Stat buffer flush failed: #{e.message}" }
+      end
     rescue StandardError => e
-      Pgbus.logger.debug { "[Pgbus] Stat buffer flush failed: #{e.message}" }
+      Pgbus.logger.warn { "[Pgbus] Stat buffer flush failed: #{e.message}" }
     end
 
     def monotonic_now

--- a/spec/integration/stat_buffer_spec.rb
+++ b/spec/integration/stat_buffer_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe "StatBuffer integration", :integration do
     # Ensure latency columns exist (may be missing if only base migration ran)
     unless conn.column_exists?(:pgbus_job_stats, :enqueue_latency_ms)
       conn.execute("ALTER TABLE pgbus_job_stats ADD COLUMN enqueue_latency_ms BIGINT")
+    end
+    unless conn.column_exists?(:pgbus_job_stats, :retry_count)
       conn.execute("ALTER TABLE pgbus_job_stats ADD COLUMN retry_count INTEGER DEFAULT 0")
     end
 
@@ -93,41 +95,39 @@ RSpec.describe "StatBuffer integration", :integration do
   end
 
   describe "Executor records stats via buffer" do
-    it "stats appear in the database after buffer flush" do # rubocop:disable RSpec/ExampleLength
-      client = Pgbus.client
-      client.ensure_queue("default")
-      config = Pgbus.configuration
+    let(:client) { Pgbus.client.tap { |c| c.ensure_queue("default") } }
+    let(:config) { Pgbus.configuration }
+    let(:buffer) { Pgbus::StatBuffer.new(flush_size: 100, flush_interval: 60) }
+    let(:executor) { Pgbus::ActiveJob::Executor.new(client: client, config: config, stat_buffer: buffer) }
+
+    before do
+      stub_const("PlainBenchJob", Class.new(ActiveJob::Base) { def perform(*); end })
+    end
+
+    around do |example|
+      original = config.stats_enabled
       config.stats_enabled = true
+      example.run
+    ensure
+      config.stats_enabled = original
+    end
 
-      buffer = Pgbus::StatBuffer.new(flush_size: 100, flush_interval: 60)
-      executor = Pgbus::ActiveJob::Executor.new(client: client, config: config, stat_buffer: buffer)
-
-      # Enqueue and execute a plain job
+    it "stats appear in the database after buffer flush" do
       payload = { "job_class" => "PlainBenchJob", "arguments" => [], "queue_name" => "default" }
       client.send_message("default", payload)
       msg = client.read_batch("default", qty: 1).first
 
-      # Define a minimal job class for deserialization
-      stub_const("PlainBenchJob", Class.new(ActiveJob::Base) { def perform(*); end })
-
       executor.execute(msg, "default")
 
-      # Stats should be buffered, not yet in DB
-      count_before = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pgbus_job_stats")
-      expect(count_before).to eq(0)
       expect(buffer.size).to eq(1)
-
-      # Flush should persist them
       buffer.flush
 
-      count_after = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pgbus_job_stats")
-      expect(count_after).to eq(1)
+      count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pgbus_job_stats")
+      expect(count).to eq(1)
 
       row = ActiveRecord::Base.connection.select_one("SELECT * FROM pgbus_job_stats LIMIT 1")
       expect(row["status"]).to eq("success")
       expect(row["duration_ms"]).to be > 0
-    ensure
-      config.stats_enabled = true
     end
   end
 end

--- a/spec/integration/stat_buffer_spec.rb
+++ b/spec/integration/stat_buffer_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+require "active_job"
+
+RSpec.describe "StatBuffer integration", :integration do
+  before do
+    conn = ActiveRecord::Base.connection
+
+    unless conn.table_exists?("pgbus_job_stats")
+      conn.execute(<<~SQL)
+        CREATE TABLE pgbus_job_stats (
+          id BIGSERIAL PRIMARY KEY,
+          job_class VARCHAR NOT NULL,
+          queue_name VARCHAR NOT NULL,
+          status VARCHAR NOT NULL,
+          duration_ms INTEGER NOT NULL DEFAULT 0,
+          enqueue_latency_ms BIGINT,
+          retry_count INTEGER DEFAULT 0,
+          created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+      SQL
+    end
+
+    # Ensure latency columns exist (may be missing if only base migration ran)
+    unless conn.column_exists?(:pgbus_job_stats, :enqueue_latency_ms)
+      conn.execute("ALTER TABLE pgbus_job_stats ADD COLUMN enqueue_latency_ms BIGINT")
+      conn.execute("ALTER TABLE pgbus_job_stats ADD COLUMN retry_count INTEGER DEFAULT 0")
+    end
+
+    conn.execute("DELETE FROM pgbus_job_stats")
+
+    # Clear memoized flags and schema cache so they're re-evaluated against the real DB
+    Pgbus::JobStat.remove_instance_variable(:@table_exists) if Pgbus::JobStat.instance_variable_defined?(:@table_exists)
+    Pgbus::JobStat.remove_instance_variable(:@latency_columns) if Pgbus::JobStat.instance_variable_defined?(:@latency_columns)
+    Pgbus::JobStat.reset_column_information
+  end
+
+  let(:stat_attrs) do
+    {
+      job_class: "TestJob",
+      queue_name: "default",
+      status: "success",
+      duration_ms: 42,
+      enqueue_latency_ms: 150,
+      retry_count: 0
+    }
+  end
+
+  describe "StatBuffer#flush inserts rows into pgbus_job_stats" do
+    it "persists buffered stats to the real database" do
+      buffer = Pgbus::StatBuffer.new(flush_size: 100, flush_interval: 60)
+
+      3.times { buffer.push(stat_attrs) }
+      buffer.flush
+
+      count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pgbus_job_stats")
+      expect(count).to eq(3)
+    end
+
+    it "sets created_at via database default" do
+      buffer = Pgbus::StatBuffer.new(flush_size: 100, flush_interval: 60)
+
+      buffer.push(stat_attrs)
+      buffer.flush
+
+      row = ActiveRecord::Base.connection.select_one("SELECT * FROM pgbus_job_stats LIMIT 1")
+      expect(row["job_class"]).to eq("TestJob")
+      expect(row["duration_ms"]).to eq(42)
+      expect(row["enqueue_latency_ms"]).to eq(150)
+      expect(row["created_at"]).not_to be_nil
+    end
+
+    it "auto-flushes at flush_size" do
+      buffer = Pgbus::StatBuffer.new(flush_size: 2, flush_interval: 60)
+
+      2.times { buffer.push(stat_attrs) }
+
+      count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pgbus_job_stats")
+      expect(count).to eq(2)
+      expect(buffer.size).to eq(0)
+    end
+
+    it "flushes remaining entries on stop" do
+      buffer = Pgbus::StatBuffer.new(flush_size: 100, flush_interval: 60)
+
+      buffer.push(stat_attrs)
+      buffer.stop
+
+      count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pgbus_job_stats")
+      expect(count).to eq(1)
+    end
+  end
+
+  describe "Executor records stats via buffer" do
+    it "stats appear in the database after buffer flush" do # rubocop:disable RSpec/ExampleLength
+      client = Pgbus.client
+      client.ensure_queue("default")
+      config = Pgbus.configuration
+      config.stats_enabled = true
+
+      buffer = Pgbus::StatBuffer.new(flush_size: 100, flush_interval: 60)
+      executor = Pgbus::ActiveJob::Executor.new(client: client, config: config, stat_buffer: buffer)
+
+      # Enqueue and execute a plain job
+      payload = { "job_class" => "PlainBenchJob", "arguments" => [], "queue_name" => "default" }
+      client.send_message("default", payload)
+      msg = client.read_batch("default", qty: 1).first
+
+      # Define a minimal job class for deserialization
+      stub_const("PlainBenchJob", Class.new(ActiveJob::Base) { def perform(*); end })
+
+      executor.execute(msg, "default")
+
+      # Stats should be buffered, not yet in DB
+      count_before = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pgbus_job_stats")
+      expect(count_before).to eq(0)
+      expect(buffer.size).to eq(1)
+
+      # Flush should persist them
+      buffer.flush
+
+      count_after = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pgbus_job_stats")
+      expect(count_after).to eq(1)
+
+      row = ActiveRecord::Base.connection.select_one("SELECT * FROM pgbus_job_stats LIMIT 1")
+      expect(row["status"]).to eq("success")
+      expect(row["duration_ms"]).to be > 0
+    ensure
+      config.stats_enabled = true
+    end
+  end
+end

--- a/spec/pgbus/stat_buffer_spec.rb
+++ b/spec/pgbus/stat_buffer_spec.rb
@@ -121,11 +121,24 @@ RSpec.describe Pgbus::StatBuffer do
       buffer.flush
 
       expect(calls.size).to eq(2)
-      # First call includes latency columns
       expect(calls[0].first).to have_key(:enqueue_latency_ms)
-      # Second call (fallback) omits them
       expect(calls[1].first).not_to have_key(:enqueue_latency_ms)
       expect(calls[1].first).to include(job_class: "TestJob")
+    end
+
+    it "retries with base columns on UnknownAttributeError" do
+      calls = []
+      allow(Pgbus::JobStat).to receive(:insert_all) do |rows|
+        calls << rows
+        raise ActiveModel::UnknownAttributeError.new(nil, "enqueue_latency_ms") if calls.size == 1
+      end
+
+      buffer.push(stat_attrs)
+      buffer.flush
+
+      expect(calls.size).to eq(2)
+      expect(calls[0].first).to have_key(:enqueue_latency_ms)
+      expect(calls[1].first).not_to have_key(:enqueue_latency_ms)
     end
   end
 end

--- a/spec/pgbus/stat_buffer_spec.rb
+++ b/spec/pgbus/stat_buffer_spec.rb
@@ -48,8 +48,7 @@ RSpec.describe Pgbus::StatBuffer do
       buffer.flush
 
       expect(Pgbus::JobStat).to have_received(:insert_all).with(
-        array_including(hash_including(job_class: "TestJob")),
-        record_timestamps: true
+        array_including(hash_including(job_class: "TestJob"))
       )
       expect(buffer.size).to eq(0)
     end
@@ -95,19 +94,38 @@ RSpec.describe Pgbus::StatBuffer do
     end
   end
 
-  describe "without latency columns" do
-    before { allow(Pgbus::JobStat).to receive(:latency_columns?).and_return(false) }
+  describe "always includes all columns" do
+    it "includes latency fields regardless of latency_columns? memoization" do
+      allow(Pgbus::JobStat).to receive(:latency_columns?).and_return(false)
 
-    it "omits latency fields from the insert" do
       buffer.push(stat_attrs)
       buffer.flush
 
-      expect(Pgbus::JobStat).to have_received(:insert_all) do |rows, **_opts|
+      expect(Pgbus::JobStat).to have_received(:insert_all) do |rows|
         row = rows.first
-        expect(row).to include(job_class: "TestJob", duration_ms: 42)
-        expect(row).not_to have_key(:enqueue_latency_ms)
-        expect(row).not_to have_key(:retry_count)
+        expect(row).to include(job_class: "TestJob", duration_ms: 42,
+                               enqueue_latency_ms: 10, retry_count: 0)
       end
+    end
+  end
+
+  describe "fallback when latency columns missing in DB" do
+    it "retries with base columns on StatementInvalid" do
+      calls = []
+      allow(Pgbus::JobStat).to receive(:insert_all) do |rows|
+        calls << rows
+        raise ActiveRecord::StatementInvalid, 'column "enqueue_latency_ms" does not exist' if calls.size == 1
+      end
+
+      buffer.push(stat_attrs)
+      buffer.flush
+
+      expect(calls.size).to eq(2)
+      # First call includes latency columns
+      expect(calls[0].first).to have_key(:enqueue_latency_ms)
+      # Second call (fallback) omits them
+      expect(calls[1].first).not_to have_key(:enqueue_latency_ms)
+      expect(calls[1].first).to include(job_class: "TestJob")
     end
   end
 end


### PR DESCRIPTION
## Summary

- **StatBuffer#flush silently discarded all stats** when the latency migration (`add_job_stats_latency`) hadn't been run. `insert_all` with `enqueue_latency_ms`/`retry_count` columns raised `ActiveModel::UnknownAttributeError`, which was swallowed by a broad `rescue StandardError`. Zero rows were persisted, breaking the Insights dashboard.
- **Fix**: always attempt all 6 columns, catch `UnknownAttributeError` and `StatementInvalid` specifically, retry with base 4 columns on failure.
- **Removed dependency on memoized `latency_columns?`** flag which could be permanently stuck at `false` if evaluated before the DB connection was ready.

## Root cause

```ruby
# Before: silently swallowed UnknownAttributeError
JobStat.insert_all(rows)
rescue StandardError => e
  Pgbus.logger.debug { "..." }  # logged at debug, invisible in production
```

`insert_all` validates column names against the AR model's schema cache. If `enqueue_latency_ms` isn't in the cache (memoized `latency_columns?` returned `false`, or the migration hasn't run), `ActiveModel::UnknownAttributeError` is raised — not `ActiveRecord::StatementInvalid`.

## Test plan

- [x] Unit tests: 11 passing (including new fallback test)
- [x] Integration test: 5 new tests against real PostgreSQL verifying full buffer → flush → insert_all → SELECT round-trip
- [x] Full unit suite: 729 passing
- [ ] Integration suite on CI (PG 17 + PG 18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust job statistics persistence: now always attempts full-column insert, falls back to core columns if optional DB fields are missing, and logs non-fatal failures rather than raising. Logging for persistence failures now surfaces at a higher severity.

* **Tests**
  * Added integration and unit tests covering buffer flush, auto-flush behavior, DB persistence, and fallback when optional database columns are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->