### PR TITLE
feat(config): coerce ActiveSupport::Duration on assignment for time settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Pgbus.configure do |config|
   config.outbox_enabled = true
   config.outbox_poll_interval = 1.0  # seconds
   config.outbox_batch_size = 100
-  config.outbox_retention = 24 * 3600  # keep published entries for 24h
+  config.outbox_retention = 1.day    # ActiveSupport::Duration also accepted
 end
 ```
 
@@ -600,7 +600,7 @@ PGMQ archive tables grow unbounded. Pgbus automatically purges old entries:
 
 ```ruby
 Pgbus.configure do |config|
-  config.archive_retention = 7 * 24 * 3600       # 7 days (default)
+  config.archive_retention = 7.days               # ActiveSupport::Duration (default 7 days)
   config.archive_compaction_interval = 3600       # run every hour (default)
   config.archive_compaction_batch_size = 1000     # delete in batches (default)
 end
@@ -619,7 +619,7 @@ The dispatcher runs archive compaction as part of its maintenance loop, deleting
 | `workers` | `[{queues: ["default"], threads: 5}]` | Worker process definitions |
 | `event_consumers` | `nil` | Event consumer process definitions (same format as workers) |
 | `polling_interval` | `0.1` | Seconds between polls (LISTEN/NOTIFY is primary) |
-| `visibility_timeout` | `30` | Seconds before unacked message becomes visible again |
+| `visibility_timeout` | `30` | Time before unacked message becomes visible again. Accepts seconds or `ActiveSupport::Duration` (e.g. `10.minutes`) |
 | `max_retries` | `5` | Failed reads before routing to dead letter queue |
 | `max_jobs_per_worker` | `nil` | Recycle worker after N jobs (nil = unlimited) |
 | `max_memory_mb` | `nil` | Recycle worker when memory exceeds N MB |
@@ -633,21 +633,21 @@ The dispatcher runs archive compaction as part of its maintenance loop, deleting
 | `circuit_breaker_max_backoff` | `600` | Max backoff cap in seconds |
 | `priority_levels` | `nil` | Number of priority sub-queues (nil = disabled, 2-10) |
 | `default_priority` | `1` | Default priority for jobs without explicit priority |
-| `archive_retention` | `604800` | Seconds to keep archived messages (7 days) |
+| `archive_retention` | `604800` (7 days) | How long to keep archived messages. Accepts seconds, `ActiveSupport::Duration` (e.g. `7.days`), or `nil` to disable cleanup |
 | `archive_compaction_interval` | `3600` | Seconds between archive cleanup runs |
 | `archive_compaction_batch_size` | `1000` | Rows deleted per batch during compaction |
 | `outbox_enabled` | `false` | Enable transactional outbox poller process |
 | `outbox_poll_interval` | `1.0` | Seconds between outbox poll cycles |
 | `outbox_batch_size` | `100` | Max entries per outbox poll cycle |
-| `outbox_retention` | `86400` | Seconds to keep published outbox entries (1 day) |
-| `idempotency_ttl` | `604800` | Seconds to keep processed event records (7 days, cleaned hourly) |
+| `outbox_retention` | `86400` (1 day) | How long to keep published outbox entries. Accepts seconds, Duration, or `nil` to disable cleanup |
+| `idempotency_ttl` | `604800` (7 days) | How long to keep processed event records. Accepts seconds, Duration, or `nil` to disable cleanup |
 | `base_controller_class` | `"::ActionController::Base"` | Base class for dashboard controllers (string, constantized at load time) |
 | `return_to_app_url` | `nil` | URL for "back to app" button in dashboard nav (nil hides the button) |
 | `web_auth` | `nil` | Lambda for dashboard authentication |
 | `web_refresh_interval` | `5000` | Dashboard auto-refresh interval in milliseconds |
 | `web_live_updates` | `true` | Enable Turbo Frames auto-refresh on dashboard |
 | `stats_enabled` | `true` | Record job execution stats for insights dashboard |
-| `stats_retention` | `604800` | Seconds to keep job stats (7 days) |
+| `stats_retention` | `2592000` (30 days) | How long to keep job stats. Accepts seconds, Duration, or `nil` to disable cleanup |
 
 ## Architecture
 

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -11,8 +11,8 @@ module Pgbus
     attr_accessor :default_queue, :queue_prefix
 
     # Worker settings
