### PR TITLE
docs(lfg): explicit rule for markdown inside quoted heredocs

### DIFF
--- a/.claude/commands/lfg.md
+++ b/.claude/commands/lfg.md
@@ -235,7 +235,7 @@ git push -u origin $(git branch --show-current)
 
 gh pr create --title "feat(scope): brief description" --body "$(cat <<'EOF'
 ## Summary
-- Key change 1
+- Key change 1 touching `lib/foo.rb`
 - Key change 2
 
 Closes #<issue_number>
@@ -246,6 +246,27 @@ Closes #<issue_number>
 EOF
 )"
 ```
+
+**Markdown inside the quoted heredoc is literal — do not escape.** The single-quoted `<<'EOF'` delimiter disables shell expansion on the body, so:
+
+- Write backticks as backticks: `` `foo` ``. Do NOT write `\`foo\``; that writes a literal backslash-backtick and breaks the code span.
+- Write dollar signs as-is: `$HOME`. No escaping needed.
+- Write backslashes as-is: `\n` stays `\n`.
+
+The body is copied verbatim into the PR / commit message. If you would not type a backslash in a GitHub comment, do not type one in the heredoc.
+
+If the body is long or contains many backticks / tables, prefer writing it to a temp file and passing `--body-file`:
+
+```bash
+cat > /tmp/pr-body.md << 'EOF'
+## Summary
+...any markdown...
+EOF
+gh pr create --title "..." --body-file /tmp/pr-body.md
+rm /tmp/pr-body.md
+```
+
+The `--body-file` path avoids the double-layer of shell interpretation entirely and makes long PR bodies easier to read in the terminal buffer.
 
 ---
 


### PR DESCRIPTION
## Summary

On PR #100 I escaped every backtick in the PR body as `\` out of misplaced caution about shell interpretation. The single-quoted `<<'EOF'` delimiter already disables expansion; the escapes ended up as visible backslashes in the rendered markdown and broke all code spans. User caught it and pointed out that the project's own `/lfg` command docs didn't actually say what needs escaping and what doesn't inside a heredoc body.

This adds an explicit rule to `.claude/commands/lfg.md`'s Push & PR section.

## Rule

Inside `"$(cat <<'EOF' ... EOF)"` with a **single-quoted** heredoc delimiter:

- Backticks are literal. Write `` `foo` ``, not `\`foo\``.
- Dollar signs are literal. `$HOME` stays `$HOME`.
- Backslashes are literal. `\n` stays as two characters.

The body is copied verbatim. If you would not type a backslash in a GitHub comment, do not type one in the heredoc.

## For long PR bodies with many code spans

The rule also points operators at the `--body-file` pattern, which avoids the double-layer shell interpretation entirely:

```bash
cat > /tmp/pr-body.md << 'EOF'
...markdown...
EOF
gh pr create --title "..." --body-file /tmp/pr-body.md
rm /tmp/pr-body.md
```

This PR's own body was written this way as a practice run.

## Test plan

- [x] Render this PR body on GitHub and verify all code spans display correctly (no visible backslashes)
- [x] Confirm the updated `.claude/commands/lfg.md` reads clearly in a plain text viewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR creation guidance with improved examples and instructions for handling complex pull request bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->