### PR TITLE
feat(config): add capsule string DSL parser

### DIFF
--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -24,7 +24,12 @@ module Pgbus
     def loader
       @loader ||= begin
         loader = Zeitwerk::Loader.for_gem
-        loader.inflector.inflect("pgbus" => "Pgbus", "cli" => "CLI", "dsl" => "DSL")
+        loader.inflector.inflect(
+          "pgbus" => "Pgbus",
+          "cli" => "CLI",
+          "dsl" => "DSL",
+          "capsule_dsl" => "CapsuleDSL"
+        )
         loader.ignore("#{__dir__}/generators")
         loader.ignore("#{__dir__}/active_job")
         loader

--- a/lib/pgbus/configuration/capsule_dsl.rb
+++ b/lib/pgbus/configuration/capsule_dsl.rb
@@ -30,8 +30,21 @@ module Pgbus
     class CapsuleDSL
       DEFAULT_THREADS = 5
       WILDCARD = "*"
-      # Valid queue tokens: bare wildcard ("*"), bare name ("default"),
-      # or prefix wildcard ("staging_*"). Names are alphanumeric + underscore.
+
+      # Valid queue tokens accepted by the DSL:
+      #   "*"         bare wildcard (matches all queues at runtime)
+      #   "default"   bare queue name
+      #   "staging_*" prefix wildcard (matches queues by prefix at runtime)
+      #
+      # The character class for queue names — alphanumerics and underscores
+      # only — intentionally matches Pgbus::QueueNameValidator::VALID_QUEUE_NAME_PATTERN.
+      # Hyphens, dots, and other punctuation are NOT permitted because PGMQ
+      # interpolates queue names directly into SQL identifiers (q_<name>,
+      # a_<name>) and only those characters are safe there. If you change
+      # this pattern, also update QueueNameValidator to keep them in sync.
+      #
+      # The "*" tokens (bare and trailing) are DSL-only — they get expanded
+      # to concrete queue names at runtime before reaching QueueNameValidator.
       QUEUE_NAME_PATTERN = /\A(?:\*|[a-zA-Z0-9_]+\*?)\z/
       THREAD_COUNT_PATTERN = /\A\d+\z/
 

