### PR TITLE
fix(web): pause auto-refresh on interaction, fix recurring nav, add queue detail rows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -176,4 +176,19 @@ task :release, %i[version force] do |_t, args|
   puts "    • Upload assets to the release"
 end
 
+namespace :dummy do
+  desc "Start dummy app with stub data for dashboard QA (PORT=3003, no database required)"
+  task :server do
+    port = ENV.fetch("PORT", "3003")
+    ENV["PGBUS_STUB_DATA"] = "1"
+    ENV["RAILS_ENV"] = "development"
+
+    puts "\n\e[32m→ Starting dummy app with stub data at http://localhost:#{port}/pgbus\e[0m"
+    puts "  Dashboard:  http://localhost:#{port}/pgbus"
+    puts "  Using stub data source (no database needed)"
+    puts "  Press Ctrl+C to stop\n\n"
+    sh("bundle exec puma spec/dummy/config.ru -p #{port}")
+  end
+end
+
 task default: %i[spec rubocop]

--- a/app/controllers/pgbus/recurring_tasks_controller.rb
+++ b/app/controllers/pgbus/recurring_tasks_controller.rb
@@ -18,10 +18,12 @@ module Pgbus
     end
 
     def toggle
-      if data_source.toggle_recurring_task(params[:id])
-        redirect_to pgbus.recurring_tasks_path, notice: "Task toggled"
+      result = data_source.toggle_recurring_task(params[:id])
+      if result
+        message = result == :enabled ? t("pgbus.recurring_tasks.toggle.enabled") : t("pgbus.recurring_tasks.toggle.disabled")
+        redirect_to pgbus.recurring_tasks_path, notice: message
       else
-        redirect_to pgbus.recurring_tasks_path, alert: "Failed to toggle task"
+        redirect_to pgbus.recurring_tasks_path, alert: t("pgbus.recurring_tasks.toggle.failed")
       end
     end
 

--- a/app/frontend/pgbus/application.js
+++ b/app/frontend/pgbus/application.js
@@ -114,12 +114,24 @@ initBulkSelect();
 document.addEventListener("turbo:load", initBulkSelect);
 document.addEventListener("turbo:frame-load", initBulkSelect);
 
