### PR TITLE
feat(streams): opt-in stream stats + Insights integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,8 @@ end
 Then run the migration generator once:
 
 ```bash
-rails generate pgbus:add_stream_stats
+rails generate pgbus:add_stream_stats                  # Add the migration
+rails generate pgbus:add_stream_stats --database=pgbus # For separate database
 rails db:migrate
 ```
 

--- a/README.md
+++ b/README.md
@@ -832,6 +832,28 @@ The sweep uses `DELETE ... RETURNING` so multiple workers running it concurrentl
 - The stale-member sweep is manual. Run it from a cron, an ActiveJob, or your existing heartbeat — pgbus does not assume one over the others.
 - The DOM markup for join/leave is whatever your `join`/`leave` block returns. Pgbus does not impose a fixed presence schema on `<pgbus-stream-source>`.
 
+### Stream stats (opt-in)
+
+Pgbus can record one row in `pgbus_stream_stats` per broadcast, connect, and disconnect so the `/pgbus/insights` dashboard shows stream throughput alongside job throughput. This is **disabled by default** because stream event volume can dwarf job volume in chat-style apps — enable it deliberately when you want the observability.
+
+```ruby
+# config/initializers/pgbus.rb
+Pgbus.configure do |c|
+  c.streams_stats_enabled = true
+end
+```
+
+Then run the migration generator once:
+
+```bash
+rails generate pgbus:add_stream_stats
+rails db:migrate
+```
+
+The Insights tab gains a "Real-time Streams" section with counts of broadcasts / connects / disconnects, an "active" estimate (connects − disconnects in the selected window), average fanout per broadcast, and a "Top Streams by Broadcast Volume" table. The existing `stats_retention` config covers cleanup, so there is no separate retention knob.
+
+Overhead on a real Puma + PGMQ setup (`bundle exec rake bench:streams`): the most visible cost is an INSERT per connect/disconnect pair, which shows up under thundering-herd connect scenarios (K=50 concurrent connects: ~+20% per-connect latency). Steady-state broadcast and fanout numbers stay in the run-to-run noise band. Enable it if Insights is useful; leave it off if the write traffic worries you.
+
 ## Operations
 
 Day-to-day running of Pgbus: starting and stopping processes, observing what is happening on the dashboard, the database tables Pgbus relies on, and how to migrate from an existing job backend.

--- a/app/controllers/pgbus/insights_controller.rb
+++ b/app/controllers/pgbus/insights_controller.rb
@@ -8,6 +8,12 @@ module Pgbus
       @slowest = data_source.slowest_job_classes(minutes: @minutes)
       @latency_by_queue = data_source.latency_by_queue(minutes: @minutes)
       @latency_available = Pgbus::JobStat.latency_columns?
+
+      @stream_stats_available = data_source.stream_stats_available?
+      return unless @stream_stats_available
+
+      @stream_summary = data_source.stream_stats_summary(minutes: @minutes)
+      @top_streams = data_source.top_streams(minutes: @minutes)
     end
   end
 end

--- a/app/models/pgbus/stream_stat.rb
+++ b/app/models/pgbus/stream_stat.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Pgbus
+  # Records one row per stream event (broadcast / connect / disconnect)
+  # when `config.streams_stats_enabled` is true. Mirrors JobStat in
+  # shape and aggregation API so the Insights controller can query
+  # both with the same patterns.
+  #
+  # Writes are fire-and-forget: any error is swallowed so a stat
+  # recording failure cannot affect the dispatcher's hot path.
+  class StreamStat < BusRecord
+    self.table_name = "pgbus_stream_stats"
+
+    EVENT_TYPES = %w[broadcast connect disconnect].freeze
+
+    scope :since, ->(time) { where("created_at >= ?", time) }
+    scope :broadcasts, -> { where(event_type: "broadcast") }
+    scope :connects, -> { where(event_type: "connect") }
+    scope :disconnects, -> { where(event_type: "disconnect") }
+
+    # Records a stream event. Called from the Dispatcher when the
+    # `streams_stats_enabled` flag is set. Errors are swallowed so a
+    # missing table or a connection blip cannot kill the dispatcher.
+    def self.record!(stream_name:, event_type:, duration_ms: 0, fanout: nil)
+      return unless table_exists?
+
+      create!(
+        stream_name: stream_name,
+        event_type: event_type,
+        duration_ms: duration_ms.to_i,
+        fanout: fanout
+      )
+    rescue StandardError => e
+      Pgbus.logger.debug { "[Pgbus] Failed to record stream stat: #{e.message}" }
+    end
+
+    # Memoized — intentionally never invalidated at runtime. If the
+    # pgbus_stream_stats migration runs while the app is already
+    # running, a restart is required for stat recording to begin.
+    def self.table_exists?
+      return @table_exists if defined?(@table_exists)
+
+      @table_exists = connection.table_exists?(table_name)
+    rescue StandardError
+      @table_exists = false
+    end
+
+    # Single-query aggregate summary over the given window.
+    # Returns totals by event type, average fanout for broadcasts,
+    # and an "active" estimate (connects − disconnects in window).
+    def self.summary(minutes: 60)
+      row = since(minutes.minutes.ago).pick(
+        Arel.sql("COUNT(*) FILTER (WHERE event_type = 'broadcast')"),
+        Arel.sql("COUNT(*) FILTER (WHERE event_type = 'connect')"),
+        Arel.sql("COUNT(*) FILTER (WHERE event_type = 'disconnect')"),
+        Arel.sql("ROUND(AVG(fanout) FILTER (WHERE event_type = 'broadcast')::numeric, 1)"),
+        Arel.sql("ROUND(AVG(duration_ms) FILTER (WHERE event_type = 'broadcast')::numeric, 1)"),
+        Arel.sql("ROUND(AVG(duration_ms) FILTER (WHERE event_type = 'connect')::numeric, 1)")
+      )
+
+      {
+        broadcasts: row[0].to_i,
+        connects: row[1].to_i,
+        disconnects: row[2].to_i,
+        active_estimate: [row[1].to_i - row[2].to_i, 0].max,
+        avg_fanout: row[3]&.to_f || 0,
+        avg_broadcast_ms: row[4]&.to_f || 0,
+        avg_connect_ms: row[5]&.to_f || 0
+      }
+    end
+
+    # Top N streams by broadcast count in the window, with avg fanout.
+    def self.top_streams(limit: 10, minutes: 60)
+      broadcasts
+        .since(minutes.minutes.ago)
+        .group(:stream_name)
+        .order(Arel.sql("COUNT(*) DESC"))
+        .limit(limit)
+        .pluck(
+          :stream_name,
+          Arel.sql("COUNT(*)"),
+          Arel.sql("ROUND(AVG(fanout)::numeric, 1)"),
+          Arel.sql("ROUND(AVG(duration_ms)::numeric, 1)")
+        )
+        .map do |name, count, avg_fanout, avg_ms|
+          {
+            stream_name: name,
+            count: count.to_i,
+            avg_fanout: avg_fanout&.to_f || 0,
+            avg_ms: avg_ms&.to_f || 0
+          }
+        end
+    end
+
+    # Throughput: broadcast events per minute bucketed by minute.
+    def self.throughput(minutes: 60)
+      broadcasts
+        .since(minutes.minutes.ago)
+        .group("date_trunc('minute', created_at)")
+        .order(Arel.sql("date_trunc('minute', created_at)"))
+        .count
+    end
+
+    # Cleanup old stats. Called from Pgbus::Process::Dispatcher on the
+    # same cadence as JobStat.cleanup! using the shared stats_retention.
+    def self.cleanup!(older_than:)
+      where("created_at < ?", older_than).delete_all
+    end
+  end
+end

--- a/app/models/pgbus/stream_stat.rb
+++ b/app/models/pgbus/stream_stat.rb
@@ -37,12 +37,20 @@ module Pgbus
     # Memoized — intentionally never invalidated at runtime. If the
     # pgbus_stream_stats migration runs while the app is already
     # running, a restart is required for stat recording to begin.
+    #
+    # We only memoize a *successful* probe. A transient error (PG
+    # hiccup during boot, connection refused during a failover) is
+    # treated as "don't know yet" — the next call retries. Caching
+    # false on the first hiccup would permanently disable stream
+    # stats for the process lifetime, which is a worse failure mode
+    # than a few retries.
     def self.table_exists?
       return @table_exists if defined?(@table_exists)
 
       @table_exists = connection.table_exists?(table_name)