--- a/lib/pgbus/configuration/capsule_dsl.rb
+++ b/lib/pgbus/configuration/capsule_dsl.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class Configuration
+    # Parses the capsule string DSL into the internal worker config array.
+    #
+    # The DSL lets users describe worker thread pools (capsules) compactly:
+    #
+    #   "*: 5"                                # one capsule, all queues, 5 threads
+    #   "critical: 5; default: 10"            # two capsules
+    #   "critical, default: 5"                # one capsule, list = strict priority
+    #   "default, mailers: 10; *: 2"          # specialized + fallback wildcard
+    #   "staging_*: 3"                        # prefix wildcard
+    #
+    # Operators:
+    #   ,    queue separator within a capsule (list order = strict priority)
+    #   ;    capsule separator (each becomes its own thread pool)
+    #   :N   thread count for the capsule (default 5)
+    #   *    wildcard, matches all queues
+    #   *_   trailing wildcard, prefix match (e.g. "staging_*")
+    #
+    # Returns +Array<Hash>+ in the same shape as the legacy +workers:+ array,
+    # so the rest of the codebase can consume it without changes:
+    #
+    #   [{ queues: ["critical"], threads: 5 },
+    #    { queues: ["default", "mailers"], threads: 10 }]
+    #
+    # Validation runs at parse time. Errors include the offending input and
+    # a clear message naming the rule that was violated.
+    class CapsuleDSL
+      DEFAULT_THREADS = 5
+      WILDCARD = "*"
+      # Valid queue tokens: bare wildcard ("*"), bare name ("default"),
+      # or prefix wildcard ("staging_*"). Names are alphanumeric + underscore.
+      QUEUE_NAME_PATTERN = /\A(?:\*|[a-zA-Z0-9_]+\*?)\z/
+      THREAD_COUNT_PATTERN = /\A\d+\z/
+
+      class ParseError < ArgumentError; end
+
+      def self.parse(input)
+        new(input).parse
+      end
+
+      def initialize(input)
+        @input = input
+      end
+
+      def parse
+        validate_input_type!
+        validate_input_not_empty!
+
+        capsules = split_capsules(@input).map { |segment| parse_capsule(segment) }
+        validate_no_duplicate_queues_across_capsules!(capsules)
+        capsules
+      end
+
+      private
+
+      def validate_input_type!
+        return if @input.is_a?(String)
+
+        raise ParseError,
+              "expected String, got #{@input.class} (#{@input.inspect})"
+      end
+
+      def validate_input_not_empty!
+        return if @input.strip != ""
+
+        raise ParseError, "empty capsule string — must declare at least one queue"
+      end
+
+      # Splits on `;` and trims whitespace, dropping a trailing empty segment
+      # so `"a; b;"` is treated the same as `"a; b"`. Leading-empty segments
+      # ("; a") are kept and rejected by parse_capsule with a clearer error.
+      def split_capsules(string)
+        segments = string.strip.split(";").map(&:strip)
+        segments.pop if segments.last == "" # trailing semicolon
+        segments
+      end
+
+      def parse_capsule(segment)
+        if segment == ""
+          raise ParseError,
+                "empty capsule in #{@input.inspect} — leading or doubled semicolons are not allowed"
+        end
+
+        queues_part, threads_part = split_on_threads(segment)
+        queues = parse_queue_list(queues_part, segment)
+        threads = parse_thread_count(threads_part, segment)
+        validate_no_duplicates_within_capsule!(queues, segment)
+
+        { queues: queues, threads: threads }
+      end
+
+      # Splits a capsule segment on the LAST `:` so queue names containing
+      # underscores or digits are unaffected. Returns [queues_part, threads_part]
+      # where threads_part is nil when no `:` is present.
+      def split_on_threads(segment)
+        idx = segment.rindex(":")
+        return [segment, nil] unless idx
+
+        [segment[0...idx].strip, segment[(idx + 1)..].strip]
+      end
+
+      def parse_queue_list(queues_part, original_segment)
+        if queues_part.empty?
+          raise ParseError,
+                "expected queue name before ':' in #{original_segment.inspect}"
+        end
+
+        queues = queues_part.split(",").map(&:strip)
+        queues.each { |q| validate_queue_name!(q, original_segment) }
+        queues
+      end
+
+      def validate_queue_name!(name, original_segment)
+        return if name.match?(QUEUE_NAME_PATTERN)
+
+        raise ParseError,
+              "invalid character in queue name #{name.inspect} (in #{original_segment.inspect}) — " \
+              "queue names must match /[a-zA-Z0-9_]+\\*?/"
+      end
+
+      def parse_thread_count(threads_part, original_segment)
+        return DEFAULT_THREADS if threads_part.nil?
+
+        if threads_part.empty?
+          raise ParseError,
+                "expected thread count after ':' in #{original_segment.inspect}"
+        end
+
+        unless threads_part.match?(THREAD_COUNT_PATTERN)
+          raise ParseError,
+                "invalid thread count #{threads_part.inspect} in #{original_segment.inspect} — " \
+                "must be a positive integer"
+        end
+
+        n = threads_part.to_i
+        if n.zero?
+          raise ParseError,
+                "thread count must be a positive integer, got 0 in #{original_segment.inspect}"
+        end
+
+        n
+      end
+
+      def validate_no_duplicates_within_capsule!(queues, original_segment)
+        seen = {}
+        queues.each do |q|
+          if seen[q]
+            raise ParseError,
+                  "queue #{q.inspect} listed twice in capsule #{original_segment.inspect} — " \
+                  "duplicate queues within a capsule are not allowed"
+          end
+          seen[q] = true
+        end
+      end
+
+      def validate_no_duplicate_queues_across_capsules!(capsules)
+        return if capsules.size < 2
+
+        seen = {}
+        capsules.each_with_index do |capsule, idx|
+          capsule[:queues].each do |q|
+            if seen[q]
+              label = (q == WILDCARD ? "wildcard '*'" : "queue #{q.inspect}")
+              raise ParseError,
+                    "#{label} appears in two capsules (positions #{seen[q]} and #{idx + 1}) " \
+                    "in #{@input.inspect} — each queue can only be assigned to one capsule"
+            end
+            seen[q] = idx + 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/timezone_spec.rb
+++ b/spec/integration/timezone_spec.rb
@@ -12,7 +12,7 @@ require "active_support/core_ext/time/zones"
 # - System timezone (ENV['TZ']) set to the same non-UTC timezone
 #
 # This combination is common in apps that store timestamps in local time
