### PR TITLE
test: close coverage gaps flagged by the pre-v1 codebase audit

### DIFF
--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -334,5 +334,99 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         )
       end
     end
+
+    # Uniqueness locking has three code paths in Executor#execute:
+    #   1. No uniqueness key → no locking calls, no lock release
+    #   2. Strategy = :until_executed → release on success OR dead-letter
+    #   3. Strategy = :while_executing → acquire before perform, release on success
+    # All three have been shipped without direct unit coverage; the audit
+    # agents flagged this as one of the top test gaps.
+    context "with uniqueness key in payload" do
+      let(:uniqueness_payload) do
+        job_payload.merge(
+          "pgbus_uniqueness_key" => "TestJob:user-42",
+          "pgbus_uniqueness_strategy" => "until_executed"
+        )
+      end
+      let(:message_json) { JSON.generate(uniqueness_payload) }
+      let(:message) { build_message_double(msg_id: 70, message: message_json, read_ct: 1) }
+
+      before do
+        allow(ActiveJob::Base).to receive(:deserialize).with(uniqueness_payload).and_return(job_double)
+        allow(Pgbus::Uniqueness).to receive_messages(extract_key: "TestJob:user-42", extract_strategy: :until_executed)
+        allow(Pgbus::Uniqueness).to receive(:release_lock)
+      end
+
+      context "with the until_executed strategy" do
+        it "releases the lock after a successful run" do
+          executor.execute(message, queue_name)
+
+          expect(Pgbus::Uniqueness).to have_received(:release_lock).with("TestJob:user-42")
+        end
+
+        it "does not release the lock if archive_from fails (retry path)" do
+          # If archive fails, job_succeeded stays false, the ensure block
+          # skips release — so the next retry still sees the lock and
+          # enforces at-most-once semantics.
+          allow(mock_client).to receive(:archive_message).and_raise(StandardError, "DB gone")
+
+          executor.execute(message, queue_name)
+
+          expect(Pgbus::Uniqueness).not_to have_received(:release_lock)
+        end
+
+        it "does not release the lock when perform_now raises (retry path)" do
+          allow(job_double).to receive(:perform_now).and_raise(StandardError, "transient")
+
+          executor.execute(message, queue_name)
+
+          expect(Pgbus::Uniqueness).not_to have_received(:release_lock)
+        end
+
+        it "releases the lock on dead-lettering (terminal state)" do
+          dlq_message = build_message_double(msg_id: 71, message: message_json, read_ct: config.max_retries + 1)
+
+          executor.execute(dlq_message, queue_name)
+
+          expect(Pgbus::Uniqueness).to have_received(:release_lock).with("TestJob:user-42")
+        end
+      end
+
+      context "with the while_executing strategy" do
+        before do
+          allow(Pgbus::Uniqueness).to receive_messages(extract_strategy: :while_executing, acquire_execution_lock: true)
+        end
+
+        it "acquires the execution lock before perform_now and releases on success" do
+          executor.execute(message, queue_name)
+
+          expect(Pgbus::Uniqueness).to have_received(:acquire_execution_lock).with(
+            "TestJob:user-42", uniqueness_payload
+          )
+          expect(job_double).to have_received(:perform_now)
+          expect(Pgbus::Uniqueness).to have_received(:release_lock).with("TestJob:user-42")
+        end
+
+        it "returns :skipped without performing if another worker already holds the lock" do
+          allow(Pgbus::Uniqueness).to receive(:acquire_execution_lock).and_return(false)
+
+          result = executor.execute(message, queue_name)
+
+          expect(job_double).not_to have_received(:perform_now)
+          expect(mock_client).not_to have_received(:archive_message)
+          expect(result).to eq(:skipped)
+        end
+      end
+
+      it "does not crash when uniqueness_key is nil (payload has strategy but no key)" do
+        allow(Pgbus::Uniqueness).to receive(:extract_key).and_return(nil)
+
+        expect do
+          executor.execute(message, queue_name)
+        end.not_to raise_error
+        # ensure block guards with `if uniqueness_key` — no release call
+        expect(Pgbus::Uniqueness).not_to have_received(:release_lock)
+      end
+    end
   end
 end