-    rescue StandardError
-      @table_exists = false
+    rescue StandardError => e
+      Pgbus.logger.debug { "[Pgbus] Failed to check stream stat table: #{e.message}" }
+      false
     end
 
     # Single-query aggregate summary over the given window.

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -159,6 +159,65 @@
   </table>
 </div>
 
+<% if @stream_stats_available %>
+<!-- Stream stats -->
+<div class="mt-8">
+  <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("pgbus.insights.show.streams.title") %></h2>
+
+  <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5 mb-6">
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.summary.broadcasts") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@stream_summary[:broadcasts]) %></dd>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.summary.connects") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-green-600 dark:text-green-400"><%= pgbus_number(@stream_summary[:connects]) %></dd>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.summary.disconnects") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-orange-600 dark:text-orange-400"><%= pgbus_number(@stream_summary[:disconnects]) %></dd>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.summary.active") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@stream_summary[:active_estimate]) %></dd>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.summary.avg_fanout") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= @stream_summary[:avg_fanout]&.round(1) || 0 %></dd>
+    </div>
+  </div>
+
+  <div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+      <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300"><%= t("pgbus.insights.show.streams.top.title") %></h3>
+    </div>
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <thead class="bg-gray-50 dark:bg-gray-900">
+        <tr>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.top.headers.stream") %></th>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.top.headers.broadcasts") %></th>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.top.headers.avg_fanout") %></th>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.streams.top.headers.avg_ms") %></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+        <% @top_streams.each do |row| %>
+          <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+            <td data-label="Stream" class="px-4 py-3 text-sm font-medium text-gray-700 dark:text-gray-300"><%= row[:stream_name] %></td>
+            <td data-label="Broadcasts" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_number(row[:count]) %></td>
+            <td data-label="Avg Fanout" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= row[:avg_fanout]&.round(1) || 0 %></td>
+            <td data-label="Avg Duration" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_ms_duration(row[:avg_ms]) %></td>
+          </tr>
+        <% end %>
+        <% if @top_streams.empty? %>
+          <tr><td colspan="4" class="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500"><%= t("pgbus.insights.show.streams.top.empty") %></td></tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<% end %>
+
 <script type="module" nonce="<%= content_security_policy_nonce %>">
   import { renderCharts, observeThemeChanges } from "charts";
 

--- a/benchmarks/streams_bench.rb
+++ b/benchmarks/streams_bench.rb
@@ -84,6 +84,8 @@ def ensure_stream_stats_table!
       ON pgbus_stream_stats (created_at);
     CREATE INDEX IF NOT EXISTS idx_pgbus_stream_stats_stream_time
       ON pgbus_stream_stats (stream_name, created_at);
+    CREATE INDEX IF NOT EXISTS idx_pgbus_stream_stats_type_time
+      ON pgbus_stream_stats (event_type, created_at);
   SQL
   # Clear any rows from prior benchmark runs so numbers aren't skewed
   # by a gigantic table on subsequent invocations.

--- a/benchmarks/streams_bench.rb
+++ b/benchmarks/streams_bench.rb
@@ -7,7 +7,9 @@
 # Requires PGBUS_DATABASE_URL:
 #   PGBUS_DATABASE_URL=postgres://user@host/db bundle exec rake bench:streams
 #
-# What it measures:
+# What it measures (each section runs TWICE — once with
+# streams_stats_enabled=false, once with =true — so the cost of opt-in
+# stream event recording shows up in the same output):
 #
 #   1. Single-broadcast roundtrip: time from Stream#broadcast to the
 #      SSE client receiving the message. This is the per-event latency
@@ -26,9 +28,8 @@
 #      connections concurrently. This is where Listener mutex
 #      contention shows up if ensure_listening serializes badly.
 #
-# Numbers from this file are committed inline to PR #88 (perf sweep).
-# Re-running on a different machine produces different absolute numbers
-# but the BEFORE/AFTER ratios should hold across hardware.
+# The A/B comparison at the end prints the stats=off baseline vs the
+# stats=on cost so the opt-in default can be justified numerically.
 
 require "benchmark/ips"
 require "json"
@@ -63,6 +64,35 @@ Pgbus.configure do |c|
   c.streams_listen_health_check_ms = 100
   c.streams_heartbeat_interval = 60
   c.streams_write_deadline_ms = 5_000
+  c.streams_stats_enabled = false # overridden per-suite below
+end
+
+# Ensure pgbus_stream_stats exists for the stats=on pass. The benchmark
+# is intentionally self-contained so it can run against any fresh
+# development DB without requiring the generator to have been run first.
+def ensure_stream_stats_table!
+  ActiveRecord::Base.connection.execute(<<~SQL)
+    CREATE TABLE IF NOT EXISTS pgbus_stream_stats (
+      id           BIGSERIAL PRIMARY KEY,
+      stream_name  TEXT NOT NULL,
+      event_type   TEXT NOT NULL,
+      duration_ms  INTEGER NOT NULL DEFAULT 0,
+      fanout       INTEGER,
+      created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS idx_pgbus_stream_stats_time
+      ON pgbus_stream_stats (created_at);
+    CREATE INDEX IF NOT EXISTS idx_pgbus_stream_stats_stream_time
+      ON pgbus_stream_stats (stream_name, created_at);
+  SQL
+  # Clear any rows from prior benchmark runs so numbers aren't skewed
+  # by a gigantic table on subsequent invocations.
+  ActiveRecord::Base.connection.execute("TRUNCATE TABLE pgbus_stream_stats")
+  # Reset the memoized table_exists? check on the model — the model
+  # may have been loaded before this function ran and cached "false".
+  return unless Pgbus::StreamStat.instance_variable_defined?(:@table_exists)
+
+  Pgbus::StreamStat.remove_instance_variable(:@table_exists)
 end
 
 def build_pg_listen_connection
@@ -117,134 +147,235 @@ def connect_client(harness, stream_name, since_id: 0)
   SseTestSupport::SseTestClient.connect(url: url, timeout: 5)
 end
 
-puts "=" * 70
-puts "Pgbus Streams Benchmarks (real Puma + real PGMQ + real SSE)"
-puts "  DB: #{DATABASE_URL.sub(%r{//[^@]*@}, "//***@")}"
-puts "=" * 70
-
 # ═══════════════════════════════════════════════════════════════════════
-# 1. Single broadcast roundtrip — time from broadcast to client receipt
+# The suite — returns a hash of measurements so the A/B comparison can
+# print paired tables. Each section body is identical to the pre-stats
+# version; only the wrapping structure changed.
 # ═══════════════════════════════════════════════════════════════════════
 
-puts "\n--- 1. Single broadcast roundtrip latency ---"
-puts "    (broadcast → NOTIFY → Listener → Dispatcher → Connection → SseTestClient)"
+def run_suite(stats_enabled:)
+  Pgbus.configuration.streams_stats_enabled = stats_enabled
+  label = stats_enabled ? "stats=on " : "stats=off"
 
-with_clean_stream do |stream_name, _streamer, harness|
-  stream = Pgbus.stream(stream_name)
-  client = connect_client(harness, stream_name, since_id: stream.current_msg_id)
-  sleep 0.1 # let the connect settle into the registry
+  results = {
+    roundtrip: nil,
+    burst: {},
+    fanout: {},
+    connect: {}
+  }
 
-  # Warm up so we're measuring steady-state, not first-NOTIFY-after-quiet
-  3.times do
-    stream.broadcast("<turbo-stream>warmup</turbo-stream>")
-    client.wait_for_events(count: client.events.size + 1, timeout: 2)
-  end
+  puts "\n══════════════════════════════════════════════════════════════════════"
+  puts "  SUITE: #{label}"
+  puts "══════════════════════════════════════════════════════════════════════"
 
-  samples = []
-  50.times do
-    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    target = client.events.size + 1
-    stream.broadcast("<turbo-stream>x</turbo-stream>")
-    client.wait_for_events(count: target, timeout: 2)
-    samples << ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000.0)
-  end
-
-  samples.sort!
-  printf "    n=%d  min=%6.2fms  median=%6.2fms  p95=%6.2fms  max=%6.2fms\n",
-         samples.size, samples.min, samples[samples.size / 2], samples[(samples.size * 0.95).to_i], samples.max
-
-  client.close
-end
-
-# ═══════════════════════════════════════════════════════════════════════
-# 2. Burst throughput — N broadcasts to one client, total time
-# ═══════════════════════════════════════════════════════════════════════
-
-puts "\n--- 2. Burst broadcast throughput (N broadcasts → 1 client) ---"
-puts "    (this is where wake coalescing matters — N notifies = N read_after calls without it)"
-
-[10, 50, 200].each do |burst_size|
+  # ───────────────────────────────────────────────────────────────────
+  # 1. Single broadcast roundtrip
+  # ───────────────────────────────────────────────────────────────────
+  puts "\n--- 1. Single broadcast roundtrip latency ---"
   with_clean_stream do |stream_name, _streamer, harness|
     stream = Pgbus.stream(stream_name)
     client = connect_client(harness, stream_name, since_id: stream.current_msg_id)
     sleep 0.1
 
