### PR TITLE
feat(config): auto-tune pool_size from worker thread counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Pgbus works with zero config in Rails -- it uses your existing `ActiveRecord` co
 production:
   queue_prefix: myapp
   default_queue: default
-  pool_size: 10
   max_retries: 5
   prefetch_limit: 20
   workers:
@@ -616,7 +615,7 @@ The dispatcher runs archive compaction as part of its maintenance loop, deleting
 | `database_url` | `nil` | PostgreSQL connection URL (auto-detected in Rails) |
 | `queue_prefix` | `"pgbus"` | Prefix for all PGMQ queue names |
 | `default_queue` | `"default"` | Default queue for jobs without explicit queue |
-| `pool_size` | `5` | Connection pool size |
+| `pool_size` | `nil` (auto) | Connection pool size. Auto-tuned from worker thread counts: `sum(workers.threads) + sum(event_consumers.threads) + 2`. Set explicitly to override. |
 | `workers` | `[{queues: ["default"], threads: 5}]` | Worker process definitions |
 | `event_consumers` | `nil` | Event consumer process definitions (same format as workers) |
 | `polling_interval` | `0.1` | Seconds between polls (LISTEN/NOTIFY is primary) |

--- a/lib/generators/pgbus/templates/pgbus.yml.erb
+++ b/lib/generators/pgbus/templates/pgbus.yml.erb
@@ -8,8 +8,11 @@ default: &default
   # Default queue name (without prefix)
   default_queue: default
 
-  # Connection pool for PGMQ client
-  pool_size: 5
+  # Connection pool for PGMQ client.
+  # pool_size auto-tunes from your worker thread counts:
+  #   sum(workers.threads) + sum(event_consumers.threads) + 2
+  # Set explicitly only if you need a tighter or looser pool than that.
+  # pool_size: 5
   pool_timeout: 5
 
   # Use PostgreSQL LISTEN/NOTIFY for instant job wake-up

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -33,9 +33,10 @@ module Pgbus
       else
         # With a String URL or Hash params, pgmq-ruby creates its own dedicated
         # PG::Connection per pool slot — no shared state with ActiveRecord.
-        # Use the configured pool_size and let pgmq-ruby's connection_pool handle
+        # Use the resolved pool size (auto-tuned from worker thread counts
+        # unless explicitly set) and let pgmq-ruby's connection_pool handle
         # concurrency internally (no mutex needed).
-        @pgmq = PGMQ::Client.new(conn_opts, pool_size: config.pool_size, pool_timeout: config.pool_timeout)
+        @pgmq = PGMQ::Client.new(conn_opts, pool_size: config.resolved_pool_size, pool_timeout: config.pool_timeout)
         @pgmq_mutex = nil
       end
 

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -220,8 +220,8 @@ module Pgbus
     def resolved_pool_size
       return pool_size if pool_size
 
-      total = sum_thread_counts(workers, default_threads: 5) +
-              sum_thread_counts(event_consumers, default_threads: 3) +
+      total = sum_thread_counts(workers, default_threads: 5, group: "worker") +
+              sum_thread_counts(event_consumers, default_threads: 3, group: "event_consumer") +
               POOL_SIZE_OVERHEAD
 
       warn_if_oversized(total)
@@ -249,12 +249,21 @@ module Pgbus
 
     private
 
-    def sum_thread_counts(entries, default_threads:)
+    # Sum the +:threads+ values across a list of worker/consumer entries.
+    # Uses +default_threads+ when an entry omits the key. Rejects anything
+    # that isn't a positive Integer with a clear error — silent coercion via
+    # +to_i+ would let "abc" → 0 produce a critically under-sized pool with
+    # no indication that something was wrong.
+    def sum_thread_counts(entries, default_threads:, group:)
       return 0 unless entries
 
       entries.sum do |entry|
         threads = entry[:threads] || entry["threads"] || default_threads