--- a/spec/pgbus/streams/presence_spec.rb
+++ b/spec/pgbus/streams/presence_spec.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pgbus/streams/presence"
+
+RSpec.describe Pgbus::Streams::Presence do
+  subject(:presence) { described_class.new(stream) }
+
+  let(:stream) { double("Pgbus::Streams::Stream", name: "room:42") }
+  let(:raw_connection) { double("PG::Connection") }
+
+  let(:ar_connection) { double("ActiveRecord::ConnectionAdapters::Connection", raw_connection: raw_connection) }
+
+  before do
+    # Force the single-database path (Pgbus.configuration.connects_to == nil)
+    # so the spec doesn't require BusRecord to be connected. The multi-DB
+    # branch is a one-line delegation to BusRecord.connection.raw_connection
+    # and is exercised by spec/integration/streams/presence_spec.rb.
+    allow(Pgbus.configuration).to receive(:connects_to).and_return(nil)
+    stub_const("ActiveRecord::Base", Class.new)
+    allow(ActiveRecord::Base).to receive(:connection).and_return(ar_connection)
+  end
+
+  describe "#join" do
+    let(:upsert_row) do
+      {
+        "member_id" => "7",
+        "metadata" => '{"name":"Alice"}',
+        "joined_at" => "2026-04-09T00:00:00Z",
+        "last_seen_at" => "2026-04-09T00:00:00Z"
+      }
+    end
+
+    before do
+      allow(raw_connection).to receive(:exec_params).and_return([upsert_row])
+    end
+
+    it "upserts the member and returns a hash with parsed metadata" do
+      result = presence.join(member_id: 7, metadata: { name: "Alice" })
+
+      expect(result["id"]).to eq("7")
+      expect(result["metadata"]).to eq({ "name" => "Alice" })
+    end
+
+    it "coerces member_id to string before inserting" do
+      presence.join(member_id: 7)
+
+      expect(raw_connection).to have_received(:exec_params).with(
+        anything,
+        ["room:42", "7", "{}"]
+      )
+    end
+
+    it "generates JSON for metadata even when empty" do
+      presence.join(member_id: "7")
+
+      expect(raw_connection).to have_received(:exec_params).with(
+        anything,
+        ["room:42", "7", "{}"]
+      )
+    end
+
+    it "broadcasts the yielded HTML when the block returns a non-empty string" do
+      allow(stream).to receive(:broadcast)
+      presence.join(member_id: "7") { |_record| "<turbo-stream>join</turbo-stream>" }
+
+      expect(stream).to have_received(:broadcast).with("<turbo-stream>join</turbo-stream>")
+    end
+
+    it "skips broadcast when the block returns an empty string" do
+      allow(stream).to receive(:broadcast)
+      presence.join(member_id: "7") { "" }
+
+      expect(stream).not_to have_received(:broadcast)
+    end
+
+    it "skips broadcast when the block returns nil" do
+      allow(stream).to receive(:broadcast)
+      presence.join(member_id: "7") { nil }
+
+      expect(stream).not_to have_received(:broadcast)
+    end
+  end
+
+  describe "#leave" do
+    context "when the member exists" do
+      let(:deleted_row) do
+        {
+          "member_id" => "7",
+          "metadata" => '{"name":"Alice"}',
+          "joined_at" => "2026-04-09T00:00:00Z",
+          "last_seen_at" => "2026-04-09T00:05:00Z"
+        }
+      end
+
+      before do
+        allow(raw_connection).to receive(:exec_params).and_return([deleted_row])
+      end
+
+      it "returns the deleted record" do
+        result = presence.leave(member_id: "7")
+        expect(result["id"]).to eq("7")
+        expect(result["metadata"]).to eq({ "name" => "Alice" })
+      end
+
+      it "broadcasts the yielded HTML" do
+        allow(stream).to receive(:broadcast)
+        presence.leave(member_id: "7") { "<turbo-stream>leave</turbo-stream>" }
+
+        expect(stream).to have_received(:broadcast).with("<turbo-stream>leave</turbo-stream>")
+      end
+    end
+
+    context "when the member does not exist" do
+      before { allow(raw_connection).to receive(:exec_params).and_return([]) }
+
+      it "returns nil" do
+        expect(presence.leave(member_id: "missing")).to be_nil
+      end
+
+      it "does not yield the block" do
+        yielded = false
+        presence.leave(member_id: "missing") { |_| yielded = true }
+        expect(yielded).to be false
+      end
+
+      it "does not broadcast" do
+        allow(stream).to receive(:broadcast)
+        presence.leave(member_id: "missing") { "<turbo-stream>nope</turbo-stream>" }
+        expect(stream).not_to have_received(:broadcast)
+      end
+    end
+  end
+
+  describe "#touch" do
+    it "refreshes last_seen_at for the given member" do
+      allow(raw_connection).to receive(:exec_params)
+
+      presence.touch(member_id: 42)
+
+      expect(raw_connection).to have_received(:exec_params).with(
+        a_string_matching(/UPDATE pgbus_presence_members.*SET last_seen_at = NOW\(\)/m),
+        ["room:42", "42"]
+      )
+    end
+  end
+
+  describe "#members" do
+    context "with well-formed metadata" do
+      before do
+        allow(raw_connection).to receive(:exec_params).and_return([
+                                                                    {
+                                                                      "member_id" => "1",
+                                                                      "metadata" => '{"name":"Alice"}',
+                                                                      "joined_at" => "2026-04-09T00:00:00Z",
+                                                                      "last_seen_at" => "2026-04-09T00:00:00Z"
+                                                                    },
+                                                                    {
+                                                                      "member_id" => "2",
+                                                                      "metadata" => '{"name":"Bob"}',
+                                                                      "joined_at" => "2026-04-09T00:01:00Z",
+                                                                      "last_seen_at" => "2026-04-09T00:01:00Z"
+                                                                    }
+                                                                  ])
+      end
+
+      it "returns an array of hashes with parsed metadata" do
+        result = presence.members
+        expect(result.size).to eq(2)
+        expect(result[0]["id"]).to eq("1")
+        expect(result[0]["metadata"]).to eq({ "name" => "Alice" })
+        expect(result[1]["id"]).to eq("2")
+      end
+    end
+
+    context "with corrupt JSON metadata" do
+      # parse_metadata must not crash the whole members() call on one bad
+      # row — production data can have legacy / manually-edited entries.
+      before do
+        allow(raw_connection).to receive(:exec_params).and_return([
+                                                                    {
+                                                                      "member_id" => "1",
+                                                                      "metadata" => "{not valid json",
+                                                                      "joined_at" => "2026-04-09T00:00:00Z",
+                                                                      "last_seen_at" => "2026-04-09T00:00:00Z"
+                                                                    }
+                                                                  ])
+      end
+
+      it "falls back to an empty hash without raising" do
+        result = presence.members
+        expect(result.size).to eq(1)
+        expect(result[0]["metadata"]).to eq({})
+      end
+
+      it "logs the failure at debug level with truncation" do
+        fake_logger = double("logger")
+        allow(fake_logger).to receive(:debug).and_yield
+        allow(Pgbus).to receive(:logger).and_return(fake_logger)
+
+        presence.members
+
+        expect(fake_logger).to have_received(:debug)
+      end
+    end
+
+    context "with nil or empty metadata" do
+      before do
+        allow(raw_connection).to receive(:exec_params).and_return([
+                                                                    { "member_id" => "1", "metadata" => nil,
+                                                                      "joined_at" => "2026-04-09T00:00:00Z",
+                                                                      "last_seen_at" => "2026-04-09T00:00:00Z" },
+                                                                    { "member_id" => "2", "metadata" => "",
+                                                                      "joined_at" => "2026-04-09T00:01:00Z",
+                                                                      "last_seen_at" => "2026-04-09T00:01:00Z" }
+                                                                  ])
+      end
+
+      it "returns empty-hash metadata for both without raising" do
+        result = presence.members
+        expect(result[0]["metadata"]).to eq({})
+        expect(result[1]["metadata"]).to eq({})
+      end
+    end
+  end
+
+  describe "#count" do
+    it "returns the integer count of members" do
+      allow(raw_connection).to receive(:exec_params).and_return([{ "n" => "5" }])
+      expect(presence.count).to eq(5)
+    end
+  end
+
+  describe "#sweep!" do
+    it "deletes expired members and returns the number of rows deleted" do
+      expired = Time.now - 300
+      allow(raw_connection).to receive(:exec_params).and_return([
+                                                                  { "member_id" => "1" },
+                                                                  { "member_id" => "2" }
+                                                                ])
+
+      result = presence.sweep!(older_than: expired)
+
+      expect(result).to eq(2)
+      expect(raw_connection).to have_received(:exec_params).with(
+        a_string_matching(/DELETE FROM pgbus_presence_members.*RETURNING/m),
+        ["room:42", expired]
+      )
+    end
+
+    it "returns 0 when nothing to sweep" do
+      allow(raw_connection).to receive(:exec_params).and_return([])
+      expect(presence.sweep!(older_than: Time.now)).to eq(0)
+    end
+  end
+
+  describe "connection resolution" do
+    it "raises ConfigurationError when ActiveRecord is not loaded" do
+      hide_const("ActiveRecord::Base")
+
+      expect do
+        presence.count
+      end.to raise_error(Pgbus::ConfigurationError, /requires ActiveRecord/)
+    end
+
+    # The connects_to branch (Pgbus::BusRecord.connection.raw_connection)
+    # is exercised by spec/integration/streams/presence_spec.rb against
+    # a real DB — it's a 3-line delegation not worth stubbing AR's full
+    # internals for here.
+  end
+end

