### PR TITLE
feat(generators): pgbus:update auto-detects and installs missing migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ end
 
 The capsule string DSL is the shortest form for the common case. Use `c.capsule` when you need named capsules with advanced options like `single_active_consumer` or `consumer_priority`. See [Routing and ordering](#routing-and-ordering) for the full set.
 
-> **Migrating from `config/pgbus.yml`?** Run `rails generate pgbus:update` to convert your YAML config to a Ruby initializer using the modern DSL. The original YAML stays in place for review; delete it once the new initializer looks right.
+> **Upgrading from an older pgbus?** Run `rails generate pgbus:update`. It does two things in one pass:
+>
+> - Converts any legacy `config/pgbus.yml` to a Ruby initializer at `config/initializers/pgbus.rb` (skipped if the initializer already exists).
+> - Inspects your live database and adds any missing pgbus migrations to `db/migrate` (or `db/pgbus_migrate` if you use `connects_to`). The generator detects your separate-database config automatically from `Pgbus.configuration.connects_to` or by scanning the initializer / `config/application.rb`, so you don't have to re-specify `--database=pgbus` every time.
+>
+> Useful flags: `--dry-run` (print the plan without creating files), `--skip-config`, `--skip-migrations`, `--quiet`. Running it on a database with no pgbus tables at all will redirect you to `pgbus:install` instead of stacking individual add_* migrations.
 
 ### 2. Use as ActiveJob backend
 

--- a/lib/generators/pgbus/update_generator.rb
+++ b/lib/generators/pgbus/update_generator.rb
@@ -2,58 +2,171 @@
 
 require "rails/generators"
 require "pgbus/generators/config_converter"
+require "pgbus/generators/migration_detector"
+require "pgbus/generators/database_target_detector"
 
 module Pgbus
   module Generators
-    # Converts an existing config/pgbus.yml to a Ruby initializer at
-    # config/initializers/pgbus.rb using the modern DSL.
+    # Upgrade command with two independent jobs:
     #
-    # The original YAML file is left in place — the user reviews the
-    # generated initializer and deletes the YAML when ready.
+    #   1. Config conversion: if config/pgbus.yml exists, convert it to
+    #      config/initializers/pgbus.rb using the modern Ruby DSL. Skip
+    #      silently if the initializer already exists or the YAML is
+    #      absent — safe to re-run.
+    #
+    #   2. Migration detection: inspect the live database and add any
+    #      missing pgbus migrations to db/migrate (or db/pgbus_migrate
+    #      if a separate database is configured). Invokes each matching
+    #      sub-generator in-process via Thor's invoke, so this mirrors
+    #      what the user would get running each generator by hand.
     #
     # Usage:
     #
     #   bin/rails generate pgbus:update
-    #   bin/rails generate pgbus:update --force      # overwrite existing initializer
-    #   bin/rails generate pgbus:update --source=path/to/pgbus.yml
+    #   bin/rails generate pgbus:update --dry-run
+    #   bin/rails generate pgbus:update --skip-config
+    #   bin/rails generate pgbus:update --skip-migrations
+    #   bin/rails generate pgbus:update --database=pgbus
+    #   bin/rails generate pgbus:update --quiet
     class UpdateGenerator < Rails::Generators::Base
-      desc "Convert config/pgbus.yml to config/initializers/pgbus.rb using the Ruby DSL"
+      desc "Upgrade pgbus: convert YAML config + add any missing migrations"
 
       class_option :source,
                    type: :string,
                    default: "config/pgbus.yml",
-                   desc: "Path to the existing YAML config (default: config/pgbus.yml)"
+                   desc: "Path to an existing YAML config to convert (default: config/pgbus.yml)"
 
       class_option :destination,
                    type: :string,
                    default: "config/initializers/pgbus.rb",
                    desc: "Path to the generated initializer (default: config/initializers/pgbus.rb)"
 
-      def convert
+      class_option :skip_config,
+                   type: :boolean,
+                   default: false,
+                   desc: "Skip the YAML → Ruby initializer conversion step"
+
+      class_option :skip_migrations,
+                   type: :boolean,
+                   default: false,
+                   desc: "Skip the migration detection step"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (default: auto-detect " \
+                         "from Pgbus.configuration.connects_to or config/initializers/pgbus.rb)"
+
+      class_option :dry_run,
+                   type: :boolean,
+                   default: false,
+                   desc: "Print what would be done without creating any files"
+
+      class_option :quiet,
+                   type: :boolean,
+                   default: false,
+                   desc: "Suppress verbose per-step output"
+
+      def convert_yaml_if_present
+        return if options[:skip_config]
+
         source_path = File.expand_path(options[:source], destination_root)
         destination_path = File.expand_path(options[:destination], destination_root)
 
-        # Thor::Error is the idiomatic way to abort a Rails generator. Thor
-        # catches it, prints the message in red, and exits with status 1
-        # without a Ruby backtrace. exit 1 would skip the framework's
-        # cleanup hooks and is hard to test.
-        raise Thor::Error, "Source file not found: #{options[:source]}" unless File.exist?(source_path)
+        unless File.exist?(source_path)
+          log "YAML config not found at #{options[:source]}; skipping config conversion."
+          return
+        end
+
+        if File.exist?(destination_path)
+          log "Initializer already exists at #{options[:destination]}; skipping config conversion."
+          return
+        end
 
         ruby_source = load_and_convert(source_path)
-        create_file destination_path, ruby_source
+        if options[:dry_run]
+          log_change "[dry-run] would create #{options[:destination]}"
+        else
+          create_file destination_path, ruby_source
+        end
+      end
+
+      def detect_and_install_missing_migrations
+        return if options[:skip_migrations]
+
+        unless active_record_available?
+          log "ActiveRecord not loaded — skipping migration detection. Run this generator from a Rails app."
+          return
+        end
+
+        connection = resolve_connection
+        unless connection
+          log "No ActiveRecord connection available — skipping migration detection."
+          return
+        end
+
+        detector = MigrationDetector.new(connection)
+        missing = detector.missing_migrations
+
+        if missing.empty?
+          log "Database schema is up to date — no migrations needed."
+          return
+        end
+
+        if missing == [MigrationDetector::FRESH_INSTALL]
+          say ""
+          say "Database looks empty of pgbus tables — this is a fresh install.", :yellow
+          say "Run `rails generate pgbus:install` instead of `pgbus:update`.", :yellow
+          say ""
+          return
+        end
+
+        database_name = options[:database] || detected_database_name
+        log "Auto-detected separate database: #{database_name}" if options[:database].nil? && database_name
+
+        log "Found #{missing.size} missing migration(s):"
+        missing.each do |key|
+          description = MigrationDetector::DESCRIPTIONS[key] || key.to_s
+          log "  - #{key}: #{description}"
+        end
+
+        # Two loops on purpose: print the full plan first so operators
+        # see what's coming, then execute. Combining would interleave
+        # "  - add_presence: foo" with "Invoking pgbus:add_presence..."
+        # which hides the shape of the upgrade from the reader.
+        missing.each do |key| # rubocop:disable Style/CombinableLoops
+          generator = MigrationDetector::GENERATOR_MAP[key]
+          unless generator
+            say "  !  no generator mapped for #{key}, skipping", :red
+            next
+          end
+
+          if options[:dry_run]
+            log_change "[dry-run] would invoke #{generator}#{" --database=#{database_name}" if database_name}"
+            next
+          end
+
+          invoke_args = []
+          invoke_args << "--database=#{database_name}" if database_name
+          log "Invoking #{generator}#{" --database=#{database_name}" if database_name}..."
+          invoke generator, invoke_args
+        end
       end
 
       def display_post_install
+        return if options[:quiet]
+
         say ""
-        say "Pgbus initializer generated at #{options[:destination]}!", :green
+        say "Pgbus update complete.", :green
         say ""
-        say "Next steps:"
-        say "  1. Review the generated initializer for correctness"
-        say "  2. Boot your app and verify everything still works"
-        say "  3. Delete #{options[:source]} when satisfied (Pgbus will stop reading it)"
-        say ""
-        say "If you spot a setting that didn't translate cleanly, please open an issue:"
-        say "  https://github.com/mhenrixon/pgbus/issues", :cyan
+        if options[:dry_run]
+          say "Dry-run: no files were created.", :yellow
+        else
+          say "Next steps:"
+          say "  1. Review the generated migration files in db/migrate (or db/pgbus_migrate)"
+          say "  2. Run: rails db:migrate#{":#{effective_database_name}" if effective_database_name}"
+          say "  3. Restart pgbus: bin/pgbus start"
+        end
         say ""
       end
 
@@ -69,6 +182,46 @@ module Pgbus
         ConfigConverter.from_yaml(source_path)
       rescue ConfigConverter::Error, Psych::Exception, Errno::ENOENT, Errno::EACCES => e
         raise Thor::Error, "Failed to convert #{options[:source]}: #{e.message}"
+      end
+
+      def active_record_available?
+        defined?(::ActiveRecord::Base) && ::ActiveRecord::Base.respond_to?(:connection)
+      end
+
+      # Resolve the AR connection to inspect. If pgbus is configured to
+      # use a separate database (via connects_to), use BusRecord's
+      # connection so the detector probes the right schema.
+      def resolve_connection
+        if defined?(Pgbus) && Pgbus.respond_to?(:configuration) && Pgbus.configuration.connects_to
+          Pgbus::BusRecord.connection
+        else
+          ::ActiveRecord::Base.connection
+        end
+      rescue StandardError => e
+        say "  !  could not resolve AR connection: #{e.class}: #{e.message}", :red
+        nil
+      end
+
+      def detected_database_name
+        @detected_database_name ||= DatabaseTargetDetector.new(
+          destination_root: destination_root
+        ).detect
+      end
+
+      def effective_database_name
+        options[:database] || detected_database_name
+      end
+
+      def log(message)
+        return if options[:quiet]
+
+        say message
+      end
+
+      def log_change(message)
+        return if options[:quiet]
+
+        say message, :yellow
       end
     end
   end

--- a/lib/pgbus/generators/database_target_detector.rb
+++ b/lib/pgbus/generators/database_target_detector.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Generators
+    # Detects whether the host application has configured pgbus to use
+    # a separate database via connects_to, and returns the database name
+    # that --database flags should be set to for sub-generators.
+    #
+    # Detection sources, in priority order:
+    #
+    #   1. Pgbus.configuration.connects_to (runtime — authoritative if
+    #      the initializer has already booted)
+    #   2. config/initializers/pgbus.rb (text scan)
+    #   3. config/application.rb (text scan — fallback for apps that
+    #      call connects_to in application config instead of the pgbus
+    #      initializer)
+    #
+    # Returns a String (the database name, e.g. "pgbus") or nil if no
+    # separate database is configured.
+    class DatabaseTargetDetector
+      # Matches:
+      #   c.connects_to = { database: { writing: :pgbus } }
+      #   c.connects_to(database: { writing: :queue_db })
+      #   Pgbus.configuration.connects_to = { database: { writing: :pgbus } }
+      #
+      # Rejects:
+      #   c.connects_to = { role: :writing }        (different API shape)
+      #   connects_to :something                    (no database: key)
+      #
+      # The [^;\n]*? and [^}]*? laziness keeps the scan within a
+      # reasonable window so a stray "writing:" later in the file
+      # can't cross-contaminate.
+      CONNECTS_TO_PATTERN = /connects_to\b[^;\n]*?database\s*:\s*\{[^}]*?writing\s*:\s*:?(?<name>[a-zA-Z_][a-zA-Z0-9_]*)/m
+
+      def initialize(destination_root:)
+        @destination_root = destination_root
+      end
+
+      # Returns the database name string if a separate DB is configured,
+      # nil otherwise. Checks runtime config first, then falls back to
+      # static file scanning.
+      def detect
+        runtime_database_name || scan_initializer || scan_application_config
+      end
+
+      private
+
+      attr_reader :destination_root
+
+      # Runtime path: Pgbus.configuration.connects_to. Only works if the
+      # host app has loaded pgbus AND booted the initializer. The update
+      # generator runs after Rails app boot so this is usually available.
+      def runtime_database_name
+        return nil unless defined?(Pgbus) && Pgbus.respond_to?(:configuration)
+
+        extract_database_name(Pgbus.configuration.connects_to)
+      rescue StandardError
+        nil
+      end
+
+      def scan_initializer
+        scan_file(File.join(destination_root, "config", "initializers", "pgbus.rb"))
+      end
+
+      def scan_application_config
+        scan_file(File.join(destination_root, "config", "application.rb"))
+      end
+
+      def scan_file(path)
+        return nil unless File.exist?(path)
+
+        content = File.read(path)
+        match = content.match(CONNECTS_TO_PATTERN)
+        return nil unless match
+
+        match[:name]
+      rescue StandardError
+        nil
+      end
+
+      # Parses `{ database: { writing: :name } }` or the String variant
+      # into the database name. Returns nil for anything we don't
+      # recognize.
+      def extract_database_name(connects_to)
+        return nil unless connects_to.is_a?(Hash)
+
+        db = connects_to[:database] || connects_to["database"]
+        return nil unless db.is_a?(Hash)
+
+        (db[:writing] || db["writing"])&.to_s
+      end
+    end
+  end
+end

--- a/lib/pgbus/generators/migration_detector.rb
+++ b/lib/pgbus/generators/migration_detector.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Generators
+    # Inspects a live ActiveRecord connection and determines which of
+    # pgbus's migration generators need to run to bring the schema up
+    # to date.
+    #
+    # Usage:
+    #
+    #   detector = Pgbus::Generators::MigrationDetector.new(connection)
+    #   detector.missing_migrations
+    #   # => [:add_uniqueness_keys, :add_job_stats_queue_index, ...]
+    #
+    # The returned symbols correspond to generator names that the
+    # pgbus:update generator invokes via Thor composition. Each symbol
+    # maps to exactly one generator (see GENERATOR_MAP).
+    #
+    # Detection rules:
+    #
+    # 1. Fresh install (no core tables) → returns [:fresh_install] as a
+    #    sentinel. The caller should tell the user to run pgbus:install
+    #    instead of stacking 8 migrations.
+    #
+    # 2. Core tables missing → queued unconditionally. These are features
+    #    pgbus assumes are present.
+    #
+    # 3. Opt-in feature tables missing → queued unconditionally. The user
+    #    asked for update-to-latest, so we add the migration files but
+    #    don't enable the feature in config. They'll opt in separately.
+    #
+    # 4. Columns missing on existing tables → queued. These are in-place
+    #    schema upgrades (e.g. add_job_stats_latency adds
+    #    enqueue_latency_ms + retry_count).
+    #
+    # 5. Indexes missing on existing tables → queued. Additive, safe.
+    #
+    # 6. Modern replacements for legacy tables (e.g. pgbus_job_locks →
+    #    pgbus_uniqueness_keys) → queue the migration path only if the
+    #    legacy table still exists. Otherwise queue the fresh install.
+    class MigrationDetector
+      # Sentinel returned when the database looks empty of pgbus tables.
+      # The caller (pgbus:update generator) should redirect the user to
+      # pgbus:install rather than trying to stack the full schema as
+      # individual add_* migrations.
+      FRESH_INSTALL = :fresh_install
+
+      # The set of tables that the base pgbus:install migration creates.
+      # If NONE of these exist, we treat the DB as a fresh install.
+      CORE_INSTALL_TABLES = %w[
+        pgbus_processed_events
+        pgbus_processes
+        pgbus_failed_events
+        pgbus_semaphores
+        pgbus_blocked_executions
+        pgbus_batches
+      ].freeze
+
+      # generator_key → Rails generator name. Passed to Thor's invoke.
+      #
+      # Note: uniqueness_keys uses the migrate_job_locks generator for
+      # both the fresh-install and upgrade-from-job_locks paths. The
+      # template is idempotent: `unless table_exists?(:pgbus_uniqueness_keys)`
+      # creates it, and `if table_exists?(:pgbus_job_locks)` drops the
+      # legacy table. One generator covers both cases.
+      GENERATOR_MAP = {
+        uniqueness_keys: "pgbus:migrate_job_locks",
+        add_job_stats: "pgbus:add_job_stats",
+        add_job_stats_latency: "pgbus:add_job_stats_latency",
+        add_job_stats_queue_index: "pgbus:add_job_stats_queue_index",
+        add_stream_stats: "pgbus:add_stream_stats",
+        add_presence: "pgbus:add_presence",
+        add_queue_states: "pgbus:add_queue_states",
+        add_outbox: "pgbus:add_outbox",
+        add_recurring: "pgbus:add_recurring",
+        add_failed_events_index: "pgbus:add_failed_events_index"
+      }.freeze
+
+      # Human-friendly description of each migration for the generator
+      # output. Keeps the update generator's run log readable.
+      DESCRIPTIONS = {
+        uniqueness_keys: "uniqueness keys table (job deduplication, also upgrades legacy job_locks if present)",
+        add_job_stats: "job stats table (Insights dashboard)",
+        add_job_stats_latency: "job stats latency columns (enqueue_latency_ms, retry_count)",
+        add_job_stats_queue_index: "job stats (queue_name, created_at) index",
+        add_stream_stats: "stream stats table (opt-in real-time Insights)",
+        add_presence: "presence members table (Turbo Streams presence)",
+        add_queue_states: "queue states table (pause/resume)",
+        add_outbox: "outbox entries table (transactional outbox)",
+        add_recurring: "recurring tasks + executions tables",
+        add_failed_events_index: "unique index on pgbus_failed_events (queue_name, msg_id)"
+      }.freeze
+
+      def initialize(connection)
+        @connection = connection
+      end
+
+      # Returns an Array of generator keys (symbols) in the order they
+      # should run. Dependencies are resolved implicitly via order: the
+      # base table creation for a feature always comes before the
+      # column/index add-ons.
+      def missing_migrations
+        return [FRESH_INSTALL] if fresh_install?
+
+        [
+          *uniqueness_key_migrations,
+          *job_stats_migrations,
+          *stream_stats_migrations,
+          *presence_migrations,
+          *queue_states_migrations,
+          *outbox_migrations,
+          *recurring_migrations,
+          *failed_events_index_migrations
+        ]
+      end
+
+      private
+
+      attr_reader :connection
+
+      def fresh_install?
+        CORE_INSTALL_TABLES.none? { |t| table_exists?(t) }
+      end
+
+      # Legacy pgbus_job_locks → modern pgbus_uniqueness_keys.
+      # The migrate_job_locks template is idempotent: it creates
+      # uniqueness_keys if missing and drops job_locks if present.
+      # One symbol covers both cases; see GENERATOR_MAP.
+      def uniqueness_key_migrations
+        return [] if table_exists?("pgbus_uniqueness_keys")
+
+        [:uniqueness_keys]
+      end
+
+      def job_stats_migrations
+        migrations = []
+
+        unless table_exists?("pgbus_job_stats")
+          migrations << :add_job_stats
+          # The latency columns and queue index are add-ons to job_stats.
+          # If we're creating the base table now, the add_job_stats
+          # template doesn't include them — add the upgrade migrations
+          # so a fresh install lands on the current schema.
+          migrations << :add_job_stats_latency
+          migrations << :add_job_stats_queue_index
+          return migrations
+        end
+
+        # Base table exists — check each add-on independently.
+        cols = column_names("pgbus_job_stats")
+        migrations << :add_job_stats_latency unless cols.include?("enqueue_latency_ms") && cols.include?("retry_count")
+
+        migrations << :add_job_stats_queue_index unless index_exists?("pgbus_job_stats", "idx_pgbus_job_stats_queue_time")
+
+        migrations
+      end
+
+      def stream_stats_migrations
+        table_exists?("pgbus_stream_stats") ? [] : [:add_stream_stats]
+      end
+
+      def presence_migrations
+        table_exists?("pgbus_presence_members") ? [] : [:add_presence]
+      end
+
+      def queue_states_migrations
+        table_exists?("pgbus_queue_states") ? [] : [:add_queue_states]
+      end
+
+      def outbox_migrations
+        table_exists?("pgbus_outbox_entries") ? [] : [:add_outbox]
+      end
+
+      def recurring_migrations
+        # pgbus_recurring_tasks + pgbus_recurring_executions are the two
+        # tables the recurring generator creates. If BOTH exist, nothing
+        # to do. If either is missing, we need the generator (which is
+        # idempotent via if_not_exists on both tables).
+        return [] if table_exists?("pgbus_recurring_tasks") && table_exists?("pgbus_recurring_executions")
+
+        [:add_recurring]
+      end
+
+      def failed_events_index_migrations
+        # pgbus_failed_events is created by pgbus:install, but the
+        # unique (queue_name, msg_id) index was added later via its own
+        # generator. If the table exists without the unique index,
+        # FailedEventRecorder's upsert silently swallows ON CONFLICT
+        # errors — so this is a real bug waiting to bite.
+        return [] unless table_exists?("pgbus_failed_events")
+        return [] if index_exists?("pgbus_failed_events", "idx_pgbus_failed_events_queue_msg")
+
+        [:add_failed_events_index]
+      end
+
+      # --- schema probes -------------------------------------------------
+
+      def table_exists?(name)
+        connection.table_exists?(name)
+      rescue StandardError
+        false
+      end
+
+      def column_names(table)
+        connection.columns(table).map(&:name)
+      rescue StandardError
+        []
+      end
+
+      def index_exists?(table, index_name)
+        connection.indexes(table).any? { |idx| idx.name == index_name }
+      rescue StandardError
+        false
+      end
+    end
+  end
+end

--- a/spec/generators/pgbus/update_generator_spec.rb
+++ b/spec/generators/pgbus/update_generator_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     end
 
     it "has a description" do
-      expect(described_class.desc).to include("config/pgbus.yml")
-      expect(described_class.desc).to include("config/initializers/pgbus.rb")
+      expect(described_class.desc).to match(/Upgrade pgbus/)
+      expect(described_class.desc).to include("YAML")
+      expect(described_class.desc).to include("migrations")
     end
 
     it "exposes a --source option defaulting to config/pgbus.yml" do
@@ -28,9 +29,15 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
       expect(option).not_to be_nil
       expect(option.default).to eq("config/initializers/pgbus.rb")
     end
+
+    it "exposes --skip-config, --skip-migrations, --database, --dry-run, and --quiet options" do
+      %i[skip_config skip_migrations database dry_run quiet].each do |opt|
+        expect(described_class.class_options[opt]).not_to be_nil, "missing #{opt} option"
+      end
+    end
   end
 
-  describe "end-to-end conversion" do
+  describe "end-to-end YAML conversion" do
     let(:tmpdir) { Dir.mktmpdir }
     let(:source_path) { File.join(tmpdir, "config/pgbus.yml") }
     let(:dest_path) { File.join(tmpdir, "config/initializers/pgbus.rb") }
@@ -49,7 +56,15 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     after { FileUtils.rm_rf(tmpdir) }
 
     it "writes the converted Ruby source to config/initializers/pgbus.rb" do
-      generator = described_class.new([], destination: dest_path, source: source_path)
+      # skip_migrations: the converter test focuses on the YAML->Ruby
+      # path; the migration detector path is covered by its own tests.
+      generator = described_class.new(
+        [],
+        destination: dest_path,
+        source: source_path,
+        skip_migrations: true,
+        quiet: true
+      )
       generator.destination_root = tmpdir
       capture_io { generator.invoke_all }
 
@@ -58,6 +73,130 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
       expect(content).to include("Pgbus.configure do |c|")
       expect(content).to include("c.visibility_timeout = 10.minutes")
       expect(content).to include('c.workers = "*: 5"')
+    end
+  end
+
+  describe "migration detection orchestration" do
+    # These tests exercise the new orchestration layer added to
+    # UpdateGenerator: given a detector result, verify the generator
+    # translates it into the right invoke calls with the right args.
+    #
+    # MigrationDetector and DatabaseTargetDetector are covered by their
+    # own unit specs; here we only care that the UpdateGenerator wires
+    # them together correctly.
+
+    let(:mock_connection) { double("ActiveRecord::Connection") }
+    let(:tmpdir) { Dir.mktmpdir }
+
+    before do
+      FileUtils.mkdir_p(File.join(tmpdir, "config", "initializers"))
+      FileUtils.mkdir_p(File.join(tmpdir, "db", "migrate"))
+
+      # Replace AR::Base with a minimal stub so the generator's
+      # "ActiveRecord::Base.connection" path fires without loading the
+      # real ActiveRecord. The no-op abstract_class= lets Pgbus::BusRecord
+      # autoload cleanly if connects_to is set in a test.
+      fake_ar_base = Class.new do
+        def self.abstract_class=(*); end
+      end
+      stub_const("ActiveRecord::Base", fake_ar_base)
+      allow(ActiveRecord::Base).to receive(:connection).and_return(mock_connection)
+      allow(Pgbus.configuration).to receive(:connects_to).and_return(nil)
+    end
+
+    after { FileUtils.rm_rf(tmpdir) }
+
+    def build_generator(opts = {})
+      defaults = { skip_config: true, skip_migrations: false, dry_run: true, quiet: true }
+      gen = described_class.new([], defaults.merge(opts))
+      gen.destination_root = tmpdir
+      gen
+    end
+
+    it "prints the fresh-install redirect when the detector reports FRESH_INSTALL" do
+      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
+        .and_return([Pgbus::Generators::MigrationDetector::FRESH_INSTALL])
+
+      generator = build_generator(quiet: false)
+      allow(generator).to receive(:invoke)
+
+      expect { generator.detect_and_install_missing_migrations }.to output(/fresh install/i).to_stdout
+      expect(generator).not_to have_received(:invoke)
+    end
+
+    it "logs 'up to date' and does nothing when the detector returns an empty list" do
+      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
+        .and_return([])
+
+      generator = build_generator(quiet: false)
+      allow(generator).to receive(:invoke)
+
+      expect { generator.detect_and_install_missing_migrations }.to output(/up to date/i).to_stdout
+      expect(generator).not_to have_received(:invoke)
+    end
+
+    it "invokes each missing migration's generator in order" do
+      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
+        .and_return(%i[add_presence add_stream_stats])
+
+      generator = build_generator(dry_run: false)
+      allow(generator).to receive(:invoke)
+
+      generator.detect_and_install_missing_migrations
+
+      expect(generator).to have_received(:invoke).with("pgbus:add_presence", []).ordered
+      expect(generator).to have_received(:invoke).with("pgbus:add_stream_stats", []).ordered
+    end
+
+    it "skips invocation on dry_run and prints 'would invoke'" do
+      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
+        .and_return(%i[add_presence])
+
+      generator = build_generator(dry_run: true, quiet: false)
+      allow(generator).to receive(:invoke)
+
+      expect do
+        generator.detect_and_install_missing_migrations
+      end.to output(/would invoke pgbus:add_presence/).to_stdout
+      expect(generator).not_to have_received(:invoke)
+    end
+
+    it "passes --database through when explicitly set via options" do
+      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
+        .and_return(%i[add_presence])
+
+      generator = build_generator(dry_run: false, database: "queue_db")
+      allow(generator).to receive(:invoke)
+
+      generator.detect_and_install_missing_migrations
+
+      expect(generator).to have_received(:invoke).with("pgbus:add_presence", ["--database=queue_db"])
+    end
+
+    it "auto-detects --database from Pgbus.configuration.connects_to" do
+      allow(Pgbus.configuration).to receive(:connects_to).and_return(database: { writing: :pgbus })
+      allow(Pgbus::BusRecord).to receive(:connection).and_return(mock_connection)
+      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
+        .and_return(%i[add_presence])
+
+      generator = build_generator(dry_run: false)
+      allow(generator).to receive(:invoke)
+
+      generator.detect_and_install_missing_migrations
+
+      expect(generator).to have_received(:invoke).with("pgbus:add_presence", ["--database=pgbus"])
+    end
+
+    it "logs a skip message and does not invoke anything when ActiveRecord is not loaded" do
+      hide_const("ActiveRecord::Base")
+
+      generator = build_generator(quiet: false)
+      allow(generator).to receive(:invoke)
+
+      expect do
+        generator.detect_and_install_missing_migrations
+      end.to output(/ActiveRecord not loaded/).to_stdout
+      expect(generator).not_to have_received(:invoke)
     end
   end
 

--- a/spec/pgbus/generators/database_target_detector_spec.rb
+++ b/spec/pgbus/generators/database_target_detector_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "pgbus/generators/database_target_detector"
+
+RSpec.describe Pgbus::Generators::DatabaseTargetDetector do
+  # @tmpdir is set inside an around block so Dir.mktmpdir's block
+  # semantics (auto-cleanup) work. A `let` can't bridge the block
+  # boundary, so the instance variable is the idiomatic shape here.
+  subject(:detector) { described_class.new(destination_root: @tmpdir) } # rubocop:disable RSpec/InstanceVariable
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      FileUtils.mkdir_p(File.join(dir, "config", "initializers"))
+      example.run
+    end
+  end
+
+  # The runtime path takes priority over file scanning. Tests that
+  # exercise the static scanners need to neutralise it.
+  before do
+    allow(Pgbus.configuration).to receive(:connects_to).and_return(nil)
+  end
+
+  def write_file(relative, content)
+    path = File.join(@tmpdir, relative) # rubocop:disable RSpec/InstanceVariable
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  describe "#detect" do
+    context "with runtime configuration taking priority" do
+      it "returns the writing database name from Pgbus.configuration.connects_to" do
+        allow(Pgbus.configuration).to receive(:connects_to)
+          .and_return(database: { writing: :pgbus })
+
+        expect(detector.detect).to eq("pgbus")
+      end
+
+      it "handles string-keyed hashes" do
+        allow(Pgbus.configuration).to receive(:connects_to)
+          .and_return("database" => { "writing" => "queue_db" })
+
+        expect(detector.detect).to eq("queue_db")
+      end
+
+      it "returns nil when connects_to is not a hash" do
+        allow(Pgbus.configuration).to receive(:connects_to).and_return(:unexpected)
+
+        expect(detector.detect).to be_nil
+      end
+
+      it "returns nil when connects_to is nil (runtime falls through to file scan)" do
+        allow(Pgbus.configuration).to receive(:connects_to).and_return(nil)
+
+        expect(detector.detect).to be_nil
+      end
+
+      it "does not raise if accessing the configuration fails" do
+        allow(Pgbus.configuration).to receive(:connects_to).and_raise(StandardError, "boom")
+
+        expect(detector.detect).to be_nil
+      end
+    end
+
+    context "when scanning config/initializers/pgbus.rb" do
+      it "extracts the database name from a symbol-keyed connects_to" do
+        write_file("config/initializers/pgbus.rb", <<~RUBY)
+          Pgbus.configure do |c|
+            c.connects_to = { database: { writing: :pgbus } }
+          end
+        RUBY
+
+        expect(detector.detect).to eq("pgbus")
+      end
+
+      it "extracts from a parenthesized call form" do
+        write_file("config/initializers/pgbus.rb", <<~RUBY)
+          Pgbus.configure do |c|
+            c.connects_to(database: { writing: :queue_db })
+          end
+        RUBY
+
+        expect(detector.detect).to eq("queue_db")
+      end
+
+      it "returns nil when the initializer exists but has no connects_to" do
+        write_file("config/initializers/pgbus.rb", <<~RUBY)
+          Pgbus.configure do |c|
+            c.database_url = ENV["DATABASE_URL"]
+          end
+        RUBY
+
+        expect(detector.detect).to be_nil
+      end
+
+      it "returns nil when the initializer is absent" do
+        expect(detector.detect).to be_nil
+      end
+    end
+
+    context "when scanning config/application.rb" do
+      it "extracts the database name from connects_to in application.rb" do
+        write_file("config/application.rb", <<~RUBY)
+          module MyApp
+            class Application < Rails::Application
+              config.after_initialize do
+                Pgbus.configuration.connects_to = { database: { writing: :pgbus } }
+              end
+            end
+          end
+        RUBY
+
+        expect(detector.detect).to eq("pgbus")
+      end
+    end
+
+    context "with conflicting sources" do
+      it "prefers the runtime configuration over the initializer scan" do
+        allow(Pgbus.configuration).to receive(:connects_to)
+          .and_return(database: { writing: :runtime_db })
+        write_file("config/initializers/pgbus.rb", <<~RUBY)
+          Pgbus.configure do |c|
+            c.connects_to = { database: { writing: :file_db } }
+          end
+        RUBY
+
+        expect(detector.detect).to eq("runtime_db")
+      end
+
+      it "prefers the initializer over application.rb" do
+        write_file("config/initializers/pgbus.rb", <<~RUBY)
+          Pgbus.configure { |c| c.connects_to = { database: { writing: :init_db } } }
+        RUBY
+        write_file("config/application.rb", <<~RUBY)
+          Pgbus.configuration.connects_to = { database: { writing: :app_db } }
+        RUBY
+
+        expect(detector.detect).to eq("init_db")
+      end
+    end
+  end
+end

--- a/spec/pgbus/generators/migration_detector_spec.rb
+++ b/spec/pgbus/generators/migration_detector_spec.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pgbus/generators/migration_detector"
+
+RSpec.describe Pgbus::Generators::MigrationDetector do
+  subject(:detector) { described_class.new(connection) }
+
+  let(:connection) { double("ActiveRecord::Connection") }
+
+  # Default: every core table exists so fresh_install? is false. Tests
+  # override specific tables via stub_table / stub_missing helpers.
+  before do
+    stub_tables(described_class::CORE_INSTALL_TABLES + %w[pgbus_uniqueness_keys pgbus_failed_events])
+    allow(connection).to receive_messages(columns: [], indexes: [])
+  end
+
+  # Test helpers -----------------------------------------------------------
+  #
+  # Tests in this file stub connection.table_exists? by building up a
+  # set of "present" tables and routing the predicate through it. That
+  # lets us write tests as "given the DB has tables X and Y, expect the
+  # detector to return..." without tons of boilerplate.
+
+  def stub_tables(names)
+    present = Set.new(names.map(&:to_s))
+    allow(connection).to receive(:table_exists?) { |name| present.include?(name.to_s) }
+    @present_tables = present
+  end
+
+  # Both add_table and remove_table mutate the set captured by
+  # stub_tables. The instance-variable pattern is deliberate: helper
+  # methods need a shared reference across before/example boundaries,
+  # and let() blocks would need a workaround for the mutation.
+  def add_table(name)
+    @present_tables << name.to_s # rubocop:disable RSpec/InstanceVariable
+  end
+
+  def remove_table(name)
+    @present_tables.delete(name.to_s) # rubocop:disable RSpec/InstanceVariable
+  end
+
+  def stub_columns(table, names)
+    allow(connection).to receive(:columns).with(table).and_return(
+      names.map { |n| double("Column", name: n) }
+    )
+  end
+
+  def stub_indexes(table, names)
+    allow(connection).to receive(:indexes).with(table).and_return(
+      names.map { |n| double("Index", name: n) }
+    )
+  end
+
+  describe "#missing_migrations" do
+    context "when the database has no pgbus tables at all" do
+      it "returns the FRESH_INSTALL sentinel so the caller redirects to pgbus:install" do
+        stub_tables([]) # truly empty
+
+        expect(detector.missing_migrations).to eq([described_class::FRESH_INSTALL])
+      end
+    end
+
+    context "when pgbus_uniqueness_keys is present and up to date" do
+      it "does not queue the uniqueness_keys migration" do
+        expect(detector.missing_migrations).not_to include(:uniqueness_keys)
+      end
+    end
+
+    context "when pgbus_uniqueness_keys is missing" do
+      before { remove_table("pgbus_uniqueness_keys") }
+
+      it "queues the uniqueness_keys migration" do
+        expect(detector.missing_migrations).to include(:uniqueness_keys)
+      end
+
+      it "queues it exactly once even if legacy pgbus_job_locks also exists" do
+        add_table("pgbus_job_locks")
+
+        # The migrate_job_locks template is idempotent — handles both
+        # fresh-install and legacy-upgrade paths. We only need one
+        # entry in the output list.
+        expect(detector.missing_migrations.count(:uniqueness_keys)).to eq(1)
+      end
+    end
+
+    context "with job stats detection" do
+      context "when pgbus_job_stats is missing entirely" do
+        before { remove_table("pgbus_job_stats") }
+
+        it "queues add_job_stats + latency + queue_index so the table lands on the current schema" do
+          missing = detector.missing_migrations
+          expect(missing).to include(:add_job_stats, :add_job_stats_latency, :add_job_stats_queue_index)
+        end
+      end
+
+      context "when pgbus_job_stats exists without latency columns" do
+        before do
+          add_table("pgbus_job_stats")
+          stub_columns("pgbus_job_stats", %w[id job_class queue_name status duration_ms created_at])
+          stub_indexes("pgbus_job_stats", %w[idx_pgbus_job_stats_time idx_pgbus_job_stats_queue_time])
+        end
+
+        it "queues add_job_stats_latency but not add_job_stats" do
+          missing = detector.missing_migrations
+          expect(missing).to include(:add_job_stats_latency)
+          expect(missing).not_to include(:add_job_stats)
+        end
+
+        it "does NOT queue add_job_stats_queue_index when that index already exists" do
+          expect(detector.missing_migrations).not_to include(:add_job_stats_queue_index)
+        end
+      end
+
+      context "when pgbus_job_stats exists with latency columns but missing queue_index" do
+        before do
+          add_table("pgbus_job_stats")
+          stub_columns("pgbus_job_stats", %w[id job_class queue_name status duration_ms enqueue_latency_ms retry_count created_at])
+          stub_indexes("pgbus_job_stats", %w[idx_pgbus_job_stats_time idx_pgbus_job_stats_class_time])
+        end
+
+        it "queues only add_job_stats_queue_index" do
+          missing = detector.missing_migrations
+          expect(missing).to include(:add_job_stats_queue_index)
+          expect(missing).not_to include(:add_job_stats, :add_job_stats_latency)
+        end
+      end
+    end
+
+    context "with stream stats detection" do
+      it "queues add_stream_stats when the table is missing" do
+        expect(detector.missing_migrations).to include(:add_stream_stats)
+      end
+
+      it "does not queue add_stream_stats when the table already exists" do
+        add_table("pgbus_stream_stats")
+
+        expect(detector.missing_migrations).not_to include(:add_stream_stats)
+      end
+    end
+
+    context "with presence detection" do
+      it "queues add_presence when pgbus_presence_members is missing" do
+        expect(detector.missing_migrations).to include(:add_presence)
+      end
+
+      it "does not queue add_presence when the table already exists" do
+        add_table("pgbus_presence_members")
+
+        expect(detector.missing_migrations).not_to include(:add_presence)
+      end
+    end
+
+    context "with queue states detection" do
+      it "queues add_queue_states when pgbus_queue_states is missing" do
+        expect(detector.missing_migrations).to include(:add_queue_states)
+      end
+    end
+
+    context "with outbox detection" do
+      it "queues add_outbox when pgbus_outbox_entries is missing" do
+        expect(detector.missing_migrations).to include(:add_outbox)
+      end
+    end
+
+    context "with recurring detection" do
+      it "queues add_recurring when both recurring tables are missing" do
+        expect(detector.missing_migrations).to include(:add_recurring)
+      end
+
+      it "queues add_recurring when only one of the two recurring tables is missing" do
+        add_table("pgbus_recurring_tasks")
+        # pgbus_recurring_executions still missing
+
+        expect(detector.missing_migrations).to include(:add_recurring)
+      end
+
+      it "does not queue add_recurring when both recurring tables exist" do
+        add_table("pgbus_recurring_tasks")
+        add_table("pgbus_recurring_executions")
+
+        expect(detector.missing_migrations).not_to include(:add_recurring)
+      end
+    end
+
+    context "with failed events index detection" do
+      it "queues add_failed_events_index when the table exists but the unique index does not" do
+        stub_indexes("pgbus_failed_events", %w[idx_pgbus_failed_events_queue idx_pgbus_failed_events_time])
+
+        expect(detector.missing_migrations).to include(:add_failed_events_index)
+      end
+
+      it "does not queue it when the unique index already exists" do
+        stub_indexes("pgbus_failed_events", %w[idx_pgbus_failed_events_queue_msg])
+
+        expect(detector.missing_migrations).not_to include(:add_failed_events_index)
+      end
+
+      it "does not queue it when the table itself does not exist (fresh install handles it)" do
+        remove_table("pgbus_failed_events")
+
+        expect(detector.missing_migrations).not_to include(:add_failed_events_index)
+      end
+    end
+
+    context "with a realistic partially-upgraded database snapshot" do
+      # Given a realistic "partially-upgraded" database (core install
+      # migration ran, job stats base migration ran, but neither latency
+      # nor queue_index were applied), we expect a specific ordered list
+      # of upgrade migrations so operators see a predictable plan.
+      before do
+        stub_tables(%w[
+                      pgbus_processed_events
+                      pgbus_processes
+                      pgbus_failed_events
+                      pgbus_semaphores
+                      pgbus_blocked_executions
+                      pgbus_batches
+                      pgbus_uniqueness_keys
+                      pgbus_job_stats
+                      pgbus_recurring_tasks
+                      pgbus_recurring_executions
+                    ])
+        stub_columns("pgbus_job_stats", %w[id job_class queue_name status duration_ms created_at])
+        stub_indexes("pgbus_job_stats", %w[idx_pgbus_job_stats_time])
+        stub_indexes("pgbus_failed_events", %w[idx_pgbus_failed_events_queue_msg])
+      end
+
+      it "queues only the specific add-on migrations that are missing" do
+        expect(detector.missing_migrations).to contain_exactly(
+          :add_job_stats_latency,
+          :add_job_stats_queue_index,
+          :add_stream_stats,
+          :add_presence,
+          :add_queue_states,
+          :add_outbox
+        )
+      end
+    end
+
+    context "when connection.table_exists? raises" do
+      # Defensive: the detector should not crash the generator if the
+      # AR connection is in a weird state. A raising probe is treated
+      # as "table does not exist".
+      before do
+        allow(connection).to receive(:table_exists?).and_raise(StandardError, "db connection reset")
+      end
+
+      it "treats all probes as missing and returns FRESH_INSTALL" do
+        expect(detector.missing_migrations).to eq([described_class::FRESH_INSTALL])
+      end
+    end
+  end
+
+  describe "GENERATOR_MAP" do
+    it "has an entry for every symbol returned by missing_migrations (excluding FRESH_INSTALL)" do
+      # Sanity check: if a new migration key is added to the detector
+      # without a GENERATOR_MAP entry, the update generator would
+      # silently skip it. Verify the mapping is complete by scanning
+      # every code path through the detector.
+      keys = %i[
+        uniqueness_keys
+        add_job_stats
+        add_job_stats_latency
+        add_job_stats_queue_index
+        add_stream_stats
+        add_presence
+        add_queue_states
+        add_outbox
+        add_recurring
+        add_failed_events_index
+      ]
+
+      keys.each do |key|
+        expect(described_class::GENERATOR_MAP).to have_key(key),
+                                                  "missing GENERATOR_MAP entry for #{key}"
+        expect(described_class::DESCRIPTIONS).to have_key(key),
+                                                 "missing DESCRIPTIONS entry for #{key}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extends `rails generate pgbus:update` beyond YAML-to-Ruby config conversion. It now inspects the live database and adds any pgbus migrations that are missing, in one pass. Auto-detects separate-database (`connects_to`) setups so users don't have to re-specify `--database=pgbus` every time.

## New behavior

Running `rails generate pgbus:update` now does three things in sequence, each independently skippable:

1. **YAML → Ruby conversion** (existing, unchanged). Skipped if `config/pgbus.yml` is absent OR the initializer already exists.

2. **Migration detection.** A new `MigrationDetector` class inspects the AR connection's tables, columns, and indexes against the known pgbus schema. For each gap, it queues the matching generator (e.g. `pgbus:add_presence`, `pgbus:add_stream_stats`, `pgbus:add_job_stats_queue_index`). Missing migrations are printed as a plan before execution so operators see what's coming.

3. **Generator invocation.** Each queued generator is invoked in-process via Thor's `invoke`, mirroring what the user would get running each generator by hand. Migrations land in `db/migrate/` (or `db/pgbus_migrate/` if a separate database is configured).

## Auto-detection of separate-database setups

A new `DatabaseTargetDetector` class figures out whether pgbus is configured to use a separate database and passes `--database=<name>` to each sub-generator automatically. Detection sources, in priority order:

1. `Pgbus.configuration.connects_to` (runtime, authoritative if the initializer has booted)
2. `config/initializers/pgbus.rb` (text scan)
3. `config/application.rb` (text scan — catches apps that set `connects_to` in app config instead of the pgbus initializer)

The regex rejects false positives like `connects_to role: :writing` by requiring the `database:` key.

## Flags

| Flag | Purpose |
|---|---|
| `--dry-run` | Print the plan without creating files |
| `--skip-config` | Skip the YAML conversion step |
| `--skip-migrations` | Skip the migration detection step |
| `--database=NAME` | Override auto-detection |
| `--quiet` | Suppress verbose per-step output |

## Edge cases handled

- **Fresh install (no pgbus tables):** the detector returns a `FRESH_INSTALL` sentinel, and the generator prints a redirect to `pgbus:install` instead of stacking 8 separate add_* migrations.
- **Legacy `pgbus_job_locks` → modern `pgbus_uniqueness_keys`:** one generator (`pgbus:migrate_job_locks`) handles both the fresh-install path and the legacy-upgrade path because its template is idempotent.
- **Partial job_stats upgrade:** if `pgbus_job_stats` exists but `enqueue_latency_ms` is missing, only `add_job_stats_latency` is queued (not the base table again).
- **AR not loaded:** logs a skip message and exits gracefully instead of crashing.
- **Connection probe raises:** each schema probe is rescued; a raising `table_exists?` is treated as "missing", so the detector falls through to FRESH_INSTALL.

## Test Coverage

Three new/updated spec files with 49 examples total:

- `spec/pgbus/generators/migration_detector_spec.rb` (24 examples) — every code path in the detector including the partially-upgraded-database snapshot, the fresh-install sentinel, and a map-completeness check that verifies every detector symbol has a matching `GENERATOR_MAP` + `DESCRIPTIONS` entry.
- `spec/pgbus/generators/database_target_detector_spec.rb` (12 examples) — runtime/initializer/application.rb paths, precedence rules, false-positive rejection, error resilience.
- `spec/generators/pgbus/update_generator_spec.rb` (13 examples, consolidated from the existing 5-test file plus 8 new) — FRESH_INSTALL redirect, up-to-date no-op, ordered invocation, dry-run skip, `--database` passthrough, auto-detection, AR-not-loaded skip.

## README

Updated the "Upgrading from an older pgbus?" callout to describe the new two-in-one behavior, the auto-detection, and the useful flags.

## Verification

- [x] `bundle exec rubocop` passes (290 files, 0 offenses)
- [x] `bundle exec rspec` unit suite: 1289 examples, 0 failures (was 1214 — 75 new tests)
- [ ] Integration/system tests — CI will run them; no changes to that surface
- [ ] Real-world end-to-end test: run `rails g pgbus:update --dry-run` in a target app to verify the detected plan looks right before actually creating files

## Follow-ups

Not in this PR, but worth noting for future consideration:

- `pgbus:update` could also detect schema drift on tables it doesn't have a specific generator for (e.g. a missing check constraint added in a later pgbus version). Out of scope for v1 — most schema drift today has a matching generator.
- The MigrationDetector currently uses hard-coded index names. If an index is renamed in a future pgbus release, the detector needs to be updated. A map of "known-good index name → table" is probably the right abstraction if this pattern grows.
