### PR TITLE
feat(config): named capsules + string DSL shim + CLI capsule selection

### DIFF
--- a/lib/pgbus/cli.rb
+++ b/lib/pgbus/cli.rb
@@ -64,12 +64,14 @@ module Pgbus
     def apply_capsule_filter(name)
       capsule = Pgbus.configuration.capsule_named(name)
       unless capsule
-        available = (Pgbus.configuration.workers || []).filter_map { |c| c[:name] }.compact
+        available = (Pgbus.configuration.workers || []).filter_map { |c| c[:name] || c["name"] }.compact
         raise ArgumentError,
               "no capsule named #{name.inspect} (available: #{available.join(", ")})"
       end
 
-      Pgbus.configuration.instance_variable_set(:@workers, [capsule])
+      # Go through the public setter so any future normalization/validation
+      # in workers= is applied consistently to the CLI override path too.
+      Pgbus.configuration.workers = [capsule]
     end
 
     def show_status

--- a/lib/pgbus/cli.rb
+++ b/lib/pgbus/cli.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "optparse"
+
 module Pgbus
   module CLI
     module_function
@@ -9,7 +11,7 @@ module Pgbus
 
       case command
       when "start"
-        start_supervisor
+        start_supervisor(args[1..] || [])
       when "status"
         show_status
       when "queues"
@@ -25,11 +27,49 @@ module Pgbus
       end
     end
 
-    def start_supervisor
+    def start_supervisor(args = [])
+      apply_start_options(args)
       Pgbus.logger.info { "[Pgbus] Starting Pgbus #{Pgbus::VERSION}..." }
 
       supervisor = Process::Supervisor.new
       supervisor.run
+    end
+
+    # Parses CLI flags for `pgbus start` and applies them to the global
+    # configuration before the supervisor boots. Designed to override the
+    # initializer config without requiring a redeploy.
+    def apply_start_options(args)
+      options = parse_start_options(args)
+
+      Pgbus.configuration.workers = options[:queues] if options[:queues]
+      apply_capsule_filter(options[:capsule]) if options[:capsule]
+    end
+
+    def parse_start_options(args)
+      options = {}
+      OptionParser.new do |opts|
+        opts.banner = "Usage: pgbus start [options]"
+
+        opts.on("--queues STRING", "Override worker capsules (e.g. \"critical: 5; default: 10\")") do |v|
+          options[:queues] = v
+        end
+
+        opts.on("--capsule NAME", "Run only the named capsule from the configured workers") do |v|
+          options[:capsule] = v
+        end
+      end.parse!(args.dup)
+      options
+    end
+
+    def apply_capsule_filter(name)
+      capsule = Pgbus.configuration.capsule_named(name)
+      unless capsule
+        available = (Pgbus.configuration.workers || []).filter_map { |c| c[:name] }.compact
+        raise ArgumentError,
+              "no capsule named #{name.inspect} (available: #{available.join(", ")})"
+      end
+
+      Pgbus.configuration.instance_variable_set(:@workers, [capsule])
     end
 
     def show_status
@@ -65,7 +105,7 @@ module Pgbus
 
     def print_help
       puts <<~HELP
-        Usage: pgbus <command>
+        Usage: pgbus <command> [options]
 
         Commands:
           start    Start the Pgbus supervisor (workers + dispatcher)
@@ -73,6 +113,13 @@ module Pgbus
           queues   List queues with metrics
           version  Show version
           help     Show this help
+
+        Options for `start`:
+          --queues STRING    Override worker capsules from the CLI
+                             (e.g. "critical: 5; default: 10")
+          --capsule NAME     Run only the named capsule from the configured
+                             workers (useful for one-capsule-per-process
+                             deployments)
       HELP
     end
   end

--- a/lib/pgbus/cli.rb
+++ b/lib/pgbus/cli.rb
@@ -64,7 +64,7 @@ module Pgbus
     def apply_capsule_filter(name)
       capsule = Pgbus.configuration.capsule_named(name)
       unless capsule
