### PR TITLE
fix(uniqueness): auto-serialize GlobalID objects in uniqueness keys

### DIFF
--- a/lib/pgbus/uniqueness.rb
+++ b/lib/pgbus/uniqueness.rb
@@ -81,11 +81,16 @@ module Pgbus
 
         args = active_job.arguments
         last = args.last
-        if last.is_a?(Hash) && last.each_key.all?(Symbol)
-          config[:key].call(*args[...-1], **last)
-        else
-          config[:key].call(*args)
-        end
+        key = if last.is_a?(Hash) && last.each_key.all?(Symbol)
+                config[:key].call(*args[...-1], **last)
+              else
+                config[:key].call(*args)
+              end
+
+        # Automatically serialize GlobalID-compatible objects (e.g. ActiveRecord models)
+        # so users can pass model instances directly without manual .to_global_id.to_s
+        key = key.to_global_id.to_s if key.respond_to?(:to_global_id)
+        key
       end
 
       def inject_metadata(active_job, payload_hash)

--- a/spec/pgbus/uniqueness_spec.rb
+++ b/spec/pgbus/uniqueness_spec.rb
@@ -85,6 +85,31 @@ RSpec.describe Pgbus::Uniqueness do
 
       expect(described_class.resolve_key(job)).to eq("MyUniqueJob")
     end
+
+    it "automatically serializes GlobalID-compatible objects returned by the key lambda" do
+      global_id = instance_double(GlobalID, to_s: "gid://app/Order/42")
+      record = double("Order", to_global_id: global_id)
+
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness key: ->(order:, **) { order }
+      end
+      job = job_class.new(order: record)
+
+      expect(described_class.resolve_key(job)).to eq("gid://app/Order/42")
+    end
+
+    it "does not modify key values that are not GlobalID-compatible" do
+      job_class = Class.new(ActiveJob::Base) do
+        include Pgbus::Uniqueness
+
+        ensures_uniqueness key: ->(id) { "order-#{id}" }
+      end
+      job = job_class.new(42)
+
+      expect(described_class.resolve_key(job)).to eq("order-42")
+    end
   end
 
   describe ".inject_metadata" do


### PR DESCRIPTION
## Summary

- Automatically serialize GlobalID-compatible objects (e.g. ActiveRecord models) returned by uniqueness key lambdas
- Prevents `TypeError: can't cast <ModelName>` when users pass model instances directly in their key lambdas
- Aligns with ActiveJob's own GlobalID serialization convention

## Problem

When a uniqueness key lambda returns an ActiveRecord model instance:

```ruby
ensures_uniqueness key: ->(card_topup:, **) { card_topup }
```

pgbus passes the object directly as a SQL bind parameter in `UniquenessKey.acquire!`. PostgreSQL's quoting layer can't handle arbitrary Ruby objects, causing:

```
TypeError: can't cast CardTopup
```

## Solution

After the key lambda executes in `resolve_key()`, check if the return value responds to `to_global_id` and convert it to a GlobalID URI string (e.g. `gid://app/CardTopup/abc-123`). This is a 2-line change.

## Test plan

- [x] New spec: GlobalID-compatible objects are serialized to `gid://` URIs
- [x] New spec: plain string/integer keys pass through unchanged
- [x] All 16 existing uniqueness specs pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced uniqueness key serialization to properly handle GlobalID-compatible objects, ensuring consistent string representation and improved reliability of job uniqueness tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->