### PR TITLE
fix(dashboard): discard/retry of failed events must touch the queue message

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,6 +206,8 @@ jobs:
                 ON pgbus_failed_events (queue_name);
               CREATE INDEX IF NOT EXISTS idx_pgbus_failed_events_time
                 ON pgbus_failed_events (failed_at);
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_pgbus_failed_events_queue_msg
+                ON pgbus_failed_events (queue_name, msg_id);
             SQL
             conn.close
           "

--- a/lib/pgbus/failed_event_recorder.rb
+++ b/lib/pgbus/failed_event_recorder.rb
@@ -32,7 +32,14 @@ module Pgbus
           ]
         )
       rescue StandardError => e
-        Pgbus.logger.debug { "[Pgbus] Failed to record failed event: #{e.message}" }
+        # ERROR-level: silent loss of failure-tracking data defeats the
+        # purpose of the dashboard's "Failed Jobs" section. If recording
+        # fails, surface it loudly so the broken state can be diagnosed
+        # rather than silently masked.
+        Pgbus.logger.error do
+          "[Pgbus] Failed to record failed event for queue=#{queue_name} msg_id=#{msg_id}: " \
+            "#{e.class}: #{e.message}"
+        end
       end
 
       def clear!(queue_name:, msg_id:)
@@ -42,7 +49,13 @@ module Pgbus
           [queue_name, msg_id.to_i]
         )
       rescue StandardError => e
-        Pgbus.logger.debug { "[Pgbus] Failed to clear failed event: #{e.message}" }
+        # ERROR-level: a failed clear leaves a stale row in the dashboard
+        # AFTER the job actually succeeded — confusing and load-bearing
+        # for users debugging recurring duplicates.
+        Pgbus.logger.error do
+          "[Pgbus] Failed to clear failed event for queue=#{queue_name} msg_id=#{msg_id}: " \
+            "#{e.class}: #{e.message}"
+        end
       end
 
       private

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -177,16 +177,24 @@ module Pgbus
         event = failed_event(id)
         return false unless event
 
-        payload = JSON.parse(event["payload"])
-        headers = event["headers"]
-        headers = JSON.parse(headers) if headers.is_a?(String)
-
-        connection.transaction do
+        # Prefer resetting the existing message's visibility timeout to 0
+        # so the worker picks it up immediately. This avoids creating a
+        # duplicate (the original is still in the queue waiting for retry).
+        # Falls back to enqueueing a fresh copy only if the original is gone
+        # (e.g., already moved to DLQ).
+        msg_id = event["msg_id"]
+        if msg_id && message_exists_in_queue?(event["queue_name"], msg_id.to_i)
+          @client.set_visibility_timeout(event["queue_name"], msg_id.to_i, vt: 0)
+        else
+          payload = JSON.parse(event["payload"])
+          headers = event["headers"]
+          headers = JSON.parse(headers) if headers.is_a?(String)
           @client.send_message(event["queue_name"], payload, headers: headers)
-          connection.exec_delete(
-            "DELETE FROM pgbus_failed_events WHERE id = $1", "Pgbus Delete Failed Event", [id.to_i]
-          )
         end
+
+        connection.exec_delete(
+          "DELETE FROM pgbus_failed_events WHERE id = $1", "Pgbus Delete Failed Event", [id.to_i]
+        )
         true
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error retrying failed event #{id}: #{e.message}" }
@@ -195,7 +203,10 @@ module Pgbus
 
       def discard_failed_event(id)
         event = failed_event(id)
