### PR TITLE
refactor(config): cull silent settings to constants on owner classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,16 +529,19 @@ Pgbus automatically pauses queues that fail repeatedly, preventing cascading fai
 ```ruby
 Pgbus.configure do |config|
   config.circuit_breaker_enabled = true   # default
-  config.circuit_breaker_threshold = 5    # consecutive failures before tripping
-  config.circuit_breaker_base_backoff = 30  # seconds (doubles per trip)
-  config.circuit_breaker_max_backoff = 600  # 10 minute cap
 end
 ```
+
+The trip threshold (`5` consecutive failures), base backoff (`30s`), and
+max backoff (`600s`) are tuned via constants on `Pgbus::CircuitBreaker`.
+Override the constants in an initializer if you need different values —
+they are not exposed as configuration because tweaking them at runtime
+has never proved useful in practice.
 
 When a queue hits the failure threshold:
 1. The circuit breaker **auto-pauses** the queue with exponential backoff
 2. After the backoff expires, the queue **auto-resumes** and the trip counter resets
-3. If failures continue, each trip doubles the backoff (capped at `max_backoff`)
+3. If failures continue, each trip doubles the backoff (capped at `MAX_BACKOFF`)
 
 You can also **manually pause/resume** queues from the dashboard. The pause state is stored in the `pgbus_queue_states` table and survives restarts.
 
@@ -601,12 +604,16 @@ PGMQ archive tables grow unbounded. Pgbus automatically purges old entries:
 ```ruby
 Pgbus.configure do |config|
   config.archive_retention = 7.days               # ActiveSupport::Duration (default 7 days)
-  config.archive_compaction_interval = 3600       # run every hour (default)
-  config.archive_compaction_batch_size = 1000     # delete in batches (default)
 end
 ```
 
-The dispatcher runs archive compaction as part of its maintenance loop, deleting archived messages older than `archive_retention` in batches to avoid long-running transactions.
+The compaction loop runs every hour and deletes up to 1000 rows per
+queue per cycle. Both knobs live as constants on
+`Pgbus::Process::Dispatcher` (`ARCHIVE_COMPACTION_INTERVAL`,
+`ARCHIVE_COMPACTION_BATCH_SIZE`) — they have never been worth surfacing
+as configuration. The dispatcher runs archive compaction as part of its
+maintenance loop, deleting archived messages older than `archive_retention`
+in batches to avoid long-running transactions.
 
 ## Configuration reference
 
@@ -627,15 +634,10 @@ The dispatcher runs archive compaction as part of its maintenance loop, deleting
 | `listen_notify` | `true` | Use PGMQ's LISTEN/NOTIFY for instant wake-up |
 | `prefetch_limit` | `nil` | Max in-flight messages per worker (nil = unlimited) |
 | `dispatch_interval` | `1.0` | Seconds between dispatcher maintenance ticks |
-| `circuit_breaker_enabled` | `true` | Enable auto-pause on consecutive failures |
-| `circuit_breaker_threshold` | `5` | Consecutive failures before tripping |
-| `circuit_breaker_base_backoff` | `30` | Base backoff seconds (doubles per trip) |
-| `circuit_breaker_max_backoff` | `600` | Max backoff cap in seconds |
+| `circuit_breaker_enabled` | `true` | Enable auto-pause on consecutive failures (threshold and backoff are tuned via `Pgbus::CircuitBreaker` constants) |
 | `priority_levels` | `nil` | Number of priority sub-queues (nil = disabled, 2-10) |
 | `default_priority` | `1` | Default priority for jobs without explicit priority |
 | `archive_retention` | `604800` (7 days) | How long to keep archived messages. Accepts seconds, `ActiveSupport::Duration` (e.g. `7.days`), or `nil` to disable cleanup |