-    attr_accessor :polling_interval, :visibility_timeout, :prefetch_limit
-    attr_reader :workers
+    attr_accessor :polling_interval, :prefetch_limit
+    attr_reader :workers, :visibility_timeout # rubocop:disable Style/AccessorGrouping
 
     # Supervisor role selection.
     # nil = boot all roles (default behavior).
@@ -40,13 +40,16 @@ module Pgbus
     attr_accessor :priority_levels, :default_priority
 
     # Archive compaction
-    attr_accessor :archive_retention, :archive_compaction_interval, :archive_compaction_batch_size
+    attr_accessor :archive_compaction_interval, :archive_compaction_batch_size
+    attr_reader :archive_retention # rubocop:disable Style/AccessorGrouping
 
     # Transactional outbox
-    attr_accessor :outbox_enabled, :outbox_poll_interval, :outbox_batch_size, :outbox_retention
+    attr_accessor :outbox_enabled, :outbox_poll_interval, :outbox_batch_size
+    attr_reader :outbox_retention # rubocop:disable Style/AccessorGrouping
 
     # Event bus
-    attr_accessor :idempotency_ttl, :allowed_global_id_models
+    attr_accessor :allowed_global_id_models
+    attr_reader :idempotency_ttl # rubocop:disable Style/AccessorGrouping
 
     # Logging
     attr_accessor :logger
@@ -61,8 +64,8 @@ module Pgbus
     attr_accessor :event_consumers
 
     # Recurring jobs
-    attr_accessor :recurring_tasks, :recurring_schedule_interval, :recurring_tasks_file,
-                  :skip_recurring, :recurring_execution_retention
+    attr_accessor :recurring_tasks, :recurring_schedule_interval, :recurring_tasks_file, :skip_recurring
+    attr_reader :recurring_execution_retention # rubocop:disable Style/AccessorGrouping
 
     # Multi-database support (optional separate database for pgbus tables)
     # Set to { database: { writing: :pgbus, reading: :pgbus } } to use a separate database.
@@ -70,7 +73,8 @@ module Pgbus
     attr_accessor :connects_to
 
     # Job stats
-    attr_accessor :stats_retention, :stats_enabled
+    attr_accessor :stats_enabled
+    attr_reader :stats_retention # rubocop:disable Style/AccessorGrouping
 
     # Web dashboard
     attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source,
@@ -314,6 +318,38 @@ module Pgbus
       @roles = normalized
     end
 
+    # Duration setters: each accepts either a Numeric (seconds) or an
+    # ActiveSupport::Duration (e.g. 10.minutes, 7.days). Validation runs
+    # immediately on assignment so misconfigurations crash at boot rather
+    # than leaving stale state until a `validate!` call somewhere.
+    #
+    # Numeric values are stored unchanged (preserving Float for sub-second
+    # values). Duration values are coerced to Integer seconds via .to_i.
+
+    def visibility_timeout=(value)
+      @visibility_timeout = coerce_duration!(value, :visibility_timeout)
+    end
+
+    def archive_retention=(value)
+      @archive_retention = coerce_duration!(value, :archive_retention)
+    end
+
+    def outbox_retention=(value)
+      @outbox_retention = coerce_duration!(value, :outbox_retention)
+    end
+
+    def idempotency_ttl=(value)
+      @idempotency_ttl = coerce_duration!(value, :idempotency_ttl)
+    end
+
+    def stats_retention=(value)
+      @stats_retention = coerce_duration!(value, :stats_retention)
+    end
+
+    def recurring_execution_retention=(value)
+      @recurring_execution_retention = coerce_duration!(value, :recurring_execution_retention)
+    end
+
     # Returns the connection pool size to use for the PGMQ client.
     #
     # If +pool_size+ was explicitly set, returns that value unchanged. Otherwise
@@ -370,11 +406,41 @@ module Pgbus
 
     private
 