-        available = (Pgbus.configuration.workers || []).filter_map { |c| c[:name] || c["name"] }.compact
+        available = (Pgbus.configuration.workers || []).filter_map { |c| c[:name] || c["name"] }
         raise ArgumentError,
               "no capsule named #{name.inspect} (available: #{available.join(", ")})"
       end

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -182,7 +182,7 @@ module Pgbus
       raise ArgumentError, "visibility_timeout must be > 0" unless visibility_timeout.is_a?(Numeric) && visibility_timeout.positive?
       raise ArgumentError, "max_retries must be >= 0" unless max_retries.is_a?(Integer) && max_retries >= 0
 
-      workers.each do |w|
+      Array(workers).each do |w|
         threads = w[:threads] || w["threads"] || 5
         raise ArgumentError, "worker threads must be > 0" unless threads.is_a?(Integer) && threads.positive?
       end
@@ -224,7 +224,7 @@ module Pgbus
                  when nil
                    nil
                  when String
-                   CapsuleDSL.parse(value).map { |entry| entry.merge(name: entry[:queues].first) }
+                   CapsuleDSL.parse(value).map { |entry| entry.merge(name: entry[:queues].first.to_s) }
                  when Array
                    value
                  else
@@ -246,18 +246,14 @@ module Pgbus
       raise ArgumentError, "capsule queues must be a non-empty Array" unless queues.is_a?(Array) && queues.any?
       raise ArgumentError, "capsule threads must be a positive Integer" unless threads.is_a?(Integer) && threads.positive?
 
+      normalized_name = name.to_s
       @workers ||= []
 
-      raise ArgumentError, "capsule #{name.inspect} is already defined" if @workers.any? { |c| c[:name] == name }
+      raise ArgumentError, "capsule #{name.inspect} is already defined" if @workers.any? { |c| capsule_name(c) == normalized_name }
 
-      conflict = find_queue_overlap(queues)
-      if conflict
-        raise ArgumentError,
-              "queue #{conflict.inspect} is already assigned to another capsule — " \
-              "each queue can only belong to one capsule"
-      end
+      validate_no_queue_overlap!(queues)
 
-      @workers << { name: name, queues: queues, threads: threads, ** }
+      @workers << { name: normalized_name, queues: queues, threads: threads, ** }
     end
 
     # Look up a capsule by its name. Accepts symbol or string. Returns the
@@ -266,7 +262,7 @@ module Pgbus
       return nil unless @workers
 
       key = name.to_s
-      @workers.find { |c| c[:name].to_s == key }
+      @workers.find { |c| capsule_name(c) == key }
     end
 
     # Returns the connection pool size to use for the PGMQ client.
@@ -324,11 +320,40 @@ module Pgbus
     # that isn't a positive Integer with a clear error — silent coercion via
     # +to_i+ would let "abc" → 0 produce a critically under-sized pool with
     # no indication that something was wrong.
-    # Returns the first queue from +new_queues+ that's already assigned to
-    # any existing capsule, or nil if no overlap.
-    def find_queue_overlap(new_queues)
+    # Read a capsule's name from either symbol or string key, normalized
+    # to a string for comparison. Returns nil for unnamed (legacy) entries.
+    def capsule_name(entry)
+      raw = entry[:name] || entry["name"]
+      raw&.to_s
+    end
+
+    # Validates that no queue in +new_queues+ would overlap with any
+    # existing capsule. The wildcard '*' counts as overlapping with EVERY
+    # other queue (and vice versa) because at runtime '*' is expanded to
+    # all known queues. Raises ArgumentError on overlap.
+    def validate_no_queue_overlap!(new_queues)
       existing = (@workers || []).flat_map { |c| c[:queues] || c["queues"] || [] }