--- a/spec/pgbus/streams/presence_spec.rb
+++ b/spec/pgbus/streams/presence_spec.rb
@@ -193,14 +193,36 @@ RSpec.describe Pgbus::Streams::Presence do
         expect(result[0]["metadata"]).to eq({})
       end
 
-      it "logs the failure at debug level with truncation" do
+      it "logs the failure at debug level with the raw metadata truncated to 200 chars" do
+        # Inject a metadata blob much longer than the 200-char cap so
+        # we can distinguish "truncated" from "not truncated". The
+        # production code does value.to_s[0, 200], then interpolates
+        # via .inspect — the logged string contains the first 200
+        # source characters and must NOT contain characters past 200.
+        long_invalid = "{#{"x" * 500}"
+        allow(raw_connection).to receive(:exec_params).and_return([
+                                                                    {
+                                                                      "member_id" => "1",
+                                                                      "metadata" => long_invalid,
+                                                                      "joined_at" => "2026-04-09T00:00:00Z",
+                                                                      "last_seen_at" => "2026-04-09T00:00:00Z"
+                                                                    }
+                                                                  ])
+
+        logged_message = nil
         fake_logger = double("logger")
-        allow(fake_logger).to receive(:debug).and_yield
+        allow(fake_logger).to receive(:debug) { |&blk| logged_message = blk&.call }
         allow(Pgbus).to receive(:logger).and_return(fake_logger)
 
         presence.members
 
         expect(fake_logger).to have_received(:debug)