-    # Sum the +:threads+ values across a list of worker/consumer entries.
-    # Uses +default_threads+ when an entry omits the key. Rejects anything
-    # that isn't a positive Integer with a clear error — silent coercion via
-    # +to_i+ would let "abc" → 0 produce a critically under-sized pool with
-    # no indication that something was wrong.
+    # Coerce a duration setting value to a positive Numeric.
+    #
+    # Accepts an ActiveSupport::Duration (coerced to Integer seconds via .to_i)
+    # or a Numeric (stored as-is, preserving Float for sub-second values).
+    # Raises ArgumentError immediately for nil, zero, negative, or non-numeric
+    # input — callers crash at boot rather than carrying silently-broken state.
+    def coerce_duration!(value, name)
+      # nil is a valid sentinel for "feature disabled" (e.g. archive_retention,
+      # idempotency_ttl, recurring_execution_retention all use nil to skip the
+      # corresponding maintenance task in the dispatcher).
+      return nil if value.nil?
+
+      # Check Duration FIRST because ActiveSupport overrides Numeric#is_a?
+      # to return true for Integer, so a duration would otherwise be caught
+      # by the Numeric branch and stored as-is (uncoerced).
+      duration_class_loaded = defined?(ActiveSupport::Duration)
+      return validate_positive_duration!(value.to_i, name) if duration_class_loaded && value.is_a?(ActiveSupport::Duration)
+
+      # Plain Numeric (Integer, Float, Rational). Use class identity rather
+      # than is_a? for the Duration exclusion because ActiveSupport overrides
+      # is_a? — see comment above.
+      if value.is_a?(Numeric) && (!defined?(ActiveSupport::Duration) || value.class != ActiveSupport::Duration)
+        return validate_positive_duration!(value, name)
+      end
+
+      raise ArgumentError,
+            "#{name} must be a Numeric (seconds), ActiveSupport::Duration, or nil to disable, got #{value.inspect}"
+    end
+
+    def validate_positive_duration!(numeric, name)
+      raise ArgumentError, "#{name} must be a positive number, got #{numeric}" unless numeric.positive?
+
+      numeric
+    end
+
     # Read a capsule's name from either symbol or string key, normalized
     # to a string for comparison. Returns nil for unnamed (legacy) entries.
     def capsule_name(entry)

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -592,6 +592,94 @@ RSpec.describe Pgbus::Configuration do
     end
   end
 
+  describe "duration coercion on assignment" do
+    let(:duration_settings) do
+      %i[
+        visibility_timeout
+        archive_retention
+        idempotency_ttl
+        outbox_retention
+        stats_retention
+        recurring_execution_retention
+      ]
+    end
+
+    it "accepts a Numeric (interpreted as seconds, existing behavior)" do
+      duration_settings.each do |setting|
+        config.public_send("#{setting}=", 60)
+        expect(config.public_send(setting)).to eq(60)
+      end
+    end
+
+    it "accepts an ActiveSupport::Duration and stores as integer seconds" do
+      config.visibility_timeout = 10.minutes
+      expect(config.visibility_timeout).to eq(600)
+
+      config.archive_retention = 7.days
+      expect(config.archive_retention).to eq(7 * 24 * 3600)
+
+      config.idempotency_ttl = 7.days
+      expect(config.idempotency_ttl).to eq(7 * 24 * 3600)
+
+      config.outbox_retention = 1.day
+      expect(config.outbox_retention).to eq(24 * 3600)
+
+      config.stats_retention = 30.days
+      expect(config.stats_retention).to eq(30 * 24 * 3600)
+
+      config.recurring_execution_retention = 7.days
+      expect(config.recurring_execution_retention).to eq(7 * 24 * 3600)
+    end
+
+    it "raises ArgumentError immediately when assigned a negative number" do
+      duration_settings.each do |setting|
+        expect { config.public_send("#{setting}=", -1) }.to raise_error(
+          ArgumentError, /#{setting}.*positive/
+        )
+      end
+    end
+
+    it "raises ArgumentError immediately when assigned zero" do
+      duration_settings.each do |setting|
+        expect { config.public_send("#{setting}=", 0) }.to raise_error(
+          ArgumentError, /#{setting}.*positive/
+        )
+      end
+    end
+
+    it "raises ArgumentError immediately when assigned a non-numeric value" do
+      duration_settings.each do |setting|
+        expect { config.public_send("#{setting}=", "five seconds") }.to raise_error(
+          ArgumentError, /#{setting}.*Numeric.*Duration/
+        )
+      end
+    end
+
+    it "accepts nil as a valid sentinel for 'feature disabled'" do
+      # archive_retention, idempotency_ttl, recurring_execution_retention all
+      # use nil to skip the corresponding maintenance task in the dispatcher.
+      duration_settings.each do |setting|
+        expect { config.public_send("#{setting}=", nil) }.not_to raise_error
+        expect(config.public_send(setting)).to be_nil
+      end
+    end
+
+    it "stores Duration values as a plain Integer (downstream code reads seconds)" do
+      config.visibility_timeout = 30.seconds
+      # ActiveSupport::Duration overrides BOTH is_a? AND instance_of? to return
+      # true for Integer, so we have to check the actual class identity to
+      # confirm the Duration was coerced rather than stored as-is.
+      expect(config.visibility_timeout.class).to eq(Integer)
+      expect(config.visibility_timeout).to eq(30)
+    end
+
+    it "preserves Float values for sub-second settings" do
+      # Numerics that happen to be float should pass through unchanged
+      config.visibility_timeout = 0.5
+      expect(config.visibility_timeout).to eq(0.5)
+    end
+  end
+
   describe "#validate!" do
     it "rejects invalid prefetch_limit" do
       config.prefetch_limit = 0


