### PR TITLE
fix(spec): eliminate signal-handling race + enable macOS integration tests

### DIFF
--- a/spec/integration/signal_handling_spec.rb
+++ b/spec/integration/signal_handling_spec.rb
@@ -3,23 +3,27 @@
 require_relative "../integration_helper"
 
 # These tests fork child processes that create new PG connections.
-# pg gem 1.6.x has a known segfault when connecting after fork on macOS ARM64
-# (libpq SSL context corruption). These tests run reliably on Linux (CI).
-FORK_PG_SAFE = !RUBY_PLATFORM.include?("darwin")
-
+#
+# Historical note: pg gem 1.6.x on macOS ARM64 segfaults when libpq
+# initializes GSSAPI state after fork. The fix is gssencmode=disable
+# in the connection URL — done in connection_url below and in
+# integration_helper.rb for the parent's AR connection. With that
+# flag, these tests run on both Linux (CI) and darwin.
 RSpec.describe "Signal handling (integration)", :integration do
   let(:client) { Pgbus.client }
 
   before do
-    skip "Fork + PG.connect segfaults on macOS ARM64 (pg gem bug)" unless FORK_PG_SAFE
     client.ensure_queue("default")
   end
 
   # Build a connection URL with the given pool size, safely merging query params.
+  # Always sets gssencmode=disable so fork+PG.connect doesn't segfault on
+  # macOS ARM64 (see module-level comment above).
   def connection_url(pool:)
     parsed = URI.parse(PGBUS_DATABASE_URL)
     params = URI.decode_www_form(parsed.query || "").to_h
     params["pool"] = pool.to_s
+    params["gssencmode"] = "disable"
     parsed.query = URI.encode_www_form(params)
     parsed.to_s
   end
@@ -178,13 +182,50 @@ RSpec.describe "Signal handling (integration)", :integration do
 
         # Override boot_processes to fork a simple child that sleeps,
         # register it in @forks so the supervisor manages it properly.
+        #
+        # CRITICAL: the forked child inherits the supervisor's signal
+        # handlers installed by setup_signals (see signal_handler.rb).
+        # Those handlers are closures over the supervisor's @signal_queue
+        # and @self_pipe_w — both of which are per-process. When the
+        # child receives SIGTERM before it installs its own trap, the
+        # inherited closure fires, writes to the CHILD'S copy of the
+        # queue/pipe (which nothing reads), and RETURNS NORMALLY instead
+        # of exiting. The child then continues to sleep 120 and the
+        # supervisor never sees its child die. That produced the
+        # intermittent 30-second timeout in CI.
+        #
+        # Fix: the child uses its own IO.pipe to notify its parent
+        # (the supervisor) that it has installed its TERM handler and
+        # is ready to receive signals. boot_processes blocks on that
+        # handshake before writing "S" back to the test runner. That
+        # guarantees signal_children cannot fire before the child has
+        # a working trap installed.
         supervisor.define_singleton_method(:boot_processes) do
+          ready_r, ready_w = IO.pipe
           child_pid = fork do
-            # Simple child that exits on TERM
+            ready_r.close
+            # Reset inherited traps to default first — harmless if the
+            # signal arrives before we install our own: the default
+            # SIGTERM handler kills the process, which is the correct
+            # behavior for a sleep-forever test child.
+            %w[INT TERM QUIT].each { |sig| Signal.trap(sig, "DEFAULT") }
             trap("TERM") { exit 0 }
             trap("QUIT") { exit 0 }
+            # Tell the supervisor we're ready. Any signal delivered
+            # before this point either hits the DEFAULT handler (kill)
+            # or our own trap (clean exit) — both valid.
+            ready_w.write("R")
+            ready_w.close
             sleep 120
           end
+          ready_w.close
+          # Wait for the child to confirm trap installation. If the
+          # handshake stalls, there's a deeper bug — bail out with a
+          # short timeout rather than hanging the whole test.
+          ready_r.wait_readable(5)
+          ready_r.read(1)
+          ready_r.close
+
           @forks[child_pid] = { type: :worker, config: {} }
           write_pipe.write("S")
           write_pipe.flush

--- a/spec/integration/signal_handling_spec.rb
+++ b/spec/integration/signal_handling_spec.rb
@@ -219,12 +219,26 @@ RSpec.describe "Signal handling (integration)", :integration do
             sleep 120
           end
           ready_w.close