-# (e.g. getzazu/app using Africa/Casablanca).
+# (e.g. an app using Africa/Casablanca for both DB and process timezones).
 RSpec.describe "Timezone handling (integration)", :integration do
   # Rails 8.1 moved default_timezone from ActiveRecord::Base to ActiveRecord module.
   def ar_default_timezone

--- a/spec/pgbus/configuration/capsule_dsl_spec.rb
+++ b/spec/pgbus/configuration/capsule_dsl_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Configuration::CapsuleDSL do
+  describe ".parse" do
+    subject(:parse) { described_class.parse(input) }
+
+    context "with a single capsule" do
+      context "with the wildcard alone" do
+        let(:input) { "*" }
+
+        it "returns one capsule with all queues and the default thread count" do
+          expect(parse).to eq([{ queues: ["*"], threads: 5 }])
+        end
+      end
+
+      context "with the wildcard and an explicit thread count" do
+        let(:input) { "*: 5" }
+
+        it "returns one capsule with the explicit thread count" do
+          expect(parse).to eq([{ queues: ["*"], threads: 5 }])
+        end
+      end
+
+      context "with a single named queue" do
+        let(:input) { "default" }
+
+        it "returns one capsule with the queue and default threads" do
+          expect(parse).to eq([{ queues: ["default"], threads: 5 }])
+        end
+      end
+
+      context "with a single named queue and explicit thread count" do
+        let(:input) { "default: 3" }
+
+        it "returns one capsule with the explicit thread count" do
+          expect(parse).to eq([{ queues: ["default"], threads: 3 }])
+        end
+      end
+
+      context "with multiple queues in priority order" do
+        let(:input) { "critical, default" }
+
+        it "returns one capsule with the queues in declaration order" do
+          expect(parse).to eq([{ queues: %w[critical default], threads: 5 }])
+        end
+      end
+
+      context "with multiple queues and an explicit thread count" do
+        let(:input) { "critical, default: 10" }
+
+        it "returns one capsule with all queues and the explicit count" do
+          expect(parse).to eq([{ queues: %w[critical default], threads: 10 }])
+        end
+      end
+
+      context "with a prefix wildcard" do
+        let(:input) { "staging_*: 3" }
+
+        it "returns the prefix wildcard as a single queue token" do
+          expect(parse).to eq([{ queues: ["staging_*"], threads: 3 }])
+        end
+      end
+    end
+
+    context "with multiple capsules" do
+      context "with two capsules separated by semicolon" do
+        let(:input) { "critical: 5; default: 10" }
+
+        it "returns two independent capsules" do
+          expect(parse).to eq([
+                                { queues: ["critical"], threads: 5 },
+                                { queues: ["default"], threads: 10 }
+                              ])
+        end
+      end
+
+      context "with multi-queue capsules and a fallback wildcard" do
+        let(:input) { "critical: 3; default, mailers: 10; *: 2" }
+
+        it "returns three capsules with the queue lists in order" do
+          expect(parse).to eq([
+                                { queues: ["critical"], threads: 3 },
+                                { queues: %w[default mailers], threads: 10 },
+                                { queues: ["*"], threads: 2 }
+                              ])
+        end
+      end
+    end
+
+    context "with whitespace variations" do
+      it "ignores leading and trailing whitespace" do
+        expect(described_class.parse("  *: 5  ")).to eq([{ queues: ["*"], threads: 5 }])
+      end
+
+      it "ignores whitespace around commas, colons, and semicolons" do
+        expect(described_class.parse("critical , default :  5 ;  mailers : 2"))
+          .to eq([
+                   { queues: %w[critical default], threads: 5 },
+                   { queues: ["mailers"], threads: 2 }
+                 ])
+      end
+
+      it "tolerates a trailing semicolon" do
+        expect(described_class.parse("*: 5;")).to eq([{ queues: ["*"], threads: 5 }])
+      end
+    end
+
+    context "with no explicit thread count" do
+      it "is 5 when omitted" do
+        expect(described_class.parse("default")).to eq([{ queues: ["default"], threads: 5 }])
+      end
+
+      it "applies per capsule when multiple capsules omit threads" do
+        expect(described_class.parse("a; b")).to eq([
+                                                      { queues: ["a"], threads: 5 },
+                                                      { queues: ["b"], threads: 5 }
+                                                    ])
+      end
+    end
+
+    context "with invalid input" do
+      def expect_parse_error(input, message_regex)
+        expect { described_class.parse(input) }.to raise_error(
+          Pgbus::Configuration::CapsuleDSL::ParseError,
+          message_regex
+        )
+      end
+
+      it "rejects nil" do
+        expect_parse_error(nil, /expected String/i)
+      end
+
+      it "rejects an empty string" do
+        expect_parse_error("", /empty/i)
+      end
+
+      it "rejects a whitespace-only string" do
+        expect_parse_error("   ", /empty/i)
+      end
+
+      it "rejects a leading semicolon (empty capsule)" do
+        expect_parse_error("; default: 5", /empty capsule/i)
+      end
+
+      it "rejects a colon with no queue before it" do
+        expect_parse_error(":5", /queue name.*before/i)
+      end
+
+      it "rejects a colon with no thread count after it" do
+        expect_parse_error("default:", /thread count/i)
+      end
+
+      it "rejects a non-numeric thread count" do
+        expect_parse_error("default: abc", /thread count.*abc/i)
+      end
+
+      it "rejects a fractional thread count" do
+        expect_parse_error("default: 5.5", /thread count.*5\.5/i)
+      end
+
+      it "rejects zero threads" do
+        expect_parse_error("default: 0", /positive integer.*0/i)
+      end
+
+      it "rejects negative threads" do
+        expect_parse_error("default: -1", /thread count.*-1/i)
+      end
+
+      it "rejects a queue name with spaces" do
+        expect_parse_error("queue with spaces: 5", /invalid character|expected/i)
+      end
+
+      it "rejects two queues separated by space instead of comma" do
+        expect_parse_error("default mailers: 5", /invalid character|expected/i)
+      end
+
+      it "rejects the same queue listed in two capsules" do
+        expect_parse_error("default: 5; default: 3", /default.*two capsules|appears in two/i)
+      end
+
+      it "rejects the same queue listed twice within one capsule" do
+        expect_parse_error("default, default: 5", /default.*twice|duplicate/i)
+      end
+
+      it "rejects the wildcard in two capsules" do
+        expect_parse_error("*: 5; *: 3", /wildcard.*two capsules|\*.*appears in two/i)
+      end
+
+      it "includes the offending input in the error message" do
+        expect { described_class.parse("default: bogus") }.to raise_error(
+          Pgbus::Configuration::CapsuleDSL::ParseError,
+          /default: bogus/
+        )
+      end
+    end
+
+    context "with real-world configurations" do
+      it "parses the simplest single-wildcard shape" do
+        expect(described_class.parse("*: 5")).to eq([{ queues: ["*"], threads: 5 }])
+      end
+
+      it "parses a higher-thread production wildcard" do
+        expect(described_class.parse("*: 15")).to eq([{ queues: ["*"], threads: 15 }])
+      end
+
+      it "parses a fast/slow capsule split for reserving capacity" do
+        result = described_class.parse("default, statistics, low: 2; *: 3")
+        expect(result).to eq([
+                               { queues: %w[default statistics low], threads: 2 },
+                               { queues: ["*"], threads: 3 }
+                             ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR 2 of 10 in the configuration UX overhaul. Adds the parser for the new worker capsule string DSL, in a standalone module that doesn't yet wire into \`Configuration#workers=\`. PR 3 will do that wiring.

## The DSL

\`\`\`ruby
\"*: 5\"                              # one capsule, all queues, 5 threads
\"critical: 5; default: 10\"          # two capsules
\"critical, default: 5\"              # one capsule, list = strict priority
\"default, mailers: 10; *: 2\"        # specialized + fallback wildcard
\"staging_*: 3\"                      # prefix wildcard
\`\`\`

**Operators** (Sidekiq + SolidQueue style, NOT GoodJob's \`+\`/\`-\` operators):

| Token | Meaning |
|---|---|
| \`,\` | Queue separator within a capsule. List order = strict priority |
| \`;\` | Capsule separator. Each becomes its own thread pool |
| \`:N\` | Thread count for the capsule (default 5) |
| \`*\` | Wildcard, matches all queues (existing Pgbus behavior) |
| \`prefix_*\` | Trailing wildcard, prefix match (SolidQueue-inspired) |

**Why no \`+\` or \`-\`?** List order already means strict priority — no operator needed. SolidQueue and Sidekiq use the same convention. Negation (\`-\`) doesn't exist in either.

## Output shape

The parser returns the same \`Array<Hash>\` shape the existing internals already consume:

\`\`\`ruby
[{ queues: [\"critical\"], threads: 5 },
 { queues: [\"default\", \"mailers\"], threads: 10 }]
\`\`\`

So PR 3 can wire it into \`Configuration#workers=\` as a simple shim: _if String, parse it; if Array, use as-is._ Backwards compatible with every existing \`workers:\` config.

## Validation

All checks run at parse time. Errors include the offending input and identify the rule that was violated:

- Empty/whitespace/nil input
- Leading/doubled semicolons (empty capsule)
- Missing queue name before \`:\`
- Missing/non-numeric/zero/negative thread count
- Invalid characters in queue names (e.g. spaces)
- Duplicate queues within one capsule
- Duplicate queues across capsules (would cause double-processing)
- Wildcard appearing in two capsules

## Test plan

- [x] 33 unit tests covering the full happy path + error matrix
- [x] Real-world examples (wildcard-only, fast/slow capsule split)
- [x] 823 unit tests pass, 0 failures
- [x] 97 integration tests pass, 0 failures
- [x] Rubocop clean

## Coming next

- **PR 3**: Named capsule API (\`c.capsule :critical, ...\`) + \`Configuration#workers=\` shim that accepts a string + CLI \`--capsule NAME\` selection
- **PR 4**: CLI role flags (\`--workers-only\`, \`--scheduler-only\`, \`--dispatcher-only\`)
- **PR 5**: Ruby DSL improvements (\`10.minutes\`, validation on assignment)
- **PR 6**: \`rails generate pgbus:update\` migration tool
- **PR 7-8**: Cull constants (move silent settings out of \`Configuration\`)
- **PR 9**: README reorg
- **PR 10**: Drop YAML loader (next minor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a capsule DSL parser for worker configuration: parse compact strings into [{ queues: [...], threads: N }], supporting wildcards, per-capsule thread counts, defaults, and strict validation.

* **Tests**
  * Added comprehensive tests covering parsing behavior, whitespace tolerance, defaults, valid examples, and detailed error cases including duplicate and malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->