-        release_lock_for_payload(event["payload"]) if event
+        if event
+          release_lock_for_payload(event["payload"])
+          archive_failed_message(event)
+        end
 
         connection.exec_delete(
           "DELETE FROM pgbus_failed_events WHERE id = $1", "Pgbus Delete Failed Event", [id.to_i]
@@ -235,6 +246,7 @@ module Pgbus
 
       def discard_all_failed
         release_locks_for_failed_events
+        archive_all_failed_messages
 
         result = connection.execute("DELETE FROM pgbus_failed_events")
         result.cmd_tuples
@@ -847,6 +859,42 @@ module Pgbus
         UniquenessKey.where(lock_key: keys).delete_all if keys.any?
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error releasing locks for failed events: #{e.message}" }
+      end
+
+      # Archive the queue message a failed_event row points to. Idempotent —
+      # silently no-ops if the message no longer exists in the queue.
+      def archive_failed_message(event)
+        return unless event["queue_name"] && event["msg_id"]
+
+        @client.archive_message(event["queue_name"], event["msg_id"].to_i)
+      rescue StandardError => e
+        Pgbus.logger.debug do
+          "[Pgbus::Web] Error archiving message for failed event #{event["id"]}: #{e.message}"
+        end
+      end
+
+      # Archive every queue message referenced by a failed_event row.
+      def archive_all_failed_messages
+        rows = connection.select_all(
+          "SELECT id, queue_name, msg_id FROM pgbus_failed_events WHERE msg_id IS NOT NULL",
+          "Pgbus Collect Failed Messages"
+        )
+        rows.to_a.each { |row| archive_failed_message(row) }
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error archiving failed messages: #{e.message}" }
+      end
+
+      # Check whether a message with the given msg_id is still in the queue.
+      def message_exists_in_queue?(queue_name, msg_id)
+        full = Pgbus.configuration.queue_name(queue_name)
+        sanitized = QueueNameValidator.sanitize!(full)
+        connection.select_value(
+          "SELECT 1 FROM pgmq.q_#{sanitized} WHERE msg_id = $1 LIMIT 1",
+          "Pgbus check message exists",
+          [msg_id]
+        ).present?
+      rescue ActiveRecord::StatementInvalid
+        false
       end
 
       # Release all uniqueness keys associated with a queue before purge/drop.

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -183,7 +183,7 @@ module Pgbus
         # Falls back to enqueueing a fresh copy only if the original is gone
         # (e.g., already moved to DLQ).
         msg_id = event["msg_id"]
-        if msg_id && message_exists_in_queue?(event["queue_name"], msg_id.to_i)
+        if msg_id && @client.message_exists?(event["queue_name"], msg_id: msg_id.to_i)
           @client.set_visibility_timeout(event["queue_name"], msg_id.to_i, vt: 0)
         else
           payload = JSON.parse(event["payload"])
@@ -882,19 +882,6 @@ module Pgbus
         rows.to_a.each { |row| archive_failed_message(row) }
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error archiving failed messages: #{e.message}" }
-      end
-
-      # Check whether a message with the given msg_id is still in the queue.
-      def message_exists_in_queue?(queue_name, msg_id)
-        full = Pgbus.configuration.queue_name(queue_name)
-        sanitized = QueueNameValidator.sanitize!(full)
-        connection.select_value(
-          "SELECT 1 FROM pgmq.q_#{sanitized} WHERE msg_id = $1 LIMIT 1",
-          "Pgbus check message exists",
-          [msg_id]
-        ).present?
-      rescue ActiveRecord::StatementInvalid
-        false
       end
 
       # Release all uniqueness keys associated with a queue before purge/drop.

--- a/spec/integration/dashboard_failed_event_handlers_spec.rb
+++ b/spec/integration/dashboard_failed_event_handlers_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+# Regression coverage for the dashboard's failed event handlers.
+#
+# History: discard_failed_event/discard_all_failed deleted the row from
+# pgbus_failed_events and released the uniqueness lock — but never touched
+# the actual message in the PGMQ queue. The message stayed there, vt expired,
+# the worker re-read it, the job failed again, a NEW pgbus_failed_events row
+# was created. Meanwhile the lock was gone, so the recurring scheduler could
+# also enqueue duplicates. Same problem for retry_failed_event: it sent a
+# NEW message via send_message and deleted the row, but the original was
+# still in the queue.
+#
+# The fix: discard archives the message from the queue. Retry resets the
+# message's visibility timeout to 0 so the worker picks it up immediately
+# (no new message produced).
+RSpec.describe "Dashboard failed event handlers (integration)", :integration do
+  let(:client) { Pgbus.client }
+  let(:data_source) { Pgbus::Web::DataSource.new(client: client) }
+  let(:queue_name) { "default" }
+  let(:full_queue) { Pgbus.configuration.queue_name(queue_name) }
+  let(:lock_key) { "TestJob:42" }
+
+  let(:payload) do
+    {
+      "job_class" => "TestJob",
+      "arguments" => [42],
+      Pgbus::Uniqueness::METADATA_KEY => lock_key,
+      Pgbus::Uniqueness::STRATEGY_KEY => "until_executed",
+      Pgbus::Uniqueness::TTL_KEY => 86_400
+    }
+  end
+
+  before do
+    Pgbus::UniquenessKey.delete_all
+    client.ensure_queue(queue_name)
+  end
+
+  # Helper: enqueue a message, register a failed_event row pointing to it,
+  # and acquire the uniqueness lock — mimicking what happens after a job fails.
+  def setup_failed_message
+    msg_id = client.send_message(queue_name, payload)
+    Pgbus::UniquenessKey.acquire!(lock_key, queue_name: queue_name, msg_id: 0)
+    Pgbus::FailedEventRecorder.record!(
+      queue_name: queue_name,
+      msg_id: msg_id,
+      payload: payload,
+      headers: nil,
+      error: StandardError.new("boom"),
+      retry_count: 1
+    )
+    msg_id
+  end
+
+  def message_in_queue?(msg_id)
+    ActiveRecord::Base.connection.select_value(
+      "SELECT 1 FROM pgmq.q_#{full_queue} WHERE msg_id = $1 LIMIT 1", "test", [msg_id]
+    ).present?
+  end
+
+  describe "#discard_failed_event" do
+    it "archives the message from the queue" do
+      msg_id = setup_failed_message
+      expect(message_in_queue?(msg_id)).to be(true)
+
+      event = data_source.failed_events.first
+      data_source.discard_failed_event(event["id"])
+
+      expect(message_in_queue?(msg_id)).to be(false)
+    end
+
+    it "releases the uniqueness lock" do
+      setup_failed_message
+      expect(Pgbus::UniquenessKey.locked?(lock_key)).to be(true)
+
+      event = data_source.failed_events.first
+      data_source.discard_failed_event(event["id"])
+
+      expect(Pgbus::UniquenessKey.locked?(lock_key)).to be(false)
+    end
+
+    it "deletes the failed_event row" do
+      setup_failed_message
+      event = data_source.failed_events.first
+      data_source.discard_failed_event(event["id"])
+
+      expect(data_source.failed_events).to be_empty
+    end
+
+    it "is idempotent when the message is already gone" do
+      msg_id = setup_failed_message
+      client.archive_message(queue_name, msg_id)
+      expect(message_in_queue?(msg_id)).to be(false)
+
+      event = data_source.failed_events.first
+      result = data_source.discard_failed_event(event["id"])
+
+      expect(result).to be(true)
+      expect(data_source.failed_events).to be_empty
+    end
+  end
+
+  describe "#discard_all_failed" do
+    it "archives all messages from the queue and releases their locks" do
+      msg_ids = 3.times.map do |i|
+        key = "TestJob:#{i}"
+        msg_payload = payload.merge(Pgbus::Uniqueness::METADATA_KEY => key, "arguments" => [i])
+        msg_id = client.send_message(queue_name, msg_payload)
+        Pgbus::UniquenessKey.acquire!(key, queue_name: queue_name, msg_id: 0)
+        Pgbus::FailedEventRecorder.record!(
+          queue_name: queue_name, msg_id: msg_id, payload: msg_payload, headers: nil,
+          error: StandardError.new("boom #{i}"), retry_count: 0
+        )
+        msg_id
+      end
+
+      data_source.discard_all_failed
+
+      msg_ids.each { |id| expect(message_in_queue?(id)).to be(false) }
+      expect(Pgbus::UniquenessKey.count).to eq(0)
+      expect(data_source.failed_events).to be_empty
+    end
+  end
+
+  describe "#retry_failed_event" do
+    it "resets the existing message vt to 0 (does NOT enqueue a duplicate)" do
+      msg_id = setup_failed_message
+
+      # Read+lock the message so vt is in the future
+      client.read_message(queue_name, vt: 600)
+
+      # Verify vt is set in the future
+      vt_before = ActiveRecord::Base.connection.select_value(
+        "SELECT vt FROM pgmq.q_#{full_queue} WHERE msg_id = $1", "test", [msg_id]
+      )
+      expect(Time.parse(vt_before.to_s)).to be > Time.current
+
+      event = data_source.failed_events.first
+      data_source.retry_failed_event(event["id"])
+
+      # The original message should still be the only one in the queue
+      count = ActiveRecord::Base.connection.select_value(
+        "SELECT COUNT(*) FROM pgmq.q_#{full_queue}", "test"
+      )
+      expect(count.to_i).to eq(1)
+
+      # And its vt should be at-or-before now (immediately visible)
+      vt_after = ActiveRecord::Base.connection.select_value(
+        "SELECT vt FROM pgmq.q_#{full_queue} WHERE msg_id = $1", "test", [msg_id]
+      )
+      expect(Time.parse(vt_after.to_s)).to be <= Time.current + 1
+    end
+
+    it "deletes the failed_event row" do
+      setup_failed_message
+      event = data_source.failed_events.first
+      data_source.retry_failed_event(event["id"])
+
+      expect(data_source.failed_events).to be_empty
+    end
+
+    it "does NOT release the uniqueness lock (job is being retried)" do
+      setup_failed_message
+      event = data_source.failed_events.first
+      data_source.retry_failed_event(event["id"])
+
+      expect(Pgbus::UniquenessKey.locked?(lock_key)).to be(true)
+    end
+
+    it "falls back to send_message when the original is gone (e.g. moved to DLQ)" do
+      msg_id = setup_failed_message
+      client.archive_message(queue_name, msg_id)
+      expect(message_in_queue?(msg_id)).to be(false)
+
+      event = data_source.failed_events.first
+      result = data_source.retry_failed_event(event["id"])
+
+      expect(result).to be(true)
+      # A fresh copy was enqueued
+      count = ActiveRecord::Base.connection.select_value(
+        "SELECT COUNT(*) FROM pgmq.q_#{full_queue}", "test"
+      )
+      expect(count.to_i).to eq(1)
+    end
+  end
+end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -37,10 +37,19 @@ def bootstrap_integration_tables(conn)
         retry_count INTEGER DEFAULT 0,
         failed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
       );
