### PR TITLE
fix(recurring): fail closed when uniqueness lock check errors

### DIFF
--- a/lib/pgbus/recurring/schedule.rb
+++ b/lib/pgbus/recurring/schedule.rb
@@ -151,8 +151,11 @@ module Pgbus
           :already_locked
         end
       rescue StandardError => e
-        Pgbus.logger.warn { "[Pgbus] Uniqueness lock failed for #{task.key}: #{e.message}" }
-        nil # Fail open — allow enqueue if lock check errors
+        Pgbus.logger.error do
+          "[Pgbus] Uniqueness lock check failed for #{task.key}: #{e.class}: #{e.message} — " \
+            "skipping enqueue to prevent duplicates"
+        end
+        :already_locked # Fail closed — skip enqueue when lock check errors
       end
 
       # Release a uniqueness lock. Safe to call with nil or :already_locked.

--- a/spec/pgbus/recurring/schedule_dedup_spec.rb
+++ b/spec/pgbus/recurring/schedule_dedup_spec.rb
@@ -154,5 +154,16 @@ RSpec.describe Pgbus::Recurring::Schedule do # deduplication
       expect(mock_client).not_to have_received(:send_message)
       expect(Pgbus::UniquenessKey).not_to have_received(:release!)
     end
+
+    it "skips enqueue when lock acquisition raises (fail closed)" do
+      allow(Pgbus::UniquenessKey).to receive(:acquire!)
+        .and_raise(ActiveRecord::StatementInvalid, "PG::UndefinedTable")
+
+      schedule = described_class.new(config: config)
+      task = schedule.tasks.first
+      schedule.enqueue_task(task, run_at: Time.utc(2026, 4, 6, 7, 5, 0))
+
+      expect(mock_client).not_to have_received(:send_message)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **Problem**: When `acquire_uniqueness_lock` encounters ANY error during lock acquisition (table missing, connection issue, schema mismatch), it catches `StandardError` and returns `nil` — **failing open** and allowing duplicate enqueue. This is the most likely cause of duplicate `FetchTransactionsJob` entries despite `ensures_uniqueness strategy: :until_executed` being configured.
- **Fix**: Changed to **fail closed** — return `:already_locked` on error, which skips the enqueue. Also upgraded log level from `warn` to `error` for visibility.

### Before (fail open)
```ruby
rescue StandardError => e
  Pgbus.logger.warn { "..." }
  nil # Fail open — allow enqueue if lock check errors
```

### After (fail closed)
```ruby
rescue StandardError => e
  Pgbus.logger.error { "..." }
  :already_locked # Fail closed — skip enqueue when lock check errors
```

### Debugging tip
After deploying, check logs for `"Uniqueness lock check failed"` — if you see these, it confirms the lock check was erroring and causing duplicates. The error message will include the exception class and message to identify the root cause.

## Test plan

- [x] New test: skips enqueue when lock acquisition raises (fail closed)
- [x] Existing tests: lock held → skip, lock acquired → enqueue, AlreadyRecorded → release
- [x] 758 unit tests pass, 0 failures
- [x] Rubocop clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in recurring task scheduling: when lock acquisition fails unexpectedly, the system now prevents task enqueuing and logs errors at error level for better visibility into operational issues. Previously, the system would proceed with enqueuing despite errors and only log warnings, potentially masking problems in background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->