### PR TITLE
feat(cli): add --workers-only / --scheduler-only / --dispatcher-only flags

### DIFF
--- a/lib/pgbus/cli.rb
+++ b/lib/pgbus/cli.rb
@@ -43,6 +43,7 @@ module Pgbus
 
       Pgbus.configuration.workers = options[:queues] if options[:queues]
       apply_capsule_filter(options[:capsule]) if options[:capsule]
+      apply_role_filter(options)
     end
 
     def parse_start_options(args)
@@ -57,8 +58,43 @@ module Pgbus
         opts.on("--capsule NAME", "Run only the named capsule from the configured workers") do |v|
           options[:capsule] = v
         end
+
+        opts.on("--workers-only", "Run only the worker processes (no scheduler/dispatcher/consumers)") do
+          options[:workers_only] = true
+        end
+
+        opts.on("--scheduler-only", "Run only the recurring scheduler (the cron pod pattern)") do
+          options[:scheduler_only] = true
+        end
+
+        opts.on("--dispatcher-only", "Run only the dispatcher (the maintenance pod pattern)") do
+          options[:dispatcher_only] = true
+        end
       end.parse!(args.dup)
       options
+    end
+
+    ROLE_FLAG_TO_ROLE = {
+      workers_only: :workers,
+      scheduler_only: :scheduler,
+      dispatcher_only: :dispatcher
+    }.freeze
+    private_constant :ROLE_FLAG_TO_ROLE
+
+    # Translates --workers-only / --scheduler-only / --dispatcher-only into
+    # the corresponding +Pgbus.configuration.roles+ array. Mutually exclusive —
+    # passing more than one of the three flags raises ArgumentError.
+    def apply_role_filter(options)
+      role_flags = options.slice(*ROLE_FLAG_TO_ROLE.keys).compact
+      return if role_flags.empty?
+
+      if role_flags.size > 1
+        raise ArgumentError,
+              "--workers-only, --scheduler-only, and --dispatcher-only are mutually exclusive " \
+              "(got: #{role_flags.keys.map { |k| "--#{k.to_s.tr("_", "-")}" }.join(", ")})"
+      end
+
+      Pgbus.configuration.roles = [ROLE_FLAG_TO_ROLE.fetch(role_flags.keys.first)]
     end
 
     def apply_capsule_filter(name)
@@ -122,6 +158,12 @@ module Pgbus
           --capsule NAME     Run only the named capsule from the configured
                              workers (useful for one-capsule-per-process
                              deployments)
+          --workers-only     Run only worker processes (no scheduler/
+                             dispatcher/consumers — for worker-only containers)
+          --scheduler-only   Run only the recurring scheduler (the cron pod
+                             pattern — exactly one of these per deployment)
+          --dispatcher-only  Run only the dispatcher (the maintenance pod
+                             pattern)
       HELP
     end
   end

--- a/lib/pgbus/cli.rb
+++ b/lib/pgbus/cli.rb
@@ -59,7 +59,7 @@ module Pgbus
           options[:capsule] = v
         end
 
-        opts.on("--workers-only", "Run only the worker processes (no scheduler/dispatcher/consumers)") do
+        opts.on("--workers-only", "Run only the worker processes (no scheduler/dispatcher/consumers/outbox)") do
           options[:workers_only] = true
         end
 
