### PR TITLE
feat(executor): record job failures in pgbus_failed_events for dashboard visibility

### DIFF
--- a/lib/generators/pgbus/add_failed_events_index_generator.rb
+++ b/lib/generators/pgbus/add_failed_events_index_generator.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class AddFailedEventsIndexGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Add unique index on pgbus_failed_events (queue_name, msg_id) for failure tracking upserts"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
+      def create_migration_file
+        if separate_database?
+          migration_template "add_failed_events_unique_index.rb.erb",
+                             "db/pgbus_migrate/add_pgbus_failed_events_unique_index.rb"
+        else
+          migration_template "add_failed_events_unique_index.rb.erb",
+                             "db/migrate/add_pgbus_failed_events_unique_index.rb"
+        end
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus failed events unique index added!", :green
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
+        say "  2. Failed jobs will now be tracked in the dashboard"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/templates/add_failed_events_unique_index.rb.erb
+++ b/lib/generators/pgbus/templates/add_failed_events_unique_index.rb.erb
@@ -1,0 +1,7 @@
+class AddPgbusFailedEventsUniqueIndex < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_index :pgbus_failed_events, [:queue_name, :msg_id],
+      unique: true, name: "idx_pgbus_failed_events_queue_msg",
+      if_not_exists: true
+  end
+end

--- a/lib/generators/pgbus/templates/migration.rb.erb
+++ b/lib/generators/pgbus/templates/migration.rb.erb
@@ -65,6 +65,8 @@ class CreatePgbusTables < ActiveRecord::Migration<%= migration_version %>
 
     add_index :pgbus_failed_events, :queue_name, name: "idx_pgbus_failed_events_queue"
     add_index :pgbus_failed_events, :failed_at, name: "idx_pgbus_failed_events_time"
+    add_index :pgbus_failed_events, [:queue_name, :msg_id],
+      unique: true, name: "idx_pgbus_failed_events_queue_msg"
 
     # Concurrency semaphores (counting locks for job concurrency limits)
     create_table :pgbus_semaphores do |t|

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -20,6 +20,7 @@ module Pgbus
 
         if read_count > config.max_retries
           handle_dead_letter(message, queue_name, payload, source_queue: source_queue)
+          FailedEventRecorder.clear!(queue_name: queue_name, msg_id: message.msg_id.to_i)
           signal_concurrency(payload)
           signal_batch_discarded(payload)
           Uniqueness.release_lock(Uniqueness.extract_key(payload))
@@ -54,6 +55,7 @@ module Pgbus
           job = ::ActiveJob::Base.deserialize(payload)
           execute_job(job)
           archive_from(queue_name, message.msg_id.to_i, source_queue: source_queue)
+          FailedEventRecorder.clear!(queue_name: queue_name, msg_id: message.msg_id.to_i)
           job_succeeded = true
         end
 
@@ -61,7 +63,7 @@ module Pgbus
         record_stat(payload, queue_name, "success", execution_start, message: message)
         :success
       rescue StandardError => e
-        handle_failure(message, queue_name, e)
+        handle_failure(message, queue_name, e, payload: payload)
         instrument("pgbus.job_failed", queue: queue_name, job_class: payload&.dig("job_class"), error: e.class.name)
         record_stat(payload, queue_name, "failed", execution_start, message: message)
         # Don't signal concurrency on transient failure — the job will be retried.
@@ -143,13 +145,22 @@ module Pgbus
         [((Time.now.utc - enqueued_at) * 1000).round, 0].max
       end
 
-      def handle_failure(_message, _queue_name, error)
+      def handle_failure(message, queue_name, error, payload: nil)
         Pgbus.logger.error { "[Pgbus] Job failed: #{error.class}: #{error.message}" }
         Pgbus.logger.debug { error.backtrace&.join("\n") }
 
+        # Record failure for dashboard visibility.
         # Message visibility timeout will expire and it becomes available again.
         # read_ct tracks delivery attempts — when it exceeds max_retries,
         # the next read will route to DLQ.
+        FailedEventRecorder.record!(
+          queue_name: queue_name,
+          msg_id: message.msg_id.to_i,
+          payload: payload || message.message,
+          headers: message.respond_to?(:headers) ? message.headers : nil,
+          error: error,
+          retry_count: [message.read_ct.to_i - 1, 0].max
+        )
       end
 
       def instrument(event_name, payload = {})