-| `archive_compaction_interval` | `3600` | Seconds between archive cleanup runs |
-| `archive_compaction_batch_size` | `1000` | Rows deleted per batch during compaction |
 | `outbox_enabled` | `false` | Enable transactional outbox poller process |
 | `outbox_poll_interval` | `1.0` | Seconds between outbox poll cycles |
 | `outbox_batch_size` | `100` | Max entries per outbox poll cycle |

--- a/app/controllers/pgbus/dead_letter_controller.rb
+++ b/app/controllers/pgbus/dead_letter_controller.rb
@@ -13,9 +13,7 @@ module Pgbus
 
     def retry
       queue_name = params[:queue_name].to_s
-      unless queue_name.end_with?(Pgbus.configuration.dead_letter_queue_suffix)
-        return redirect_to dead_letter_index_path, alert: "Invalid DLQ queue."
-      end
+      return redirect_to dead_letter_index_path, alert: "Invalid DLQ queue." unless queue_name.end_with?(Pgbus::DEAD_LETTER_SUFFIX)
 
       if data_source.retry_dlq_message(queue_name, params[:id])
         redirect_to dead_letter_index_path, notice: "Message re-enqueued to original queue."
@@ -26,9 +24,7 @@ module Pgbus
 
     def discard
       queue_name = params[:queue_name].to_s
-      unless queue_name.end_with?(Pgbus.configuration.dead_letter_queue_suffix)
-        return redirect_to dead_letter_index_path, alert: "Invalid DLQ queue."
-      end
+      return redirect_to dead_letter_index_path, alert: "Invalid DLQ queue." unless queue_name.end_with?(Pgbus::DEAD_LETTER_SUFFIX)
 
       if data_source.discard_dlq_message(queue_name, params[:id])
         redirect_to dead_letter_index_path, notice: "Message discarded."
@@ -57,7 +53,7 @@ module Pgbus
       count = 0
       selections.each do |sel|
         queue_name = sel[:queue_name].to_s
-        next unless queue_name.end_with?(Pgbus.configuration.dead_letter_queue_suffix)
+        next unless queue_name.end_with?(Pgbus::DEAD_LETTER_SUFFIX)
 
         count += 1 if data_source.discard_dlq_message(queue_name, sel[:msg_id])
       end

--- a/app/views/pgbus/dead_letter/_messages_table.html.erb
+++ b/app/views/pgbus/dead_letter/_messages_table.html.erb
@@ -24,8 +24,7 @@
       <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
         <% @messages.each do |m| %>
           <% payload = pgbus_parse_message(m[:message]) %>
-          <% dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX %>
-          <% source_queue = m[:queue_name].to_s.delete_suffix(dlq_suffix) %>
+          <% source_queue = m[:queue_name].to_s.delete_suffix(Pgbus::DEAD_LETTER_SUFFIX) %>
           <tr>
             <td class="w-10 px-4 py-3 align-top">
               <input type="checkbox" data-bulk-item data-pgbus-action="bulk-row-toggle"

--- a/app/views/pgbus/dead_letter/_messages_table.html.erb
+++ b/app/views/pgbus/dead_letter/_messages_table.html.erb
@@ -24,7 +24,7 @@
       <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
         <% @messages.each do |m| %>
           <% payload = pgbus_parse_message(m[:message]) %>
-          <% dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix %>
+          <% dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX %>
           <% source_queue = m[:queue_name].to_s.delete_suffix(dlq_suffix) %>
           <tr>
             <td class="w-10 px-4 py-3 align-top">

--- a/lib/generators/pgbus/templates/pgbus.yml.erb
+++ b/lib/generators/pgbus/templates/pgbus.yml.erb
@@ -17,7 +17,6 @@ default: &default
 
   # Use PostgreSQL LISTEN/NOTIFY for instant job wake-up
   listen_notify: true
-  notify_throttle_ms: 250
 
   # Visibility timeout in seconds (how long a message is invisible after being read)
   visibility_timeout: 30

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -3,6 +3,13 @@
 require "zeitwerk"
 
 module Pgbus
