### PR TITLE
fix(config): allow anonymous duplicate capsules (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [0.5.1] - 2026-04-08
+
+### Fixed
+
+- **Capsule DSL: anonymous duplicate capsules are now allowed.** Configurations like `c.workers = "*: 3; *: 3; *: 3; *: 3; *: 3"` (the legacy YAML pattern of 5 forks × 3 threads, all reading every queue) were rejected at boot in 0.5.0 with `Pgbus::Configuration::CapsuleDSL::ParseError: wildcard '*' appears in two capsules`. PGMQ tolerates multiple processes reading the same queue natively (`FOR UPDATE SKIP LOCKED`), and this is the canonical way to scale CPU parallelism across forks, so the rejection was wrong.
+
+  The fix introduces a "named vs anonymous" distinction:
+
+  - The string DSL parser is now purely syntactic — it no longer enforces overlap rules.
+  - `Pgbus::Configuration#workers=` auto-assigns `:name` only to capsules whose first queue would yield a *unique* name AND is not the bare wildcard. Wildcards stay anonymous; collision-prone first-queues stay anonymous.
+  - `Pgbus::Configuration#validate_no_queue_overlap!` (called by `c.capsule :name, ...`) now only checks against existing **named** capsules. Anonymous capsules can overlap freely with each other and with named capsules.
+  - Net result: `"*: 3; *: 3; *: 3"` produces 3 anonymous capsules (3 forks), `"critical: 5; default: 10"` produces 2 named capsules (CLI `--capsule critical` still works), and named-vs-named overlap is still rejected as before.
+
+  No changes required to user configuration — legacy YAML patterns and the modern DSL both work as documented.
+
 ## [Unreleased]
 
 ### Breaking Changes

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -230,12 +230,34 @@ module Pgbus
     #            dispatcher-only processes).
     #
     # Raises ArgumentError for any other type.
+    #
+    # NAMING SEMANTICS for the String form:
+    #
+    # The parser produces anonymous capsules (no :name). The setter then
+    # auto-assigns a :name to capsules whose first queue would yield a
+    # *unique* name across the parsed list AND is not the bare wildcard
+    # (`*`). Anything else stays anonymous.
+    #
+    #   "critical: 5; default: 10"  -> two NAMED capsules ("critical", "default")
+    #   "*: 5"                       -> one anonymous capsule (wildcard never names)
+    #   "*: 3; *: 3; *: 3"           -> three anonymous capsules — legal,
+    #                                   represents "3 forks all reading every
+    #                                   queue", restoring the legacy YAML
+    #                                   `5 × {queues: ["*"], threads: 3}` shape
+    #   "default: 5; default: 3"     -> two anonymous capsules — same logic
+    #
+    # The point of the carve-out is the legacy "I want N forks of the same
+    # worker pool" pattern: it must keep working since PGMQ tolerates it
+    # natively (multiple processes reading the same queue with FOR UPDATE
+    # SKIP LOCKED). The CLI's --capsule selector only matches NAMED
+    # capsules, so anonymous duplicates can't be ambiguously addressed.
     def workers=(value)
       @workers = case value
                  when nil
                    nil
                  when String
-                   CapsuleDSL.parse(value).map { |entry| entry.merge(name: entry[:queues].first.to_s) }
+                   parsed = CapsuleDSL.parse(value)
+                   assign_auto_names(parsed)
                  when Array
                    value
                  else
@@ -445,33 +467,58 @@ module Pgbus
       raw&.to_s
     end
 
-    # Validates that no queue in +new_queues+ would overlap with any
-    # existing capsule. The wildcard '*' counts as overlapping with EVERY
-    # other queue (and vice versa) because at runtime '*' is expanded to
-    # all known queues. Raises ArgumentError on overlap.
-    def validate_no_queue_overlap!(new_queues)
-      existing = (@workers || []).flat_map { |c| c[:queues] || c["queues"] || [] }
-      return if existing.empty?
+    # Auto-assign :name to parsed capsules where the first queue token would
+    # yield a unique name and is not the bare wildcard. See the long comment
+    # on +workers=+ for the why. Returns the same array with :name merged in
+    # where applicable.
+    def assign_auto_names(parsed_capsules)
+      first_queue_counts = parsed_capsules.each_with_object(Hash.new(0)) do |capsule, h|
+        h[capsule[:queues].first] += 1
+      end
 
-      if existing.include?(CapsuleDSL::WILDCARD)
+      parsed_capsules.map do |capsule|
+        first = capsule[:queues].first
+        nameable = first != CapsuleDSL::WILDCARD && first_queue_counts[first] == 1
+        nameable ? capsule.merge(name: first.to_s) : capsule
+      end
+    end
+
+    # Validates that the new capsule (added via +c.capsule :name, ...+) does
+    # not overlap with any existing NAMED capsule. Anonymous capsules (parsed
+    # from the string DSL with auto-naming skipped, e.g. wildcards or
+    # would-collide first-queues) are intentionally invisible here — they
+    # represent "N forks of the same pool" and are allowed to overlap with
+    # each other and with named capsules.
+    #
+    # The wildcard '*' counts as overlapping with EVERY other queue (and
+    # vice versa) because at runtime '*' is expanded to all known queues.
+    # Raises ArgumentError on overlap.
+    def validate_no_queue_overlap!(new_queues)
+      existing_named = (@workers || []).select { |c| capsule_name(c) }
+      return if existing_named.empty?
+
+      existing_queues = existing_named.flat_map { |c| c[:queues] || c["queues"] || [] }
+      return if existing_queues.empty?
+
+      if existing_queues.include?(CapsuleDSL::WILDCARD)
         raise ArgumentError,
-              "an existing capsule already uses '*' (matches every queue) — " \
+              "an existing named capsule already uses '*' (matches every queue) — " \
               "the new capsule's queues #{new_queues.inspect} would overlap with it"
       end
 
       if new_queues.include?(CapsuleDSL::WILDCARD)
         raise ArgumentError,
-              "the new capsule uses '*' (matches every queue) but other capsules " \
-              "are already defined with queues #{existing.inspect} — " \
+              "the new capsule uses '*' (matches every queue) but other named capsules " \
+              "are already defined with queues #{existing_queues.inspect} — " \
               "the wildcard would overlap with all of them"
       end
 
-      conflict = new_queues.find { |q| existing.include?(q) }
+      conflict = new_queues.find { |q| existing_queues.include?(q) }
       return unless conflict
 
       raise ArgumentError,
-            "queue #{conflict.inspect} is already assigned to another capsule — " \
-            "each queue can only belong to one capsule"
+            "queue #{conflict.inspect} is already assigned to another named capsule — " \
+            "named capsules cannot share queues"
     end
 
     def sum_thread_counts(entries, default_threads:, group:)

--- a/lib/pgbus/configuration/capsule_dsl.rb
+++ b/lib/pgbus/configuration/capsule_dsl.rb
@@ -62,9 +62,12 @@ module Pgbus
         validate_input_type!
         validate_input_not_empty!
 
-        capsules = split_capsules(@input).map { |segment| parse_capsule(segment) }
-        validate_no_duplicate_queues_across_capsules!(capsules)
-        capsules
+        # Pure tokenization: split, parse each capsule, return them in order.
+        # Cross-capsule overlap rules live in Pgbus::Configuration#workers=
+        # because they depend on whether the resulting capsules are named or
+        # anonymous, and naming is a Configuration concern (not a parser one).
+        # Within-capsule duplicate-queue checks still happen in parse_capsule.
+        split_capsules(@input).map { |segment| parse_capsule(segment) }
       end
 
       private
@@ -166,23 +169,6 @@ module Pgbus
                   "duplicate queues within a capsule are not allowed"
           end
           seen[q] = true
-        end
-      end
-
-      def validate_no_duplicate_queues_across_capsules!(capsules)
-        return if capsules.size < 2
-
-        seen = {}
-        capsules.each_with_index do |capsule, idx|
-          capsule[:queues].each do |q|
-            if seen[q]
-              label = (q == WILDCARD ? "wildcard '*'" : "queue #{q.inspect}")
-              raise ParseError,
-                    "#{label} appears in two capsules (positions #{seen[q]} and #{idx + 1}) " \
-                    "in #{@input.inspect} — each queue can only be assigned to one capsule"
-            end
-            seen[q] = idx + 1
-          end
         end
       end
     end

--- a/lib/pgbus/version.rb
+++ b/lib/pgbus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pgbus
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/spec/pgbus/cli_spec.rb
+++ b/spec/pgbus/cli_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe Pgbus::CLI do
       it "supports --queues=STRING with equals sign" do
         original_workers = Pgbus.configuration.workers
         described_class.start(["start", "--queues=*: 7"])
-        expect(Pgbus.configuration.workers).to eq([{ queues: ["*"], threads: 7, name: "*" }])
+        # Wildcard capsules are anonymous (no auto-assigned :name) — see
+        # the long comment on Pgbus::Configuration#workers= for the why.
+        expect(Pgbus.configuration.workers).to eq([{ queues: ["*"], threads: 7 }])
       ensure
         Pgbus.configuration.instance_variable_set(:@workers, original_workers)
       end

--- a/spec/pgbus/configuration/capsule_dsl_spec.rb
+++ b/spec/pgbus/configuration/capsule_dsl_spec.rb
@@ -176,16 +176,27 @@ RSpec.describe Pgbus::Configuration::CapsuleDSL do
         expect_parse_error("default mailers: 5", /invalid character|expected/i)
       end
 
-      it "rejects the same queue listed in two capsules" do
-        expect_parse_error("default: 5; default: 3", /default.*two capsules|appears in two/i)
-      end
-
       it "rejects the same queue listed twice within one capsule" do
         expect_parse_error("default, default: 5", /default.*twice|duplicate/i)
       end
 
-      it "rejects the wildcard in two capsules" do
-        expect_parse_error("*: 5; *: 3", /wildcard.*two capsules|\*.*appears in two/i)
+      # Same-queue across capsules is now ALLOWED — see the carve-out in
+      # Pgbus::Configuration#workers= for the rationale. The parser is
+      # purely syntactic and doesn't enforce overlap rules.
+      it "accepts the same queue listed in two capsules (parser is purely syntactic now)" do
+        result = described_class.parse("default: 5; default: 3")
+        expect(result).to eq([
+                               { queues: ["default"], threads: 5 },
+                               { queues: ["default"], threads: 3 }
+                             ])
+      end
+
+      it "accepts the wildcard in two capsules (the legacy 'N forks' pattern)" do
+        result = described_class.parse("*: 5; *: 3")
+        expect(result).to eq([
+                               { queues: ["*"], threads: 5 },
+                               { queues: ["*"], threads: 3 }
+                             ])
       end
 
       it "includes the offending input in the error message" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -296,15 +296,39 @@ RSpec.describe Pgbus::Configuration do
     end
 
     context "when given a String (new DSL form)" do
-      it "parses the string into the legacy array shape" do
+      it "parses the wildcard form to an anonymous capsule (no :name)" do
+        # Wildcards never get auto-named — see the long comment on
+        # Configuration#workers= for the rationale. Anonymous capsules
+        # let the user run multiple identical forks without colliding
+        # with the named-capsule overlap check.
         config.workers = "*: 5"
-        expect(config.workers).to eq([{ queues: ["*"], threads: 5, name: "*" }])
+        expect(config.workers).to eq([{ queues: ["*"], threads: 5 }])
+        expect(config.workers.first).not_to have_key(:name)
       end
 
-      it "auto-names each capsule by its first queue" do
+      it "auto-names each capsule whose first-queue is unique and not the wildcard" do
         config.workers = "critical, default: 5; mailers: 2"
         names = config.workers.map { |c| c[:name] }
         expect(names).to eq(%w[critical mailers])
+      end
+
+      it "leaves duplicate-first-queue capsules anonymous (the 'N forks' pattern)" do
+        # Restores the legacy YAML pattern: 5 × {queues: ["*"], threads: 3}.
+        # Each capsule becomes its own forked process at boot time.
+        config.workers = "*: 3; *: 3; *: 3"
+        expect(config.workers.size).to eq(3)
+        expect(config.workers).to all(eq(queues: ["*"], threads: 3))
+        config.workers.each { |c| expect(c).not_to have_key(:name) }
+      end
+
+      it "leaves duplicate non-wildcard first-queues anonymous too" do
+        # Same logic — if naming would collide, neither side gets a name.
+        config.workers = "default: 5; default: 3"
+        expect(config.workers).to eq([
+                                       { queues: ["default"], threads: 5 },
+                                       { queues: ["default"], threads: 3 }
+                                     ])
+        config.workers.each { |c| expect(c).not_to have_key(:name) }
       end
 
       it "raises CapsuleDSL::ParseError for invalid strings" do
@@ -458,19 +482,59 @@ RSpec.describe Pgbus::Configuration do
   end
 
   describe "wildcard overlap detection" do
-    it "rejects adding a capsule when an existing capsule has '*'" do
-      config.workers = "*: 5"
+    # Anonymous capsules (parsed from "*: N" or duplicate-first-queue
+    # strings) are intentionally invisible to overlap detection — they
+    # represent "N forks of the same pool" rather than addressable units.
+    # Only named capsules trigger the overlap rule.
+    it "allows adding a named capsule when an existing anonymous '*' capsule exists" do
+      config.workers = "*: 5" # anonymous (wildcard never gets auto-named)
       expect do
         config.capsule(:critical, queues: %w[critical], threads: 3)
-      end.to raise_error(ArgumentError, /already.*capsule|wildcard/i)
+      end.not_to raise_error
     end
 
-    it "rejects adding a '*' capsule when other queues already exist" do
+    it "allows adding a wildcard capsule on top of anonymous wildcards" do
+      config.workers = "*: 3; *: 3"
+      expect do
+        config.capsule(:catch_all, queues: ["*"], threads: 5)
+      end.not_to raise_error
+    end
+
+    it "rejects adding a wildcard capsule when an existing NAMED capsule exists" do
       config.workers = nil
       config.capsule(:critical, queues: %w[critical], threads: 3)
       expect do
         config.capsule(:catch_all, queues: ["*"], threads: 5)
       end.to raise_error(ArgumentError, /already.*capsule|wildcard/i)
+    end
+
+    it "rejects adding a named capsule when an existing NAMED wildcard capsule exists" do
+      config.workers = nil
+      config.capsule(:catch_all, queues: ["*"], threads: 5)
+      expect do
+        config.capsule(:critical, queues: %w[critical], threads: 3)
+      end.to raise_error(ArgumentError, /already.*capsule|wildcard/i)
+    end
+  end
+
+  describe "anonymous N-forks pattern (legacy YAML compatibility)" do
+    # The pattern that triggered the v0.5.1 regression fix: legacy YAML
+    # could declare 5 × {queues: ["*"], threads: 3} to mean "5 forked
+    # processes each running 3 threads, all reading every queue". The
+    # PR-3 capsule DSL initially rejected this as a queue overlap. The
+    # fix: anonymous capsules can overlap freely, named capsules cannot.
+    it "produces N capsules from N-fork wildcard syntax" do
+      config.workers = "*: 3; *: 3; *: 3; *: 3; *: 3"
+      expect(config.workers.size).to eq(5)
+      expect(config.workers.map { |c| c[:threads] }.sum).to eq(15)
+    end
+
+    it "still rejects two named capsules with the same explicit queue" do
+      config.workers = nil
+      config.capsule(:foo, queues: %w[shared], threads: 5)
+      expect do
+        config.capsule(:bar, queues: %w[shared], threads: 5)
+      end.to raise_error(ArgumentError, /shared.*already.*capsule/i)
     end
   end
 


### PR DESCRIPTION
## Summary

Backport branch for v0.5.1 — fixes a regression in 0.5.0 where the legacy YAML pattern of "N forks of the same worker pool" was rejected at boot.

## The bug

```ruby
Pgbus.configure do |c|
  c.workers = "*: 3; *: 3; *: 3; *: 3; *: 3"   # 5 forks × 3 threads
end
```

```text
Pgbus::Configuration::CapsuleDSL::ParseError: wildcard '*' appears in two
capsules (positions 1 and 2) — each queue can only be assigned to one capsule
```

This is the canonical way to scale CPU parallelism across forks. PGMQ tolerates multiple processes reading the same queue natively (`FOR UPDATE SKIP LOCKED`), so the rejection was wrong. It also broke any user migrating from a YAML config with that shape (the pgbus.yml → Ruby converter shipped in #79 produces exactly this output).

## The fix

Introduce a "named vs anonymous" distinction:

| Input | Result |
|---|---|
| `"*: 5"` | 1 anonymous capsule |
| `"*: 3; *: 3; *: 3"` | 3 anonymous capsules (the fixed case) |
| `"default: 5; default: 3"` | 2 anonymous capsules (would-collide first-queue) |
| `"critical: 5; default: 10"` | 2 named capsules (`--capsule critical` still works) |
| `c.capsule :a, queues: %w[x]` then `c.capsule :b, queues: %w[x]` | still rejected (named overlap) |

Three changes:

1. **`Pgbus::Configuration::CapsuleDSL`** — parser is now purely syntactic. The cross-capsule duplicate-queue check is removed.
2. **`Pgbus::Configuration#workers=`** — auto-assigns `:name` only to capsules whose first queue is *unique* across the parsed list AND not the bare wildcard.
3. **`Pgbus::Configuration#validate_no_queue_overlap!`** (called by `c.capsule :name, ...`) — only checks against existing **named** capsules. Anonymous capsules are invisible to overlap detection.

The CLI's `--capsule NAME` selector continues to operate only on named capsules, which is the correct semantics: anonymous duplicates aren't individually addressable.

## Test coverage

- `"*: 3; *: 3; *: 3; *: 3; *: 3"` produces 5 capsules (15 total threads)
- `"default: 5; default: 3"` produces 2 anonymous capsules
- Wildcard never gets `:name`
- Two named capsules with the same queue → still rejected
- CLI wildcard auto-name assertion updated
- Existing wildcard overlap detection specs flipped to assert the new "anonymous capsules invisible" rule

## Test plan

- [x] `bundle exec rubocop` — clean (226 files, 0 offenses)
- [x] `bundle exec rspec --exclude-pattern "spec/system/**/*,spec/i18n_spec.rb"` — 1038 examples, 0 failures
- [x] `gem build pgbus.gemspec` — Successfully built `pgbus-0.5.1.gem`
- [x] `lib/pgbus/version.rb` bumped to `0.5.1`
- [x] `CHANGELOG.md` updated with the fix entry
- [x] Tag `v0.5.1` already pushed to origin

## Release process

This PR is **against `main`** so the diff is reviewable. The branch itself is `0.5-stable` (cut from the `v0.5.0` tag). Once merged:

1. Create a GitHub release for `v0.5.1` (tag already exists)
2. The `.github/workflows/release.yml` workflow builds the gem with Sigstore attestation and pushes to RubyGems
3. The fix needs forward-porting to `main` separately (post-0.5.0 turbo-streams work means a clean cherry-pick is preferred over a merge)

⚠️ **Do not squash-merge** — `0.5-stable` should keep the linear history from the v0.5.0 tag forward so future 0.5.x bug fixes branch cleanly from it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved rejection of duplicate wildcard capsule definitions in worker configuration; multiple wildcard specifications can now be used without triggering boot-time errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->