### PR DESCRIPTION
## Summary

PR 5 of 10. Six time-valued settings now accept `ActiveSupport::Duration` in addition to plain seconds, AND validate on assignment so misconfigurations crash at boot rather than carrying broken state.

## Before / After

```ruby
# Before
Pgbus.configure do |c|
  c.visibility_timeout = 600           # 10 min — must exceed longest job
  c.archive_retention = 7 * 24 * 3600  # 7 days
  c.idempotency_ttl = 604800           # 7 days
  c.outbox_retention = 24 * 3600       # 1 day
  c.stats_retention = 30 * 24 * 3600   # 30 days
end

# After
Pgbus.configure do |c|
  c.visibility_timeout = 10.minutes
  c.archive_retention = 7.days
  c.idempotency_ttl = 7.days
  c.outbox_retention = 1.day
  c.stats_retention = 30.days
end
```

The comments explaining "what 604800 means" are gone — the code IS the comment.

## Settings affected

| Setting | Default | Used by |
|---|---|---|
| `visibility_timeout` | 30s | PGMQ message visibility |
| `archive_retention` | 7 days | dispatcher archive cleanup |
| `idempotency_ttl` | 7 days | dispatcher processed_events cleanup |
| `outbox_retention` | 1 day | dispatcher outbox cleanup |
| `stats_retention` | 30 days | dispatcher job_stats cleanup |
| `recurring_execution_retention` | 7 days | dispatcher recurring_executions cleanup |

## Validation on assignment

```ruby
config.visibility_timeout = -5
# => ArgumentError: visibility_timeout must be a positive number, got -5

config.archive_retention = "seven days"
# => ArgumentError: archive_retention must be a Numeric (seconds), ActiveSupport::Duration, or nil to disable, got "seven days"

config.idempotency_ttl = nil
# => OK — nil is a valid sentinel for "feature disabled"
```

The dispatcher already uses `nil` to mean "skip this maintenance task" (`return unless retention&.positive?`), so `nil` had to remain valid. Two existing dispatcher tests verify this behavior.

## Two ActiveSupport gotchas the implementation handles

1. `ActiveSupport::Duration` overrides `is_a?(Numeric)` to return true via delegation. The duration check has to come FIRST, otherwise the Numeric branch catches it and stores the Duration object unchanged.
2. `ActiveSupport::Duration` ALSO overrides `is_a?(Integer)` and `instance_of?(Integer)`. The "is this really coerced to Integer" test has to use `.class == Integer`.

I learned the second one the hard way — my first version of the test passed even when the coercion wasn't happening.

## Backwards compatibility

- Numeric values keep working unchanged (`config.visibility_timeout = 30` still does what it always did)
- Float values are preserved (no surprise `.to_i` truncation)
- `nil` still means "disabled" for the settings the dispatcher checks

## Test plan

- [x] 8 new tests cover Numeric input, Duration input, negative/zero/non-numeric/nil handling, plain-Integer storage assertion
- [x] 889 unit tests pass, 0 failures
- [x] 97 integration tests pass, 0 failures
- [x] Rubocop clean

Also fixed a pre-existing README bug where `stats_retention` was documented as 7 days but the actual default is 30 days.

## Coming next

- **PR 6**: `rails generate pgbus:update` migration tool — converts `config/pgbus.yml` to a Ruby initializer using all the niceties added in PRs 1-5
- **PR 7-8**: Cull constants (move silent settings out of `Configuration`)
- **PR 9**: README reorg
- **PR 10**: Drop YAML loader (next minor)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now accepts `ActiveSupport::Duration` objects (e.g., `1.day`, `10.minutes`) in addition to numeric seconds for retention and timeout settings.

* **Improvements**
  * Configuration validation now occurs at assignment time, catching invalid settings earlier during initialization.

* **Documentation**
  * Updated configuration reference to document supported formats and defaults for duration-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->