+  # Suffix appended to a queue name to derive its dead-letter companion
+  # (e.g. "pgbus_default" -> "pgbus_default_dlq"). Hard-coded here because
+  # changing it on a running deployment would orphan every existing DLQ
+  # message; nothing in the codebase or in user reports has ever needed
+  # this to be configurable.
+  DEAD_LETTER_SUFFIX = "_dlq"
+
   class Error < StandardError; end
   class ConfigurationError < Error; end
   class SerializationError < Error; end

--- a/lib/pgbus/circuit_breaker.rb
+++ b/lib/pgbus/circuit_breaker.rb
@@ -4,6 +4,20 @@ require "concurrent"
 
 module Pgbus
   class CircuitBreaker
+    # Number of consecutive failures on a queue before the breaker trips
+    # and pauses the queue. Tuned via constants rather than configuration
+    # because the value rarely needs adjusting and exposing it as a setting
+    # never proved useful in practice.
+    THRESHOLD = 5
+
+    # Initial backoff (seconds) on the first trip. Doubles on each
+    # subsequent trip up to MAX_BACKOFF.
+    BASE_BACKOFF = 30
+
+    # Cap on the exponential backoff (seconds). After ~5 trips the curve
+    # plateaus here so a perpetually-failing queue stops spamming retries.
+    MAX_BACKOFF = 600
+
     attr_reader :config
 
     def initialize(config: Pgbus.configuration)
@@ -22,7 +36,7 @@ module Pgbus
 
       count = @failure_counts.compute(queue_name) { |val| (val || 0) + 1 }
 
-      return unless count >= config.circuit_breaker_threshold
+      return unless count >= THRESHOLD
 
       trip!(queue_name, count)
     end
@@ -105,8 +119,8 @@ module Pgbus
     end
 
     def calculate_backoff(trip_count)
-      backoff = config.circuit_breaker_base_backoff * (2**(trip_count - 1))
-      [backoff, config.circuit_breaker_max_backoff].min
+      backoff = BASE_BACKOFF * (2**(trip_count - 1))
+      [backoff, MAX_BACKOFF].min
     end
   end
 end

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -9,6 +9,14 @@ module Pgbus
     PGMQ_REQUIRE_MUTEX = Mutex.new
     private_constant :PGMQ_REQUIRE_MUTEX
 
+    # Throttle window for PGMQ's enable_notify_insert trigger. Postgres
+    # NOTIFYs are coalesced into one wake-up per window, so a value of 250ms
+    # means: at most 4 broadcasts/sec per queue, regardless of insert rate.
+    # The trigger is a Postgres-level concern; exposing it as a setting
+    # never came up in practice and changing it on the fly would require
+    # re-running the trigger DDL on every queue.
+    NOTIFY_THROTTLE_MS = 250
+
     def initialize(config = Pgbus.configuration)
       # Define the PGMQ module before requiring the gem so that Zeitwerk's
       # eager_load (called inside pgmq.rb) can resolve the constant.
@@ -432,7 +440,7 @@ module Pgbus
       @queues_created.compute_if_absent(full_name) do
         synchronized do
           @pgmq.create(full_name)
-          @pgmq.enable_notify_insert(full_name, throttle_interval_ms: config.notify_throttle_ms) if config.listen_notify
+          @pgmq.enable_notify_insert(full_name, throttle_interval_ms: NOTIFY_THROTTLE_MS) if config.listen_notify
         end
         true
       end

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -29,19 +29,21 @@ module Pgbus
     # Dispatcher settings
     attr_accessor :dispatch_interval
 
-    # Circuit breaker
-    attr_accessor :circuit_breaker_enabled, :circuit_breaker_threshold,
-                  :circuit_breaker_base_backoff, :circuit_breaker_max_backoff
+    # Circuit breaker. Only `enabled` is user-facing — the trip threshold and
+    # backoff curve are tuned via constants on Pgbus::CircuitBreaker because
+    # they are implementation details that have never been worth exposing.
+    attr_accessor :circuit_breaker_enabled
 
     # Dead letter queue
