### PR TITLE
fix(connection): use dedicated PG connections instead of sharing AR raw_connection

### DIFF
--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -202,14 +202,48 @@ module Pgbus
       elsif connection_params
         connection_params
       elsif defined?(ActiveRecord::Base)
-        if connects_to
-          -> { Pgbus::BusRecord.connection.raw_connection }
-        else
-          -> { ActiveRecord::Base.connection.raw_connection }
-        end
+        # Extract connection config from ActiveRecord so pgmq-ruby creates its
+        # own dedicated PG connections. Sharing AR's raw_connection via a Proc
+        # is NOT thread-safe: the ConnectionPool caches the PG::Connection from
+        # whichever thread first called the Proc, then hands that same object to
+        # other threads — causing nil results, segfaults, and data corruption
+        # when AR and PGMQ issue concurrent queries on the same connection.
+        extract_ar_connection_hash
       else
         raise ConfigurationError, "No database connection configured. " \
                                   "Set Pgbus.configuration.database_url, connection_params, or use with Rails."
+      end
+    end
+
+    private
+
+    def extract_ar_connection_hash
+      base = connects_to ? Pgbus::BusRecord : ActiveRecord::Base
+      db_config = base.connection_db_config
+
+      # Rails 7.1+ db_config.configuration_hash returns the full config
+      config_hash = db_config.configuration_hash
+
+      {
+        host: config_hash[:host] || "localhost",
+        port: (config_hash[:port] || 5432).to_i,
+        dbname: config_hash[:database],
+        user: config_hash[:username],
+        password: config_hash[:password]
+      }.compact
+    rescue StandardError => e
+      # Fallback to Proc path if AR config extraction fails (e.g., adapter
+      # doesn't expose standard config keys). Log a warning since this path
+      # is not thread-safe.
+      Pgbus.logger.warn do
+        "[Pgbus] Could not extract AR connection config (#{e.class}: #{e.message}). " \
+          "Falling back to shared raw_connection — this is NOT thread-safe with multiple workers. " \
+          "Set Pgbus.configuration.database_url explicitly for thread-safe operation."
+      end
+      if connects_to
+        -> { Pgbus::BusRecord.connection.raw_connection }
+      else
+        -> { ActiveRecord::Base.connection.raw_connection }
       end
     end
   end

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -715,7 +715,7 @@ RSpec.describe Pgbus::Client do
       )
     end
 
-    it "forces pool_size=1 when connection_options returns a Proc (shared connection)" do
+    it "forces pool_size=1 when connection_options falls back to Proc (shared connection)" do
       lambda_config = Pgbus::Configuration.new.tap do |c|
         c.database_url = nil
         c.connection_params = nil
@@ -723,10 +723,12 @@ RSpec.describe Pgbus::Client do
         c.queue_prefix = "pgbus_test"
       end
 
-      # Simulate the Rails path where connection_options returns a lambda
+      # Simulate the Rails path where AR config extraction fails, falling back to Proc
       raw_conn = double("PG::Connection")
       ar_connection = double("AR::ConnectionAdapter", raw_connection: raw_conn)
-      stub_const("ActiveRecord::Base", double("AR::Base", connection: ar_connection))
+      ar_base = double("AR::Base", connection: ar_connection)
+      allow(ar_base).to receive(:connection_db_config).and_raise(StandardError, "no config")
+      stub_const("ActiveRecord::Base", ar_base)
 
       allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
       described_class.new(lambda_config)
@@ -747,7 +749,7 @@ RSpec.describe Pgbus::Client do
       expect(client.instance_variable_get(:@pgmq_mutex)).to be_nil
     end
 
-    it "uses mutex synchronization for shared (Proc) connections" do
+    it "uses mutex synchronization when falling back to shared (Proc) connections" do
       lambda_config = Pgbus::Configuration.new.tap do |c|
         c.database_url = nil
         c.connection_params = nil
@@ -757,7 +759,9 @@ RSpec.describe Pgbus::Client do
 
       raw_conn = double("PG::Connection")
       ar_connection = double("AR::ConnectionAdapter", raw_connection: raw_conn)