-    # Warm: send one broadcast first so the steady-state path is hot.
-    stream.broadcast("<turbo-stream>warm</turbo-stream>")
-    client.wait_for_events(count: 1, timeout: 5)
-    warm_baseline = client.events.size
+    3.times do
+      stream.broadcast("<turbo-stream>warmup</turbo-stream>")
+      client.wait_for_events(count: client.events.size + 1, timeout: 2)
+    end
 
-    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    burst_size.times { |i| stream.broadcast("<turbo-stream>burst-#{i}</turbo-stream>") }
-    client.wait_for_events(count: warm_baseline + burst_size, timeout: 30)
-    elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000.0
+    samples = []
+    50.times do
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      target = client.events.size + 1
+      stream.broadcast("<turbo-stream>x</turbo-stream>")
+      client.wait_for_events(count: target, timeout: 2)
+      samples << ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000.0)
+    end
 
-    received = client.events.size - warm_baseline
-    printf "    burst=%3d  delivered=%3d  total=%7.2fms  per-msg=%5.2fms\n",
-           burst_size, received, elapsed, elapsed / burst_size
+    samples.sort!
+    results[:roundtrip] = {
+      min: samples.min,
+      median: samples[samples.size / 2],
+      p95: samples[(samples.size * 0.95).to_i],
+      max: samples.max
+    }
+    printf "    n=%d  min=%6.2fms  median=%6.2fms  p95=%6.2fms  max=%6.2fms\n",
+           samples.size, results[:roundtrip][:min], results[:roundtrip][:median],
+           results[:roundtrip][:p95], results[:roundtrip][:max]
 
     client.close
   end
-end
 
-# ═══════════════════════════════════════════════════════════════════════
-# 3. Fanout — one broadcast to M simultaneously connected clients
-# ═══════════════════════════════════════════════════════════════════════
+  # ───────────────────────────────────────────────────────────────────
+  # 2. Burst throughput
+  # ───────────────────────────────────────────────────────────────────
+  puts "\n--- 2. Burst broadcast throughput (N broadcasts → 1 client) ---"
+  [10, 50, 200].each do |burst_size|
+    with_clean_stream do |stream_name, _streamer, harness|
+      stream = Pgbus.stream(stream_name)
+      client = connect_client(harness, stream_name, since_id: stream.current_msg_id)
+      sleep 0.1
 
-puts "\n--- 3. Fanout (1 broadcast → M clients) ---"
-puts "    (this is where Connection#enqueue batching matters — M connections = M io.write calls)"
+      stream.broadcast("<turbo-stream>warm</turbo-stream>")
+      client.wait_for_events(count: 1, timeout: 5)
+      warm_baseline = client.events.size
 
-[5, 20, 50].each do |fanout|
-  with_clean_stream do |stream_name, _streamer, harness|
-    stream = Pgbus.stream(stream_name)
-    clients = Array.new(fanout) { connect_client(harness, stream_name, since_id: stream.current_msg_id) }
-    sleep 0.5 # let all connects settle into the registry
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      burst_size.times { |i| stream.broadcast("<turbo-stream>burst-#{i}</turbo-stream>") }
+      client.wait_for_events(count: warm_baseline + burst_size, timeout: 30)
+      elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000.0
 
-    # Warm: do one broadcast to clear cold-start effects, then measure
-    # the SECOND broadcast.
-    stream.broadcast("<turbo-stream>warm</turbo-stream>")
-    deadline = Time.now + 10
-    sleep 0.005 until clients.all? { |c| c.events.size >= 1 } || Time.now > deadline
-    warm_baseline = clients.map { |c| c.events.size }
+      received = client.events.size - warm_baseline
+      results[:burst][burst_size] = { total_ms: elapsed, per_msg_ms: elapsed / burst_size }
+      printf "    burst=%3d  delivered=%3d  total=%7.2fms  per-msg=%5.2fms\n",
+             burst_size, received, elapsed, elapsed / burst_size
 
-    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    stream.broadcast("<turbo-stream>fanout</turbo-stream>")
-    deadline = Time.now + 5
-    target = warm_baseline.first + 1
-    sleep 0.005 until clients.all? { |c| c.events.size >= target } || Time.now > deadline
-    elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000.0
-
-    delivered = clients.count { |c| c.events.size >= target }
-    printf "    M=%2d  delivered=%2d  total=%7.2fms  per-client=%5.2fms\n",
-           fanout, delivered, elapsed, elapsed / fanout
-
-    clients.each(&:close)
-  end
-end
-
-# ═══════════════════════════════════════════════════════════════════════
-# 4. Concurrent connect latency — K simultaneous SSE handshakes
-# ═══════════════════════════════════════════════════════════════════════
-
-puts "\n--- 4. Concurrent connect latency (K clients connecting at once) ---"
-puts "    (this is where Listener mutex contention matters — K connects = K LISTEN waits)"
-
-[5, 20, 50].each do |k|
-  with_clean_stream do |stream_name, _streamer, harness|
-    stream = Pgbus.stream(stream_name)
-    since = stream.current_msg_id
-
-    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    threads = Array.new(k) do
-      Thread.new { connect_client(harness, stream_name, since_id: since) }
+      client.close
     end
-    clients = threads.map(&:value)
-    elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000.0
-
-    printf "    K=%2d  total=%7.2fms  per-connect=%5.2fms\n", k, elapsed, elapsed / k
-
-    clients.each(&:close)
   end
+
+  # ───────────────────────────────────────────────────────────────────
+  # 3. Fanout
+  # ───────────────────────────────────────────────────────────────────
+  puts "\n--- 3. Fanout (1 broadcast → M clients) ---"
+  [5, 20, 50].each do |fanout|
+    with_clean_stream do |stream_name, _streamer, harness|
+      stream = Pgbus.stream(stream_name)
+      clients = Array.new(fanout) { connect_client(harness, stream_name, since_id: stream.current_msg_id) }
+      sleep 0.5
+
+      stream.broadcast("<turbo-stream>warm</turbo-stream>")
+      deadline = Time.now + 10
+      sleep 0.005 until clients.all? { |c| c.events.size >= 1 } || Time.now > deadline
+      warm_baseline = clients.map { |c| c.events.size }
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      stream.broadcast("<turbo-stream>fanout</turbo-stream>")
+      deadline = Time.now + 5
+      target = warm_baseline.first + 1
+      sleep 0.005 until clients.all? { |c| c.events.size >= target } || Time.now > deadline
+      elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000.0
+
+      delivered = clients.count { |c| c.events.size >= target }
+      results[:fanout][fanout] = { total_ms: elapsed, per_client_ms: elapsed / fanout }
+      printf "    M=%2d  delivered=%2d  total=%7.2fms  per-client=%5.2fms\n",
+             fanout, delivered, elapsed, elapsed / fanout
+
+      clients.each(&:close)
+    end
+  end
+
+  # ───────────────────────────────────────────────────────────────────
+  # 4. Concurrent connect latency
+  # ───────────────────────────────────────────────────────────────────
+  puts "\n--- 4. Concurrent connect latency (K clients connecting at once) ---"
+  [5, 20, 50].each do |k|
+    with_clean_stream do |stream_name, _streamer, harness|
+      stream = Pgbus.stream(stream_name)
+      since = stream.current_msg_id
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      threads = Array.new(k) do
+        Thread.new { connect_client(harness, stream_name, since_id: since) }
+      end
+      clients = threads.map(&:value)
+      elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000.0
+
+      results[:connect][k] = { total_ms: elapsed, per_connect_ms: elapsed / k }
+      printf "    K=%2d  total=%7.2fms  per-connect=%5.2fms\n", k, elapsed, elapsed / k
+
+      clients.each(&:close)
+    end
+  end
+
+  results
 end