+        expect(logged_message).to include("parse_metadata failed")
+        # First 200 chars are preserved in the log line
+        expect(logged_message).to include(long_invalid[0, 200])
+        # Characters past the 200-char boundary are dropped
+        tail = long_invalid[200..]
+        expect(logged_message).not_to include(tail)
       end
     end
 

--- a/spec/system/dashboard_edge_cases_spec.rb
+++ b/spec/system/dashboard_edge_cases_spec.rb
@@ -99,8 +99,10 @@ RSpec.describe "Dashboard edge cases", type: :system do
 
       it "does not 500 on an off-the-end page number" do
         # page=999 is well past the end; the controller should clamp
-        # or render empty without raising. Status <400 means the view
-        # rendered (Capybara raises on 5xx by default).
+        # or render empty without raising. The have_css assertion
+        # doubles as a health check — if the server 500'd, the H1
+        # would never render and the test would fail, regardless of
+        # whether the Capybara driver surfaces the status code.
         visit "/pgbus/jobs?page=999"
         expect(page).to have_css("h1", text: "Jobs")
       end

--- a/spec/system/dashboard_edge_cases_spec.rb
+++ b/spec/system/dashboard_edge_cases_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Covers security + pagination edge cases across the dashboard that
+# previously had no system-level coverage. These are the scenarios
+# the codebase audit flagged as most likely to go wrong: user-supplied
+# strings rendered into admin views, empty lists, and pages requested
+# beyond the end of the available data.
+RSpec.describe "Dashboard edge cases", type: :system do
+  describe "XSS safety" do
+    # ERB's <%= %> auto-escapes by default, so every string from
+    # user-supplied data (job payloads, error messages, queue names)
+    # should render as literal text, not as active HTML. This test
+    # confirms that by looking for the escaped bracket in the page
+    # source and the absence of an actual <script> element.
+    context "with a failed job containing a <script> payload in the error message" do
+      before do
+        @stub_data_source.failed_events_list = [
+          {
+            "id" => 1,
+            "queue_name" => "pgbus_default",
+            "msg_id" => 42,
+            "job_class" => "ExploitJob",
+            "error_class" => "RuntimeError",
+            "error_message" => "<script>window.pwned=true</script>",
+            "failed_at" => Time.now.utc.iso8601,
+            "payload" => '{"job_class":"ExploitJob","arguments":["<img src=x onerror=alert(1)>"]}',
+            "backtrace" => "line1\nline2",
+            "retry_count" => 0
+          }
+        ]
+        @stub_data_source.stats[:failed_count] = 1
+      end
+
+      it "escapes the error message on the recent failures card" do
+        visit "/pgbus"
+
+        # The literal angle bracket should appear in the rendered page
+        # body (as text, escaped to &lt; in the DOM source). If the
+        # template were NOT escaping, Playwright would see <script>
+        # parsed as a tag and the text would not be findable.
+        expect(page).to have_text("<script>")
+        expect(page.evaluate_script("window.pwned")).to be_nil
+      end
+
+      it "escapes the error message on the failed job show page" do
+        visit "/pgbus/jobs/1"
+
+        expect(page).to have_text("<script>")
+        expect(page).to have_text("<img src=x onerror=alert(1)>")
+        # Sanity check: no alert / no attribute-based XSS fired.
+        expect(page.evaluate_script("window.pwned")).to be_nil
+      end
+    end
+
+    context "with a queue name containing angle brackets" do
+      before do
+        @stub_data_source.queues = [
+          { name: "<script>alert(1)</script>", queue_length: 0, queue_visible_length: 0,
+            oldest_msg_age_sec: nil, newest_msg_age_sec: nil, total_messages: 0 }
+        ]
+      end
+
+      it "renders the queue name as literal text on the dashboard queues table" do
+        visit "/pgbus"
+
+        expect(page).to have_text("<script>alert(1)</script>")
+        expect(page.evaluate_script("window.pwned")).to be_nil
+      end
+    end
+  end
+
+  describe "pagination edges" do
+    context "when the failed jobs list is empty" do
+      before do
+        @stub_data_source.failed_events_list = []
+        @stub_data_source.stats[:failed_count] = 0
+      end
+
+      it "renders the empty state without crashing" do
+        visit "/pgbus/jobs"
+
+        expect(page).to have_css("h1", text: "Jobs")
+        # Empty state text from the failed_table partial
+        expect(page).to have_text("No failed jobs").or have_text("0")
+      end
+    end
+
+    context "when requesting a page past the end of the data" do
+      before do
+        @stub_data_source.failed_events_list = [
+          { "id" => 1, "queue_name" => "pgbus_default", "msg_id" => 1,
+            "error_class" => "RuntimeError", "error_message" => "boom",
+            "failed_at" => Time.now.utc.iso8601, "retry_count" => 0 }
+        ]
+        @stub_data_source.stats[:failed_count] = 1
+      end
+
+      it "does not 500 on an off-the-end page number" do
+        # page=999 is well past the end; the controller should clamp
+        # or render empty without raising. Status <400 means the view
+        # rendered (Capybara raises on 5xx by default).
+        visit "/pgbus/jobs?page=999"
+        expect(page).to have_css("h1", text: "Jobs")
+      end
+
+      it "does not 500 on a negative page number" do
+        visit "/pgbus/jobs?page=-1"
+        expect(page).to have_css("h1", text: "Jobs")
+      end
+
+      it "does not 500 on a non-numeric page parameter" do
+        visit "/pgbus/jobs?page=abc"
+        expect(page).to have_css("h1", text: "Jobs")
+      end
+    end
+
+    context "when requesting a non-existent failed job by id" do
+      before { @stub_data_source.failed_events_list = [] }
+
+      it "renders the not-found template without raising" do
+        visit "/pgbus/jobs/99999"
+
+        expect(page).to have_text("Job not found")
+      end
+    end
+  end
+
+  describe "failed job with a null/missing backtrace" do
+    before do
+      @stub_data_source.failed_events_list = [
+        {
+          "id" => 2,
+          "queue_name" => "pgbus_default",
+          "msg_id" => 50,
+          "job_class" => "NoBacktraceJob",
+          "error_class" => "ArgumentError",
+          "error_message" => "invalid",
+          "failed_at" => Time.now.utc.iso8601,
+          "payload" => '{"job_class":"NoBacktraceJob","arguments":[]}',
+          "backtrace" => nil,
+          "retry_count" => 0
+        }
+      ]
+    end
+
+    it "renders the show page without crashing on missing backtrace" do
+      visit "/pgbus/jobs/2"
+
+      expect(page).to have_text("ArgumentError")
+      expect(page).to have_text("invalid")
+      # The backtrace section should simply be absent, not explode.
+      expect(page).to have_no_text("undefined method")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three test-coverage gaps flagged by the codebase audit, all in critical subsystems that had weak or absent unit/system-level coverage.