-          # Wait for the child to confirm trap installation. If the
-          # handshake stalls, there's a deeper bug — bail out with a
-          # short timeout rather than hanging the whole test.
-          ready_r.wait_readable(5)
-          ready_r.read(1)
+          # Wait for the child to confirm trap installation.
+          #
+          # Three cases to handle explicitly:
+          #   a) wait_readable returns nil → 5s timeout elapsed. The
+          #      child is stuck somewhere before writing "R". Fail the
+          #      handshake rather than letting read(1) block forever
+          #      (which would defeat the timeout entirely).
+          #   b) wait_readable returns truthy but read(1) returns "" →
+          #      EOF. The child exited before writing "R". That means
+          #      it hit the DEFAULT trap during a signal race OR
+          #      crashed during trap setup. Either way, the child is
+          #      gone and we should fail loudly instead of registering
+          #      a dead pid in @forks.
+          #   c) read(1) returns "R" → child confirmed. Proceed.
+          ready = ready_r.wait_readable(5)
+          raise "child readiness handshake timed out after 5s (pid=#{child_pid})" unless ready
+
+          byte = ready_r.read(1)
           ready_r.close
+          raise "child exited before readiness handshake (pid=#{child_pid}, got=#{byte.inspect})" unless byte == "R"
 
           @forks[child_pid] = { type: :worker, config: {} }
           write_pipe.write("S")

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -88,9 +88,16 @@ RSpec.configure do |config|
 
   # Connect ActiveRecord with a pool large enough for concurrent tests.
   # Merge pool via URI parsing to avoid breaking URLs with existing query params.
+  #
+  # gssencmode=disable is the macOS fix: libpq 1.6.x on darwin/arm64 initializes
+  # GSSAPI state lazily in a way that segfaults when a child process tries to
+  # open a new PG connection after fork. Disabling GSSAPI entirely skips the
+  # bad code path. Harmless on Linux (GSSAPI isn't used in pgbus anyway), so
+  # we set it unconditionally to keep one canonical URL for both platforms.
   parsed = URI.parse(PGBUS_DATABASE_URL)
   url_params = URI.decode_www_form(parsed.query || "").to_h
   url_params["pool"] = "20"
+  url_params["gssencmode"] = "disable"
   parsed.query = URI.encode_www_form(url_params)
   ActiveRecord::Base.establish_connection(parsed.to_s)
 

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -94,16 +94,30 @@ RSpec.configure do |config|
   # open a new PG connection after fork. Disabling GSSAPI entirely skips the
   # bad code path. Harmless on Linux (GSSAPI isn't used in pgbus anyway), so
   # we set it unconditionally to keep one canonical URL for both platforms.
-  parsed = URI.parse(PGBUS_DATABASE_URL)
-  url_params = URI.decode_www_form(parsed.query || "").to_h
-  url_params["pool"] = "20"
-  url_params["gssencmode"] = "disable"
-  parsed.query = URI.encode_www_form(url_params)
-  ActiveRecord::Base.establish_connection(parsed.to_s)
+  parsed_base = URI.parse(PGBUS_DATABASE_URL)
+  base_params = URI.decode_www_form(parsed_base.query || "").to_h
+  base_params["gssencmode"] = "disable"
 
-  # Configure pgbus with the real database
+  # Pgbus::Client#connection_options reads config.database_url and
+  # passes it straight to PG.connect (lib/pgbus/client.rb:431).
+  # libpq's conninfo_parse rejects "pool" (it's an AR-only param),
+  # so the pgbus URL must NOT include pool. It MUST include
+  # gssencmode=disable so forked children (which call
+  # Pgbus.reset_client! and open fresh PG connections) don't
+  # re-trigger the libpq GSSAPI post-fork segfault on macOS ARM64.
+  parsed_base.query = URI.encode_www_form(base_params)
+  pgbus_url = parsed_base.to_s
+
+  # ActiveRecord wants the same URL plus pool=20. Merge on top of
+  # the pgbus URL so they share the gssencmode fix.
+  parsed_ar = URI.parse(pgbus_url)
+  ar_params = URI.decode_www_form(parsed_ar.query || "").to_h
+  ar_params["pool"] = "20"
+  parsed_ar.query = URI.encode_www_form(ar_params)
+  ActiveRecord::Base.establish_connection(parsed_ar.to_s)
+
   Pgbus.configure do |c|
-    c.database_url = PGBUS_DATABASE_URL
+    c.database_url = pgbus_url
     c.queue_prefix = "pgbus_int"
     c.default_queue = "default"
     c.logger = Logger.new(IO::NULL)


### PR DESCRIPTION
## Summary