-      new_queues.find { |q| existing.include?(q) }
+      return if existing.empty?
+
+      if existing.include?(CapsuleDSL::WILDCARD)
+        raise ArgumentError,
+              "an existing capsule already uses '*' (matches every queue) — " \
+              "the new capsule's queues #{new_queues.inspect} would overlap with it"
+      end
+
+      if new_queues.include?(CapsuleDSL::WILDCARD)
+        raise ArgumentError,
+              "the new capsule uses '*' (matches every queue) but other capsules " \
+              "are already defined with queues #{existing.inspect} — " \
+              "the wildcard would overlap with all of them"
+      end
+
+      conflict = new_queues.find { |q| existing.include?(q) }
+      return unless conflict
+
+      raise ArgumentError,
+            "queue #{conflict.inspect} is already assigned to another capsule — " \
+            "each queue can only belong to one capsule"
     end
 
     def sum_thread_counts(entries, default_threads:, group:)

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -11,7 +11,8 @@ module Pgbus
     attr_accessor :default_queue, :queue_prefix
 
     # Worker settings
-    attr_accessor :workers, :polling_interval, :visibility_timeout, :prefetch_limit
+    attr_accessor :polling_interval, :visibility_timeout, :prefetch_limit
+    attr_reader :workers
 
     # Worker recycling
     attr_accessor :max_jobs_per_worker, :max_memory_mb, :max_worker_lifetime
@@ -199,6 +200,75 @@ module Pgbus
       self
     end
 
+    # Set the worker capsule list. Accepts:
+    #
+    #   String — parsed via Pgbus::Configuration::CapsuleDSL into capsules
+    #            with auto-generated names (each capsule's :name is its
+    #            first queue token).
+    #
+    #     c.workers "*: 5"
+    #     c.workers "critical: 5; default, mailers: 10"
+    #
+    #   Array  — legacy explicit form. Each entry is a Hash with :queues
+    #            and :threads (and optionally :name, :single_active_consumer,
+    #            :consumer_priority, :prefetch_limit).
+    #
+    #     c.workers [{ queues: %w[default], threads: 5 }]
+    #
+    #   nil    — no workers configured (used when running scheduler-only or
+    #            dispatcher-only processes).
+    #
+    # Raises ArgumentError for any other type.
+    def workers=(value)
+      @workers = case value
+                 when nil
+                   nil
+                 when String
+                   CapsuleDSL.parse(value).map { |entry| entry.merge(name: entry[:queues].first) }
+                 when Array
+                   value
+                 else
+                   raise ArgumentError,
+                         "workers must be a String (DSL), Array (legacy form), or nil — got #{value.class}"
+                 end
+    end
+
+    # Define a named capsule and append it to the workers list.
+    #
+    #   c.capsule :critical, queues: %w[critical], threads: 5
+    #   c.capsule :gated, queues: %w[gated], threads: 1, single_active_consumer: true
+    #
+    # Names must be unique. Queues must not overlap with capsules already
+    # defined (would cause double-processing). Composes with the string DSL —
+    # +c.workers "..."+ followed by +c.capsule :name, ...+ appends the
+    # named capsule to the list parsed from the string.
+    def capsule(name, queues:, threads:, **)
+      raise ArgumentError, "capsule queues must be a non-empty Array" unless queues.is_a?(Array) && queues.any?
+      raise ArgumentError, "capsule threads must be a positive Integer" unless threads.is_a?(Integer) && threads.positive?
+
+      @workers ||= []
+
+      raise ArgumentError, "capsule #{name.inspect} is already defined" if @workers.any? { |c| c[:name] == name }
+
+      conflict = find_queue_overlap(queues)
+      if conflict
+        raise ArgumentError,
+              "queue #{conflict.inspect} is already assigned to another capsule — " \
+              "each queue can only belong to one capsule"
+      end
+
+      @workers << { name: name, queues: queues, threads: threads, ** }
+    end
+
+    # Look up a capsule by its name. Accepts symbol or string. Returns the
+    # matching Hash, or nil. Used by the CLI's --capsule selector.
+    def capsule_named(name)
+      return nil unless @workers
+
+      key = name.to_s
+      @workers.find { |c| c[:name].to_s == key }
+    end
+
     # Returns the connection pool size to use for the PGMQ client.
     #
     # If +pool_size+ was explicitly set, returns that value unchanged. Otherwise