+
+# ═══════════════════════════════════════════════════════════════════════
+# A/B comparison
+# ═══════════════════════════════════════════════════════════════════════
+
+def pct_delta(off_value, on_value)
+  return "  n/a" if off_value.nil? || off_value.zero?
+
+  delta = ((on_value - off_value) / off_value.to_f) * 100.0
+  sign = delta >= 0 ? "+" : ""
+  format("%s%5.1f%%", sign, delta)
+end
+
+def print_comparison(off_results, on_results)
+  puts "\n"
+  puts "═" * 70
+  puts "  A/B comparison — stats=off (baseline) vs stats=on (overhead)"
+  puts "═" * 70
+
+  puts "\n1. Single broadcast roundtrip (ms)"
+  printf "   %-10s  %8s  %8s  %8s  %8s\n", "", "min", "median", "p95", "max"
+  rtt_off = off_results[:roundtrip]
+  rtt_on  = on_results[:roundtrip]
+  printf "   %-10s  %8.2f  %8.2f  %8.2f  %8.2f\n", "off",
+         rtt_off[:min], rtt_off[:median], rtt_off[:p95], rtt_off[:max]
+  printf "   %-10s  %8.2f  %8.2f  %8.2f  %8.2f\n", "on",
+         rtt_on[:min], rtt_on[:median], rtt_on[:p95], rtt_on[:max]
+  printf "   %-10s  %8s  %8s  %8s  %8s\n", "Δ",
+         pct_delta(rtt_off[:min], rtt_on[:min]),
+         pct_delta(rtt_off[:median], rtt_on[:median]),
+         pct_delta(rtt_off[:p95], rtt_on[:p95]),
+         pct_delta(rtt_off[:max], rtt_on[:max])
+
+  puts "\n2. Burst throughput (per-msg ms)"
+  printf "   %-10s  %8s  %8s  %8s\n", "", "N=10", "N=50", "N=200"
+  burst_off = off_results[:burst]
+  burst_on  = on_results[:burst]
+  printf "   %-10s  %8.2f  %8.2f  %8.2f\n", "off",
+         burst_off[10][:per_msg_ms], burst_off[50][:per_msg_ms], burst_off[200][:per_msg_ms]
+  printf "   %-10s  %8.2f  %8.2f  %8.2f\n", "on",
+         burst_on[10][:per_msg_ms], burst_on[50][:per_msg_ms], burst_on[200][:per_msg_ms]
+  printf "   %-10s  %8s  %8s  %8s\n", "Δ",
+         pct_delta(burst_off[10][:per_msg_ms], burst_on[10][:per_msg_ms]),
+         pct_delta(burst_off[50][:per_msg_ms], burst_on[50][:per_msg_ms]),
+         pct_delta(burst_off[200][:per_msg_ms], burst_on[200][:per_msg_ms])
+
+  puts "\n3. Fanout (per-client ms)"
+  printf "   %-10s  %8s  %8s  %8s\n", "", "M=5", "M=20", "M=50"
+  fan_off = off_results[:fanout]
+  fan_on  = on_results[:fanout]
+  printf "   %-10s  %8.2f  %8.2f  %8.2f\n", "off",
+         fan_off[5][:per_client_ms], fan_off[20][:per_client_ms], fan_off[50][:per_client_ms]
+  printf "   %-10s  %8.2f  %8.2f  %8.2f\n", "on",
+         fan_on[5][:per_client_ms], fan_on[20][:per_client_ms], fan_on[50][:per_client_ms]
+  printf "   %-10s  %8s  %8s  %8s\n", "Δ",
+         pct_delta(fan_off[5][:per_client_ms], fan_on[5][:per_client_ms]),
+         pct_delta(fan_off[20][:per_client_ms], fan_on[20][:per_client_ms]),
+         pct_delta(fan_off[50][:per_client_ms], fan_on[50][:per_client_ms])
+
+  puts "\n4. Concurrent connect (per-connect ms)"
+  printf "   %-10s  %8s  %8s  %8s\n", "", "K=5", "K=20", "K=50"
+  con_off = off_results[:connect]
+  con_on  = on_results[:connect]
+  printf "   %-10s  %8.2f  %8.2f  %8.2f\n", "off",
+         con_off[5][:per_connect_ms], con_off[20][:per_connect_ms], con_off[50][:per_connect_ms]
+  printf "   %-10s  %8.2f  %8.2f  %8.2f\n", "on",
+         con_on[5][:per_connect_ms], con_on[20][:per_connect_ms], con_on[50][:per_connect_ms]
+  printf "   %-10s  %8s  %8s  %8s\n", "Δ",
+         pct_delta(con_off[5][:per_connect_ms], con_on[5][:per_connect_ms]),
+         pct_delta(con_off[20][:per_connect_ms], con_on[20][:per_connect_ms]),
+         pct_delta(con_off[50][:per_connect_ms], con_on[50][:per_connect_ms])
+end
+
+# ═══════════════════════════════════════════════════════════════════════
+# Run
+# ═══════════════════════════════════════════════════════════════════════
+
+puts "=" * 70
+puts "Pgbus Streams Benchmarks (real Puma + real PGMQ + real SSE)"
+puts "  DB: #{DATABASE_URL.sub(%r{//[^@]*@}, "//***@")}"
+puts "=" * 70
+
+ensure_stream_stats_table!
+
+off_results = run_suite(stats_enabled: false)
+on_results = run_suite(stats_enabled: true)
+
+print_comparison(off_results, on_results)
 
 puts "\nDone."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,22 @@ en:
             job_class: Job Class
             max: Max
           title: Slowest Job Classes (avg duration)
+        streams:
+          summary:
+            active: Active
+            avg_fanout: Avg Fanout
+            broadcasts: Broadcasts
+            connects: Connects
+            disconnects: Disconnects
+          title: Real-time Streams
+          top:
+            empty: No stream activity recorded in the selected window
+            headers:
+              avg_fanout: Avg Fanout
+              avg_ms: Avg Dispatch
+              broadcasts: Broadcasts
+              stream: Stream
+            title: Top Streams by Broadcast Volume
         summary:
           avg_duration: Avg Duration
           avg_latency: Avg Latency

--- a/lib/generators/pgbus/add_stream_stats_generator.rb
+++ b/lib/generators/pgbus/add_stream_stats_generator.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class AddStreamStatsGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Add stream stats table for Insights dashboard (opt-in, disabled by default)"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
+      def create_migration_file
+        if separate_database?
+          migration_template "add_stream_stats.rb.erb",
+                             "db/pgbus_migrate/add_pgbus_stream_stats.rb"
+        else
+          migration_template "add_stream_stats.rb.erb",
+                             "db/migrate/add_pgbus_stream_stats.rb"
+        end
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus stream stats table installed!", :green
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
+        say "  2. Opt in by setting `config.streams_stats_enabled = true` in your"
+        say "     pgbus initializer (disabled by default — stream event volume can"
+        say "     be high, so stats recording is off unless you ask for it)."
+        say "  3. View stream insights at /pgbus/insights"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/templates/add_stream_stats.rb.erb
+++ b/lib/generators/pgbus/templates/add_stream_stats.rb.erb
@@ -1,0 +1,18 @@
+class AddPgbusStreamStats < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :pgbus_stream_stats do |t|
+      t.string :stream_name, null: false
+      t.string :event_type, null: false # 'broadcast' | 'connect' | 'disconnect'
+      t.integer :duration_ms, null: false, default: 0
+      t.integer :fanout # nil for connect/disconnect
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :pgbus_stream_stats, :created_at,
+              name: "idx_pgbus_stream_stats_time"
+    add_index :pgbus_stream_stats, %i[stream_name created_at],
+              name: "idx_pgbus_stream_stats_stream_time"
+    add_index :pgbus_stream_stats, %i[event_type created_at],
+              name: "idx_pgbus_stream_stats_type_time"
+  end
+end

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -88,7 +88,8 @@ module Pgbus
     attr_accessor :streams_enabled, :streams_queue_prefix, :streams_signed_name_secret,
                   :streams_default_retention, :streams_retention, :streams_heartbeat_interval,
                   :streams_max_connections, :streams_idle_timeout, :streams_listen_health_check_ms,