**1. `spec/pgbus/streams/presence_spec.rb`** — NEW, 20 examples. Presence shipped with only an integration spec (PGBUS_DATABASE_URL-gated), so live edits to \`presence.rb\` had zero CI safety net. Covers join/leave/touch/members/count/sweep!, the corrupt-metadata fallback (which is the reason the rescue exists), and the AR-missing configuration error.

**2. \`spec/pgbus/active_job/executor_spec.rb\`** — 8 new examples under \"with uniqueness key in payload\". The Executor had zero Uniqueness coverage despite being the enforcement point for at-most-once job semantics. The most important case is the \`until_executed\` strategy with archive failure: \`job_succeeded\` stays false, the ensure block skips \`release_lock\`, and the next retry still sees the lock. A refactor could break that silently without this test.

**3. \`spec/system/dashboard_edge_cases_spec.rb\`** — NEW, 9 Playwright examples:

- XSS: failed job error message with \`<script>\` tag renders as escaped text on both the dashboard and the failed job show page. Asserts \`window.pwned\` is nil — if ERB escaping were off, the script would execute in the Playwright browser.
- XSS: queue name with angle brackets renders as literal text.
- Pagination: empty failed list, \`page=999\`, \`page=-1\`, \`page=abc\` all render without 500ing.
- Not found: \`/pgbus/jobs/99999\` renders the not-found template.
- Null backtrace: failed job with nil backtrace renders without crashing the \`backtrace.present?\` check.

## Test Counts

| Suite | Before | After |
|---|---|---|
| Unit | 1207 | 1234 |
| System | 92 | 101 |

## Verification

- [x] \`bundle exec rubocop\` passes (285 files, 0 offenses)
- [x] \`bundle exec rspec\` (unit) passes (1234 examples, 0 failures)
- [x] \`bundle exec rspec spec/system/\` passes (101 examples, 0 failures)

## What's next

This is PR 2 of 2 from the audit. PR 1 (#95) covers the correctness + perf fixes (DLQ pagination SQL pushdown, paused_queues Set conversion, archive_batch for discard_all_failed, job_stats queue_name index generator). The remaining audit findings will go into a tracking issue for P1/P2 items and feature gaps (Prometheus metrics endpoint, retry backoff per job class, data_source.rb split, etc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added specs for job execution uniqueness locking covering lock acquire/release across success, retry/exception, lock-fail, and dead-letter paths.
  * Added presence stream tests for join/leave/touch/members/count/sweep, metadata parsing/fallbacks, broadcasting behavior, and DB interaction.
  * Added dashboard system tests for XSS safety, pagination edge cases, and graceful handling of missing backtraces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->