@@ -254,6 +324,13 @@ module Pgbus
     # that isn't a positive Integer with a clear error — silent coercion via
     # +to_i+ would let "abc" → 0 produce a critically under-sized pool with
     # no indication that something was wrong.
+    # Returns the first queue from +new_queues+ that's already assigned to
+    # any existing capsule, or nil if no overlap.
+    def find_queue_overlap(new_queues)
+      existing = (@workers || []).flat_map { |c| c[:queues] || c["queues"] || [] }
+      new_queues.find { |q| existing.include?(q) }
+    end
+
     def sum_thread_counts(entries, default_threads:, group:)
       return 0 unless entries
 

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -42,8 +42,9 @@ module Pgbus
       private
 
       def boot_processes
-        # Boot workers
-        config.workers.each do |worker_config|
+        # Boot workers (workers may be nil for scheduler-only or
+        # dispatcher-only deployments via the upcoming --workers-only flag).
+        Array(config.workers).each do |worker_config|
           fork_worker(worker_config)
         end
 

--- a/spec/pgbus/cli_spec.rb
+++ b/spec/pgbus/cli_spec.rb
@@ -29,6 +29,75 @@ RSpec.describe Pgbus::CLI do
     end
   end
 
+  describe ".start with start command" do
+    let(:supervisor) { instance_double(Pgbus::Process::Supervisor, run: nil) }
+
+    before do
+      allow(Pgbus::Process::Supervisor).to receive(:new).and_return(supervisor)
+      allow(Pgbus.logger).to receive(:info)
+    end
+
+    context "with --queues flag" do
+      it "overrides Pgbus.configuration.workers from the CLI" do
+        original_workers = Pgbus.configuration.workers
+        described_class.start(["start", "--queues", "critical: 5; default: 10"])
+        expect(Pgbus.configuration.workers.size).to eq(2)
+        expect(Pgbus.configuration.workers.map { |c| c[:name] }).to eq(%w[critical default])
+      ensure
+        Pgbus.configuration.instance_variable_set(:@workers, original_workers)
+      end
+
+      it "supports --queues=STRING with equals sign" do
+        original_workers = Pgbus.configuration.workers
+        described_class.start(["start", "--queues=*: 7"])
+        expect(Pgbus.configuration.workers).to eq([{ queues: ["*"], threads: 7, name: "*" }])
+      ensure
+        Pgbus.configuration.instance_variable_set(:@workers, original_workers)
+      end
+
+      it "raises a parse error for invalid queue strings" do
+        expect do
+          described_class.start(["start", "--queues", "default: 0"])
+        end.to raise_error(Pgbus::Configuration::CapsuleDSL::ParseError)
+      end
+    end
+
+    context "with --capsule flag" do
+      it "filters workers to only the named capsule" do
+        original_workers = Pgbus.configuration.workers
+        Pgbus.configuration.instance_variable_set(:@workers, nil)
+        Pgbus.configuration.capsule(:critical, queues: %w[critical], threads: 5)
+        Pgbus.configuration.capsule(:default, queues: %w[default], threads: 10)
+
+        described_class.start(["start", "--capsule", "critical"])
+
+        expect(Pgbus.configuration.workers.size).to eq(1)
+        expect(Pgbus.configuration.workers.first[:name]).to eq(:critical)
+      ensure
+        Pgbus.configuration.instance_variable_set(:@workers, original_workers)
+      end
+
+      it "raises when the named capsule does not exist" do
+        original_workers = Pgbus.configuration.workers
+        Pgbus.configuration.instance_variable_set(:@workers, nil)
+        Pgbus.configuration.capsule(:critical, queues: %w[critical], threads: 5)
+
+        expect do
+          described_class.start(["start", "--capsule", "missing"])
+        end.to raise_error(/no capsule named.*missing/i)
+      ensure
+        Pgbus.configuration.instance_variable_set(:@workers, original_workers)
+      end
+    end
+
+    context "without flags" do
+      it "starts the supervisor with the existing workers config" do
+        described_class.start(["start"])
+        expect(supervisor).to have_received(:run)
+      end
+    end
+  end
+
   describe ".show_status" do
     it "prints processes table when processes exist" do
       process = double("ProcessEntry",

--- a/spec/pgbus/cli_spec.rb
+++ b/spec/pgbus/cli_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Pgbus::CLI do
         described_class.start(["start", "--capsule", "critical"])
 
         expect(Pgbus.configuration.workers.size).to eq(1)
-        expect(Pgbus.configuration.workers.first[:name]).to eq(:critical)
+        expect(Pgbus.configuration.workers.first[:name]).to eq("critical")
       ensure
         Pgbus.configuration.instance_variable_set(:@workers, original_workers)
       end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -304,11 +304,14 @@ RSpec.describe Pgbus::Configuration do
       end
     end
 
-    context "when given anything else" do
-      it "raises ArgumentError for nil" do
-        expect { config.workers = nil }.not_to raise_error # nil is allowed (no workers)
+    context "when given nil" do
+      it "allows nil (no workers configured — used by scheduler-only / dispatcher-only deployments)" do
+        expect { config.workers = nil }.not_to raise_error
+        expect(config.workers).to be_nil
       end
+    end
 
+    context "when given anything else" do
       it "raises ArgumentError for an Integer" do
         expect { config.workers = 5 }.to raise_error(ArgumentError, /String.*Array|Array.*String/)
       end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -320,11 +320,11 @@ RSpec.describe Pgbus::Configuration do
   end
 
   describe "#capsule" do
-    it "appends a named capsule to workers" do
+    it "appends a named capsule to workers (with name normalized to string)" do
       config.workers = nil
       config.capsule(:critical, queues: %w[critical], threads: 5)
       expect(config.workers).to eq([
-                                     { name: :critical, queues: %w[critical], threads: 5 }
+                                     { name: "critical", queues: %w[critical], threads: 5 }
                                    ])
     end
 
@@ -343,17 +343,17 @@ RSpec.describe Pgbus::Configuration do
     end
 
     it "appends to an existing workers list set via the string DSL" do
-      config.workers = "*: 5"
+      config.workers = "default: 5"
       config.capsule(:critical, queues: %w[critical], threads: 3)
       names = config.workers.map { |c| c[:name] }
-      expect(names).to eq(["*", :critical])
+      expect(names).to eq(%w[default critical])
     end
 
     it "appends to an existing workers list set via the legacy array form" do
       config.workers = [{ queues: %w[default], threads: 5 }]
       config.capsule(:reports, queues: %w[reports], threads: 2)
       expect(config.workers.size).to eq(2)
-      expect(config.workers.last[:name]).to eq(:reports)
+      expect(config.workers.last[:name]).to eq("reports")
     end
 
     it "raises if the same name is registered twice" do
@@ -399,11 +399,11 @@ RSpec.describe Pgbus::Configuration do
     end
 
     it "returns the matching capsule by symbol name" do
-      expect(config.capsule_named(:critical)).to include(name: :critical, threads: 5)
+      expect(config.capsule_named(:critical)).to include(name: "critical", threads: 5)
     end
 
     it "returns the matching capsule by string name" do
-      expect(config.capsule_named("critical")).to include(name: :critical, threads: 5)
+      expect(config.capsule_named("critical")).to include(name: "critical", threads: 5)
     end
 
     it "returns nil when no capsule matches" do
@@ -413,6 +413,50 @@ RSpec.describe Pgbus::Configuration do
     it "returns nil when workers is nil" do
       config.workers = nil
       expect(config.capsule_named(:any)).to be_nil
+    end
+  end
+
+  describe "capsule name normalization" do
+    it "stores symbol-named capsules as strings internally" do
+      config.workers = nil
+      config.capsule(:critical, queues: %w[critical], threads: 5)
+      expect(config.workers.first[:name]).to eq("critical")
+    end
+
+    it "stores string-named capsules as strings internally" do
+      config.workers = nil
+      config.capsule("critical", queues: %w[critical], threads: 5)
+      expect(config.workers.first[:name]).to eq("critical")
+    end
+
+    it "rejects symbol/string name collision (treats them as the same name)" do
+      config.workers = nil
+      config.capsule(:critical, queues: %w[critical], threads: 5)
+      expect do
+        config.capsule("critical", queues: %w[urgent], threads: 3)
+      end.to raise_error(ArgumentError, /already defined/)
+    end
+
+    it "string DSL stores auto-generated names as strings" do
+      config.workers = "critical: 5"
+      expect(config.workers.first[:name]).to eq("critical")
+    end
+  end
+
+  describe "wildcard overlap detection" do
+    it "rejects adding a capsule when an existing capsule has '*'" do
+      config.workers = "*: 5"
+      expect do
+        config.capsule(:critical, queues: %w[critical], threads: 3)
+      end.to raise_error(ArgumentError, /already.*capsule|wildcard/i)
+    end
+
+    it "rejects adding a '*' capsule when other queues already exist" do
+      config.workers = nil
+      config.capsule(:critical, queues: %w[critical], threads: 3)
+      expect do
+        config.capsule(:catch_all, queues: ["*"], threads: 5)
+      end.to raise_error(ArgumentError, /already.*capsule|wildcard/i)
     end
   end
 
@@ -450,6 +494,11 @@ RSpec.describe Pgbus::Configuration do
     it "rejects negative insights_default_minutes" do
       config.insights_default_minutes = -1
       expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
+    end
+
+    it "accepts nil workers (workerless modes like scheduler-only or dispatcher-only)" do
+      config.workers = nil
+      expect { config.validate! }.not_to raise_error
     end
 
     it "rejects fractional insights_default_minutes" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -271,6 +271,151 @@ RSpec.describe Pgbus::Configuration do
     end
   end
 
+  describe "#workers=" do
+    context "when given an Array (legacy form)" do
+      it "stores the array unchanged" do
+        config.workers = [{ queues: %w[default], threads: 5 }]
+        expect(config.workers).to eq([{ queues: %w[default], threads: 5 }])
+      end
+
+      it "preserves additional keys like single_active_consumer" do
+        config.workers = [{ queues: %w[critical], threads: 3, single_active_consumer: true }]
+        expect(config.workers.first[:single_active_consumer]).to be(true)
+      end
+    end
+
+    context "when given a String (new DSL form)" do
+      it "parses the string into the legacy array shape" do
+        config.workers = "*: 5"
+        expect(config.workers).to eq([{ queues: ["*"], threads: 5, name: "*" }])
+      end
+
+      it "auto-names each capsule by its first queue" do
+        config.workers = "critical, default: 5; mailers: 2"
+        names = config.workers.map { |c| c[:name] }
+        expect(names).to eq(%w[critical mailers])
+      end
+
+      it "raises CapsuleDSL::ParseError for invalid strings" do
+        expect { config.workers = "default: 0" }.to raise_error(
+          Pgbus::Configuration::CapsuleDSL::ParseError,
+          /positive integer/
+        )
+      end
+    end
+
+    context "when given anything else" do
+      it "raises ArgumentError for nil" do
+        expect { config.workers = nil }.not_to raise_error # nil is allowed (no workers)
+      end
+
+      it "raises ArgumentError for an Integer" do
+        expect { config.workers = 5 }.to raise_error(ArgumentError, /String.*Array|Array.*String/)
+      end
+
+      it "raises ArgumentError for a Hash" do
+        expect { config.workers = { queues: %w[default] } }.to raise_error(ArgumentError, /String.*Array|Array.*String/)
+      end
+    end
+  end
+
+  describe "#capsule" do
+    it "appends a named capsule to workers" do
+      config.workers = nil
+      config.capsule(:critical, queues: %w[critical], threads: 5)
+      expect(config.workers).to eq([
+                                     { name: :critical, queues: %w[critical], threads: 5 }
+                                   ])
+    end
+
+    it "preserves additional keys (single_active_consumer, consumer_priority)" do
+      config.workers = nil
+      config.capsule(
+        :gated,
+        queues: %w[gated],
+        threads: 1,
+        single_active_consumer: true,
+        consumer_priority: 10
+      )
+      capsule = config.workers.first
+      expect(capsule[:single_active_consumer]).to be(true)
+      expect(capsule[:consumer_priority]).to eq(10)
+    end
+
+    it "appends to an existing workers list set via the string DSL" do
+      config.workers = "*: 5"
+      config.capsule(:critical, queues: %w[critical], threads: 3)
+      names = config.workers.map { |c| c[:name] }
+      expect(names).to eq(["*", :critical])
+    end
+
+    it "appends to an existing workers list set via the legacy array form" do
+      config.workers = [{ queues: %w[default], threads: 5 }]
+      config.capsule(:reports, queues: %w[reports], threads: 2)
+      expect(config.workers.size).to eq(2)
+      expect(config.workers.last[:name]).to eq(:reports)
+    end
+
+    it "raises if the same name is registered twice" do
+      config.workers = nil
+      config.capsule(:critical, queues: %w[critical], threads: 5)
+      expect do
+        config.capsule(:critical, queues: %w[urgent], threads: 3)
+      end.to raise_error(ArgumentError, /:critical.*already defined/)
+    end
+
+    it "rejects nil queues" do
+      expect do
+        config.capsule(:bad, queues: nil, threads: 5)
+      end.to raise_error(ArgumentError, /queues/)
+    end
+
+    it "rejects empty queues" do
+      expect do
+        config.capsule(:bad, queues: [], threads: 5)
+      end.to raise_error(ArgumentError, /queues/)
+    end
+
+    it "rejects non-positive threads" do
+      expect do
+        config.capsule(:bad, queues: %w[a], threads: 0)
+      end.to raise_error(ArgumentError, /threads/)
+    end
+
+    it "raises if a queue overlaps with an already-defined capsule" do
+      config.workers = nil
+      config.capsule(:a, queues: %w[shared], threads: 5)
+      expect do
+        config.capsule(:b, queues: %w[shared], threads: 5)
+      end.to raise_error(ArgumentError, /shared.*already.*capsule/i)
+    end
+  end
+
+  describe "#capsule_named" do
+    before do
+      config.workers = nil
+      config.capsule(:critical, queues: %w[critical], threads: 5)
+      config.capsule(:default, queues: %w[default], threads: 10)
+    end
+
+    it "returns the matching capsule by symbol name" do
+      expect(config.capsule_named(:critical)).to include(name: :critical, threads: 5)
+    end
+
+    it "returns the matching capsule by string name" do
+      expect(config.capsule_named("critical")).to include(name: :critical, threads: 5)
+    end
+
+    it "returns nil when no capsule matches" do
+      expect(config.capsule_named(:missing)).to be_nil
+    end
+
+    it "returns nil when workers is nil" do
+      config.workers = nil
+      expect(config.capsule_named(:any)).to be_nil
+    end
+  end
+
   describe "#validate!" do
     it "rejects invalid prefetch_limit" do
       config.prefetch_limit = 0


### PR DESCRIPTION
## Summary

PR 3 of 10. Wires the string DSL parser (PR 2, merged) into the public Configuration API and adds the named capsule form, plus CLI flags for runtime override.

This is the first user-visible PR in the configuration UX overhaul series — after this lands, users can write `c.workers \"*: 5\"` in their initializer and `pgbus start --capsule critical` on the command line.

## What changes for users

**Before:**
```yaml
# config/pgbus.yml
workers:
  - queues: [\"*\"]
    threads: 5
```

**After (any of these works):**
```ruby
# config/initializers/pgbus.rb
Pgbus.configure do |c|
  c.workers \"*: 5\"                                           # string DSL
end

# Or named form for advanced cases
Pgbus.configure do |c|
  c.capsule :critical, queues: %w[critical], threads: 5,
                       single_active_consumer: true
  c.capsule :default,  queues: %w[default mailers], threads: 10
end
```

```bash
# Override worker config from the CLI
bundle exec pgbus start --queues \"critical: 5; default: 10\"

# Run only one named capsule (one-container-per-capsule pattern)
bundle exec pgbus start --capsule critical
```

## API additions

### `Configuration#workers=`
Now accepts:
- **String** — parsed via `CapsuleDSL` into capsules with auto-generated names (each capsule's `:name` is its first queue token)
- **Array** (legacy) — stored unchanged for backwards compatibility
- **nil** — no workers configured

### `Configuration#capsule(name, queues:, threads:, **opts)`
- Defines a named capsule and appends it to the workers list
- Names must be unique across capsules
- Queues must not overlap with already-defined capsules (would cause double-processing)
- Composes with the string DSL: `c.workers \"...\"` followed by `c.capsule :name, ...` appends

### `Configuration#capsule_named(name)`
- Lookup helper used by the CLI's `--capsule` selector
- Accepts symbol or string
- Returns the matching Hash, or nil

### CLI flags
- `pgbus start --queues STRING` — override worker capsules from the CLI
- `pgbus start --capsule NAME` — run only the named capsule
- Both compose. Both are no-ops if not passed. Uses `optparse` (stdlib).

## Backwards compatibility

- Every existing array-form `workers:` config keeps working unchanged
- Existing tests that set `config.workers = [{...}]` still pass
- The default config (`[{queues: %w[default], threads: 5}]`) is unchanged
- The new String form is opt-in
- The new CLI flags are opt-in

## Test plan

- [x] 26 new tests cover `Configuration#workers=` (Array, String, nil, type rejection), `#capsule` (basic, options, composition, name uniqueness, queue overlap, validation), `#capsule_named` (symbol, string, missing, nil-workers)
- [x] 5 new CLI tests cover `--queues`, `--queues=`, parse errors, `--capsule`, missing-capsule errors
- [x] 850 unit tests pass, 0 failures
- [x] 97 integration tests pass, 0 failures
- [x] Rubocop clean

## Coming next

- **PR 4**: CLI role flags (`--workers-only`, `--scheduler-only`, `--dispatcher-only`) for splitting roles across containers
- **PR 5**: Ruby DSL improvements (`c.visibility_timeout 10.minutes`, validation on assignment)
- **PR 6**: `rails generate pgbus:update` migration tool
- **PR 7-8**: Cull constants (move silent settings out of `Configuration`)
- **PR 9**: README reorg
- **PR 10**: Drop YAML loader (next minor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pgbus start` accepts and applies start options (including `--queues` and `--capsule`) to override which workers run.
* **Bug Fixes**
  * Configuration validation rejects overlapping queues (including wildcard conflicts) and safely handles no-workers (no crash).
* **Documentation**
  * Start command usage/help updated to document the new options.
* **Tests**
  * Added tests covering start option parsing, capsule filtering, workers assignment, and validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->