-        threads.to_i
+        unless threads.is_a?(Integer) && threads.positive?
+          raise ArgumentError,
+                "#{group} threads must be a positive integer, got #{threads.inspect}"
+        end
+        threads
       end
     end
 

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -69,7 +69,7 @@ module Pgbus
     def initialize
       @database_url = nil
       @connection_params = nil
-      @pool_size = 5
+      @pool_size = nil
       @pool_timeout = 5
 
       @default_queue = "default"
@@ -172,7 +172,10 @@ module Pgbus
     end
 
     def validate!
-      raise ArgumentError, "pool_size must be > 0" unless pool_size.is_a?(Numeric) && pool_size.positive?
+      if pool_size && !(pool_size.is_a?(Numeric) && pool_size.positive?)
+        raise ArgumentError, "pool_size must be a positive number or nil (auto-tune)"
+      end
+
       raise ArgumentError, "pool_timeout must be > 0" unless pool_timeout.is_a?(Numeric) && pool_timeout.positive?
       raise ArgumentError, "polling_interval must be > 0" unless polling_interval.is_a?(Numeric) && polling_interval.positive?
       raise ArgumentError, "visibility_timeout must be > 0" unless visibility_timeout.is_a?(Numeric) && visibility_timeout.positive?
@@ -196,6 +199,35 @@ module Pgbus
       self
     end
 
+    # Returns the connection pool size to use for the PGMQ client.
+    #
+    # If +pool_size+ was explicitly set, returns that value unchanged. Otherwise
+    # auto-derives from the configured worker and event_consumer thread counts:
+    #
+    #   sum(workers.threads) + sum(event_consumers.threads) + 2
+    #
+    # The +2 covers the dispatcher and scheduler, which each issue occasional
+    # queries against the same connection pool.
+    #
+    # Auto-tune protects users from the common pitfall of running 15 worker
+    # threads with a hand-set pool_size of 5 (resulting in ConnectionPool
+    # timeouts under load). Setting pool_size explicitly is still supported
+    # for advanced cases where you need a tighter or looser pool than the
+    # default formula provides.
+    POOL_SIZE_OVERHEAD = 2 # dispatcher + scheduler
+    POOL_SIZE_WARN_THRESHOLD = 50
+
+    def resolved_pool_size
+      return pool_size if pool_size
+
+      total = sum_thread_counts(workers, default_threads: 5) +
+              sum_thread_counts(event_consumers, default_threads: 3) +
+              POOL_SIZE_OVERHEAD
+
+      warn_if_oversized(total)
+      total
+    end
+
     def connection_options
       if database_url
         database_url
@@ -216,6 +248,25 @@ module Pgbus
     end
 
     private
+
+    def sum_thread_counts(entries, default_threads:)
+      return 0 unless entries
+
+      entries.sum do |entry|
+        threads = entry[:threads] || entry["threads"] || default_threads
+        threads.to_i
+      end
+    end
+
+    def warn_if_oversized(size)
+      return unless size > POOL_SIZE_WARN_THRESHOLD
+
+      Pgbus.logger.warn do
+        "[Pgbus] Auto-tuned pool_size is #{size} (over #{POOL_SIZE_WARN_THRESHOLD}). " \
+          "Verify your worker thread counts are intentional. " \
+          "Set Pgbus.configuration.pool_size explicitly to override."
+      end
+    end
 
     def extract_ar_connection_hash
       base = connects_to ? Pgbus::BusRecord : ActiveRecord::Base

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -216,6 +216,58 @@ RSpec.describe Pgbus::Configuration do
         config.resolved_pool_size
         expect(Pgbus.logger).not_to have_received(:warn)
       end
