### PR TITLE
fix(generators): do not leak env-specific settings across all envs

### DIFF
--- a/lib/pgbus/generators/config_converter.rb
+++ b/lib/pgbus/generators/config_converter.rb
@@ -151,15 +151,23 @@ module Pgbus
       end
 
       # Returns [constant_settings, varying_settings].
-      # constant_settings: { "key" => value }   (same value across all envs)
+      # constant_settings: { "key" => value }   (same value in EVERY env)
       # varying_settings:  { "key" => { env => value, ... } }
+      #
+      # A setting is only "constant" when it is present in every env
+      # and all envs agree on the value. If any env is missing the
+      # setting entirely (e.g. `polling_interval: 0.01` set only under
+      # `test:`), emitting it as an unconditional line would silently
+      # apply the value to envs that never asked for it — see #93.
       def partition_by_variance(all_settings)
         constant = {}
         varying = {}
         all_settings.each do |key, env_values|
           present_values = env_values.reject { |_, v| v == :__missing__ }
           unique_values = present_values.values.uniq
-          if unique_values.size <= 1
+          all_envs_present = present_values.size == env_values.size
+
+          if all_envs_present && unique_values.size <= 1
             constant[key] = unique_values.first
           else
             varying[key] = present_values
@@ -182,6 +190,18 @@ module Pgbus
 
       def render_varying_setting(key, env_values)
         envs = env_values.keys
+
+        # Single-env coverage: the setting exists in exactly one env.
+        # Emit an `if Rails.env.X?` modifier rather than a case block
+        # so other envs fall back to the gem default. This is the
+        # fix for #93 — without it, a `test:`-only `polling_interval`
+        # would leak into dev and prod as an unconditional assignment.
+        if envs.size == 1
+          env = envs.first
+          value = env_values[env]
+          return ["c.#{key} = #{render_value(key, value)} if Rails.env.#{env}?"]
+        end
+
         if envs.size == 2 && envs.include?("development")
           # Special case: "everything except dev" — common pattern
           non_dev_value = env_values.except("development").values.first

--- a/spec/pgbus/generators/config_converter_spec.rb
+++ b/spec/pgbus/generators/config_converter_spec.rb
@@ -138,6 +138,84 @@ RSpec.describe Pgbus::Generators::ConfigConverter do
       end
     end
 