-    attr_accessor :max_retries, :dead_letter_queue_suffix
+    attr_accessor :max_retries
 
     # Priority queues
     attr_accessor :priority_levels, :default_priority
 
-    # Archive compaction
-    attr_accessor :archive_compaction_interval, :archive_compaction_batch_size
-    attr_reader :archive_retention # rubocop:disable Style/AccessorGrouping
+    # Archive compaction. Only the user-facing retention window is configurable;
+    # the loop interval and batch size are tuned via constants on
+    # Pgbus::Process::Dispatcher.
+    attr_reader :archive_retention
 
     # Transactional outbox
     attr_accessor :outbox_enabled, :outbox_poll_interval, :outbox_batch_size
@@ -54,8 +56,10 @@ module Pgbus
     # Logging
     attr_accessor :logger
 
-    # LISTEN/NOTIFY
-    attr_accessor :listen_notify, :notify_throttle_ms
+    # LISTEN/NOTIFY. Only the on/off switch is user-facing — the throttle
+    # interval is a Postgres-side tuning knob that lives as a constant on
+    # Pgbus::Client (NOTIFY_THROTTLE_MS).
+    attr_accessor :listen_notify
 
     # PGMQ schema installation mode (:auto, :extension, :embedded)
     attr_reader :pgmq_schema_mode
@@ -103,19 +107,13 @@ module Pgbus
       @dispatch_interval = 1.0
 
       @circuit_breaker_enabled = true
-      @circuit_breaker_threshold = 5
-      @circuit_breaker_base_backoff = 30
-      @circuit_breaker_max_backoff = 600
 
       @max_retries = 5
-      @dead_letter_queue_suffix = "_dlq"
 
       @priority_levels = nil
       @default_priority = 1
 
       @archive_retention = 7 * 24 * 3600 # 7 days
-      @archive_compaction_interval = 3600
-      @archive_compaction_batch_size = 1000
 
       @outbox_enabled = false
       @outbox_poll_interval = 1.0
@@ -128,7 +126,6 @@ module Pgbus
       @logger = (defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger) || Logger.new($stdout)
 
       @listen_notify = true
-      @notify_throttle_ms = 250
 
       @pgmq_schema_mode = :auto
 
@@ -162,7 +159,7 @@ module Pgbus
     end
 
     def dead_letter_queue_name(name)
-      "#{queue_name(name)}#{dead_letter_queue_suffix}"
+      "#{queue_name(name)}#{Pgbus::DEAD_LETTER_SUFFIX}"
     end
 
     def priority_queue_name(name, priority)

--- a/lib/pgbus/generators/config_converter.rb
+++ b/lib/pgbus/generators/config_converter.rb
@@ -36,21 +36,33 @@ module Pgbus
         outbox_retention stats_retention recurring_execution_retention
       ].freeze
 