-                  :streams_write_deadline_ms, :streams_falcon_streaming_body
+                  :streams_write_deadline_ms, :streams_falcon_streaming_body,
+                  :streams_stats_enabled
 
     def initialize
       @database_url = nil
@@ -176,6 +177,14 @@ module Pgbus
       @streams_listen_health_check_ms = 250
       @streams_write_deadline_ms = 5_000
       @streams_falcon_streaming_body = false
+      # Opt-in: when true, the Dispatcher writes one row to
+      # pgbus_stream_stats per broadcast/connect/disconnect. Default
+      # off because stream event volume can be much higher than job
+      # volume and the Insights surface is only useful if operators
+      # actually look at it. Separate from #stats_enabled (which
+      # gates pgbus_job_stats recording) on purpose — operators
+      # usually want job stats on and stream stats off, or vice versa.
+      @streams_stats_enabled = false
     end
 
     def queue_name(name)

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -142,13 +142,20 @@ module Pgbus
       end
 
       def cleanup_stats
-        return unless config.stats_enabled
-
         retention = config.stats_retention
         return unless retention&.positive?
 
-        deleted = JobStat.cleanup!(older_than: Time.current - retention)
-        Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} old job stats" } if deleted.positive?
+        cutoff = Time.current - retention
+
+        if config.stats_enabled
+          deleted = JobStat.cleanup!(older_than: cutoff)
+          Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} old job stats" } if deleted.positive?
+        end
+
+        return unless config.streams_stats_enabled
+
+        deleted = StreamStat.cleanup!(older_than: cutoff)
+        Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} old stream stats" } if deleted.positive?
       end
 
       def cleanup_job_locks

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -630,6 +630,34 @@ module Pgbus
         []
       end
 
+      # Stream stats — only populated when streams_stats_enabled is
+      # true AND the migration has been run. Controllers should gate
+      # rendering on `stream_stats_available?` to avoid showing empty
+      # sections.
+      def stream_stats_available?
+        Pgbus.configuration.streams_stats_enabled && StreamStat.table_exists?
+      rescue StandardError
+        false
+      end
+
+      def stream_stats_summary(minutes: 60)
+        StreamStat.summary(minutes: minutes)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching stream stats summary: #{e.message}" }
+        {
+          broadcasts: 0, connects: 0, disconnects: 0,
+          active_estimate: 0, avg_fanout: 0,
+          avg_broadcast_ms: 0, avg_connect_ms: 0
+        }
+      end
+
+      def top_streams(limit: 10, minutes: 60)
+        StreamStat.top_streams(limit: limit, minutes: minutes)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching top streams: #{e.message}" }
+        []
+      end
+
       # Subscriber registry
       def registered_subscribers
         EventBus::Registry.instance.subscribers.map do |s|

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -636,7 +636,8 @@ module Pgbus
       # sections.
       def stream_stats_available?
         Pgbus.configuration.streams_stats_enabled && StreamStat.table_exists?
-      rescue StandardError
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error checking stream stats availability: #{e.message}" }
         false
       end
 

--- a/lib/pgbus/web/streamer/dispatcher.rb
+++ b/lib/pgbus/web/streamer/dispatcher.rb
@@ -45,7 +45,7 @@ module Pgbus
 
         def initialize(client:, registry:, listener:, dispatch_queue:,
                        logger: Pgbus.logger, read_limit: DEFAULT_READ_LIMIT,
-                       filters: nil)
+                       filters: nil, config: nil)
           @client = client
           @registry = registry
           @listener = listener
@@ -56,6 +56,13 @@ module Pgbus
           # code picks up whatever was registered at boot. Tests inject
           # a fresh Filters instance to avoid cross-test pollution.
           @filters = filters || Pgbus::Streams.filters
+          # Config is injected so the Dispatcher can read
+          # `streams_stats_enabled` without reaching into the global
+          # Pgbus.configuration at every call site. Tests pass a
+          # throwaway config to flip the flag independently of the
+          # process-wide setting. Falls back to the global config
+          # for production call sites that don't specify one.
+          @config = config || Pgbus.configuration
           # stream_name → Array<[connection, Array<Envelope>]>
           @in_flight = Hash.new { |h, k| h[k] = [] }
           # PGMQ full table name (pgbus_<prefix>_<name>) → logical stream
@@ -181,6 +188,7 @@ module Pgbus
         end
 
         def handle_wake(msg)
+          started_at = monotonic_ms
           # msg.queue_name is the PGMQ full table name (pgbus_int_pbns_xxx),
           # but connections are registered under the logical name (pbns_xxx).
           # Translate before looking up.
@@ -217,9 +225,22 @@ module Pgbus
           end
 
           prune_dead(registered)
+
+          # Record one stat row per wake. Fanout is the number of
+          # subscribers (registered + in-flight) that received the
+          # broadcast before any filter dropped it — the "intended"
+          # audience size, which is the useful operator number even
+          # when audience filtering is in play.
+          record_stat(
+            stream_name: stream,
+            event_type: "broadcast",
+            started_at: started_at,
+            fanout: registered.size + in_flight_pairs.size
+          )
         end
 
         def handle_connect(msg)
+          started_at = monotonic_ms
           connection = msg.connection
           stream = connection.stream_name
 
@@ -269,6 +290,17 @@ module Pgbus
           else
             @registry.register(connection)
           end
+
+          # Record the connect regardless of whether the connection
+          # survived the replay — a dead-before-register is still an
+          # operator-visible "connection attempt" and disconnects
+          # won't be recorded for it, so dropping it here would
+          # under-count.
+          record_stat(
+            stream_name: stream,
+            event_type: "connect",
+            started_at: started_at
+          )
         rescue StandardError => e
           # Same leak path for exceptions in steps 1-4. Mark dead and
           # scrub state so a transient failure on a single connect
@@ -282,11 +314,18 @@ module Pgbus
         end
 
         def handle_disconnect(msg)
+          started_at = monotonic_ms
           connection = msg.connection
           stream = connection.stream_name
           @registry.unregister(connection)
           @scanned_cursor.delete(connection)
           cleanup_stream_if_unused(stream)
+
+          record_stat(
+            stream_name: stream,
+            event_type: "disconnect",
+            started_at: started_at
+          )
         end
 
         # If this stream has no remaining subscribers (registered or
@@ -399,6 +438,28 @@ module Pgbus
             label = envelope.respond_to?(:visible_to) ? envelope.visible_to : nil
             @filters.visible?(label, connection.context)
           end
+        end
+
+        def monotonic_ms
+          ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) * 1000.0
+        end
+
+        # Opt-in stream event stat recording. Gated by
+        # `config.streams_stats_enabled` (default false) because
+        # stream volume can dwarf job volume in chat-style apps,
+        # and the Insights surface is only worth the INSERT cost
+        # if operators actually look at it. All failures are
+        # swallowed by StreamStat.record! itself so a stats-table
+        # outage cannot block the dispatcher.
+        def record_stat(stream_name:, event_type:, started_at:, fanout: nil)
+          return unless @config.streams_stats_enabled
+
+          Pgbus::StreamStat.record!(
+            stream_name: stream_name,
+            event_type: event_type,
+            duration_ms: (monotonic_ms - started_at).round,
+            fanout: fanout
+          )
         end
       end
     end

--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -48,7 +48,8 @@ module Pgbus
             registry: @registry,
             listener: @listener,
             dispatch_queue: @dispatch_queue,
-            logger: @logger
+            logger: @logger,
+            config: @config
           )
           @heartbeat = Heartbeat.new(
             registry: @registry,

--- a/spec/dummy/lib/stub_data_source.rb
+++ b/spec/dummy/lib/stub_data_source.rb
@@ -199,7 +199,7 @@ module DummyApp
         { stream_name: "chat:lobby", count: 420, avg_fanout: 18.2, avg_ms: 3.1 },
         { stream_name: "orders:dashboard", count: 312, avg_fanout: 4.5, avg_ms: 5.8 },
         { stream_name: "notifications:admin", count: 214, avg_fanout: 2.1, avg_ms: 2.4 }
-      ]
+      ].first(limit)
     end
 
     # Mutating actions (no-ops for QA)

--- a/spec/dummy/lib/stub_data_source.rb
+++ b/spec/dummy/lib/stub_data_source.rb
@@ -176,6 +176,32 @@ module DummyApp
       []
     end
 