-      CREATE UNIQUE INDEX idx_pgbus_failed_events_queue_msg
-        ON pgbus_failed_events (queue_name, msg_id);
     SQL
   end
+
+  # Always ensure the unique index exists, even if the table was created
+  # by an older bootstrap (e.g. CI workflow's "Set up pgbus tables" step
+  # that predates the upsert). FailedEventRecorder.record! does
+  # ON CONFLICT (queue_name, msg_id) UPDATE — without this index it raises
+  # "no unique or exclusion constraint matching the ON CONFLICT specification"
+  # and silently swallows the error, leaving failed_events.first nil in tests.
+  conn.execute(<<~SQL)
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_pgbus_failed_events_queue_msg
+      ON pgbus_failed_events (queue_name, msg_id);
+  SQL
 rescue StandardError => e
   warn "[pgbus integration] Bootstrap warning: #{e.message}"
 end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -22,6 +22,25 @@ def bootstrap_integration_tables(conn)
       CREATE UNIQUE INDEX idx_pgbus_uniqueness_keys_key ON pgbus_uniqueness_keys (lock_key);
     SQL
   end
+
+  unless conn.table_exists?("pgbus_failed_events")
+    conn.execute(<<~SQL)
+      CREATE TABLE pgbus_failed_events (
+        id BIGSERIAL PRIMARY KEY,
+        queue_name VARCHAR NOT NULL,
+        msg_id BIGINT,
+        payload JSONB,
+        headers JSONB,
+        error_class VARCHAR,
+        error_message TEXT,
+        backtrace TEXT,
+        retry_count INTEGER DEFAULT 0,
+        failed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+      CREATE UNIQUE INDEX idx_pgbus_failed_events_queue_msg
+        ON pgbus_failed_events (queue_name, msg_id);
+    SQL
+  end
 rescue StandardError => e
   warn "[pgbus integration] Bootstrap warning: #{e.message}"
 end

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -250,26 +250,30 @@ RSpec.describe Pgbus::Web::DataSource do
   end
 
   describe "#discard_failed_event" do
-    it "deletes the event and releases the uniqueness lock" do
+    it "deletes the event, releases the uniqueness lock, and archives the queue message" do
       allow(mock_connection).to receive(:select_one)
         .with(anything, "Pgbus Failed Event", [1])
         .and_return({
                       "id" => 1,
+                      "queue_name" => "default",
+                      "msg_id" => 42,
                       "payload" => '{"job_class":"FailedJob","pgbus_uniqueness_key":"failed-1"}'
                     })
 
       allow(mock_connection).to receive(:exec_delete)
       allow(Pgbus::UniquenessKey).to receive(:release!).and_return(1)
+      allow(mock_client).to receive(:archive_message)
 
       data_source.discard_failed_event(1)
 
       expect(mock_connection).to have_received(:exec_delete)
       expect(Pgbus::UniquenessKey).to have_received(:release!).with("failed-1")
+      expect(mock_client).to have_received(:archive_message).with("default", 42)
     end
   end
 
   describe "#discard_all_failed" do
-    it "collects uniqueness keys before deleting and releases locks" do
+    before do
       allow(mock_connection).to receive(:select_all)
         .with("SELECT payload FROM pgbus_failed_events", "Pgbus Collect Failed Keys")
         .and_return([
@@ -278,17 +282,39 @@ RSpec.describe Pgbus::Web::DataSource do
                       { "payload" => '{"job_class":"PlainJob"}' }
                     ])
 
-      result_double = double("result", cmd_tuples: 3)
+      allow(mock_connection).to receive(:select_all)
+        .with(
+          "SELECT id, queue_name, msg_id FROM pgbus_failed_events WHERE msg_id IS NOT NULL",
+          "Pgbus Collect Failed Messages"
+        )
+        .and_return([
+                      { "id" => 1, "queue_name" => "default", "msg_id" => 10 },
+                      { "id" => 2, "queue_name" => "default", "msg_id" => 11 },
+                      { "id" => 3, "queue_name" => "low", "msg_id" => 99 }
+                    ])
+
       allow(mock_connection).to receive(:execute)
         .with("DELETE FROM pgbus_failed_events")
-        .and_return(result_double)
+        .and_return(double("result", cmd_tuples: 3))
 
       allow(Pgbus::UniquenessKey).to receive(:where).and_return(double(delete_all: 2))
+      allow(mock_client).to receive(:archive_message)
+    end
 
-      count = data_source.discard_all_failed
-
-      expect(count).to eq(3)
+    it "releases the uniqueness locks for every failed event" do
+      data_source.discard_all_failed
       expect(Pgbus::UniquenessKey).to have_received(:where).with(lock_key: %w[k1 k2])
+    end
+
+    it "archives every queue message referenced by a failed event" do
+      data_source.discard_all_failed
+      expect(mock_client).to have_received(:archive_message).with("default", 10)
+      expect(mock_client).to have_received(:archive_message).with("default", 11)
+      expect(mock_client).to have_received(:archive_message).with("low", 99)
+    end
+
+    it "returns the number of rows deleted" do
+      expect(data_source.discard_all_failed).to eq(3)
     end
   end
 


### PR DESCRIPTION
## Summary

Second source of duplicate jobs (separate from the dispatcher reaper bug in #67). When a user clicks **Discard** or **Retry** on a failed job in the dashboard, the handlers were inconsistent about the actual queue message:

| Action | Old behavior | Bug |
|---|---|---|
| `discard_failed_event` | delete row + release lock | message stays in queue → re-read → fail → new failed_event row created. Lock is gone, so the recurring scheduler can also enqueue duplicates on top |
| `discard_all_failed` | delete all rows + release all locks | same as above, multiplied |
| `retry_failed_event` | `send_message(new copy)` + delete row | original message still in queue → both run → duplicate execution |

One click on Retry produced two copies of the same job. One click on Discard produced an infinite loop of failed_event rows. If the user had been clicking discard while debugging, that explains a lot.

## Fix

- **discard_failed_event / discard_all_failed**: also archive the queue message via `client.archive_message`. Idempotent — silently no-ops if the message is already gone (e.g., already moved to DLQ between failure and discard).
- **retry_failed_event**: reset the existing message's visibility timeout to `0` via `client.set_visibility_timeout`, so the worker picks it up immediately. No new message is produced. Falls back to `send_message` only when the original is gone (e.g., already moved to DLQ between failure and retry click).
- **Lock semantics**: discard releases the lock (job is being discarded). Retry does NOT release the lock (job is being retried — duplicates must still be prevented).

## Test plan

New integration spec at `spec/integration/dashboard_failed_event_handlers_spec.rb` (9 cases against a real PGMQ queue):

- [x] discard archives the message from the queue
- [x] discard releases the uniqueness lock
- [x] discard deletes the failed_event row
- [x] discard is idempotent when the message is already gone
- [x] discard_all archives every message and releases every lock
- [x] retry resets vt to 0 (no duplicate produced)
- [x] retry deletes the failed_event row
- [x] retry does NOT release the lock
- [x] retry falls back to send_message when the original is gone (e.g. DLQ'd)

Plus updated unit tests in `spec/pgbus/web/data_source_spec.rb` to assert `archive_message` is called for both single and batch discard.

- 763 unit tests pass, 0 failures
- All related integration specs pass
- Rubocop clean

## Known limitation (not in scope)

For jobs that came from a priority sub-queue (`pgbus_default_p0`), the failed_events row stores the **logical** queue name (`default`), and the discard archive will look in `pgmq.q_pgbus_default` instead of `pgmq.q_pgbus_default_p0`. The archive will silently no-op (PGMQ is idempotent), the failed_event row will still be deleted, but the original message stays in the priority sub-queue and will fail again. Fix is to add a `source_queue` column to `pgbus_failed_events` — separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard controls to discard individual failed events and archive their messages.
  * Bulk discard to remove all failed events and archive their queued messages.

* **Improvements**
  * Retry now prefers reusing the original queued message when present, avoiding duplicates.
  * Retry no longer releases uniqueness locks; handlers are more idempotent and reliable.
  * Recorder logs failures at error level with richer context.

* **Tests**
  * Added integration tests and bootstrapped test table/index for failed-event scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->