--- a/lib/pgbus/failed_event_recorder.rb
+++ b/lib/pgbus/failed_event_recorder.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Pgbus
+  # Records job failures to pgbus_failed_events for dashboard visibility.
+  # Uses upsert (INSERT ON CONFLICT UPDATE) keyed on (queue_name, msg_id)
+  # so each message has at most one failed_event row tracking its latest error.
+  class FailedEventRecorder
+    class << self
+      def record!(queue_name:, msg_id:, payload:, headers:, error:, retry_count:)
+        connection.exec_query(
+          <<~SQL.squish,
+            INSERT INTO pgbus_failed_events
+              (queue_name, msg_id, payload, headers, error_class, error_message, backtrace, retry_count, failed_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CURRENT_TIMESTAMP)
+            ON CONFLICT (queue_name, msg_id) DO UPDATE SET
+              error_class = EXCLUDED.error_class,
+              error_message = EXCLUDED.error_message,
+              backtrace = EXCLUDED.backtrace,
+              retry_count = EXCLUDED.retry_count,
+              failed_at = EXCLUDED.failed_at
+          SQL
+          "FailedEvent Record",
+          [
+            queue_name,
+            msg_id.to_i,
+            payload.is_a?(String) ? payload : JSON.generate(payload),
+            headers.is_a?(String) ? headers : headers&.then { |h| JSON.generate(h) },
+            error.class.name,
+            error.message.to_s.truncate(10_000),
+            error.backtrace&.first(30)&.join("\n"),
+            retry_count
+          ]
+        )
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus] Failed to record failed event: #{e.message}" }
+      end
+
+      def clear!(queue_name:, msg_id:)
+        connection.exec_delete(
+          "DELETE FROM pgbus_failed_events WHERE queue_name = $1 AND msg_id = $2",
+          "FailedEvent Clear",
+          [queue_name, msg_id.to_i]
+        )
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus] Failed to clear failed event: #{e.message}" }
+      end
+
+      private
+
+      def connection
+        if defined?(BusRecord) && BusRecord.connected?
+          BusRecord.connection
+        else
+          ActiveRecord::Base.connection
+        end
+      end
+    end
+  end
+end

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Pgbus::ActiveJob::Executor do
     # Stub stat recording
     stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
     allow(Pgbus::JobStat).to receive_messages(record!: nil, table_exists?: true)
+    # Stub failure tracking
+    allow(Pgbus::FailedEventRecorder).to receive_messages(record!: nil, clear!: nil)
   end
 
   describe "#execute" do
@@ -41,6 +43,14 @@ RSpec.describe Pgbus::ActiveJob::Executor do
                                                                                                        job_class: "TestJob")
         expect(result).to eq(:success)
       end
+
+      it "clears any prior failed event record" do
+        executor.execute(message, queue_name)
+
+        expect(Pgbus::FailedEventRecorder).to have_received(:clear!).with(
+          queue_name: queue_name, msg_id: 5
+        )
+      end
     end
 
     context "when read_ct exceeds max_retries (DLQ routing)" do
@@ -52,6 +62,14 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         expect(mock_client).to have_received(:move_to_dead_letter).with(queue_name, message)
         expect(ActiveJob::Base).not_to have_received(:deserialize)
         expect(result).to eq(:dead_lettered)
+      end
+
+      it "clears any prior failed event record" do
+        executor.execute(message, queue_name)
+
+        expect(Pgbus::FailedEventRecorder).to have_received(:clear!).with(
+          queue_name: queue_name, msg_id: 7
+        )
       end
     end
 
@@ -71,6 +89,19 @@ RSpec.describe Pgbus::ActiveJob::Executor do
           hash_including(queue: queue_name, job_class: "TestJob", error: "StandardError")
         )
         expect(result).to eq(:failed)
+      end
+
+      it "records the failure in pgbus_failed_events" do
+        executor.execute(message, queue_name)
+
+        expect(Pgbus::FailedEventRecorder).to have_received(:record!).with(
+          queue_name: queue_name,
+          msg_id: 3,
+          payload: job_payload,
+          headers: nil,
+          error: error,
+          retry_count: 0
+        )
       end
     end
 