Fixes the consistent 30-second CI timeout on \`spec/integration/signal_handling_spec.rb\` that the user has been seeing across many branches, and unlocks macOS for running the full integration + system test suites locally.

## Root cause of the CI timeout

The failing test was \`"SIGTERM propagates to all child processes"\`. It forks a supervisor, overrides \`boot_processes\` to fork a child that does \`trap("TERM") { exit 0 }; sleep 120\`, sends SIGTERM to the supervisor, and waits for both to exit within 30 seconds.

**The race:** the forked child inherits the supervisor's signal handlers installed by \`setup_signals\` — handlers that are closures over the supervisor's \`@signal_queue\` and \`@self_pipe_w\`. When the child receives SIGTERM before it executes its own \`trap("TERM")\` line, the **inherited** closure fires, writes to the child's private copies of the queue and self-pipe (which nothing reads), and **returns normally instead of exiting**. The child then sleeps for 120 seconds; the supervisor's \`@forks\` never drains; the parent's \`Timeout.timeout(30)\` fires.

The real \`Supervisor#fork_worker\` avoids this by calling \`restore_signals\` as its very first line ([supervisor.rb:65](https://github.com/mhenrixon/pgbus/blob/main/lib/pgbus/process/supervisor.rb#L65)). The test's \`boot_processes\` override did not.

**Why it was intermittent:** whether the race fires depends on how fast the child gets scheduled between \`fork()\` and its own trap line, which depends on Ruby VM warm-up state, which depends on how many tests ran before this one. The test passed when it ran first in the file, failed when it ran after another fork-heavy test.

## Reproduction

I was able to reproduce the 30-second timeout locally on macOS by:
1. Adding \`gssencmode=disable\` to the connection URL (works around the pg gem 1.6.x fork segfault that was making the test skip on macOS)
2. Running the full \`signal_handling_spec.rb\` file in any order where the supervisor test isn't first

Added \`puts\` traces to the child and supervisor to pinpoint the race. The smoking gun in the log:

\`\`\`
[9193] TRAP TERM                                            ← supervisor gets SIGTERM
[9193] processed signals: before=1 after=0 shutting=true    ← supervisor calls signal_children(TERM)
[9195] TRAP TERM                                            ← child receives TERM via INHERITED trap
[9195] child sleeping                                       ← then child installs its own trap and enters sleep 120
\`\`\`

The child's \`sleep 120\` runs with its own trap installed, but the one SIGTERM the supervisor sent has already been silently consumed by the inherited closure. No more signals → child sleeps → supervisor never drains → timeout.

## Fix 1: handshake between child and supervisor

The \`boot_processes\` override now creates a \`ready_r/ready_w\` pipe, forks the child, and has the child:
1. Reset inherited traps to DEFAULT (so any signal between fork and the reset hits the default SIGTERM handler, which kills the process cleanly — the correct behavior for a sleep-forever test child)
2. Install its own \`trap("TERM") { exit 0 }\` / \`trap("QUIT") { exit 0 }\`
3. Write \"R\" to \`ready_w\`
4. Sleep

The supervisor blocks on \`ready_r\` before registering the child in \`@forks\` and writing \"S\" back to the test runner. This closes the race: by the time the test runner sends SIGTERM to the supervisor, the child's own trap is guaranteed to be installed.

## Fix 2: \`gssencmode=disable\` for macOS integration tests

\`spec/integration_helper.rb\` and the \`connection_url\` helper in \`signal_handling_spec.rb\` now set \`gssencmode=disable\` in the query string. libpq 1.6.x on macOS ARM64 segfaults when a forked child tries to initialize GSSAPI state; disabling GSSAPI skips the bad code path entirely. pgbus doesn't use GSSAPI anyway, so this is a free fix on both platforms.

With this, \`signal_handling_spec.rb\` no longer needs the \`skip unless FORK_PG_SAFE\` marker, and the full integration + system test suites can run locally on macOS.

## Verification

- [x] 8 runs with random seeds, full \`signal_handling_spec.rb\`: all pass in 4-9 seconds (was 30s+ timeout intermittently)
- [x] Full \`spec/integration/\` suite: 116 examples, 0 failures in 15.85s
- [x] \`bundle exec rspec\` (unit): 1214 examples, 0 failures
- [x] \`bundle exec rubocop\`: clean (283 files)

## Test plan

- [ ] CI green on PR branch
- [ ] No longer intermittent: re-run the CI job on this branch a few times to confirm the flake is gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS signal handling reliability by removing platform workarounds and making supervisor-child handshakes more robust, reducing flaky terminations on macOS.
  * Enhanced PostgreSQL connection stability by ensuring a consistent connection parameter set (disabling GSS encryption negotiation) and properly applying connection pool settings, reducing connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->