-// -- Auto-refresh --
+// -- Auto-refresh (pauses when user is interacting) --
 const refreshInterval = parseInt(document.body?.dataset.pgbusRefreshInterval || "0", 10);
 if (refreshInterval > 0) {
   let timer;
+
+  function hasUserInteraction() {
+    // Pause when any checkbox is checked
+    const checked = document.querySelector("input[data-bulk-item]:checked, input[data-bulk-select-all]:checked");
+    if (checked) return true;
+    // Pause when any job detail row is expanded
+    const openDetails = document.querySelector("turbo-frame[data-auto-refresh] details[open]");
+    if (openDetails) return true;
+    return false;
+  }
+
   function refreshFrames() {
     if (document.hidden) return;
+    if (hasUserInteraction()) return;
     document.querySelectorAll("turbo-frame[data-auto-refresh]")
       .forEach(frame => {
         try {

--- a/app/views/pgbus/queues/show.html.erb
+++ b/app/views/pgbus/queues/show.html.erb
@@ -38,41 +38,78 @@
 
 <!-- Messages in Queue -->
 <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-  <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+  <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
     <thead class="bg-gray-50 dark:bg-gray-900">
       <tr>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.id") %></th>
+        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.job_class") %></th>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.enqueued") %></th>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.reads") %></th>
         <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.vt") %></th>
-        <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.payload") %></th>
-        <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.headers.actions") %></th>
       </tr>
     </thead>
     <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
       <% @messages.each do |m| %>
-        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
-          <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white"><%= m[:msg_id] %></td>
-          <td class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(m[:enqueued_at]) %></td>
-          <td class="px-4 py-3 text-sm text-gray-500"><%= m[:read_ct] %></td>
-          <td class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(m[:vt]) %></td>
-          <td class="px-4 py-3 text-sm text-gray-600 font-mono text-xs max-w-md truncate">
-            <%= pgbus_json_preview(m[:message]) %>
-          </td>
-          <td class="px-4 py-3 text-sm text-right space-x-1 whitespace-nowrap">
-            <%= button_to t("pgbus.queues.show.retry"), pgbus.retry_message_queue_path(name: params[:name], msg_id: m[:msg_id]),
-                  method: :post,
-                  class: "text-xs text-indigo-600 hover:text-indigo-800 font-medium",
-                  data: { turbo_confirm: t("pgbus.queues.show.retry_confirm") } %>
-            <%= button_to t("pgbus.queues.show.discard"), pgbus.discard_message_queue_path(name: params[:name], msg_id: m[:msg_id]),
-                  method: :post,
-                  class: "text-xs text-red-600 hover:text-red-800 font-medium",
-                  data: { turbo_confirm: t("pgbus.queues.show.discard_confirm") } %>
+        <% payload = pgbus_parse_message(m[:message]) %>
+        <tr>
+          <td colspan="5" class="p-0">
+            <details class="group">
+              <summary class="flex cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900 list-none">
+                <span class="w-16 shrink-0 px-4 py-3 text-sm font-mono text-gray-900 dark:text-white"><%= m[:msg_id] %></span>
+                <span class="flex-1 px-4 py-3 text-sm font-medium text-gray-900 dark:text-white"><%= payload["job_class"] || "—" %></span>
+                <span class="w-28 shrink-0 px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(m[:enqueued_at]) %></span>
+                <span class="w-16 shrink-0 px-4 py-3 text-sm text-gray-500"><%= m[:read_ct] %></span>
+                <span class="w-28 shrink-0 px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(m[:vt]) %></span>
+              </summary>
+              <div class="px-4 pb-4 bg-gray-50 dark:bg-gray-900 border-t border-gray-100">
+                <div class="flex items-center mt-3 mb-3">
+                  <span class="text-xs font-mono text-gray-400"><%= t("pgbus.queues.show.job_id") %> <%= payload["job_id"] %></span>
+                </div>
+                <div class="grid grid-cols-2 gap-4 mb-3">
+                  <div>
+                    <span class="text-xs font-medium text-gray-500"><%= t("pgbus.queues.show.arguments") %></span>
+                    <pre class="text-xs text-gray-700 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-40"><%= JSON.pretty_generate(payload["arguments"] || []) rescue "—" %></pre>
+                  </div>
+                  <div>
+                    <span class="text-xs font-medium text-gray-500"><%= t("pgbus.queues.show.metadata") %></span>
+                    <div class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 space-y-1">
+                      <% if payload["queue_name"] %><p><strong><%= t("pgbus.queues.show.metadata_labels.queue") %></strong> <%= payload["queue_name"] %></p><% end %>
+                      <% if payload["priority"] %><p><strong><%= t("pgbus.queues.show.metadata_labels.priority") %></strong> <%= payload["priority"] %></p><% end %>
+                      <% if payload["locale"] %><p><strong><%= t("pgbus.queues.show.metadata_labels.locale") %></strong> <%= payload["locale"] %></p><% end %>
+                      <% if payload["timezone"] %><p><strong><%= t("pgbus.queues.show.metadata_labels.timezone") %></strong> <%= payload["timezone"] %></p><% end %>
+                      <% if payload["scheduled_at"] %><p><strong><%= t("pgbus.queues.show.metadata_labels.scheduled") %></strong> <%= payload["scheduled_at"] %></p><% end %>
+                      <% if m[:vt] %><p><strong><%= t("pgbus.queues.show.metadata_labels.visible_at") %></strong> <%= m[:vt] %></p><% end %>
+                      <% if m[:last_read_at] %><p><strong><%= t("pgbus.queues.show.metadata_labels.last_read") %></strong> <%= m[:last_read_at] %></p><% end %>
+                    </div>
+                  </div>
+                </div>
+                <details class="mt-2">
+                  <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700"><%= t("pgbus.queues.show.full_json_payload") %></summary>
+                  <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-96"><%= JSON.pretty_generate(payload) rescue m[:message] %></pre>
+                </details>
+                <% if m[:headers] %>
+                  <details class="mt-2">
+                    <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700"><%= t("pgbus.queues.show.headers_section") %></summary>
+                    <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto"><%= JSON.pretty_generate(JSON.parse(m[:headers])) rescue m[:headers] %></pre>
+                  </details>
+                <% end %>
+                <div class="flex space-x-2 mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+                  <%= button_to t("pgbus.queues.show.retry"), pgbus.retry_message_queue_path(name: params[:name], msg_id: m[:msg_id]),
+                        method: :post,
+                        class: "rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500",
+                        data: { turbo_confirm: t("pgbus.queues.show.retry_confirm") } %>
+                  <%= button_to t("pgbus.queues.show.discard"), pgbus.discard_message_queue_path(name: params[:name], msg_id: m[:msg_id]),
+                        method: :post,
+                        class: "rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-500",
+                        data: { turbo_confirm: t("pgbus.queues.show.discard_confirm") } %>
+                </div>
+              </div>
+            </details>
           </td>
         </tr>
       <% end %>
       <% if @messages.empty? %>
-        <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.queues.show.empty") %></td></tr>
+        <tr><td colspan="5" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.queues.show.empty") %></td></tr>
       <% end %>
     </tbody>
   </table>

--- a/app/views/pgbus/recurring_tasks/_tasks_table.html.erb
+++ b/app/views/pgbus/recurring_tasks/_tasks_table.html.erb
@@ -24,7 +24,8 @@
               <td data-label="Task" class="px-4 py-3">
                 <div>
                   <%= link_to task[:key], pgbus.recurring_task_path(task[:id]),
-                      class: "text-sm font-medium text-blue-600 hover:text-blue-800" %>
+                      class: "text-sm font-medium text-blue-600 hover:text-blue-800",
+                      data: { turbo_frame: "_top" } %>
                 </div>
                 <div class="text-xs text-gray-500"><%= task[:class_name] || task[:command]&.truncate(40) %></div>
                 <% if task[:description] %>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -345,6 +345,10 @@ da:
           one: "%{count} opgave konfigureret"
           other: "%{count} opgaver konfigureret"
         title: Gentagne opgaver
+      toggle:
+        disabled: Opgave deaktiveret
+        enabled: Opgave aktiveret
+        failed: Kunne ikke ændre opgave
       show:
         back: Tilbage
         configuration: Konfiguration

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -301,23 +301,35 @@ da:
         purge_confirm: Rens alle beskeder fra %{name}?
         resume: Genoptag
       show:
+        arguments: Argumenter
         delete_confirm: Slet denne kø permanent? Dette kan ikke fortrydes.
         delete_queue: Slet kø
         depth: 'Dybde:'
         discard: Kassér
         discard_confirm: Kassér denne besked?
         empty: Køen er tom
+        full_json_payload: Fuld JSON-payload
         headers:
-          actions: Handlinger
           enqueued: Sat i kø
           id: ID
-          payload: Indhold
+          job_class: Jobklasse
           reads: Læsninger
           vt: VT
+        headers_section: Headers
+        job_id: 'Job ID:'
         message_discard_failed: Kunne ikke kassere besked.
         message_discarded: Besked kasseret.
         message_retried: Beskedens synlighed nulstillet.
         message_retry_failed: Kunne ikke prøve besked igen.
+        metadata: Metadata
+        metadata_labels:
+          last_read: 'Sidst læst:'
+          locale: 'Locale:'
+          priority: 'Prioritet:'
+          queue: 'Kø:'
+          scheduled: 'Planlagt:'
+          timezone: 'Tidszone:'
+          visible_at: 'Synlig fra:'
         pause: Pause
         pause_confirm: Pause behandling?
         purge_confirm: Rens alle beskeder?

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -301,23 +301,35 @@ de:
         purge_confirm: Alle Nachrichten von %{name} löschen?
         resume: Fortsetzen
       show:
+        arguments: Argumente
         delete_confirm: Diese Warteschlange dauerhaft löschen? Dies kann nicht rückgängig gemacht werden.
         delete_queue: Warteschlange löschen
         depth: 'Tiefe:'
         discard: Verwerfen
         discard_confirm: Diese Nachricht verwerfen?
         empty: Warteschlange ist leer
+        full_json_payload: Vollständige JSON-Nutzlast
         headers:
-          actions: Aktionen
           enqueued: Eingereiht
           id: ID
-          payload: Nutzlast
+          job_class: Job-Klasse
           reads: Lesevorgänge
           vt: VT
+        headers_section: Header
+        job_id: 'Job-ID:'
         message_discard_failed: Nachricht konnte nicht verworfen werden.
         message_discarded: Nachricht verworfen.
         message_retried: Sichtbarkeit der Nachricht zurückgesetzt.
         message_retry_failed: Nachricht konnte nicht wiederholt werden.
+        metadata: Metadaten
+        metadata_labels:
+          last_read: 'Letzter Lesevorgang:'
+          locale: 'Sprache:'
+          priority: 'Priorität:'
+          queue: 'Warteschlange:'
+          scheduled: 'Geplant:'
+          timezone: 'Zeitzone:'
+          visible_at: 'Sichtbar ab:'
         pause: Pause
         pause_confirm: Verarbeitung pausieren?
         purge_confirm: Alle Nachrichten löschen?

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -345,6 +345,10 @@ de:
           one: "%{count} Aufgabe konfiguriert"
           other: "%{count} Aufgaben konfiguriert"
         title: Wiederkehrende Aufgaben
+      toggle:
+        disabled: Aufgabe deaktiviert
+        enabled: Aufgabe aktiviert
+        failed: Aufgabe konnte nicht umgeschaltet werden
       show:
         back: Zurück
         configuration: Konfiguration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,23 +347,35 @@ en:
         purge_confirm: Purge all messages from %{name}?
         resume: Resume
       show:
+        arguments: Arguments
         delete_confirm: Permanently delete this queue? This cannot be undone.
         delete_queue: Delete Queue
         depth: 'Depth:'
         discard: Discard
         discard_confirm: Discard this message?
         empty: Queue is empty
+        full_json_payload: Full JSON payload
         headers:
-          actions: Actions
           enqueued: Enqueued
           id: ID
-          payload: Payload
+          job_class: Job Class
           reads: Reads
           vt: VT
+        headers_section: Headers
+        job_id: 'Job ID:'
         message_discard_failed: Could not discard message.
         message_discarded: Message discarded.
         message_retried: Message visibility reset.
         message_retry_failed: Could not retry message.
+        metadata: Metadata
+        metadata_labels:
+          last_read: 'Last read:'
+          locale: 'Locale:'
+          priority: 'Priority:'
+          queue: 'Queue:'
+          scheduled: 'Scheduled at:'
+          timezone: 'Timezone:'
+          visible_at: 'Visible at:'
         pause: Pause
         pause_confirm: Pause processing?
         purge_confirm: Purge all messages?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,6 +391,10 @@ en:
           one: "%{count} task configured"
           other: "%{count} tasks configured"
         title: Recurring Tasks
+      toggle:
+        disabled: Task disabled
+        enabled: Task enabled
+        failed: Failed to toggle task
       show:
         back: Back
         configuration: Configuration

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -345,6 +345,10 @@ es:
           one: Tarea %{count} configurada
           other: Tareas %{count} configuradas
         title: Tareas recurrentes
+      toggle:
+        disabled: Tarea deshabilitada
+        enabled: Tarea habilitada
+        failed: No se pudo cambiar la tarea
       show:
         back: Atrás
         configuration: Configuración

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -301,23 +301,35 @@ es:
         purge_confirm: "¿Purgar todos los mensajes de %{name}?"
         resume: Reanudar
       show:
+        arguments: Argumentos
         delete_confirm: "¿Eliminar permanentemente esta cola? Esto no se puede deshacer."
         delete_queue: Eliminar cola
         depth: 'Profundidad:'
         discard: Descartar
         discard_confirm: "¿Descartar este mensaje?"
         empty: La cola está vacía
+        full_json_payload: Carga JSON completa
         headers:
-          actions: Acciones
           enqueued: Encolado
           id: ID
-          payload: Carga útil
+          job_class: Clase de Trabajo
           reads: Lecturas
           vt: VT
+        headers_section: Encabezados
+        job_id: 'ID del Trabajo:'
         message_discard_failed: No se pudo descartar el mensaje.
         message_discarded: Mensaje descartado.
         message_retried: Visibilidad del mensaje restablecida.
         message_retry_failed: No se pudo reintentar el mensaje.
+        metadata: Metadatos
+        metadata_labels:
+          last_read: 'Última lectura:'
+          locale: 'Configuración regional:'
+          priority: 'Prioridad:'
+          queue: 'Cola:'
+          scheduled: 'Programado:'
+          timezone: 'Zona horaria:'
+          visible_at: 'Visible en:'
         pause: Pausar
         pause_confirm: "¿Pausar el procesamiento?"
         purge_confirm: "¿Purgar todos los mensajes?"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -301,23 +301,35 @@ fi:
         purge_confirm: Tyhjennä kaikki viestit %{name}:sta?
         resume: Jatka
       show:
+        arguments: Argumentit
         delete_confirm: Poista tämä jono pysyvästi? Tätä ei voi kumota.
         delete_queue: Poista jono
         depth: 'Syvyys:'
         discard: Hylkää
         discard_confirm: Hylätä tämä viesti?
         empty: Jono on tyhjä
+        full_json_payload: Täysi JSON-payload
         headers:
-          actions: Toiminnot
           enqueued: Jonoon lisätty
           id: ID
-          payload: Kuorma
+          job_class: Työn luokka
           reads: Lukukerrat
           vt: VT
+        headers_section: Otsikot
+        job_id: 'Työn ID:'
         message_discard_failed: Viestiä ei voitu hylätä.
         message_discarded: Viesti hylätty.
         message_retried: Viestin näkyvyys nollattu.
         message_retry_failed: Viestiä ei voitu yrittää uudelleen.
+        metadata: Metatiedot
+        metadata_labels:
+          last_read: 'Viimeksi luettu:'
+          locale: 'Alue:'
+          priority: 'Prioriteetti:'
+          queue: 'Jono:'
+          scheduled: 'Aikataulutettu:'
+          timezone: 'Aikavyöhyke:'
+          visible_at: 'Näkyvissä:'
         pause: Tauko
         pause_confirm: Keskeytetäänkö käsittely?
         purge_confirm: Tyhjennetäänkö kaikki viestit?

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -345,6 +345,10 @@ fi:
           one: "%{count} tehtävä määritetty"
           other: "%{count} tehtävää määritetty"
         title: Toistuvat tehtävät
+      toggle:
+        disabled: Tehtävä poistettu käytöstä
+        enabled: Tehtävä otettu käyttöön
+        failed: Tehtävän vaihto epäonnistui
       show:
         back: Takaisin
         configuration: Asetukset

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -301,23 +301,35 @@ fr:
         purge_confirm: Purger tous les messages de %{name} ?
         resume: Reprendre
       show:
+        arguments: Arguments
         delete_confirm: Supprimer définitivement cette file d'attente ? Cette action est irréversible.
         delete_queue: Supprimer la file d'attente
         depth: 'Profondeur :'
         discard: Rejeter
         discard_confirm: Rejeter ce message ?
         empty: La file d'attente est vide
+        full_json_payload: Charge utile JSON complète
         headers:
-          actions: Actions
           enqueued: Enregistré
           id: ID
-          payload: Charge utile
+          job_class: Classe de travail
           reads: Lectures
           vt: VT
+        headers_section: En-têtes
+        job_id: 'ID du travail :'
         message_discard_failed: Impossible de rejeter le message.
         message_discarded: Message rejeté.
         message_retried: Visibilité du message réinitialisée.
         message_retry_failed: Impossible de réessayer le message.
+        metadata: Métadonnées
+        metadata_labels:
+          last_read: 'Dernière lecture :'
+          locale: 'Langue :'
+          priority: 'Priorité :'
+          queue: 'File d''attente :'
+          scheduled: 'Planifié :'
+          timezone: 'Fuseau horaire :'
+          visible_at: 'Visible à :'
         pause: Pause
         pause_confirm: Mettre en pause le traitement ?
         purge_confirm: Purger tous les messages ?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -345,6 +345,10 @@ fr:
           one: Tâche %{count} configurée
           other: Tâches %{count} configurées
         title: Tâches récurrentes
+      toggle:
+        disabled: Tâche désactivée
+        enabled: Tâche activée
+        failed: Impossible de basculer la tâche
       show:
         back: Retour
         configuration: Configuration

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -345,6 +345,10 @@ it:
           one: "%{count} attività configurata"
           other: "%{count} attività configurate"
         title: Attività ricorrenti
+      toggle:
+        disabled: Attività disabilitata
+        enabled: Attività abilitata
+        failed: Impossibile cambiare lo stato dell'attività
       show:
         back: Indietro
         configuration: Configurazione

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -301,23 +301,35 @@ it:
         purge_confirm: Eliminare tutti i messaggi da %{name}?
         resume: Riprendi
       show:
+        arguments: Argomenti
         delete_confirm: Eliminare permanentemente questa coda? Questa azione non può essere annullata.
         delete_queue: Elimina coda
         depth: 'Profondità:'
         discard: Scarta
         discard_confirm: Scartare questo messaggio?
         empty: La coda è vuota
+        full_json_payload: Payload JSON completo
         headers:
-          actions: Azioni
           enqueued: In coda
           id: ID
-          payload: Carico utile
+          job_class: Classe Lavoro
           reads: Letture
           vt: VT
+        headers_section: Intestazioni
+        job_id: 'ID Lavoro:'
         message_discard_failed: Impossibile scartare il messaggio.
         message_discarded: Messaggio scartato.
         message_retried: Visibilità del messaggio reimpostata.
         message_retry_failed: Impossibile riprovare il messaggio.
+        metadata: Metadati
+        metadata_labels:
+          last_read: 'Ultima lettura:'
+          locale: 'Locale:'
+          priority: 'Priorità:'
+          queue: 'Coda:'
+          scheduled: 'Programmato:'
+          timezone: 'Fuso orario:'
+          visible_at: 'Visibile alle:'
         pause: Pausa
         pause_confirm: Mettere in pausa l'elaborazione?
         purge_confirm: Eliminare tutti i messaggi?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -301,23 +301,35 @@ ja:
         purge_confirm: "%{name} からすべてのメッセージを削除しますか？"
         resume: 再開
       show:
+        arguments: 引数
         delete_confirm: このキューを完全に削除しますか？この操作は取り消せません。
         delete_queue: キューを削除
         depth: 深さ：
         discard: 破棄
         discard_confirm: このメッセージを破棄しますか？
         empty: キューは空です
+        full_json_payload: 完全なJSONペイロード
         headers:
-          actions: アクション
           enqueued: エンキュー済み
           id: ID
-          payload: ペイロード
+          job_class: ジョブクラス
           reads: 読み取り回数
           vt: VT
+        headers_section: ヘッダー
+        job_id: ジョブID：
         message_discard_failed: メッセージを破棄できませんでした。
         message_discarded: メッセージを破棄しました。
         message_retried: メッセージの可視性をリセットしました。
         message_retry_failed: メッセージをリトライできませんでした。
+        metadata: メタデータ
+        metadata_labels:
+          last_read: 最終読み取り：
+          locale: ロケール：
+          priority: 優先度：
+          queue: キュー：
+          scheduled: スケジュール済み：
+          timezone: タイムゾーン：
+          visible_at: 表示可能日時：
         pause: 一時停止
         pause_confirm: 処理を一時停止しますか？
         purge_confirm: すべてのメッセージを削除しますか？

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -345,6 +345,10 @@ ja:
           one: "%{count} タスクが設定されています"
           other: "%{count} タスクが設定されています"
         title: 定期タスク
+      toggle:
+        disabled: タスクが無効になりました
+        enabled: タスクが有効になりました
+        failed: タスクの切り替えに失敗しました
       show:
         back: 戻る
         configuration: 設定

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -345,6 +345,10 @@ nb:
           one: "%{count} oppgave konfigurert"
           other: "%{count} oppgaver konfigurert"
         title: Gjentakende oppgaver
+      toggle:
+        disabled: Oppgave deaktivert
+        enabled: Oppgave aktivert
+        failed: Kunne ikke endre oppgave
       show:
         back: Tilbake
         configuration: Konfigurasjon

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -301,23 +301,35 @@ nb:
         purge_confirm: Rens alle meldinger fra %{name}?
         resume: Gjenoppta
       show:
+        arguments: Argumenter
         delete_confirm: Slette denne køen permanent? Dette kan ikke angres.
         delete_queue: Slett kø
         depth: 'Dybde:'
         discard: Forkast
         discard_confirm: Forkaste denne meldingen?
         empty: Køen er tom
+        full_json_payload: Full JSON-payload
         headers:
-          actions: Handlinger
           enqueued: I kø
           id: ID
-          payload: Innhold
+          job_class: Jobbklasse
           reads: Lesninger
           vt: VT
+        headers_section: Overskrifter
+        job_id: 'Jobb-ID:'
         message_discard_failed: Kunne ikke forkaste meldingen.
         message_discarded: Melding forkastet.
         message_retried: Meldingens synlighet tilbakestilt.
         message_retry_failed: Kunne ikke prøve meldingen igjen.
+        metadata: Metadata
+        metadata_labels:
+          last_read: 'Sist lest:'
+          locale: 'Språk:'
+          priority: 'Prioritet:'
+          queue: 'Kø:'
+          scheduled: 'Planlagt:'
+          timezone: 'Tidssone:'
+          visible_at: 'Synlig fra:'
         pause: Pause
         pause_confirm: Pause behandling?
         purge_confirm: Rens alle meldinger?

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -345,6 +345,10 @@ nl:
           one: "%{count} taak geconfigureerd"
           other: "%{count} taken geconfigureerd"
         title: Terugkerende taken
+      toggle:
+        disabled: Taak uitgeschakeld
+        enabled: Taak ingeschakeld
+        failed: Kon taak niet omschakelen
       show:
         back: Terug
         configuration: Configuratie

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -301,23 +301,35 @@ nl:
         purge_confirm: Alle berichten verwijderen uit %{name}?
         resume: Hervatten
       show:
+        arguments: Argumenten
         delete_confirm: Deze wachtrij permanent verwijderen? Dit kan niet ongedaan worden gemaakt.
         delete_queue: Wachtrij verwijderen
         depth: 'Diepte:'
         discard: Verwerpen
         discard_confirm: Dit bericht verwerpen?
         empty: Wachtrij is leeg
+        full_json_payload: Volledige JSON payload
         headers:
-          actions: Acties
           enqueued: In de wachtrij geplaatst
           id: ID
-          payload: Inhoud
+          job_class: Taakklasse
           reads: Lezingen
           vt: VT
+        headers_section: Headers
+        job_id: 'Taak ID:'
         message_discard_failed: Kon bericht niet verwerpen.
         message_discarded: Bericht verworpen.
         message_retried: Zichtbaarheid van bericht gereset.
         message_retry_failed: Kon bericht niet opnieuw proberen.
+        metadata: Metadata
+        metadata_labels:
+          last_read: 'Laatst gelezen:'
+          locale: 'Locale:'
+          priority: 'Prioriteit:'
+          queue: 'Wachtrij:'
+          scheduled: 'Gepland:'
+          timezone: 'Tijdzone:'
+          visible_at: 'Zichtbaar op:'
         pause: Pauzeren
         pause_confirm: Verwerking pauzeren?
         purge_confirm: Alle berichten verwijderen?

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -301,23 +301,35 @@ pt:
         purge_confirm: Limpar todas as mensagens de %{name}?
         resume: Retomar
       show:
+        arguments: Argumentos
         delete_confirm: Excluir permanentemente esta fila? Esta ação não pode ser desfeita.
         delete_queue: Excluir fila
         depth: 'Profundidade:'
         discard: Descartar
         discard_confirm: Descartar esta mensagem?
         empty: Fila está vazia
+        full_json_payload: Carga JSON completa
         headers:
-          actions: Ações
           enqueued: Enfileirado
           id: ID
-          payload: Carga útil
+          job_class: Classe do Trabalho
           reads: Leituras
           vt: VT
+        headers_section: Cabeçalhos
+        job_id: 'ID do Trabalho:'
         message_discard_failed: Não foi possível descartar a mensagem.
         message_discarded: Mensagem descartada.
         message_retried: Visibilidade da mensagem redefinida.
         message_retry_failed: Não foi possível tentar novamente a mensagem.
+        metadata: Metadados
+        metadata_labels:
+          last_read: 'Última leitura:'
+          locale: 'Localidade:'
+          priority: 'Prioridade:'
+          queue: 'Fila:'
+          scheduled: 'Agendado:'
+          timezone: 'Fuso horário:'
+          visible_at: 'Visível em:'
         pause: Pausar
         pause_confirm: Pausar processamento?
         purge_confirm: Limpar todas as mensagens?

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -345,6 +345,10 @@ pt:
           one: "%{count} tarefa configurada"
           other: "%{count} tarefas configuradas"
         title: Tarefas Recorrentes
+      toggle:
+        disabled: Tarefa desativada
+        enabled: Tarefa ativada
+        failed: Falha ao alternar tarefa
       show:
         back: Voltar
         configuration: Configuração

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -301,23 +301,35 @@ sv:
         purge_confirm: Rensa alla meddelanden från %{name}?
         resume: Återuppta
       show:
+        arguments: Argument
         delete_confirm: Ta bort denna kö permanent? Detta kan inte ångras.
         delete_queue: Ta bort kö
         depth: 'Djup:'
         discard: Kassera
         discard_confirm: Kassera detta meddelande?
         empty: Kön är tom
+        full_json_payload: Fullständig JSON-payload
         headers:
-          actions: Åtgärder
           enqueued: Inlagd
           id: ID
-          payload: Innehåll
+          job_class: Jobbklass
           reads: Läsningar
           vt: VT
+        headers_section: Headers
+        job_id: 'Jobb-ID:'
         message_discard_failed: Kunde inte kassera meddelandet.
         message_discarded: Meddelande kasserat.
         message_retried: Meddelandets synlighet återställd.
         message_retry_failed: Kunde inte försöka igen med meddelandet.
+        metadata: Metadata
+        metadata_labels:
+          last_read: 'Senast läst:'
+          locale: 'Språk:'
+          priority: 'Prioritet:'
+          queue: 'Kö:'
+          scheduled: 'Schemalagt:'
+          timezone: 'Tidszon:'
+          visible_at: 'Synlig vid:'
         pause: Pausa
         pause_confirm: Pausa bearbetning?
         purge_confirm: Rensa alla meddelanden?

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -345,6 +345,10 @@ sv:
           one: "%{count} uppgift konfigurerad"
           other: "%{count} uppgifter konfigurerade"
         title: Återkommande uppgifter
+      toggle:
+        disabled: Uppgift inaktiverad
+        enabled: Uppgift aktiverad
+        failed: Kunde inte ändra uppgift
       show:
         back: Tillbaka
         configuration: Konfiguration

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -479,13 +479,13 @@ module Pgbus
 
       def toggle_recurring_task(id)
         record = RecurringTask.find_by(id: id)
-        return false unless record
+        return nil unless record
 
         record.update!(enabled: !record.enabled)
-        true
+        record.enabled ? :enabled : :disabled
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus::Web] Error toggling recurring task #{id}: #{e.message}" }
-        false
+        nil
       end
 
       def enqueue_recurring_task_now(id)

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,3 +1,7 @@
+development:
+  adapter: sqlite3
+  database: db/development.sqlite3
+
 test:
   adapter: sqlite3
   database: ":memory:"

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.eager_load = false
+  config.consider_all_requests_local = true
+  config.active_support.deprecation = :log
+  config.secret_key_base = "dev_secret_key_base_for_pgbus_dummy"
+end

--- a/spec/dummy/config/initializers/stub_data.rb
+++ b/spec/dummy/config/initializers/stub_data.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Inject rich stub data for dashboard QA when PGBUS_STUB_DATA=1
+if ENV["PGBUS_STUB_DATA"] == "1"
+  Rails.application.config.after_initialize do
+    require_relative "../../lib/stub_data_source"
+    stub = DummyApp::StubDataSource.build
+    Pgbus.configure do |c|
+      c.web_data_source = stub
+      c.web_refresh_interval = 5000
+    end
+    Rails.logger.info "[Pgbus Dummy] Stub data source loaded with sample data"
+  end
+end

--- a/spec/dummy/lib/stub_data_source.rb
+++ b/spec/dummy/lib/stub_data_source.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+# Rich stub data source for dashboard QA without a database.
+# Used by `rake dummy:server` (triggered via PGBUS_STUB_DATA=1).
+module DummyApp
+  class StubDataSource
+    def self.build
+      new
+    end
+
+    def summary_stats
+      { total_queues: 4, total_depth: 127, total_visible: 98,
+        active_processes: 2, failed_count: 5, dlq_depth: 3,
+        recurring_count: 14, throughput_rate: 42.7 }
+    end
+
+    def queues_with_metrics
+      [
+        { name: "pgbus_default", queue_length: 85, queue_visible_length: 62,
+          oldest_msg_age_sec: 300, newest_msg_age_sec: 2, total_messages: 12_450 },
+        { name: "pgbus_mailers", queue_length: 22, queue_visible_length: 18,
+          oldest_msg_age_sec: 45, newest_msg_age_sec: 1, total_messages: 8_320 },
+        { name: "pgbus_events", queue_length: 15, queue_visible_length: 13,
+          oldest_msg_age_sec: 120, newest_msg_age_sec: 5, total_messages: 45_000 },
+        { name: "pgbus_default_dlq", queue_length: 3, queue_visible_length: 3,
+          oldest_msg_age_sec: 7200, newest_msg_age_sec: 3600, total_messages: 47 }
+      ]
+    end
+
+    def queue_detail(name)
+      queues_with_metrics.find { |q| q[:name] == name }
+    end
+
+    def queue_paused?(name)
+      name == "pgbus_mailers"
+    end
+
+    def jobs(queue_name: nil, page: 1, per_page: 25) # rubocop:disable Lint/UnusedMethodArgument
+      job_classes = %w[CaptureSpaceStatsJob SendWelcomeEmailJob ProcessPaymentJob SyncInventoryJob GenerateReportJob]
+      Array.new(6) do |i|
+        id = 900 - i
+        job_class = job_classes[i % job_classes.size]
+        {
+          msg_id: id, queue_name: queue_name || "pgbus_default", read_ct: i,
+          enqueued_at: (i * 5).minutes.ago.utc.iso8601,
+          vt: (i * 3).minutes.ago.utc.iso8601,
+          last_read_at: i.positive? ? (i * 2).minutes.ago.utc.iso8601 : nil,
+          message: {
+            job_class: job_class, job_id: "job-#{SecureRandom.hex(6)}",
+            queue_name: queue_name || "default", priority: [1, 2, 5][i % 3],
+            arguments: sample_arguments(job_class), locale: "en", timezone: "UTC",
+            scheduled_at: i.even? ? 1.minute.from_now.utc.iso8601 : nil
+          }.compact.to_json,
+          headers: i.even? ? { "X-Request-Id" => SecureRandom.uuid }.to_json : nil
+        }
+      end
+    end
+
+    def failed_events(page: 1, per_page: 25) # rubocop:disable Lint/UnusedMethodArgument
+      [
+        { "id" => 1, "handler_class" => "Billing::InvoiceHandler", "event_type" => "invoice.created",
+          "error_class" => "Stripe::InvalidRequestError", "error_message" => "No such customer: cus_xxx",
+          "retry_count" => 3, "failed_at" => 30.minutes.ago.utc.iso8601,
+          "queue_name" => "pgbus_default" },
+        { "id" => 2, "handler_class" => "Notifications::SlackHandler", "event_type" => "user.signed_up",
+          "error_class" => "Net::ReadTimeout", "error_message" => "execution expired",
+          "retry_count" => 1, "failed_at" => 2.hours.ago.utc.iso8601,
+          "queue_name" => "pgbus_events" }
+      ]
+    end
+
+    def failed_events_count = 2
+    def failed_event(id) = failed_events.find { |e| e["id"].to_s == id.to_s }
+
+    def dlq_messages(page: 1, per_page: 25) # rubocop:disable Lint/UnusedMethodArgument
+      [
+        { msg_id: 501, queue_name: "pgbus_default_dlq", read_ct: 6,
+          enqueued_at: 2.hours.ago.utc.iso8601, vt: 1.hour.ago.utc.iso8601,
+          message: { job_class: "ProcessPaymentJob", job_id: "dlq-aaa",
+                     arguments: [{ amount: 99.99 }], priority: 1 }.to_json },
+        { msg_id: 502, queue_name: "pgbus_default_dlq", read_ct: 4,
+          enqueued_at: 5.hours.ago.utc.iso8601, vt: 4.hours.ago.utc.iso8601,
+          message: { job_class: "SyncInventoryJob", job_id: "dlq-bbb",
+                     arguments: [{ sku: "WIDGET-42" }], priority: 2 }.to_json }
+      ]
+    end
+
+    def dlq_message_detail(msg_id)
+      dlq_messages.find { |m| m[:msg_id].to_s == msg_id.to_s }
+    end
+
+    def processes
+      [
+        { id: 1, kind: "worker", hostname: "web-01.prod", pid: 12_345,
+          metadata: { "queues" => "default,mailers", "threads" => 5 },
+          last_heartbeat_at: 10.seconds.ago, healthy: true, created_at: 2.hours.ago },
+        { id: 2, kind: "worker", hostname: "worker-01.prod", pid: 67_890,
+          metadata: { "queues" => "events", "threads" => 3 },
+          last_heartbeat_at: 45.seconds.ago, healthy: true, created_at: 1.day.ago }
+      ]
+    end
+
+    def recurring_tasks
+      tasks = %w[capture_stats cleanup_old sync_exchange_rates generate_reports
+                 purge_expired_tokens refresh_cache send_digest_emails
+                 check_ssl_certs rotate_logs archive_events
+                 update_search_index reindex_products vacuum_analyze health_check]
+      tasks.each_with_index.map do |key, i|
+        {
+          id: i + 1, key: key, class_name: key.camelize.concat("Job"),
+          command: nil, schedule: sample_schedule(i),
+          human_schedule: sample_human_schedule(i),
+          queue_name: %w[default maintenance events][i % 3],
+          priority: [1, 2, 5][i % 3],
+          description: "#{key.humanize} recurring task",
+          enabled: i != 1, static: i < 10,
+          next_run_at: i == 1 ? nil : ((i * 5) + 1).minutes.from_now,
+          last_run_at: i.positive? ? (i * 3).minutes.ago : nil,
+          created_at: 30.days.ago, updated_at: 1.day.ago
+        }
+      end
+    end
+
+    def recurring_task(id)
+      task = recurring_tasks.find { |t| t[:id].to_s == id.to_s }
+      return nil unless task
+
+      task.merge(executions: Array.new(5) do |i|
+        { run_at: (i * 5).minutes.ago, created_at: (i * 5).minutes.ago }
+      end)
+    end
+
+    def processed_events(page: 1, per_page: 25) # rubocop:disable Lint/UnusedMethodArgument
+      []
+    end
+
+    def processed_events_count = 0
+    def processed_event(_id) = nil
+    def registered_subscribers = []
+
+    def job_locks
+      [
+        { lock_key: "uniqueness:ProcessPaymentJob:abc123", queue_name: "pgbus_default",
+          msg_id: 900, created_at: 5.minutes.ago, age_seconds: 300 },
+        { lock_key: "uniqueness:SendWelcomeEmailJob:def456", queue_name: "pgbus_mailers",
+          msg_id: 898, created_at: 2.minutes.ago, age_seconds: 120 }
+      ]
+    end
+
+    def outbox_stats
+      { unpublished: 3, total: 1250, oldest_unpublished_age: 45 }
+    end
+
+    def outbox_entries(page: 1, per_page: 25) # rubocop:disable Lint/UnusedMethodArgument
+      []
+    end
+
+    def job_stats_summary(minutes: 60) # rubocop:disable Lint/UnusedMethodArgument
+      { total: 342, success: 335, failed: 5, dead_lettered: 2,
+        avg_duration_ms: 127.4, max_duration_ms: 4521.0 }
+    end
+
+    def slowest_job_classes(limit: 10, minutes: 60) # rubocop:disable Lint/UnusedMethodArgument
+      []
+    end
+
+    def latency_by_queue(minutes: 60) # rubocop:disable Lint/UnusedMethodArgument
+      []
+    end
+
+    def latency_trend(minutes: 60) # rubocop:disable Lint/UnusedMethodArgument
+      []
+    end
+
+    def job_throughput(minutes: 60) # rubocop:disable Lint/UnusedMethodArgument
+      []
+    end
+
+    # Mutating actions (no-ops for QA)
+    def purge_queue(_name) = true
+    def drop_queue(_name) = true
+    def pause_queue(_name, reason: nil) = true # rubocop:disable Lint/UnusedMethodArgument
+    def resume_queue(_name) = true
+    def retry_job(_queue, _id) = true
+    def discard_job(_queue, _id) = true
+    def retry_failed_event(_id) = true
+    def discard_failed_event(_id) = true
+    def retry_all_failed = 2
+    def discard_all_failed = 2
+    def discard_all_enqueued = 6
+    def retry_dlq_message(_queue, _id) = true
+    def discard_dlq_message(_queue, _id) = true
+    def retry_all_dlq = 2
+    def discard_all_dlq = 2
+    def replay_event(_event) = true
+    def toggle_recurring_task(_id) = true
+    def enqueue_recurring_task_now(_id) = true
+    def discard_lock(_key) = 1
+    def discard_locks(keys) = keys.size
+    def discard_all_locks = 2
+
+    private
+
+    def sample_arguments(job_class)
+      case job_class
+      when "ProcessPaymentJob" then [{ amount: 49.99, currency: "USD" }]
+      when "SendWelcomeEmailJob" then [{ user_id: 42 }]
+      when "SyncInventoryJob" then [{ sku: "WIDGET-42", warehouse: "US-EAST" }]
+      else []
+      end
+    end
+
+    def sample_schedule(index)
+      schedules = ["*/5 * * * *", "0 3 * * *", "0 */6 * * *", "0 0 * * 1",
+                   "*/15 * * * *", "0 */2 * * *", "0 8 * * 1-5", "0 0 1 * *",
+                   "30 4 * * *", "0 2 * * 0", "*/10 * * * *", "0 6 * * *",
+                   "0 1 * * *", "*/1 * * * *"]
+      schedules[index % schedules.size]
+    end
+
+    def sample_human_schedule(index)
+      descriptions = ["Every 5 minutes", "Daily at 3:00 AM", "Every 6 hours", "Weekly on Monday",
+                      "Every 15 minutes", "Every 2 hours", "Weekdays at 8:00 AM", "Monthly on the 1st",
+                      "Daily at 4:30 AM", "Weekly on Sunday at 2:00 AM", "Every 10 minutes",
+                      "Daily at 6:00 AM", "Daily at 1:00 AM", "Every minute"]
+      descriptions[index % descriptions.size]
+    end
+  end
+end

--- a/spec/pgbus/web/dashboard_interaction_spec.rb
+++ b/spec/pgbus/web/dashboard_interaction_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Dashboard interaction UX" do # rubocop:disable RSpec/DescribeClass
+  let(:root) { Pathname.new(File.expand_path("../../..", __dir__)) }
+  let(:views_dir) { root.join("app", "views") }
+  let(:frontend_dir) { root.join("app", "frontend", "pgbus") }
+
+  describe "auto-refresh pauses on user interaction" do
+    let(:application_js) { frontend_dir.join("application.js").read }
+
+    it "checks for open details elements before refreshing" do
+      expect(application_js).to include("details[open]")
+    end
+
+    it "checks for checked checkboxes before refreshing" do
+      expect(application_js).to include("data-bulk-item]:checked")
+    end
+
+    it "skips refresh when user interaction is detected" do
+      expect(application_js).to include("hasUserInteraction")
+    end
+  end
+
+  describe "recurring tasks table links" do
+    let(:tasks_table) { views_dir.join("pgbus", "recurring_tasks", "_tasks_table.html.erb").read }
+
+    it "uses turbo_frame _top for task links to avoid Content missing" do
+      expect(tasks_table).to include("turbo_frame: \"_top\"")
+    end
+  end
+
+  describe "queue show page" do
+    let(:queue_show) { views_dir.join("pgbus", "queues", "show.html.erb").read }
+
+    it "uses expandable details/summary for message rows" do
+      expect(queue_show).to include("<details class=\"group\">")
+      expect(queue_show).to include("<summary")
+    end
+
+    it "shows job metadata in expanded section" do
+      expect(queue_show).to include("job_id")
+      expect(queue_show).to include("arguments")
+      expect(queue_show).to include("metadata")
+    end
+
+    it "shows full JSON payload in nested details" do
+      expect(queue_show).to include("full_json_payload")
+    end
+
+    it "shows headers section when available" do
+      expect(queue_show).to include("headers_section")
+    end
+
+    it "includes retry and discard actions in expanded section" do
+      expect(queue_show).to include("retry_message_queue_path")
+      expect(queue_show).to include("discard_message_queue_path")
+    end
+  end
+end

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -183,10 +183,27 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(data_source.toggle_recurring_task(1)).to eq(:disabled)
     end
 
+    it "returns :enabled when toggling a disabled task" do
+      mock_record = double("RecurringTask")
+      allow(Pgbus::RecurringTask).to receive(:find_by).with(id: 2).and_return(mock_record)
+      allow(mock_record).to receive(:enabled).and_return(false, true)
+      allow(mock_record).to receive(:update!).with(enabled: true).and_return(true)
+
+      expect(data_source.toggle_recurring_task(2)).to eq(:enabled)
+    end
+
     it "returns nil when task not found" do
       allow(Pgbus::RecurringTask).to receive(:find_by).with(id: 99).and_return(nil)
 
       expect(data_source.toggle_recurring_task(99)).to be_nil
+    end
+
+    it "returns nil when update fails" do
+      mock_record = double("RecurringTask", enabled: true)
+      allow(Pgbus::RecurringTask).to receive(:find_by).with(id: 3).and_return(mock_record)
+      allow(mock_record).to receive(:update!).and_raise(StandardError, "boom")
+
+      expect(data_source.toggle_recurring_task(3)).to be_nil
     end
   end
 

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -174,18 +174,19 @@ RSpec.describe Pgbus::Web::DataSource do
   end
 
   describe "#toggle_recurring_task" do
-    it "toggles the enabled state" do
-      mock_record = double("RecurringTask", enabled: true)
+    it "returns :disabled when toggling an enabled task" do
+      mock_record = double("RecurringTask")
       allow(Pgbus::RecurringTask).to receive(:find_by).with(id: 1).and_return(mock_record)
+      allow(mock_record).to receive(:enabled).and_return(true, false)
       allow(mock_record).to receive(:update!).with(enabled: false).and_return(true)
 
-      expect(data_source.toggle_recurring_task(1)).to be true
+      expect(data_source.toggle_recurring_task(1)).to eq(:disabled)
     end
 
-    it "returns false when task not found" do
+    it "returns nil when task not found" do
       allow(Pgbus::RecurringTask).to receive(:find_by).with(id: 99).and_return(nil)
 
-      expect(data_source.toggle_recurring_task(99)).to be false
+      expect(data_source.toggle_recurring_task(99)).to be_nil
     end
   end
 

--- a/spec/system/queues_spec.rb
+++ b/spec/system/queues_spec.rb
@@ -87,20 +87,26 @@ RSpec.describe "Queues", type: :system do
       expect(page).to have_text("Queue is empty")
     end
 
-    it "displays messages when present" do
+    it "displays messages with expandable details" do
       @stub_data_source.jobs_list = [
         { msg_id: 42, queue_name: "pgbus_default", read_ct: 3,
           enqueued_at: Time.now.utc.iso8601, vt: Time.now.utc.iso8601,
-          message: '{"job_class":"TestJob"}' }
+          message: '{"job_class":"TestJob","job_id":"abc-123","arguments":["x"],"priority":2}' }
       ]
 
       visit "/pgbus/queues/pgbus_default"
 
       expect(page).to have_text("42")
-      expect(page).to have_text("3") # read_ct
+      expect(page).to have_text("TestJob")
+
+      # Expand details
+      find("details.group summary").click
+      expect(page).to have_text("Job ID:")
+      expect(page).to have_text("abc-123")
+      expect(page).to have_text("Arguments")
     end
 
-    it "shows discard and retry buttons for each message" do
+    it "shows discard and retry buttons inside expanded row" do
       @stub_data_source.jobs_list = [
         { msg_id: 42, queue_name: "pgbus_default", read_ct: 0,
           enqueued_at: Time.now.utc.iso8601, vt: Time.now.utc.iso8601,
@@ -108,6 +114,9 @@ RSpec.describe "Queues", type: :system do
       ]
 
       visit "/pgbus/queues/pgbus_default"
+
+      # Expand details to reveal action buttons
+      find("details.group summary").click
 
       expect(page).to have_button("Discard", count: 1)
       expect(page).to have_button("Retry", count: 1)
@@ -177,20 +186,22 @@ RSpec.describe "Queues", type: :system do
         ]
       end
 
-      it "discard message: confirm and shows toast" do
+      it "discard message: expand, confirm and shows toast" do
         visit "/pgbus/queues/pgbus_default"
 
-        within("tr", text: "42") { click_button "Discard" }
+        find("details.group summary").click
+        click_button "Discard"
         accept_confirm_dialog
 
         expect(page).to have_toast("Message discarded")
         expect(@stub_data_source).to be_called(:discard_job)
       end
 
-      it "retry message: confirm and shows toast" do
+      it "retry message: expand, confirm and shows toast" do
         visit "/pgbus/queues/pgbus_default"
 
-        within("tr", text: "42") { click_button "Retry" }
+        find("details.group summary").click
+        click_button "Retry"
         accept_confirm_dialog
 
         expect(page).to have_toast("Message visibility reset")

--- a/spec/system/recurring_tasks_spec.rb
+++ b/spec/system/recurring_tasks_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe "Recurring Tasks", type: :system do
+  let(:tasks) do
+    [
+      { id: 1, key: "capture_stats", class_name: "CaptureStatsJob", command: nil,
+        schedule: "*/5 * * * *", human_schedule: "Every 5 minutes",
+        queue_name: "default", priority: 2, description: "Capture usage stats",
+        enabled: true, static: true,
+        next_run_at: 5.minutes.from_now, last_run_at: 2.minutes.ago,
+        created_at: 1.day.ago, updated_at: 1.hour.ago },
+      { id: 2, key: "cleanup_old", class_name: "CleanupJob", command: nil,
+        schedule: "0 3 * * *", human_schedule: "Daily at 3:00 AM",
+        queue_name: "maintenance", priority: 5, description: nil,
+        enabled: false, static: false,
+        next_run_at: nil, last_run_at: 1.day.ago,
+        created_at: 2.days.ago, updated_at: 2.days.ago }
+    ]
+  end
+
+  before do
+    @stub_data_source.recurring_tasks_list = tasks
+  end
+
+  describe "index page" do
+    it "lists all recurring tasks" do
+      visit "/pgbus/recurring_tasks"
+
+      expect(page).to have_css("h1", text: "Recurring Tasks")
+      expect(page).to have_text("capture_stats")
+      expect(page).to have_text("cleanup_old")
+      expect(page).to have_text("2 tasks configured")
+    end
+
+    it "shows task details in table" do
+      visit "/pgbus/recurring_tasks"
+
+      expect(page).to have_text("CaptureStatsJob")
+      expect(page).to have_text("*/5 * * * *")
+      expect(page).to have_text("Every 5 minutes")
+    end
+  end
+
+  describe "task link navigation" do
+    it "navigates to show page without Content missing" do
+      visit "/pgbus/recurring_tasks"
+
+      click_link "capture_stats"
+
+      expect(page).to have_css("h1", text: "capture_stats")
+      expect(page).to have_text("CaptureStatsJob")
+      expect(page).to have_text("Configuration")
+      expect(page).not_to have_text("Content missing")
+    end
+  end
+
+  describe "show page" do
+    it "displays task configuration" do
+      visit "/pgbus/recurring_tasks/1"
+
+      expect(page).to have_css("h1", text: "capture_stats")
+      expect(page).to have_text("*/5 * * * *")
+      expect(page).to have_text("CaptureStatsJob")
+      expect(page).to have_text("Capture usage stats")
+    end
+
+    it "shows enable/disable and run now buttons" do
+      visit "/pgbus/recurring_tasks/1"
+
+      expect(page).to have_button("Disable")
+      expect(page).to have_button("Run Now")
+    end
+
+    it "shows enable button for disabled tasks" do
+      visit "/pgbus/recurring_tasks/2"
+
+      expect(page).to have_button("Enable")
+      expect(page).not_to have_button("Run Now")
+    end
+  end
+end

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -5,7 +5,7 @@ module Pgbus
     class StubDataSource
       attr_accessor :stats, :queues, :processes_list, :failed_events_list,
                     :dlq_messages_list, :events_list, :subscribers_list, :jobs_list,
-                    :paused_queues, :locks_list
+                    :paused_queues, :locks_list, :recurring_tasks_list
       attr_reader :calls
 
       def initialize
@@ -19,6 +19,7 @@ module Pgbus
         @jobs_list = []
         @paused_queues = []
         @locks_list = []
+        @recurring_tasks_list = []
         @calls = Hash.new { |h, k| h[k] = [] }
       end
 
@@ -38,6 +39,14 @@ module Pgbus
       def jobs(queue_name: nil, page: 1, per_page: 25) = @jobs_list
       def job_locks = @locks_list
       def queue_paused?(name) = @paused_queues.include?(name)
+      def recurring_tasks = @recurring_tasks_list
+
+      def recurring_task(id)
+        @recurring_tasks_list.find { |t| t[:id].to_s == id.to_s }&.merge(executions: [])
+      end
+
+      def toggle_recurring_task(id) = record(:toggle_recurring_task, id)
+      def enqueue_recurring_task_now(id) = record(:enqueue_recurring_task_now, id)
 
       def purge_queue(name)          = record(:purge_queue, name)
       def drop_queue(name)           = record(:drop_queue, name)

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -45,7 +45,15 @@ module Pgbus
         @recurring_tasks_list.find { |t| t[:id].to_s == id.to_s }&.merge(executions: [])
       end
 
-      def toggle_recurring_task(id) = record(:toggle_recurring_task, id)
+      def toggle_recurring_task(id)
+        task = @recurring_tasks_list.find { |t| t[:id].to_s == id.to_s }
+        return nil unless task
+
+        task[:enabled] = !task[:enabled]
+        record(:toggle_recurring_task, id)
+        task[:enabled] ? :enabled : :disabled
+      end
+
       def enqueue_recurring_task_now(id) = record(:enqueue_recurring_task_now, id)
 
       def purge_queue(name)          = record(:purge_queue, name)


### PR DESCRIPTION
## Summary
- **Auto-refresh pauses** when any checkbox is checked or any job detail row is expanded — prevents the page from resetting interactive state
- **Recurring tasks links** now navigate correctly (was showing "Content missing" because links inside turbo-frame lacked `data-turbo-frame="_top"`)
- **Queue show page** now has expandable `<details>/<summary>` rows matching the Jobs and DLQ pages — showing Job ID, Arguments, Metadata, full JSON payload, Headers, and Retry/Discard actions
- **`rake dummy:server`** boots the dummy app with rich stub data on port 3003 for manual dashboard QA
- **System specs** for recurring tasks navigation and updated queue show tests
- **i18n** keys for new queue show details in all 12 locales

## Test plan
- [x] 92 system + unit tests pass (83 system + 9 interaction)
- [x] `bundle exec rubocop` clean (213 files, 0 offenses)
- [ ] Manual: `rake dummy:server` → open http://localhost:3003/pgbus
- [ ] Manual: Expand a job row on Queue show → verify details visible
- [ ] Manual: Click recurring task name → verify show page loads (no "Content missing")
- [ ] Manual: Check a checkbox or expand a row → verify auto-refresh pauses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expandable queue message details showing job class, job ID, arguments, metadata, optional headers, and full payload.

* **Bug Fixes / UX**
  * Auto-refresh now pauses when users interact (expanded details or bulk selections) to avoid disruptions.
  * Recurring task links use top-level navigation; toggle notices reflect enabled/disabled state.

* **Localization**
  * Updated queue/recurring task labels across multiple languages.

* **Chores / Tests**
  * Added local dummy server, stub data provider, and extensive dashboard interaction & system tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->