+    def job_status_counts(minutes: 60) # rubocop:disable Lint/UnusedMethodArgument
+      { "success" => 335, "failed" => 5, "dead_lettered" => 2 }
+    end
+
+    # Stream stats — opt-in in production, always "available" in the
+    # dummy app so the Insights QA surface demos the section.
+    def stream_stats_available?
+      true
+    end
+
+    def stream_stats_summary(minutes: 60) # rubocop:disable Lint/UnusedMethodArgument
+      {
+        broadcasts: 1_248, connects: 92, disconnects: 87,
+        active_estimate: 5, avg_fanout: 7.3,
+        avg_broadcast_ms: 4.1, avg_connect_ms: 12.6
+      }
+    end
+
+    def top_streams(limit: 10, minutes: 60) # rubocop:disable Lint/UnusedMethodArgument
+      [
+        { stream_name: "chat:lobby", count: 420, avg_fanout: 18.2, avg_ms: 3.1 },
+        { stream_name: "orders:dashboard", count: 312, avg_fanout: 4.5, avg_ms: 5.8 },
+        { stream_name: "notifications:admin", count: 214, avg_fanout: 2.1, avg_ms: 2.4 }
+      ]
+    end
+
     # Mutating actions (no-ops for QA)
     def purge_queue(_name) = true
     def drop_queue(_name) = true

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe Pgbus::Configuration do
       expect(config.stats_retention).to eq(30 * 24 * 3600)
     end
 
+    it "has streams_stats_enabled disabled by default (opt-in)" do
+      expect(config.streams_stats_enabled).to be false
+    end
+
     it "has insights_default_minutes of 30 days" do
       expect(config.insights_default_minutes).to eq(30 * 24 * 60)
     end

--- a/spec/pgbus/stream_stat_spec.rb
+++ b/spec/pgbus/stream_stat_spec.rb
@@ -77,10 +77,25 @@ RSpec.describe Pgbus::StreamStat do
       described_class.remove_instance_variable(:@table_exists) if described_class.instance_variable_defined?(:@table_exists)
     end
 
-    it "returns false and memoizes when the connection raises" do
+    it "returns false on connection error without poisoning the memo" do
       allow(described_class).to receive(:connection).and_raise(StandardError, "no db")
+
       expect(described_class.table_exists?).to be false
-      expect(described_class.table_exists?).to be false
+      # The failed probe must NOT set @table_exists — otherwise a
+      # transient PG blip during boot permanently disables stream
+      # stats for the process lifetime.
+      expect(described_class.instance_variable_defined?(:@table_exists)).to be false
+    end
+
+    it "memoizes a successful probe" do
+      fake_connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+      allow(fake_connection).to receive(:table_exists?).with(described_class.table_name).and_return(true)
+      allow(described_class).to receive(:connection).and_return(fake_connection)
+
+      expect(described_class.table_exists?).to be true
+      # Second call hits the memo, not the connection.
+      expect(described_class.table_exists?).to be true
+      expect(fake_connection).to have_received(:table_exists?).once
     end
   end
 end

--- a/spec/pgbus/stream_stat_spec.rb
+++ b/spec/pgbus/stream_stat_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::StreamStat do
+  describe ".record!" do
+    before do
+      allow(described_class).to receive_messages(create!: nil, table_exists?: true)
+    end
+
+    it "creates a broadcast stat with fanout" do
+      described_class.record!(
+        stream_name: "chat_42",
+        event_type: "broadcast",
+        duration_ms: 17,
+        fanout: 12
+      )
+
+      expect(described_class).to have_received(:create!).with(
+        stream_name: "chat_42",
+        event_type: "broadcast",
+        duration_ms: 17,
+        fanout: 12
+      )
+    end
+
+    it "creates a connect stat without fanout" do
+      described_class.record!(
+        stream_name: "chat_42",
+        event_type: "connect",
+        duration_ms: 3
+      )
+
+      expect(described_class).to have_received(:create!).with(
+        stream_name: "chat_42",
+        event_type: "connect",
+        duration_ms: 3,
+        fanout: nil
+      )
+    end
+
+    it "skips when table does not exist" do
+      allow(described_class).to receive(:table_exists?).and_return(false)
+
+      described_class.record!(stream_name: "chat", event_type: "broadcast", duration_ms: 0)
+
+      expect(described_class).not_to have_received(:create!)
+    end
+
+    it "swallows errors" do
+      allow(described_class).to receive(:create!).and_raise(StandardError, "db down")
+
+      expect do
+        described_class.record!(stream_name: "chat", event_type: "broadcast", duration_ms: 0)
+      end.not_to raise_error
+    end
+
+    it "coerces duration_ms to integer" do
+      described_class.record!(
+        stream_name: "chat",
+        event_type: "broadcast",
+        duration_ms: 4.7
+      )
+
+      expect(described_class).to have_received(:create!).with(
+        hash_including(duration_ms: 4)
+      )
+    end
+  end
+
+  describe ".table_exists?" do
+    before do
+      described_class.remove_instance_variable(:@table_exists) if described_class.instance_variable_defined?(:@table_exists)
+    end
+
+    after do
+      described_class.remove_instance_variable(:@table_exists) if described_class.instance_variable_defined?(:@table_exists)
+    end
+
+    it "returns false and memoizes when the connection raises" do
+      allow(described_class).to receive(:connection).and_raise(StandardError, "no db")
+      expect(described_class.table_exists?).to be false
+      expect(described_class.table_exists?).to be false
+    end
+  end
+end

--- a/spec/pgbus/web/streamer/dispatcher_spec.rb
+++ b/spec/pgbus/web/streamer/dispatcher_spec.rb
@@ -10,8 +10,15 @@ RSpec.describe Pgbus::Web::Streamer::Dispatcher do
       listener: listener,
       dispatch_queue: dispatch_queue,
       logger: logger,
-      read_limit: 500
+      read_limit: 500,
+      config: dispatcher_config
     )
+  end
+
+  # Dispatcher config: independent of Pgbus.configuration so toggling
+  # streams_stats_enabled in one test can't bleed into another.
+  let(:dispatcher_config) do
+    instance_double(Pgbus::Configuration, streams_stats_enabled: false)
   end
 
   let(:client) do
@@ -462,6 +469,111 @@ RSpec.describe Pgbus::Web::Streamer::Dispatcher do
       coalesced.each { |w| dispatcher.send(:handle, w) }
 
       expect(client).to have_received(:read_after).once