--- a/spec/pgbus/failed_event_recorder_spec.rb
+++ b/spec/pgbus/failed_event_recorder_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::FailedEventRecorder do
+  let(:mock_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+
+  before do
+    allow(ActiveRecord::Base).to receive(:connection).and_return(mock_connection)
+  end
+
+  describe ".record!" do
+    let(:error) { StandardError.new("API timeout") }
+
+    before do
+      error.set_backtrace(["app/jobs/test_job.rb:10:in `perform'", "pgbus/executor.rb:55"])
+    end
+
+    it "inserts a failed event with error details" do
+      allow(mock_connection).to receive(:exec_query)
+
+      described_class.record!(
+        queue_name: "default",
+        msg_id: 42,
+        payload: { "job_class" => "TestJob" },
+        headers: { "pgbus.recurring_key" => "test" },
+        error: error,
+        retry_count: 2
+      )
+
+      expect(mock_connection).to have_received(:exec_query).with(
+        a_string_matching(/INSERT INTO pgbus_failed_events/),
+        "FailedEvent Record",
+        array_including("default", 42)
+      )
+    end
+
+    it "does not raise on database errors" do
+      allow(mock_connection).to receive(:exec_query).and_raise(ActiveRecord::StatementInvalid, "table missing")
+
+      expect do
+        described_class.record!(
+          queue_name: "default", msg_id: 1, payload: "{}", headers: nil,
+          error: error, retry_count: 0
+        )
+      end.not_to raise_error
+    end
+
+    it "truncates long error messages" do
+      long_error = StandardError.new("x" * 20_000)
+      long_error.set_backtrace([])
+      allow(mock_connection).to receive(:exec_query)
+
+      described_class.record!(
+        queue_name: "default", msg_id: 1, payload: "{}", headers: nil,
+        error: long_error, retry_count: 0
+      )
+
+      expect(mock_connection).to have_received(:exec_query).with(
+        anything, anything,
+        a_collection_including(a_string_matching(/\A.{1,10003}\z/))
+      )
+    end
+  end
+
+  describe ".clear!" do
+    it "deletes the failed event for the given queue and msg_id" do
+      allow(mock_connection).to receive(:exec_delete)
+
+      described_class.clear!(queue_name: "default", msg_id: 42)
+
+      expect(mock_connection).to have_received(:exec_delete).with(
+        a_string_matching(/DELETE FROM pgbus_failed_events/),
+        "FailedEvent Clear",
+        ["default", 42]
+      )
+    end
+
+    it "does not raise on database errors" do
+      allow(mock_connection).to receive(:exec_delete).and_raise(ActiveRecord::StatementInvalid, "table missing")
+
+      expect do
+        described_class.clear!(queue_name: "default", msg_id: 42)
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Problem**: The `pgbus_failed_events` table was created by the install migration but **never written to** by the executor. When jobs failed (e.g. API timeouts from PlanetScale), they stayed in "Enqueued Jobs" with no error info visible. The "Failed Jobs" dashboard section always showed "No failed jobs".
- **Fix**: The executor now records each failure via `FailedEventRecorder.record!` (upsert on `queue_name + msg_id`), and clears the record when the job succeeds or moves to DLQ.
- **Result**: Failed jobs immediately appear in the "Failed Jobs" dashboard section with error class, message, backtrace, and retry count. Retry/Discard actions (already built in the dashboard) now work.

### How it works

```
Job fails → FailedEventRecorder.record!(error details) → visible in "Failed Jobs"
Job succeeds → FailedEventRecorder.clear! → removed from "Failed Jobs"  
Job → DLQ → FailedEventRecorder.clear! → tracked in DLQ instead
```

### For existing installs

```bash
rails generate pgbus:add_failed_events_index
rails db:migrate
```

## Test plan

- [x] Executor records failure with error_class, error_message, backtrace, retry_count
- [x] Executor clears failed_event on job success
- [x] Executor clears failed_event on DLQ routing
- [x] FailedEventRecorder gracefully handles DB errors (no crash)
- [x] FailedEventRecorder truncates long error messages
- [x] 757 unit tests pass, 0 failures
- [x] Rubocop clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job failure event tracking and recording system to capture error details, retry counts, and backtrace information.
  * Added new Rails generator to create database migrations for failure event infrastructure.

* **Tests**
  * Added comprehensive test coverage for failure event recording and job executor integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->