### PR TITLE
fix(streams): rename StreamStat scopes to avoid turbo-rails collision

### DIFF
--- a/app/models/pgbus/stream_stat.rb
+++ b/app/models/pgbus/stream_stat.rb
@@ -14,9 +14,14 @@ module Pgbus
     EVENT_TYPES = %w[broadcast connect disconnect].freeze
 
     scope :since, ->(time) { where("created_at >= ?", time) }
-    scope :broadcasts, -> { where(event_type: "broadcast") }
-    scope :connects, -> { where(event_type: "connect") }
-    scope :disconnects, -> { where(event_type: "disconnect") }
+    # NOTE: scope names intentionally avoid `broadcasts` / `connects` /
+    # `disconnects`. `turbo-rails` auto-includes `Turbo::Broadcastable`
+    # into every AR model, which defines a class method `broadcasts`.
+    # AR's dangerous_class_method? guard then rejects a colliding
+    # scope name at load time, crashing eager_load. See issue #92.
+    scope :broadcast_events, -> { where(event_type: "broadcast") }
+    scope :connect_events, -> { where(event_type: "connect") }
+    scope :disconnect_events, -> { where(event_type: "disconnect") }
 
     # Records a stream event. Called from the Dispatcher when the
     # `streams_stats_enabled` flag is set. Errors are swallowed so a
@@ -79,7 +84,7 @@ module Pgbus
 
     # Top N streams by broadcast count in the window, with avg fanout.
     def self.top_streams(limit: 10, minutes: 60)
-      broadcasts
+      broadcast_events
         .since(minutes.minutes.ago)
         .group(:stream_name)
         .order(Arel.sql("COUNT(*) DESC"))
@@ -102,7 +107,7 @@ module Pgbus
 
     # Throughput: broadcast events per minute bucketed by minute.
     def self.throughput(minutes: 60)
-      broadcasts
+      broadcast_events
         .since(minutes.minutes.ago)
         .group("date_trunc('minute', created_at)")
         .order(Arel.sql("date_trunc('minute', created_at)"))

--- a/spec/pgbus/stream_stat_spec.rb
+++ b/spec/pgbus/stream_stat_spec.rb
@@ -68,6 +68,66 @@ RSpec.describe Pgbus::StreamStat do
     end
   end
 
+  describe "scope names" do
+    # Regression for issue #92 — `turbo-rails` auto-includes
+    # Turbo::Broadcastable into every ActiveRecord::Base descendant,
+    # which defines a class method `broadcasts`. AR's
+    # dangerous_class_method? check then rejects any subsequent
+    # `scope :broadcasts` on an AR model, crashing eager_load.
+    #
+    # We must not define scopes whose names collide with turbo-rails'
+    # Broadcastable DSL. The equivalent filters live under
+    # broadcast_events / connect_events / disconnect_events.
+
+    # Inject a fake `broadcasts` class method onto ActiveRecord::Base
+    # (what Turbo::Broadcastable does via on_load(:active_record))
+    # and remove it after the example so later specs are not polluted.
+    around do |example|
+      fake_turbo = Module.new do
+        def broadcasts(*); end
+      end
+      ActiveRecord::Base.singleton_class.include(fake_turbo)
+      example.run
+    ensure
+      fake_turbo.send(:remove_method, :broadcasts)
+    end
+
+    it "reloads StreamStat cleanly when turbo-rails has injected `broadcasts`" do
+      # Sanity check: AR's dangerous_class_method? guard fires for
+      # any subsequent model declaring `scope :broadcasts`.
+      expect do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "pgbus_stream_stats"
+          scope :broadcasts, -> { where(event_type: "broadcast") }
+        end
+      end.to raise_error(ArgumentError, /already defined a class method/)
+
+      # With the turbo shim installed, reloading StreamStat must
+      # not raise. `load` re-evaluates the file the same way
+      # Zeitwerk's eager_load pass would. Silence the benign
+      # "already initialized constant" warning re-evaluation emits.
+      stream_stat_path = File.expand_path(
+        "../../app/models/pgbus/stream_stat.rb",
+        __dir__
+      )
+      expect do
+        original_verbose = $VERBOSE
+        $VERBOSE = nil
+        begin
+          load stream_stat_path
+        ensure
+          $VERBOSE = original_verbose
+        end
+      end.not_to raise_error
+    end
+
+    it "exposes broadcast_events / connect_events / disconnect_events scopes" do
+      expect(described_class).to respond_to(:broadcast_events)
+      expect(described_class).to respond_to(:connect_events)
+      expect(described_class).to respond_to(:disconnect_events)
+    end
+  end
+
   describe ".table_exists?" do
     before do
       described_class.remove_instance_variable(:@table_exists) if described_class.instance_variable_defined?(:@table_exists)


### PR DESCRIPTION
## Summary

`turbo-rails` auto-includes `Turbo::Broadcastable` into every `ActiveRecord::Base` descendant via an `on_load(:active_record)` hook. The module defines a class-level `broadcasts` macro (the well-known `broadcasts :posts, inserts_by: :append` DSL). AR's `dangerous_class_method?` check then rejects any subsequent `scope :broadcasts` on any model — crashing eager_load for every app that combines pgbus 0.6.0's streams feature with turbo-rails, which is the primary use case for the 0.6.0 streams subsystem.

Rename the colliding scopes on `Pgbus::StreamStat`:

| Old | New |
|---|---|
| `broadcasts` | `broadcast_events` |
| `connects` | `connect_events` |
| `disconnects` | `disconnect_events` |

Internal callers in `top_streams` and `throughput` are updated. The `.summary` return-hash keys (`broadcasts:`, `connects:`, `disconnects:`) are unchanged — those are public API consumed by the Insights dashboard views and i18n keys.

Closes #92

## Root cause

```
ArgumentError: You tried to define a scope named "broadcasts" on the model
"Pgbus::StreamStat", but Active Record already defined a class method with
the same name.
        from .../pgbus/app/models/pgbus/stream_stat.rb:17:in '<class:StreamStat>'
```

`Turbo::Broadcastable::ClassMethods#broadcasts` is injected into `ActiveRecord::Base` when turbo-rails loads. Once that happens, AR's `dangerous_class_method?` guard rejects any `scope :broadcasts` declaration because `Base.respond_to?(:broadcasts)` returns true.

## Test plan

Regression test in `spec/pgbus/stream_stat_spec.rb` simulates the exact turbo-rails injection:

1. Installs a fake `broadcasts` class method onto `ActiveRecord::Base.singleton_class` (matching what `Turbo::Broadcastable` does via `on_load(:active_record)`).
2. Asserts that a clean AR subclass declaring `scope :broadcasts` now raises `ArgumentError` — confirming the shim reproduces the bug.
3. Reloads `app/models/pgbus/stream_stat.rb` via `Kernel#load` (the closest unit-test proxy for Zeitwerk's `eager_load!` pass) with the shim installed and asserts no `ArgumentError`.
4. Asserts the renamed scopes are exposed.

### Checks

- [x] `bundle exec rubocop` — 283 files, 0 offenses
- [x] `bundle exec rspec spec/pgbus` — 1187 examples, 0 failures
- [ ] Downstream app with `turbo-rails` + `pgbus` boots with `config.eager_load = true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved internal naming conflicts in data event processing to ensure stable, uninterrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->