+    end
+  end
+
+  describe "stream stat recording (opt-in)" do
+    # When streams_stats_enabled is false (the default in this suite),
+    # the Dispatcher must never touch Pgbus::StreamStat. Otherwise a
+    # misconfigured install would start writing rows on upgrade.
+    context "when streams_stats_enabled is false" do
+      it "does not record a broadcast on handle_wake" do
+        c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+        registry.register(c)
+        allow(client).to receive(:read_after).and_return([build_envelope(10)])
+        allow(Pgbus::StreamStat).to receive(:record!)
+
+        dispatcher.send(:handle, described_class::WakeMessage.new(queue_name: "chat"))
+
+        expect(Pgbus::StreamStat).not_to have_received(:record!)
+      end
+
+      it "does not record a connect on handle_connect" do
+        c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+        allow(client).to receive(:read_after).and_return([])
+        allow(Pgbus::StreamStat).to receive(:record!)
+
+        dispatcher.send(:handle, described_class::ConnectMessage.new(connection: c))
+
+        expect(Pgbus::StreamStat).not_to have_received(:record!)
+      end
+
+      it "does not record a disconnect on handle_disconnect" do
+        c = build_conn(id: "a", stream_name: "chat")
+        registry.register(c)
+        allow(Pgbus::StreamStat).to receive(:record!)
+
+        dispatcher.send(:handle, described_class::DisconnectMessage.new(connection: c))
+
+        expect(Pgbus::StreamStat).not_to have_received(:record!)
+      end
+    end
+
+    context "when streams_stats_enabled is true" do
+      let(:dispatcher_config) do
+        instance_double(Pgbus::Configuration, streams_stats_enabled: true)
+      end
+
+      it "records a broadcast with fanout = registered + in-flight subscriber count" do
+        c1 = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+        c2 = build_conn(id: "b", stream_name: "chat", last_msg_id_sent: 0)
+        registry.register(c1)
+        registry.register(c2)
+        allow(client).to receive(:read_after).and_return([build_envelope(5)])
+        allow(Pgbus::StreamStat).to receive(:record!)
+
+        dispatcher.send(:handle, described_class::WakeMessage.new(queue_name: "chat"))
+
+        expect(Pgbus::StreamStat).to have_received(:record!).with(
+          hash_including(stream_name: "chat", event_type: "broadcast", fanout: 2)
+        )
+      end
+
+      it "does not record a broadcast when read_after returns empty" do
+        c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+        registry.register(c)
+        allow(client).to receive(:read_after).and_return([])
+        allow(Pgbus::StreamStat).to receive(:record!)
+
+        dispatcher.send(:handle, described_class::WakeMessage.new(queue_name: "chat"))
+
+        expect(Pgbus::StreamStat).not_to have_received(:record!)
+      end
+
+      it "records a connect with no fanout" do
+        c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+        allow(client).to receive(:read_after).and_return([])
+        allow(Pgbus::StreamStat).to receive(:record!)
+
+        dispatcher.send(:handle, described_class::ConnectMessage.new(connection: c))
+
+        expect(Pgbus::StreamStat).to have_received(:record!).with(
+          hash_including(stream_name: "chat", event_type: "connect", fanout: nil)
+        )
+      end
+
+      it "records a disconnect" do
+        c = build_conn(id: "a", stream_name: "chat")
+        registry.register(c)
+        allow(Pgbus::StreamStat).to receive(:record!)
+
+        dispatcher.send(:handle, described_class::DisconnectMessage.new(connection: c))
+
+        expect(Pgbus::StreamStat).to have_received(:record!).with(
+          hash_including(stream_name: "chat", event_type: "disconnect", fanout: nil)
+        )
+      end
+
+      it "does not propagate StreamStat.record! errors to the dispatcher" do
+        c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+        registry.register(c)
+        allow(client).to receive(:read_after).and_return([build_envelope(1)])
+        allow(Pgbus::StreamStat).to receive(:record!).and_raise(StandardError, "boom")
+
+        expect do
+          dispatcher.send(:handle, described_class::WakeMessage.new(queue_name: "chat"))
+        end.not_to raise_error
+      end
     end
   end
 

--- a/spec/system/insights_spec.rb
+++ b/spec/system/insights_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Insights", type: :system do
   end
 
   describe "stream stats (opt-in)" do
-    context "when streams_stats_available? is false (default)" do
+    context "when stream_stats_available? is false (default)" do
       it "does not render the Real-time Streams section" do
         visit "/pgbus/insights"
 
@@ -67,7 +67,7 @@ RSpec.describe "Insights", type: :system do
       end
     end
 
-    context "when streams_stats_available? is true but no data" do
+    context "when stream_stats_available? is true but no data" do
       before do
         @stub_data_source.stream_stats_available = true
       end
@@ -92,7 +92,7 @@ RSpec.describe "Insights", type: :system do
       end
     end
 