-      # Settings that no longer exist in the public API.
-      # pool_size is auto-tuned from worker thread counts as of PR 1.
-      DEPRECATED_SETTINGS = %w[pool_size].freeze
+      # Settings that no longer exist in the public API. The converter
+      # silently drops these from the generated initializer so users on
+      # legacy YAML get a clean migration.
+      #
+      #   - pool_size              -> auto-tuned from worker thread counts
+      #   - notify_throttle_ms     -> Pgbus::Client::NOTIFY_THROTTLE_MS
+      #   - circuit_breaker_*      -> Pgbus::CircuitBreaker constants
+      #   - archive_compaction_*   -> Pgbus::Process::Dispatcher constants
+      #   - dead_letter_queue_suffix -> Pgbus::DEAD_LETTER_SUFFIX (frozen)
+      DEPRECATED_SETTINGS = %w[
+        pool_size
+        notify_throttle_ms
+        circuit_breaker_threshold circuit_breaker_base_backoff circuit_breaker_max_backoff
+        archive_compaction_interval archive_compaction_batch_size
+        dead_letter_queue_suffix
+      ].freeze
 
       # Settings whose default we know how to compute by inspecting
       # Pgbus::Configuration.new. Any setting not listed here is emitted
       # as-is (we can't tell if it matches the default).
       KNOWN_SETTINGS = %w[
         queue_prefix default_queue pool_timeout listen_notify
-        notify_throttle_ms visibility_timeout max_retries idempotency_ttl
+        visibility_timeout max_retries idempotency_ttl
         max_jobs_per_worker max_memory_mb max_worker_lifetime
         dispatch_interval prefetch_limit
-        circuit_breaker_enabled circuit_breaker_threshold
-        circuit_breaker_base_backoff circuit_breaker_max_backoff
-        archive_retention archive_compaction_interval archive_compaction_batch_size
+        circuit_breaker_enabled
+        archive_retention
         outbox_enabled outbox_poll_interval outbox_batch_size outbox_retention
         stats_enabled stats_retention
         recurring_schedule_interval recurring_execution_retention skip_recurring

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -16,6 +16,12 @@ module Pgbus
       JOB_LOCK_CLEANUP_INTERVAL = 300 # Run job lock cleanup every 5 minutes
       STATS_CLEANUP_INTERVAL = 3600 # Run stats cleanup every hour
 
+      # Page size for archive compaction. Each cycle deletes up to this
+      # many archived rows per queue. Tuned via constant rather than
+      # configuration because the value rarely needs adjusting and a
+      # too-small value just delays cleanup, never breaks anything.
+      ARCHIVE_COMPACTION_BATCH_SIZE = 1000
+
       attr_reader :config
 
       def initialize(config: Pgbus.configuration)
@@ -72,7 +78,7 @@ module Pgbus
         run_if_due(now, :@last_concurrency_at, CONCURRENCY_INTERVAL) { cleanup_concurrency }
         run_if_due(now, :@last_batch_cleanup_at, BATCH_CLEANUP_INTERVAL) { cleanup_batches }
         run_if_due(now, :@last_recurring_cleanup_at, RECURRING_CLEANUP_INTERVAL) { cleanup_recurring_executions }
-        run_if_due(now, :@last_archive_compaction_at, archive_compaction_interval) { compact_archives }
+        run_if_due(now, :@last_archive_compaction_at, ARCHIVE_COMPACTION_INTERVAL) { compact_archives }
         run_if_due(now, :@last_outbox_cleanup_at, OUTBOX_CLEANUP_INTERVAL) { cleanup_outbox }
         run_if_due(now, :@last_job_lock_cleanup_at, JOB_LOCK_CLEANUP_INTERVAL) { cleanup_job_locks }
         run_if_due(now, :@last_stats_cleanup_at, STATS_CLEANUP_INTERVAL) { cleanup_stats }
@@ -211,16 +217,12 @@ module Pgbus
         Pgbus.logger.warn { "[Pgbus] Outbox cleanup failed: #{e.message}" }
       end
 
-      def archive_compaction_interval
-        config.archive_compaction_interval || ARCHIVE_COMPACTION_INTERVAL
-      end
-
       def compact_archives
         retention = config.archive_retention
         return unless retention&.positive?
 
         cutoff = Time.current - retention
-        batch_size = config.archive_compaction_batch_size || 1000
+        batch_size = ARCHIVE_COMPACTION_BATCH_SIZE
         prefix = config.queue_prefix
 
         conn = config.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -217,7 +217,7 @@ module Pgbus
       def resolve_wildcard_queues
         return unless @wildcard
 
-        dlq_suffix = config.dead_letter_queue_suffix
+        dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
         prefix = "#{config.queue_prefix}_"
 
         conn = Pgbus.configuration.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -16,7 +16,7 @@ module Pgbus
         queues = queues_with_metrics
         total_depth = queues.sum { |q| q[:queue_length] }
         total_visible = queues.sum { |q| q[:queue_visible_length] }
-        dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix
+        dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
         dlq_depth = queues.select { |q| q[:name].end_with?(dlq_suffix) }.sum { |q| q[:queue_length] }
 
         throughput = compute_throughput(queues)
@@ -120,7 +120,7 @@ module Pgbus
       end
 
       def discard_all_enqueued
-        dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix
+        dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
         queues = queues_with_metrics.reject { |q| q[:name].end_with?(dlq_suffix) }
         total = 0
 
@@ -259,7 +259,7 @@ module Pgbus
       # Note: DLQ queue names from queues_with_metrics are already fully qualified
       # (e.g., "pgbus_default_dlq"), so we use them directly without re-prefixing.
       def dlq_messages(page: 1, per_page: 25)
-        dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix
+        dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
         queues = queues_with_metrics.select { |q| q[:name].end_with?(dlq_suffix) }
         offset = (page - 1) * per_page
 
@@ -274,7 +274,7 @@ module Pgbus
       end
 
       def dlq_message_detail(msg_id)
-        dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix
+        dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
         queues = queues_with_metrics.select { |q| q[:name].end_with?(dlq_suffix) }
         queues.each do |q|
           row = connection.select_one(
@@ -292,7 +292,7 @@ module Pgbus
 
       def retry_dlq_message(queue_name, msg_id)
         # queue_name here is the full DLQ name (already prefixed)
-        dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix
+        dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
         original_queue = queue_name.delete_suffix(dlq_suffix)
 
         row = connection.select_one(
@@ -664,7 +664,7 @@ module Pgbus
       end
 
       def all_queue_messages(limit, offset)
-        dlq_suffix = Pgbus.configuration.dead_letter_queue_suffix
+        dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
         queues = queues_with_metrics.reject { |q| q[:name].end_with?(dlq_suffix) }
         messages = queues.flat_map do |q|
           query_queue_messages_raw(q[:name], limit + offset, 0)

--- a/spec/pgbus/circuit_breaker_spec.rb
+++ b/spec/pgbus/circuit_breaker_spec.rb
@@ -8,9 +8,6 @@ RSpec.describe Pgbus::CircuitBreaker do
   let(:config) do
     Pgbus::Configuration.new.tap do |c|
       c.circuit_breaker_enabled = true
-      c.circuit_breaker_threshold = 3
-      c.circuit_breaker_base_backoff = 10
-      c.circuit_breaker_max_backoff = 60
     end
   end
 
@@ -18,7 +15,14 @@ RSpec.describe Pgbus::CircuitBreaker do
     stub_const("Pgbus::QueueState", Class.new)
   end
 
+  # Stub the tuning constants down to small values so we don't have to record
+  # 5 failures and wait 30s in tests. THRESHOLD/BASE_BACKOFF/MAX_BACKOFF live
+  # on Pgbus::CircuitBreaker (no longer config) — see PR that culled silent
+  # configuration knobs.
   before do
+    stub_const("Pgbus::CircuitBreaker::THRESHOLD", 3)
+    stub_const("Pgbus::CircuitBreaker::BASE_BACKOFF", 10)
+    stub_const("Pgbus::CircuitBreaker::MAX_BACKOFF", 60)
     queue_state_class
     allow(Pgbus::QueueState).to receive(:pause!)
     allow(Pgbus::QueueState).to receive(:resume!)
@@ -30,20 +34,20 @@ RSpec.describe Pgbus::CircuitBreaker do
     it "resets the failure counter" do
       breaker.record_failure("test_queue")
       breaker.record_success("test_queue")
-      # After reset, we should be able to fail threshold-1 times without tripping
-      (config.circuit_breaker_threshold - 1).times { breaker.record_failure("test_queue") }
+      # After reset, we should be able to fail THRESHOLD-1 times without tripping
+      (Pgbus::CircuitBreaker::THRESHOLD - 1).times { breaker.record_failure("test_queue") }
       expect(Pgbus::QueueState).not_to have_received(:find_or_initialize_by)
     end
   end
 
   describe "#record_failure" do
     it "trips after reaching threshold" do
-      config.circuit_breaker_threshold.times { breaker.record_failure("test_queue") }
+      Pgbus::CircuitBreaker::THRESHOLD.times { breaker.record_failure("test_queue") }
       expect(Pgbus::QueueState).to have_received(:find_or_initialize_by).with(queue_name: "test_queue")
     end
 
     it "does not trip below threshold" do
-      (config.circuit_breaker_threshold - 1).times { breaker.record_failure("test_queue") }
+      (Pgbus::CircuitBreaker::THRESHOLD - 1).times { breaker.record_failure("test_queue") }
       expect(Pgbus::QueueState).not_to have_received(:find_or_initialize_by)
     end
 

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Pgbus::Client do
       config.listen_notify = true
       client.ensure_queue("jobs")
 
-      expect(mock_pgmq).to have_received(:enable_notify_insert).with("pgbus_test_jobs", throttle_interval_ms: config.notify_throttle_ms)
+      expect(mock_pgmq).to have_received(:enable_notify_insert).with("pgbus_test_jobs", throttle_interval_ms: Pgbus::Client::NOTIFY_THROTTLE_MS)
     end
 
     it "skips LISTEN/NOTIFY when listen_notify is false" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -46,9 +46,15 @@ RSpec.describe Pgbus::Configuration do
 
     it "has circuit breaker enabled by default" do
       expect(config.circuit_breaker_enabled).to be true
-      expect(config.circuit_breaker_threshold).to eq(5)
-      expect(config.circuit_breaker_base_backoff).to eq(30)
-      expect(config.circuit_breaker_max_backoff).to eq(600)
+    end
+
+    it "exposes circuit breaker tuning as constants on Pgbus::CircuitBreaker" do
+      # The threshold/backoff values were silent settings nobody tuned and
+      # were culled from configuration. They live on the CircuitBreaker
+      # class as documented constants.
+      expect(Pgbus::CircuitBreaker::THRESHOLD).to eq(5)
+      expect(Pgbus::CircuitBreaker::BASE_BACKOFF).to eq(30)
+      expect(Pgbus::CircuitBreaker::MAX_BACKOFF).to eq(600)
     end
 
     it "has no priority levels by default" do
@@ -58,8 +64,13 @@ RSpec.describe Pgbus::Configuration do
 
     it "has default archive retention of 7 days" do
       expect(config.archive_retention).to eq(7 * 24 * 3600)
-      expect(config.archive_compaction_interval).to eq(3600)
-      expect(config.archive_compaction_batch_size).to eq(1000)
+    end
+
+    it "exposes archive compaction tuning as constants on Pgbus::Process::Dispatcher" do
+      # The compaction interval and batch size were silent settings; they
+      # live on the dispatcher class as constants now.
+      expect(Pgbus::Process::Dispatcher::ARCHIVE_COMPACTION_INTERVAL).to eq(3600)
+      expect(Pgbus::Process::Dispatcher::ARCHIVE_COMPACTION_BATCH_SIZE).to eq(1000)
     end
 
     it "has stats enabled with 30 day retention by default" do

--- a/spec/pgbus/generators/config_converter_spec.rb
+++ b/spec/pgbus/generators/config_converter_spec.rb
@@ -174,6 +174,36 @@ RSpec.describe Pgbus::Generators::ConfigConverter do
       end
     end
 
+    context "with culled settings that moved to constants" do
+      # These settings used to be config knobs but were silent (nobody
+      # tuned them) so they were moved to constants on their owning
+      # classes. The converter drops them silently — users on legacy
+      # YAML get a clean migration without manual cleanup.
+      let(:input) do
+        {
+          "production" => {
+            "notify_throttle_ms" => 500,
+            "circuit_breaker_threshold" => 10,
+            "circuit_breaker_base_backoff" => 60,
+            "circuit_breaker_max_backoff" => 1200,
+            "archive_compaction_interval" => 7200,
+            "archive_compaction_batch_size" => 5000,
+            "dead_letter_queue_suffix" => "_dead",
+            "workers" => [{ "queues" => ["*"], "threads" => 5 }]
+          }
+        }
+      end
+
+      it "drops every culled setting from the generated initializer" do
+        %w[notify_throttle_ms
+           circuit_breaker_threshold circuit_breaker_base_backoff circuit_breaker_max_backoff
+           archive_compaction_interval archive_compaction_batch_size
+           dead_letter_queue_suffix].each do |key|
+          expect(output).not_to include(key)
+        end
+      end
+    end
+
     context "with a non-default pool_timeout" do
       let(:input) do
         {


### PR DESCRIPTION
## Summary

Configuration had grown a tail of "silent" settings — things nobody ever tunes in practice but that took up space in the public surface area. This PR moves them to documented constants on the classes that actually use them.

**Culled settings (now constants on their owners):**

| Old setting | New home | Default |
|---|---|---|
| `circuit_breaker_threshold` | `Pgbus::CircuitBreaker::THRESHOLD` | `5` |
| `circuit_breaker_base_backoff` | `Pgbus::CircuitBreaker::BASE_BACKOFF` | `30` |
| `circuit_breaker_max_backoff` | `Pgbus::CircuitBreaker::MAX_BACKOFF` | `600` |
| `notify_throttle_ms` | `Pgbus::Client::NOTIFY_THROTTLE_MS` | `250` |
| `archive_compaction_interval` | `Pgbus::Process::Dispatcher::ARCHIVE_COMPACTION_INTERVAL` | `3600` (already existed!) |
| `archive_compaction_batch_size` | `Pgbus::Process::Dispatcher::ARCHIVE_COMPACTION_BATCH_SIZE` | `1000` |
| `dead_letter_queue_suffix` | `Pgbus::DEAD_LETTER_SUFFIX` | `"_dlq"` |

**Settings kept:** `circuit_breaker_enabled` (users toggle this in tests), `prefetch_limit` (nil-default power-user knob), and all public, time-based, or user-named settings.

## Migration path

The YAML → Ruby converter (`rails generate pgbus:update`, shipped in #79) silently drops the culled keys when emitting the new initializer, so users on legacy YAML get a clean migration with zero manual cleanup. The install template (`pgbus.yml.erb`) no longer includes `notify_throttle_ms`.

## Why constants instead of configuration

Power users can still override the constants in an initializer if they really need different values — that path stayed wide open. But since nobody has ever filed an issue against any of these knobs, exposing them as configuration was just ceremony. README updated to document where the constants live and why.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec` (excluding pre-existing system spec failures) — 1032 examples, 0 failures
- [x] Circuit breaker spec uses `stub_const` for the new constants instead of config setters
- [x] Configuration spec asserts each constant lives where the comment claims it does
- [x] ConfigConverter spec verifies all culled keys are dropped from the generated initializer
- [x] Install template no longer references `notify_throttle_ms`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README and configuration examples to reflect the simplified, fixed tuning options and removed knobs.

* **Chores**
  * Removed several runtime configuration knobs (circuit breaker tuning, compaction tuning, dead-letter suffix, notify throttling); these are now fixed internally and the generated config template no longer includes them.
  * Standardized dead-letter queue naming.

* **Tests**
  * Updated specs to match the new constant-driven behavior and generator output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->