@@ -159,7 +159,8 @@ module Pgbus
                              workers (useful for one-capsule-per-process
                              deployments)
           --workers-only     Run only worker processes (no scheduler/
-                             dispatcher/consumers — for worker-only containers)
+                             dispatcher/consumers/outbox — for worker-only
+                             containers)
           --scheduler-only   Run only the recurring scheduler (the cron pod
                              pattern — exactly one of these per deployment)
           --dispatcher-only  Run only the dispatcher (the maintenance pod

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -14,6 +14,13 @@ module Pgbus
     attr_accessor :polling_interval, :visibility_timeout, :prefetch_limit
     attr_reader :workers
 
+    # Supervisor role selection.
+    # nil = boot all roles (default behavior).
+    # Array of role symbols = boot only the listed roles.
+    # Set via the CLI flags --workers-only / --scheduler-only / --dispatcher-only,
+    # or directly in an initializer for advanced cases.
+    attr_accessor :roles
+
     # Worker recycling
     attr_accessor :max_jobs_per_worker, :max_memory_mb, :max_worker_lifetime
 
@@ -77,6 +84,7 @@ module Pgbus
       @queue_prefix = "pgbus"
 
       @workers = [{ queues: %w[default], threads: 5 }]
+      @roles = nil
       @polling_interval = 0.1
       @visibility_timeout = 30
 
@@ -263,6 +271,20 @@ module Pgbus
 
       key = name.to_s
       @workers.find { |c| capsule_name(c) == key }
+    end
+
+    # Returns true if the given role should be booted by the supervisor.
+    # When +roles+ is nil (the default), every role is enabled — this matches
+    # the legacy single-process behavior. When +roles+ is set (e.g. via the
+    # CLI's --workers-only / --scheduler-only / --dispatcher-only flags),
+    # only the listed roles boot.
+    #
+    # Accepts symbol or string for case-insensitive comparison.
+    def role_enabled?(role)
+      return true if @roles.nil?
+
+      key = role.to_sym
+      @roles.any? { |r| r.to_sym == key }
     end
 
     # Returns the connection pool size to use for the PGMQ client.

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -19,7 +19,9 @@ module Pgbus
     # Array of role symbols = boot only the listed roles.
     # Set via the CLI flags --workers-only / --scheduler-only / --dispatcher-only,
     # or directly in an initializer for advanced cases.
-    attr_accessor :roles
+    attr_reader :roles
+
+    VALID_ROLES = %i[workers dispatcher scheduler consumers outbox].freeze
 
     # Worker recycling
     attr_accessor :max_jobs_per_worker, :max_memory_mb, :max_worker_lifetime
@@ -283,34 +285,65 @@ module Pgbus
     def role_enabled?(role)
       return true if @roles.nil?
 
-      key = role.to_sym
-      @roles.any? { |r| r.to_sym == key }
+      @roles.include?(role.to_s.downcase.to_sym)
+    end
+
+    # Set the supervisor role filter. Accepts:
+    #
+    #   nil           — boot all roles (default)
+    #   Symbol/String — wraps into a single-element array
+    #   Array         — list of roles to boot
+    #
+    # Each role is normalized to a downcased symbol and validated against
+    # VALID_ROLES. Unknown role names raise ArgumentError immediately so
+    # typos like `[:workres]` fail loud at boot rather than leaving the
+    # supervisor idling with no children.
+    def roles=(value)
+      if value.nil?
+        @roles = nil
+        return
+      end
+
+      normalized = Array(value).map { |r| r.to_s.downcase.to_sym }.uniq
+      invalid = normalized - VALID_ROLES
+      if invalid.any?
+        raise ArgumentError,
+              "invalid role(s) #{invalid.inspect} — valid roles are: #{VALID_ROLES.join(", ")}"
+      end
+
+      @roles = normalized
     end
 
     # Returns the connection pool size to use for the PGMQ client.
     #
     # If +pool_size+ was explicitly set, returns that value unchanged. Otherwise
-    # auto-derives from the configured worker and event_consumer thread counts:
+    # auto-derives from the threads needed by the roles this process actually
+    # runs (respects +Configuration#roles+ from --workers-only / --scheduler-only
+    # / --dispatcher-only):
     #
-    #   sum(workers.threads) + sum(event_consumers.threads) + 2
+    #   workers role     → sum(workers.threads)
+    #   consumers role   → sum(event_consumers.threads)
+    #   dispatcher role  → +1
+    #   scheduler role   → +1
     #
-    # The +2 covers the dispatcher and scheduler, which each issue occasional
-    # queries against the same connection pool.
+    # A --scheduler-only deployment that has 50 worker threads configured
+    # only needs 1 connection (for the scheduler), not 52.
     #
     # Auto-tune protects users from the common pitfall of running 15 worker
     # threads with a hand-set pool_size of 5 (resulting in ConnectionPool
     # timeouts under load). Setting pool_size explicitly is still supported
     # for advanced cases where you need a tighter or looser pool than the
     # default formula provides.
-    POOL_SIZE_OVERHEAD = 2 # dispatcher + scheduler
     POOL_SIZE_WARN_THRESHOLD = 50
 
     def resolved_pool_size
       return pool_size if pool_size
 
-      total = sum_thread_counts(workers, default_threads: 5, group: "worker") +
-              sum_thread_counts(event_consumers, default_threads: 3, group: "event_consumer") +
-              POOL_SIZE_OVERHEAD
+      total = 0
+      total += sum_thread_counts(workers, default_threads: 5, group: "worker") if role_enabled?(:workers)
+      total += sum_thread_counts(event_consumers, default_threads: 3, group: "event_consumer") if role_enabled?(:consumers)
+      total += 1 if role_enabled?(:dispatcher)
+      total += 1 if role_enabled?(:scheduler)
 
       warn_if_oversized(total)
       total

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -43,22 +43,16 @@ module Pgbus
 
       def boot_processes
         # Boot workers (workers may be nil for scheduler-only or
-        # dispatcher-only deployments via the upcoming --workers-only flag).
-        Array(config.workers).each do |worker_config|
-          fork_worker(worker_config)
-        end
+        # dispatcher-only deployments via --workers-only / --scheduler-only /
+        # --dispatcher-only CLI flags). Each role is gated by
+        # config.role_enabled?, which returns true unless +config.roles+ has
+        # been narrowed.
+        Array(config.workers).each { |worker_config| fork_worker(worker_config) } if config.role_enabled?(:workers)
 
-        # Boot dispatcher
-        fork_dispatcher
-
-        # Boot recurring scheduler if configured
-        boot_scheduler
-
-        # Boot event consumers if configured
-        boot_consumers
-
-        # Boot outbox poller if configured
-        boot_outbox_poller
+        fork_dispatcher if config.role_enabled?(:dispatcher)
+        boot_scheduler if config.role_enabled?(:scheduler)
+        boot_consumers if config.role_enabled?(:consumers)
+        boot_outbox_poller if config.role_enabled?(:outbox)
       end
 
       def fork_worker(worker_config)

--- a/spec/pgbus/cli_spec.rb
+++ b/spec/pgbus/cli_spec.rb
@@ -95,6 +95,75 @@ RSpec.describe Pgbus::CLI do
         described_class.start(["start"])
         expect(supervisor).to have_received(:run)
       end
+
+      it "leaves config.roles nil (boot every role)" do
+        original_roles = Pgbus.configuration.roles
+        described_class.start(["start"])
+        expect(Pgbus.configuration.roles).to be_nil
+      ensure
+        Pgbus.configuration.roles = original_roles
+      end
+    end
+
+    context "with --workers-only flag" do
+      it "sets config.roles to [:workers]" do
+        original_roles = Pgbus.configuration.roles
+        described_class.start(["start", "--workers-only"])
+        expect(Pgbus.configuration.roles).to eq([:workers])
+      ensure
+        Pgbus.configuration.roles = original_roles
+      end
+    end
+
+    context "with --scheduler-only flag" do
+      it "sets config.roles to [:scheduler]" do
+        original_roles = Pgbus.configuration.roles
+        described_class.start(["start", "--scheduler-only"])
+        expect(Pgbus.configuration.roles).to eq([:scheduler])
+      ensure
+        Pgbus.configuration.roles = original_roles
+      end
+    end
+
+    context "with --dispatcher-only flag" do
+      it "sets config.roles to [:dispatcher]" do
+        original_roles = Pgbus.configuration.roles
+        described_class.start(["start", "--dispatcher-only"])
+        expect(Pgbus.configuration.roles).to eq([:dispatcher])
+      ensure
+        Pgbus.configuration.roles = original_roles
+      end
+    end
+
+    context "with multiple --*-only flags (mutually exclusive)" do
+      it "raises ArgumentError when --workers-only and --scheduler-only are both passed" do
+        expect do
+          described_class.start(["start", "--workers-only", "--scheduler-only"])
+        end.to raise_error(ArgumentError, /mutually exclusive/i)
+      end
+
+      it "raises ArgumentError when all three are passed" do
+        expect do
+          described_class.start(["start", "--workers-only", "--scheduler-only", "--dispatcher-only"])
+        end.to raise_error(ArgumentError, /mutually exclusive/i)
+      end
+    end
+
+    context "when composing role flags with --capsule" do
+      it "allows --workers-only --capsule critical" do
+        original_workers = Pgbus.configuration.workers
+        original_roles = Pgbus.configuration.roles
+        Pgbus.configuration.instance_variable_set(:@workers, nil)
+        Pgbus.configuration.capsule(:critical, queues: %w[critical], threads: 5)
+
+        described_class.start(["start", "--workers-only", "--capsule", "critical"])
+
+        expect(Pgbus.configuration.roles).to eq([:workers])
+        expect(Pgbus.configuration.workers.first[:name]).to eq("critical")
+      ensure
+        Pgbus.configuration.instance_variable_set(:@workers, original_workers)
+        Pgbus.configuration.roles = original_roles
+      end
     end
   end
 

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -499,6 +499,99 @@ RSpec.describe Pgbus::Configuration do
     end
   end
 
+  describe "#roles=" do
+    it "stores nil unchanged" do
+      config.roles = nil
+      expect(config.roles).to be_nil
+    end
+
+    it "normalizes string roles to symbols" do
+      config.roles = %w[workers dispatcher]
+      expect(config.roles).to eq(%i[workers dispatcher])
+    end
+
+    it "lowercases mixed-case role names" do
+      config.roles = %w[WORKERS Dispatcher]
+      expect(config.roles).to eq(%i[workers dispatcher])
+    end
+
+    it "wraps a single non-array value into an array" do
+      config.roles = :workers
+      expect(config.roles).to eq([:workers])
+    end
+
+    it "deduplicates" do
+      config.roles = %i[workers workers dispatcher]
+      expect(config.roles).to eq(%i[workers dispatcher])
+    end
+
+    it "raises ArgumentError for an unknown role (typo protection)" do
+      expect { config.roles = [:workres] }.to raise_error(ArgumentError, /invalid role.*workres/i)
+    end
+
+    it "lists valid roles in the error message" do
+      expect { config.roles = [:bogus] }.to raise_error(ArgumentError, /workers.*dispatcher.*scheduler/i)
+    end
+
+    it "does not raise for any of the supported roles" do
+      %i[workers dispatcher scheduler consumers outbox].each do |role|
+        expect { config.roles = [role] }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#resolved_pool_size with role filtering" do
+    context "when roles is nil (default — boot everything)" do
+      it "includes worker + event_consumer + dispatcher + scheduler thread counts" do
+        config.pool_size = nil
+        config.roles = nil
+        config.workers = [{ queues: %w[default], threads: 5 }]
+        config.event_consumers = [{ topics: %w[orders.#], threads: 3 }]
+        # 5 workers + 3 consumers + 1 dispatcher + 1 scheduler = 10
+        expect(config.resolved_pool_size).to eq(10)
+      end
+    end
+
+    context "when running --workers-only" do
+      it "excludes dispatcher and scheduler overhead from the pool size" do
+        config.pool_size = nil
+        config.roles = [:workers]
+        config.workers = [{ queues: %w[default], threads: 5 }]
+        config.event_consumers = [{ topics: %w[orders.#], threads: 3 }]
+        # only workers: 5 threads, no overhead, no consumers
+        expect(config.resolved_pool_size).to eq(5)
+      end
+    end
+
+    context "when running --scheduler-only" do
+      it "needs only the scheduler's connection slot" do
+        config.pool_size = nil
+        config.roles = [:scheduler]
+        config.workers = [{ queues: %w[default], threads: 50 }]
+        # workers are configured but not booted by this process
+        expect(config.resolved_pool_size).to eq(1)
+      end
+    end
+
+    context "when running --dispatcher-only" do
+      it "needs only the dispatcher's connection slot" do
+        config.pool_size = nil
+        config.roles = [:dispatcher]
+        config.workers = [{ queues: %w[default], threads: 50 }]
+        expect(config.resolved_pool_size).to eq(1)
+      end
+    end
+
+    context "when explicitly set" do
+      it "ignores roles and returns the explicit value" do
+        config.pool_size = 3
+        config.roles = [:scheduler]
+        config.workers = [{ queues: %w[default], threads: 5 }]
+        expect(config.resolved_pool_size).to eq(3)
+      end
+    end
+  end
+
   describe "#validate!" do
     it "rejects invalid prefetch_limit" do
       config.prefetch_limit = 0

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -463,6 +463,42 @@ RSpec.describe Pgbus::Configuration do
     end
   end
 
+  describe "#role_enabled?" do
+    context "when roles is nil (the default — boot everything)" do
+      it "returns true for every role" do
+        config.roles = nil
+        %i[workers dispatcher scheduler consumers outbox].each do |role|
+          expect(config.role_enabled?(role)).to be(true)
+        end
+      end
+    end
+
+    context "when roles is set to a subset" do
+      it "returns true only for roles in the subset" do
+        config.roles = %i[workers dispatcher]
+        expect(config.role_enabled?(:workers)).to be(true)
+        expect(config.role_enabled?(:dispatcher)).to be(true)
+        expect(config.role_enabled?(:scheduler)).to be(false)
+        expect(config.role_enabled?(:consumers)).to be(false)
+      end
+
+      it "accepts string role names" do
+        config.roles = %i[workers]
+        expect(config.role_enabled?("workers")).to be(true)
+        expect(config.role_enabled?("scheduler")).to be(false)
+      end
+    end
+
+    context "when roles is an empty array" do
+      it "returns false for every role (effectively disables the supervisor)" do
+        config.roles = []
+        %i[workers dispatcher scheduler consumers outbox].each do |role|
+          expect(config.role_enabled?(role)).to be(false)
+        end
+      end
+    end
+  end
+
   describe "#validate!" do
     it "rejects invalid prefetch_limit" do
       config.prefetch_limit = 0


### PR DESCRIPTION
## Summary

PR 4 of 10. Adds CLI role flags so a single Rails app can split into multiple containers, each running one supervisor role.

## The cron pod pattern (the killer use case)

Today, if you run multiple worker containers, the recurring scheduler runs in **every** container and multiple processes try to enqueue the same recurring job at the same time. The `RecurringExecution` dedup catches it (after the `canonical_run_at` fix in 0.3.6), but you still pay for wasted work and contention.

With `--scheduler-only`, you can dedicate exactly one container to the scheduler and have the rest run `--workers-only`. Same trick for the dispatcher (maintenance pod).

```yaml
# config/deploy.yml (Kamal example)
servers:
  worker:
    cmd: bundle exec pgbus start --workers-only
  scheduler:
    cmd: bundle exec pgbus start --scheduler-only
  dispatcher:
    cmd: bundle exec pgbus start --dispatcher-only
```

Three containers, three roles, no leader election needed.

## What changes

### `Configuration#roles` and `#role_enabled?`

```ruby
config.roles                    # nil (default — boot all roles)
config.roles = [:workers]       # boot only workers
config.role_enabled?(:workers)  # => true if roles is nil OR includes :workers
```

Used by `Supervisor#boot_processes` to gate each role's boot. Accepts symbol or string.

### `Supervisor#boot_processes`

Each role's boot is now wrapped in `config.role_enabled?(:role)`. Default behavior (no flags) is unchanged because `roles` defaults to nil.

```ruby
def boot_processes
  Array(config.workers).each { |w| fork_worker(w) } if config.role_enabled?(:workers)
  fork_dispatcher    if config.role_enabled?(:dispatcher)
  boot_scheduler     if config.role_enabled?(:scheduler)
  boot_consumers     if config.role_enabled?(:consumers)
  boot_outbox_poller if config.role_enabled?(:outbox)
end
```

### CLI flags (mutually exclusive)

- `pgbus start --workers-only` → `config.roles = [:workers]`
- `pgbus start --scheduler-only` → `config.roles = [:scheduler]`
- `pgbus start --dispatcher-only` → `config.roles = [:dispatcher]`

Passing more than one raises `ArgumentError` with a message naming both.

### Composition with PR 3 flags

```bash
pgbus start --workers-only --capsule critical
pgbus start --workers-only --queues "critical: 5"
```

## Backwards compatibility

`pgbus start` (no flags) keeps booting everything — workers, dispatcher, scheduler, consumers, outbox. `config.roles` defaults to nil. Every existing deployment continues to work unchanged.

## Test plan

- [x] 11 new tests cover `Configuration#role_enabled?` (nil, subset, empty, string args), CLI flag parsing for each `--*-only`, mutual exclusion, composition with `--capsule`
- [x] 868 unit tests pass, 0 failures
- [x] 97 integration tests pass, 0 failures
- [x] Rubocop clean

## Coming next

- **PR 5**: Ruby DSL improvements (`c.visibility_timeout 10.minutes`, validation on assignment)
- **PR 6**: `rails generate pgbus:update` migration tool
- **PR 7-8**: Cull constants
- **PR 9**: README reorg
- **PR 10**: Drop YAML loader


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--workers-only`, `--scheduler-only`, and `--dispatcher-only` mutually-exclusive CLI flags to `pgbus start` for selective supervisor component startup
  * Enhanced connection pool auto-tuning to optimize sizing based on enabled roles, reducing unnecessary resource overhead

<!-- end of auto-generated comment: release notes by coderabbit.ai -->