-      stub_const("ActiveRecord::Base", double("AR::Base", connection: ar_connection))
+      ar_base = double("AR::Base", connection: ar_connection)
+      allow(ar_base).to receive(:connection_db_config).and_raise(StandardError, "no config")
+      stub_const("ActiveRecord::Base", ar_base)
 
       allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
       shared_client = described_class.new(lambda_config)

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -240,8 +240,10 @@ RSpec.describe Pgbus::Configuration do
       end
 
       it "falls back to Proc with a warning" do
+        allow(Pgbus.logger).to receive(:warn)
         result = config.connection_options
         expect(result).to be_a(Proc)
+        expect(Pgbus.logger).to have_received(:warn)
       end
     end
   end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -190,35 +190,58 @@ RSpec.describe Pgbus::Configuration do
     end
 
     context "with connects_to configured" do
-      let(:raw_connection) { double("raw_connection") }
-      let(:ar_connection) { double("ar_connection", raw_connection: raw_connection) }
+      let(:db_config) do
+        double("db_config", configuration_hash: {
+                 host: "pgbus-host", port: 5433, database: "pgbus_db",
+                 username: "pgbus_user", password: "secret"
+               })
+      end
 
       before do
         config.connects_to = { database: { writing: :pgbus } }
         stub_const("Pgbus::BusRecord", Class.new)
-        allow(Pgbus::BusRecord).to receive(:connection).and_return(ar_connection)
+        allow(Pgbus::BusRecord).to receive(:connection_db_config).and_return(db_config)
       end
 
-      it "returns a lambda that uses Pgbus::BusRecord connection" do
+      it "returns a connection hash extracted from BusRecord config" do
         result = config.connection_options
-        expect(result).to be_a(Proc)
-        expect(result.call).to eq(raw_connection)
+        expect(result).to be_a(Hash)
+        expect(result[:host]).to eq("pgbus-host")
+        expect(result[:dbname]).to eq("pgbus_db")
+        expect(result[:user]).to eq("pgbus_user")
       end
     end
 
     context "without connects_to" do
-      let(:raw_connection) { double("raw_connection") }
-      let(:ar_connection) { double("ar_connection", raw_connection: raw_connection) }
-
-      before do
-        stub_const("ActiveRecord::Base", Class.new)
-        allow(ActiveRecord::Base).to receive(:connection).and_return(ar_connection)
+      let(:db_config) do
+        double("db_config", configuration_hash: {
+                 host: "localhost", port: 5432, database: "myapp_dev",
+                 username: "dev_user", password: nil
+               })
       end
 
-      it "returns a lambda that uses ActiveRecord::Base connection" do
+      before do
+        allow(ActiveRecord::Base).to receive(:connection_db_config).and_return(db_config)
+      end
+
+      it "returns a connection hash extracted from ActiveRecord config" do
+        result = config.connection_options
+        expect(result).to be_a(Hash)
+        expect(result[:host]).to eq("localhost")
+        expect(result[:dbname]).to eq("myapp_dev")
+        expect(result[:user]).to eq("dev_user")
+      end
+    end
+
+    context "when AR config extraction fails" do
+      before do
+        allow(ActiveRecord::Base).to receive(:connection_db_config)
+          .and_raise(StandardError, "no connection established")
+      end
+
+      it "falls back to Proc with a warning" do
         result = config.connection_options
         expect(result).to be_a(Proc)
-        expect(result.call).to eq(raw_connection)
       end
     end
   end


### PR DESCRIPTION
## Summary

- **Problem**: `NoMethodError: undefined method 'ntuples' for nil` when archiving messages. The ConnectionPool cached one thread's PG::Connection and shared it across all worker threads, causing libpq result corruption.
- **Fix**: Extract host/port/dbname/user/password from AR config and pass as Hash so pgmq-ruby creates dedicated PG connections per pool slot.
- **Fallback**: If AR config extraction fails, falls back to Proc path with warning.

## Test plan

- [x] Connection options returns Hash (not Proc) when AR is available
- [x] Falls back to Proc with warning when AR config extraction fails
- [x] 759 unit tests pass, 0 failures
- [x] Rubocop clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved database connection resolution to return structured connection options and gracefully fall back with a warning when extraction fails.
* **Bug Fixes**
  * More reliable connection behavior and clearer fallback handling to avoid disruption.
* **Tests**
  * Updated specs to validate the new resolution behavior and the error/fallback path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->