+    context "with a setting present in only one environment" do
+      # Regression for issue #93. When a YAML uses `<<: *default`
+      # anchors and a setting like `polling_interval: 0.01` is added
+      # ONLY under `test:`, the other envs have no value for it at
+      # all. The generator must not emit the setting as an
+      # unconditional line — doing so silently applies a dev/test
+      # tuning knob to production. (10ms polling = 10x the default
+      # DB load under a 100ms default.)
+      let(:input) do
+        {
+          "development" => {
+            "workers" => [{ "queues" => ["*"], "threads" => 5 }]
+          },
+          "test" => {
+            "workers" => [{ "queues" => ["*"], "threads" => 5 }],
+            "polling_interval" => 0.01
+          },
+          "production" => {
+            "workers" => [{ "queues" => ["*"], "threads" => 5 }]
+          }
+        }
+      end
+
+      it "does not emit the setting as an unconditional line" do
+        # This is the exact regression from #93 — without the fix,
+        # the generator emitted `c.polling_interval = 0.01` flat,
+        # applying the 10ms test tuning to dev + test + prod.
+        expect(output).not_to match(/^\s*c\.polling_interval = 0\.01\s*$/)
+      end
+
+      it "guards the setting with `if Rails.env.test?`" do
+        expect(output).to include("c.polling_interval = 0.01 if Rails.env.test?")
+      end
+
+      it "still emits the constant workers line unconditionally" do
+        expect(output).to include('c.workers = "*: 5"')
+      end
+    end
+
+    context "with a setting present in a subset of environments" do
+      # Related to #93: two of three envs set the value, one doesn't.
+      # Whatever the formatter shape is (case block vs guarded line),
+      # the value MUST NOT leak to the environment that didn't set it.
+      let(:input) do
+        {
+          "development" => {
+            "workers" => [{ "queues" => ["*"], "threads" => 5 }],
+            "polling_interval" => 0.05
+          },
+          "test" => {
+            "workers" => [{ "queues" => ["*"], "threads" => 5 }],
+            "polling_interval" => 0.01
+          },
+          "production" => {
+            "workers" => [{ "queues" => ["*"], "threads" => 5 }]
+          }
+        }
+      end
+
+      it "does not emit polling_interval as an unconditional line" do
+        expect(output).not_to match(/^\s*c\.polling_interval = 0\.\d+\s*$/)
+      end
+
+      it "scopes the setting to only the environments that declared it" do
+        # Must mention development and test (the envs that set it)
+        # but NOT production. A case block with only dev+test clauses
+        # is an acceptable shape — what we must prevent is the
+        # production env silently inheriting the value.
+        expect(output).to match(/polling_interval/)
+        expect(output).to match(/development/)
+        expect(output).to match(/\btest\b/)
+        # Only `workers` should mention production (from a production:
+        # capsule/worker config); polling_interval must not.
+        polling_block = output[/c\.polling_interval[\s\S]*?(?:\n  end|$)/]
+        expect(polling_block).not_to include("production")
+      end
+    end
+
     context "with three or more environments having different values" do
       let(:input) do
         {


### PR DESCRIPTION
## Summary

The `rails generate pgbus:update` generator silently leaked environment-specific settings across all environments when converting `config/pgbus.yml` to the Ruby DSL initializer. When a setting was set in only *one* environment — the common pattern of `polling_interval: 0.01` under `test:` while dev/prod use `<<: *default` — the generator classified it as "constant" and emitted it as an unconditional line, applying the test tuning to dev AND production.

For `polling_interval` specifically, this meant a production system started polling every 10 ms instead of the 100 ms default — **10× the database load** — after a "harmless" yml-to-ruby migration.

Closes #93

## Root cause

`ConfigConverter#partition_by_variance` stripped `:__missing__` sentinels before deduping the per-env values:

```ruby
present_values = env_values.reject { |_, v| v == :__missing__ }
unique_values = present_values.values.uniq
if unique_values.size <= 1
  constant[key] = unique_values.first  # ← bug
```

So `{dev: :__missing__, test: 0.01, prod: :__missing__}` deduped to `[0.01]`, size `<= 1`, and was emitted as `c.polling_interval = 0.01` — unconditional.

## Fix

1. **`partition_by_variance`**: classify as constant only when the setting is present in **every** env AND all envs agree. Missing-in-any-env falls into the varying bucket.
2. **`render_varying_setting`**: new single-env branch that emits an `if Rails.env.X?` modifier rather than a one-clause `case Rails.env` block. Envs that didn't set the value fall back to the gem default.

### Example

Before:

```ruby
# config/pgbus.yml — polling_interval only under `test:`
Pgbus.configure do |c|
  c.workers = "*: 5"
  c.polling_interval = 0.01          # ← applied to dev + test + prod!
end
```

After:

```ruby
Pgbus.configure do |c|
  c.workers = "*: 5"
  c.polling_interval = 0.01 if Rails.env.test?   # ← scoped to test only
end
```

## Test plan

Three new regression specs in `spec/pgbus/generators/config_converter_spec.rb`:

- **single-env coverage (#93 exact repro)**: `polling_interval` set only under `test:` — asserts the generator does NOT emit an unconditional line, DOES emit `c.polling_interval = 0.01 if Rails.env.test?`, and still emits the constant `workers` line.
- **subset coverage (2 of 3 envs)**: value set in dev + test but not prod — asserts the emitted region scopes the value to dev and test and never mentions production.
- **unchanged behavior**: the existing 22 converter specs (including the `unless Rails.env.development?` 2-env dev/prod case) continue to pass untouched.

### Checks

- [x] `bundle exec rubocop` — 283 files, 0 offenses
- [x] `bundle exec rspec spec/pgbus` — 1192 examples, 0 failures
- [ ] Round-trip a real `config/pgbus.yml` with `polling_interval: 0.01` under `test:` in a downstream app and confirm the initializer is guarded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue where configuration settings defined for specific environments were incorrectly applied to other environments.
  * Improved the classification system for identifying environment-specific settings versus universal settings across all environments.
* **Tests**
  * Added comprehensive test coverage for environment-specific configuration handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->