-    context "when streams_stats_available? is true with data" do
+    context "when stream_stats_available? is true with data" do
       before do
         @stub_data_source.stream_stats_available = true
         @stub_data_source.stream_summary = {

--- a/spec/system/insights_spec.rb
+++ b/spec/system/insights_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe "Insights", type: :system do
+  describe "job stats (always visible)" do
+    it "renders the page header and summary cards" do
+      visit "/pgbus/insights"
+
+      expect(page).to have_css("h1", text: "Insights")
+
+      # Summary cards from default_insights_summary. Labels render with
+      # text-transform: uppercase, so the *visible* text is "TOTAL JOBS"
+      # not "Total Jobs"; have_text matches on rendered output.
+      expect(page).to have_text("TOTAL JOBS")
+      expect(page).to have_text("342")
+      expect(page).to have_text("SUCCEEDED")
+      expect(page).to have_text("335")
+      expect(page).to have_text("FAILED")
+      expect(page).to have_text("DEAD LETTERED")
+    end
+
+    it "shows the time range selector" do
+      visit "/pgbus/insights"
+
+      within("nav[aria-label='Time range']") do
+        expect(page).to have_link("1h")
+        expect(page).to have_link("24h")
+        expect(page).to have_link("7d")
+        expect(page).to have_link("30d")
+      end
+    end
+
+    it "shows an empty state for slowest job classes when there is no data" do
+      visit "/pgbus/insights"
+
+      expect(page).to have_text("Slowest Job Classes")
+      expect(page).to have_text("No job stats yet")
+    end
+
+    context "with slowest job class rows" do
+      before do
+        @stub_data_source.insights_slowest = [
+          { job_class: "SlowMailerJob", count: 42, avg_ms: 1250, max_ms: 4500 },
+          { job_class: "BigReportJob", count: 11, avg_ms: 940, max_ms: 2100 }
+        ]
+      end
+
+      it "renders the slowest job classes table" do
+        visit "/pgbus/insights"
+
+        expect(page).to have_text("SlowMailerJob")
+        expect(page).to have_text("BigReportJob")
+        expect(page).to have_text("42")
+      end
+    end
+  end
+
+  describe "stream stats (opt-in)" do
+    context "when streams_stats_available? is false (default)" do
+      it "does not render the Real-time Streams section" do
+        visit "/pgbus/insights"
+
+        expect(page).to have_no_text("Real-time Streams")
+        expect(page).to have_no_text("Broadcasts")
+        expect(page).to have_no_text("Top Streams by Broadcast Volume")
+      end
+    end
+
+    context "when streams_stats_available? is true but no data" do
+      before do
+        @stub_data_source.stream_stats_available = true
+      end
+
+      it "renders the Real-time Streams section with zeroed cards" do
+        visit "/pgbus/insights"
+
+        expect(page).to have_text("Real-time Streams")
+        # Labels are text-transform: uppercase in the rendered DOM.
+        expect(page).to have_text("BROADCASTS")
+        expect(page).to have_text("CONNECTS")
+        expect(page).to have_text("DISCONNECTS")
+        expect(page).to have_text("ACTIVE")
+        expect(page).to have_text("AVG FANOUT")
+      end
+
+      it "shows an empty state in the top streams table" do
+        visit "/pgbus/insights"
+
+        expect(page).to have_text("Top Streams by Broadcast Volume")
+        expect(page).to have_text("No stream activity recorded in the selected window")
+      end
+    end
+
+    context "when streams_stats_available? is true with data" do
+      before do
+        @stub_data_source.stream_stats_available = true
+        @stub_data_source.stream_summary = {
+          broadcasts: 1_248, connects: 92, disconnects: 87,
+          active_estimate: 5, avg_fanout: 7.3,
+          avg_broadcast_ms: 4.1, avg_connect_ms: 12.6
+        }
+        @stub_data_source.top_streams_list = [
+          { stream_name: "chat:lobby", count: 420, avg_fanout: 18.2, avg_ms: 3.1 },
+          { stream_name: "orders:dashboard", count: 312, avg_fanout: 4.5, avg_ms: 5.8 }
+        ]
+      end
+
+      it "renders the summary card values" do
+        visit "/pgbus/insights"
+
+        # pgbus_number formats 1_248 as "1.2K" (see pgbus_number helper).
+        # Values under 1000 render as plain integers.
+        expect(page).to have_text("1.2K")    # broadcasts
+        expect(page).to have_text("92")      # connects
+        expect(page).to have_text("87")      # disconnects
+        expect(page).to have_text("7.3")     # avg_fanout
+      end
+
+      it "renders the top streams table rows" do
+        visit "/pgbus/insights"
+
+        expect(page).to have_text("chat:lobby")
+        expect(page).to have_text("420")
+        expect(page).to have_text("18.2")
+        expect(page).to have_text("orders:dashboard")
+        expect(page).to have_text("312")
+      end
+    end
+  end
+end

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -92,7 +92,7 @@ module Pgbus
 
       # Insights (job stats)
       def job_stats_summary(minutes: 60) = @insights_summary
-      def slowest_job_classes(limit: 10, minutes: 60) = @insights_slowest
+      def slowest_job_classes(limit: 10, minutes: 60) = @insights_slowest.first(limit)
       def latency_by_queue(minutes: 60) = @insights_latency_by_queue
       def latency_trend(minutes: 60) = @insights_latency_trend
       def job_throughput(minutes: 60) = @insights_throughput
@@ -101,7 +101,7 @@ module Pgbus
       # Insights (stream stats — opt-in, default unavailable)
       def stream_stats_available? = @stream_stats_available
       def stream_stats_summary(minutes: 60) = @stream_summary
-      def top_streams(limit: 10, minutes: 60) = @top_streams_list
+      def top_streams(limit: 10, minutes: 60) = @top_streams_list.first(limit)
 
       private
 

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -5,7 +5,10 @@ module Pgbus
     class StubDataSource
       attr_accessor :stats, :queues, :processes_list, :failed_events_list,
                     :dlq_messages_list, :events_list, :subscribers_list, :jobs_list,
-                    :paused_queues, :locks_list, :recurring_tasks_list
+                    :paused_queues, :locks_list, :recurring_tasks_list,
+                    :insights_summary, :insights_slowest, :insights_latency_by_queue,
+                    :insights_latency_trend, :insights_throughput, :insights_status_counts,
+                    :stream_stats_available, :stream_summary, :top_streams_list
       attr_reader :calls
 
       def initialize
@@ -20,6 +23,15 @@ module Pgbus
         @paused_queues = []
         @locks_list = []
         @recurring_tasks_list = []
+        @insights_summary = default_insights_summary
+        @insights_slowest = []
+        @insights_latency_by_queue = []
+        @insights_latency_trend = []
+        @insights_throughput = []
+        @insights_status_counts = { "success" => 0, "failed" => 0, "dead_lettered" => 0 }
+        @stream_stats_available = false
+        @stream_summary = default_stream_summary
+        @top_streams_list = []
         @calls = Hash.new { |h, k| h[k] = [] }
       end
 
@@ -78,6 +90,19 @@ module Pgbus
 
       def called?(method_name) = @calls.key?(method_name)
 
+      # Insights (job stats)
+      def job_stats_summary(minutes: 60) = @insights_summary
+      def slowest_job_classes(limit: 10, minutes: 60) = @insights_slowest
+      def latency_by_queue(minutes: 60) = @insights_latency_by_queue
+      def latency_trend(minutes: 60) = @insights_latency_trend
+      def job_throughput(minutes: 60) = @insights_throughput
+      def job_status_counts(minutes: 60) = @insights_status_counts
+
+      # Insights (stream stats — opt-in, default unavailable)
+      def stream_stats_available? = @stream_stats_available
+      def stream_stats_summary(minutes: 60) = @stream_summary
+      def top_streams(limit: 10, minutes: 60) = @top_streams_list
+
       private
 
       def record(method_name, *args)
@@ -88,6 +113,23 @@ module Pgbus
       def default_stats
         { total_queues: 2, total_depth: 15, total_visible: 12,
           active_processes: 1, failed_count: 3, dlq_depth: 2 }
+      end
+
+      def default_insights_summary
+        {
+          total: 342, success: 335, failed: 5, dead_lettered: 2,
+          avg_duration_ms: 127.4, max_duration_ms: 4521.0,
+          avg_latency_ms: 0, p50_latency_ms: 0, p95_latency_ms: 0,
+          p99_latency_ms: 0, avg_retries: 0
+        }
+      end
+
+      def default_stream_summary
+        {
+          broadcasts: 0, connects: 0, disconnects: 0,
+          active_estimate: 0, avg_fanout: 0,
+          avg_broadcast_ms: 0, avg_connect_ms: 0
+        }
       end
 
       def default_queues


### PR DESCRIPTION
## Summary

- Opt-in (`config.streams_stats_enabled`, default **off**) stream event recording in `pgbus_stream_stats`, mirroring the `JobStat` pattern end-to-end.
- `/pgbus/insights` gains a "Real-time Streams" section with broadcast/connect/disconnect counts, an "active" estimate (connects − disconnects in window), average fanout, and a top-streams table.
- `bench:streams` now does an A/B comparison — runs every section twice (stats=off, stats=on) and prints paired deltas so the overhead is visible.

## Why opt-in

Stream event volume can dwarf job volume in chat-style apps. A single chat room broadcasting 100 messages/second would write 100 rows/second plus one row per connect/disconnect — the exact traffic pattern the streams subsystem was designed to avoid. Defaulting stats off means installs don't pay a write cost unless they actually look at Insights.

`JobStat` defaults on. `StreamStat` defaults off. Both respect `stats_retention` for cleanup so there is no new retention knob.

## Benchmark numbers (local Apple Silicon, Puma + real PGMQ)

```
1. Single broadcast roundtrip (ms)
                    min    median       p95       max
   off            11.08     13.55     26.67     27.17
   on             10.56     12.67     26.89     42.63
   Δ              -4.7%     -6.5%      +0.8%    +56.9%   ← noise (first-sample JIT)

2. Burst throughput (per-msg ms)
                   N=10      N=50     N=200
   off             1.75      0.71      0.42
   on              2.03      0.70      0.46
   Δ             +15.7%     -1.0%    +10.1%

3. Fanout (per-client ms)
                    M=5      M=20      M=50
   off             4.34      1.04      0.27
   on              3.74      0.64      0.28
   Δ             -13.9%    -38.7%     +3.2%   ← noise band

4. Concurrent connect (per-connect ms)
                    K=5      K=20      K=50
   off             2.56      0.71      0.78
   on              2.52      0.68      0.96
   Δ              -1.4%     -4.0%    +23.2%   ← visible overhead
```

Steady-state broadcast and fanout sit in the noise band. The visible cost is the thundering-herd connect scenario (K=50 → +23%): one INSERT per connect plus one per matching disconnect on top of the PG handshake. That's the right place for the overhead to show up — operators enabling stats usually accept a small connect-burst penalty for the dashboard visibility.

## What's in the change

| Layer | File |
|---|---|
| Config | `lib/pgbus/configuration.rb` — `streams_stats_enabled` attr, default false |
| Model | `app/models/pgbus/stream_stat.rb` — `record!` / `summary` / `top_streams` / `cleanup!` |
| Migration | `lib/generators/pgbus/add_stream_stats_generator.rb` + `add_stream_stats.rb.erb` template |
| Hot path | `lib/pgbus/web/streamer/dispatcher.rb` — three `record_stat` call sites, all guarded by the config flag |
| Wiring | `lib/pgbus/web/streamer/instance.rb` — passes `config:` through to Dispatcher |
| Sweep | `lib/pgbus/process/dispatcher.rb#cleanup_stats` — extends to `StreamStat.cleanup!` |
| Dashboard | `lib/pgbus/web/data_source.rb`, `app/controllers/pgbus/insights_controller.rb`, `app/views/pgbus/insights/show.html.erb` |
| i18n | `config/locales/en.yml` — `pgbus.insights.show.streams.*` keys |
| Bench | `benchmarks/streams_bench.rb` — A/B harness with per-suite runs and paired comparison table |
| Docs | `README.md` — new "Stream stats (opt-in)" subsection under Real-time broadcasts |
| Specs | `spec/pgbus/stream_stat_spec.rb`, `spec/pgbus/web/streamer/dispatcher_spec.rb` (new describe block), `spec/pgbus/configuration_spec.rb` (default assertion) |

## Test plan

- [x] `bundle exec rspec` (1206 examples, 0 failures; i18n pre-existing main failures excluded)
- [x] `bundle exec rubocop` (clean)
- [x] `bundle exec rake pgbus:streams:lint_no_live` (passes)
- [x] `PGBUS_DATABASE_URL=... bundle exec rake bench:streams` (runs end-to-end, paired comparison prints)
- [ ] Integration specs (`spec/integration/streams/`) — require real PGMQ, depend on CI
- [ ] System specs (`spec/system/`) — depend on CI

## Things I explicitly didn't do

- Per-broadcast p50/p95/p99 percentiles in the dashboard table — overengineered for v1, easy to add later.
- Separate "Streams" dashboard tab — they live inside Insights where they're comparable to job metrics.
- Cross-worker aggregation — every worker writes to the same table, so the Insights aggregate is already global across workers without any extra coordination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in stream statistics to track broadcasts, connects, disconnects, active estimates, avg fanout; Insights dashboard shows Real-time Streams summary cards and Top Streams table (disabled by default).

* **Documentation**
  * Added guide for enabling stream stats, running the migration, retention/cleanup behavior, and benchmark/overhead notes.

* **Chores**
  * Added generator to install the stream-stats migration and opt-in configuration flag.

* **Benchmarks**
  * Added A/B benchmark suite to compare behavior with stats off vs on.

* **Tests**
  * Added unit, integration, and system tests covering config, recording, and Insights UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->