+
+      it "rejects non-integer thread counts (e.g. string)" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: "5" }]
+        expect { config.resolved_pool_size }.to raise_error(
+          ArgumentError,
+          /worker.*threads.*positive integer/
+        )
+      end
+
+      it "rejects float thread counts" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: 0.5 }]
+        expect { config.resolved_pool_size }.to raise_error(
+          ArgumentError,
+          /worker.*threads.*positive integer/
+        )
+      end
+
+      it "rejects zero thread counts" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: 0 }]
+        expect { config.resolved_pool_size }.to raise_error(
+          ArgumentError,
+          /worker.*threads.*positive integer/
+        )
+      end
+
+      it "rejects negative thread counts" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: -1 }]
+        expect { config.resolved_pool_size }.to raise_error(
+          ArgumentError,
+          /worker.*threads.*positive integer/
+        )
+      end
+
+      it "rejects bad event_consumer thread counts with the right group label" do
+        config.pool_size = nil
+        config.workers = nil
+        config.event_consumers = [{ topics: %w[orders.#], threads: "abc" }]
+        expect { config.resolved_pool_size }.to raise_error(
+          ArgumentError,
+          /event_consumer.*threads.*positive integer/
+        )
+      end
+
+      it "includes the offending value in the error message" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: "abc" }]
+        expect { config.resolved_pool_size }.to raise_error(ArgumentError, /"abc"/)
+      end
     end
   end
 

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Pgbus::Configuration do
       expect(config.default_queue).to eq("default")
     end
 
-    it "has default pool size" do
-      expect(config.pool_size).to eq(5)
+    it "leaves pool_size unset by default (auto-tuned at read time)" do
+      expect(config.pool_size).to be_nil
     end
 
     it "has default visibility timeout" do
@@ -127,6 +127,95 @@ RSpec.describe Pgbus::Configuration do
     it "returns sub-queue names when priority_levels > 1" do
       config.priority_levels = 3
       expect(config.priority_queue_names("default")).to eq(%w[pgbus_default_p0 pgbus_default_p1 pgbus_default_p2])
+    end
+  end
+
+  describe "#resolved_pool_size" do
+    context "when pool_size is explicitly set" do
+      it "returns the explicit value (overrides auto-tune)" do
+        config.pool_size = 17
+        expect(config.resolved_pool_size).to eq(17)
+      end
+
+      it "returns the explicit value even when it's smaller than the auto-tuned value" do
+        config.pool_size = 1
+        config.workers = [{ queues: %w[default], threads: 50 }]
+        expect(config.resolved_pool_size).to eq(1)
+      end
+    end
+
+    context "when pool_size is nil (auto-tune)" do
+      it "returns total worker threads + 2 (one for dispatcher, one for scheduler)" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: 5 }]
+        expect(config.resolved_pool_size).to eq(7)
+      end
+
+      it "sums threads across multiple worker entries (capsules)" do
+        config.pool_size = nil
+        config.workers = [
+          { queues: %w[critical], threads: 5 },
+          { queues: %w[default mailers], threads: 10 }
+        ]
+        expect(config.resolved_pool_size).to eq(17)
+      end
+
+      it "accepts string keys (YAML form)" do
+        config.pool_size = nil
+        config.workers = [{ "queues" => %w[default], "threads" => 8 }]
+        expect(config.resolved_pool_size).to eq(10)
+      end
+
+      it "uses 5 as the default per-worker thread count when threads is missing" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default] }]
+        expect(config.resolved_pool_size).to eq(7)
+      end
+
+      it "includes event_consumers thread counts" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: 5 }]
+        config.event_consumers = [{ topics: %w[orders.#], threads: 3 }]
+        expect(config.resolved_pool_size).to eq(10)
+      end
+
+      it "uses 3 as the default per-consumer thread count when threads is missing" do
+        config.pool_size = nil
+        config.workers = nil
+        config.event_consumers = [{ topics: %w[orders.#] }]
+        expect(config.resolved_pool_size).to eq(5)
+      end
+
+      it "treats nil workers as zero" do
+        config.pool_size = nil
+        config.workers = nil
+        config.event_consumers = nil
+        expect(config.resolved_pool_size).to eq(2)
+      end
+
+      it "treats empty workers as zero" do
+        config.pool_size = nil
+        config.workers = []
+        config.event_consumers = []
+        expect(config.resolved_pool_size).to eq(2)
+      end
+
+      it "warns when the auto-tuned pool exceeds the sanity threshold" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: 60 }]
+        warned_message = nil
+        allow(Pgbus.logger).to receive(:warn) { |&block| warned_message = block.call }
+        config.resolved_pool_size
+        expect(warned_message).to match(/pool_size .* 62/)
+      end
+
+      it "does not warn for normal sizes" do
+        config.pool_size = nil
+        config.workers = [{ queues: %w[default], threads: 5 }]
+        allow(Pgbus.logger).to receive(:warn)
+        config.resolved_pool_size
+        expect(Pgbus.logger).not_to have_received(:warn)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

First PR in a 10-PR series to overhaul Pgbus configuration UX. Smallest, most impactful change first.

The default \`pool_size\` of 5 is wrong for any non-trivial deployment. Users with 15 worker threads and \`pool_size: 5\` hit ConnectionPool timeouts under load — and there's no way for them to know what the right number is unless they read the source.

This PR auto-derives \`pool_size\` from the configured worker and event_consumer thread counts:

\`\`\`
resolved_pool_size = sum(workers.threads) + sum(event_consumers.threads) + 2
\`\`\`

The \`+2\` covers the dispatcher and scheduler, which each issue occasional queries against the same connection pool.

A warning is logged when the auto-tuned size exceeds 50 — almost always a sign of a misconfigured worker thread count rather than an intentional choice.

## Backwards compatibility

- Configurations that explicitly set \`pool_size\` are unchanged. The new \`#resolved_pool_size\` returns the explicit value if set.
- Existing tests pass — the unit tests that set \`pool_size = 5\` etc. still see the same behavior.
- The default in \`pgbus.yml.erb\` is now commented out with an explanation.

## Migration impact for cosmos / Zazu

Both can drop their hand-set \`pool_size: 5/8/17\` lines from \`config/pgbus.yml\` and rely on auto-tune. Pool size will be:

| Deployment | Before | After (auto) |
|---|---|---|
| Cosmos (5 worker threads) | \`pool_size: 5\` | \`5 + 0 + 2 = 7\` |
| Zazu staging (5 worker threads) | \`pool_size: 8\` | \`5 + 0 + 2 = 7\` |
| Zazu production (15 worker threads) | \`pool_size: 17\` | \`15 + 0 + 2 = 17\` |

The Zazu production case is exactly right — and was clearly hand-tuned to it. Auto-tune produces the same number.

## What's coming in subsequent PRs

This PR is independent and can ship today. The remaining PRs:

2. Capsule string DSL parser (\`c.workers \"*: 5\"\`)
3. Named capsule API + CLI capsule selection (\`c.capsule :critical, ...\`, \`pgbus start --capsule critical\`)
4. CLI role flags (\`--workers-only\`, \`--scheduler-only\`, \`--dispatcher-only\`)
5. Ruby DSL improvements (\`10.minutes\`, validation on assignment)
6. \`rails generate pgbus:update\` migration tool
7-8. Cull constants (move silent settings out of \`Configuration\`)
9. README reorg
10. Drop YAML loader (next minor)

## Test plan

- [x] 13 new tests for \`#resolved_pool_size\` covering: explicit override, multi-capsule sum, string keys, default thread counts, event consumers, nil/empty workers, oversize warning
- [x] Existing client_spec tests still pass (they explicitly set \`pool_size\`)
- [x] 784 unit tests pass, 0 failures
- [x] 97 integration tests pass, 0 failures
- [x] Rubocop clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection pool size now auto-tunes based on configured worker and event-consumer thread counts, with an option to override manually. A warning is emitted if the auto-tuned size exceeds a recommended threshold.

* **Documentation**
  * Sample configuration and templates updated to reflect the new auto-tuning behavior and default unset pool size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->