### PR TITLE
fix(streams): handle missing PGMQ queue table on first watermark read

### DIFF
--- a/lib/pgbus/client/read_after.rb
+++ b/lib/pgbus/client/read_after.rb
@@ -24,6 +24,10 @@ module Pgbus
         end
 
         rows.map { |row| build_envelope(row) }
+      rescue StandardError => e
+        raise unless missing_stream_queue?(e, sanitized)
+
+        []
       end
 
       def stream_current_msg_id(stream_name)
@@ -34,6 +38,10 @@ module Pgbus
             conn.exec(sql).first.fetch("max").to_i
           end
         end
+      rescue StandardError => e
+        raise unless missing_stream_queue?(e, sanitized)
+
+        0
       end
 
       def stream_oldest_msg_id(stream_name)
@@ -50,9 +58,41 @@ module Pgbus
             value&.to_i
           end
         end
+      rescue StandardError => e
+        raise unless missing_stream_queue?(e, sanitized)
+
+        nil
       end
 
       private
+
+      # True if +error+ is a PG::UndefinedTable (or an
+      # ActiveRecord::StatementInvalid wrapping one) complaining about
+      # the stream's own PGMQ queue table (pgmq.q_<sanitized> or
+      # pgmq.a_<sanitized>).
+      #
+      # The stream-watermark and replay SQL above run on every page render
+      # for streams like `pgbus_stream_from Current.user`, but the queue
+      # table is only created on the FIRST broadcast via
+      # `ensure_stream_queue`. On a fresh database the very first page
+      # render therefore reads from a table that doesn't exist yet —
+      # semantically, "no queue" means "no messages" and must translate
+      # to a 0 watermark / empty replay rather than an exception. Any
+      # OTHER UndefinedTable (wrong schema, typo, operator error) still
+      # propagates so real bugs don't get swallowed.
+      #
+      # See issue #101.
+      def missing_stream_queue?(error, sanitized)
+        pg_error = pg_undefined_table?(error) ? error : error.cause
+        return false unless pg_undefined_table?(pg_error)
+
+        message = pg_error.message.to_s
+        message.include?("pgmq.q_#{sanitized}") || message.include?("pgmq.a_#{sanitized}")
+      end
+
+      def pg_undefined_table?(error)
+        defined?(::PG::UndefinedTable) && error.is_a?(::PG::UndefinedTable)
+      end
 
       # Builds the union of live and archive tables. The outer ORDER BY + LIMIT
       # ensures we never return more than `limit` rows total even if both

--- a/spec/integration/streams/missing_queue_watermark_spec.rb
+++ b/spec/integration/streams/missing_queue_watermark_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "../../integration_helper"
+
+# Issue #101 regression test.
+#
+# On a fresh database, the PGMQ queue table for a given stream
+# (pgmq.q_<sanitized>) does not exist until the FIRST broadcast calls
+# ensure_stream_queue. The canonical use case for streams —
+# `pgbus_stream_from Current.user` in a layout — reads the watermark on
+# every page render, so the very first render of a never-broadcasted
+# stream previously raised PG::UndefinedTable. "No queue" is semantically
+# equivalent to "no messages" and must translate to a 0 watermark / empty
+# replay rather than a crash. See lib/pgbus/client/read_after.rb.
+RSpec.describe "Streams: missing queue watermark (integration)", :integration do
+  let(:client) { Pgbus.client }
+  let(:stream_name) { "never_broadcast_#{SecureRandom.hex(4)}" }
+
+  describe "#stream_current_msg_id" do
+    it "returns 0 when the PGMQ queue table has never been created" do
+      expect(client.stream_current_msg_id(stream_name)).to eq(0)
+    end
+  end
+
+  describe "#stream_oldest_msg_id" do
+    it "returns nil when the PGMQ queue table has never been created" do
+      expect(client.stream_oldest_msg_id(stream_name)).to be_nil
+    end
+  end
+
+  describe "#read_after" do
+    it "returns [] when the PGMQ queue table has never been created" do
+      expect(client.read_after(stream_name, after_id: 0)).to eq([])
+    end
+  end
+
+  describe "Pgbus::Streams::Stream#current_msg_id" do
+    it "returns 0 when the stream's PGMQ queue has never been created" do
+      stream = Pgbus::Streams::Stream.new(stream_name)
+      expect(stream.current_msg_id).to eq(0)
+    end
+  end
+
+  describe "after the first broadcast" do
+    it "starts returning real msg_ids once the queue table exists" do
+      stream = Pgbus::Streams::Stream.new(stream_name)
+
+      # Before the first broadcast: queue doesn't exist, watermark is 0.
+      expect(stream.current_msg_id).to eq(0)
+
+      # First broadcast lazily creates the queue.
+      stream.broadcast("<turbo-stream></turbo-stream>")
+
+      # After broadcast: real msg_id from the just-created table.
+      expect(stream.current_msg_id).to be >= 1
+    end
+  end
+end

--- a/spec/pgbus/client/read_after_spec.rb
+++ b/spec/pgbus/client/read_after_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Pgbus::Client::ReadAfter do
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)
+    stub_const("PG::UndefinedTable", Class.new(StandardError)) unless defined?(PG::UndefinedTable)
+    stub_const("PG::ConnectionBad", Class.new(StandardError)) unless defined?(PG::ConnectionBad)
     allow(client).to receive(:with_raw_connection).and_yield(raw_conn)
   end
 
@@ -117,6 +119,24 @@ RSpec.describe Pgbus::Client::ReadAfter do
       envelopes = client.read_after("chat", after_id: 1247)
       expect(envelopes.map(&:source)).to eq(%w[live archive])
     end
+
+    # Full replay from a fresh database: before any broadcast has happened,
+    # pgmq.q_<stream> and pgmq.a_<stream> don't exist. A just-connected SSE
+    # client asking for history must get an empty array, not a crash.
+    # See issue #101.
+    it "returns [] when the PGMQ queue tables do not exist yet" do
+      allow(raw_conn).to receive(:exec_params)
+        .and_raise(PG::UndefinedTable.new('relation "pgmq.q_pgbus_test_chat" does not exist'))
+
+      expect(client.read_after("chat", after_id: 0)).to eq([])
+    end
+
+    it "re-raises PG::UndefinedTable for unrelated tables" do
+      allow(raw_conn).to receive(:exec_params)
+        .and_raise(PG::UndefinedTable.new('relation "public.unrelated" does not exist'))
+
+      expect { client.read_after("chat", after_id: 0) }.to raise_error(PG::UndefinedTable)
+    end
   end
 
   describe "#stream_current_msg_id" do
@@ -142,6 +162,46 @@ RSpec.describe Pgbus::Client::ReadAfter do
     it "rejects unsafe queue names" do
       expect { client.stream_current_msg_id("nope; DROP") }.to raise_error(ArgumentError)
     end
+
+    # A fresh database has not yet created pgmq.q_<stream> — the queue is
+    # created lazily on the first broadcast. The canonical use case for
+    # streams is `pgbus_stream_from Current.user` in a layout, which calls
+    # current_msg_id on every page render to compute the watermark. On a
+    # fresh database this query runs before any broadcast, so the queue
+    # table does not yet exist. "No queue" is semantically equivalent to
+    # "no messages", so the watermark must be 0 rather than an exception.
+    # See issue #101.
+    it "returns 0 when the PGMQ queue table does not exist yet" do
+      allow(raw_conn).to receive(:exec)
+        .and_raise(PG::UndefinedTable.new('relation "pgmq.q_pgbus_test_chat" does not exist'))
+
+      expect(client.stream_current_msg_id("chat")).to eq(0)
+    end
+
+    it "returns 0 when ActiveRecord::StatementInvalid wraps a PG::UndefinedTable" do
+      stub_const("ActiveRecord::StatementInvalid", Class.new(StandardError)) unless defined?(ActiveRecord::StatementInvalid)
+      cause = PG::UndefinedTable.new('relation "pgmq.q_pgbus_test_chat" does not exist')
+      wrapped = ActiveRecord::StatementInvalid.new(
+        'PG::UndefinedTable: ERROR:  relation "pgmq.q_pgbus_test_chat" does not exist'
+      )
+      allow(wrapped).to receive(:cause).and_return(cause)
+      allow(raw_conn).to receive(:exec).and_raise(wrapped)
+
+      expect(client.stream_current_msg_id("chat")).to eq(0)
+    end
+
+    it "re-raises PG::UndefinedTable for unrelated tables" do
+      allow(raw_conn).to receive(:exec)
+        .and_raise(PG::UndefinedTable.new('relation "public.some_other_table" does not exist'))
+
+      expect { client.stream_current_msg_id("chat") }.to raise_error(PG::UndefinedTable)
+    end
+
+    it "re-raises other PG errors" do
+      allow(raw_conn).to receive(:exec).and_raise(PG::ConnectionBad.new("server closed"))
+
+      expect { client.stream_current_msg_id("chat") }.to raise_error(PG::ConnectionBad)
+    end
   end
 
   describe "#stream_oldest_msg_id" do
@@ -162,6 +222,23 @@ RSpec.describe Pgbus::Client::ReadAfter do
       allow(result).to receive(:first).and_return({ "least" => nil })
       allow(raw_conn).to receive(:exec).and_return(result)
       expect(client.stream_oldest_msg_id("chat")).to be_nil
+    end
+
+    # Same missing-queue scenario as stream_current_msg_id — gap detection
+    # is called on every replay request, and on a fresh database the queue
+    # hasn't been created yet. See issue #101.
+    it "returns nil when the PGMQ queue tables do not exist yet" do
+      allow(raw_conn).to receive(:exec)
+        .and_raise(PG::UndefinedTable.new('relation "pgmq.q_pgbus_test_chat" does not exist'))
+
+      expect(client.stream_oldest_msg_id("chat")).to be_nil
+    end
+
+    it "re-raises PG::UndefinedTable for unrelated tables" do
+      allow(raw_conn).to receive(:exec)
+        .and_raise(PG::UndefinedTable.new('relation "public.unrelated" does not exist'))
+
+      expect { client.stream_oldest_msg_id("chat") }.to raise_error(PG::UndefinedTable)
     end
   end
 end


### PR DESCRIPTION
## Summary

Fix `PG::UndefinedTable` crash on the first read of a stream whose queue table has not been created yet. This is the canonical `pgbus_stream_from Current.user` scenario reported in #101 — 100% broken in CI on fresh databases, silently masked in dev where queue tables accumulate across runs.

Root cause: `Pgbus::Client::ReadAfter#stream_current_msg_id`, `#stream_oldest_msg_id`, and `#read_after` all query `pgmq.q_<sanitized>` / `pgmq.a_<sanitized>` unconditionally. For ephemeral per-subject streams the queue table is only created on the first broadcast via `ensure_stream_queue`, so the very first page render raises before any broadcast has had a chance to materialise the table.

Fix at `lib/pgbus/client/read_after.rb`: rescue `PG::UndefinedTable` (plus `ActiveRecord::StatementInvalid` wrapping one) **only** when the error message names the stream's own `pgmq.q_<sanitized>` or `pgmq.a_<sanitized>`. Semantically "no queue" means "no messages" — watermark 0, oldest nil, replay empty. Any other `UndefinedTable` propagates so genuine misconfigurations aren't masked.

## Why fix at the client level (not `Streams::Stream`)

The reporter's workaround prepends onto `Pgbus::Streams::Stream#current_msg_id`, but the issue itself recommends fixing at the client. That is the correct level because:

- `Stream#current_msg_id` is a thin pass-through — fixing there leaves direct callers (dashboard, tooling, custom code) exposed to the same bug
- `read_after` has the identical failure mode and is not routed through `Stream#current_msg_id`
- A single `missing_stream_queue?` helper handles all three methods uniformly

## Why not pre-check / eagerly create the queue

Pre-checking would require an extra `information_schema` lookup on every render. Eagerly creating the queue on read would defeat the whole point of lazy stream queue creation — ephemeral per-user streams would leak queue tables forever just because someone rendered a layout.

## Test plan

- [x] `bundle exec rubocop` — 291 files, 0 offenses
- [x] `bundle exec rspec spec/pgbus` — 1267 unit examples, 0 failures
- [x] `PGBUS_DATABASE_URL=... bundle exec rspec spec/integration` — 121 integration examples, 0 failures (includes 5 new real-Postgres regression tests in `spec/integration/streams/missing_queue_watermark_spec.rb`)
- [x] Integration test covers the full lazy-create lifecycle: `stream.current_msg_id` returns 0 before any broadcast, then returns real msg_ids after the first `broadcast` lazily creates the queue

## Test coverage added

**Unit** (`spec/pgbus/client/read_after_spec.rb`, +9 cases):
- `stream_current_msg_id` returns 0 when queue table doesn't exist
- `stream_current_msg_id` returns 0 when `ActiveRecord::StatementInvalid` wraps a `PG::UndefinedTable`
- `stream_current_msg_id` re-raises for unrelated tables
- `stream_current_msg_id` re-raises other `PG` errors
- `stream_oldest_msg_id` returns nil when queue tables don't exist
- `stream_oldest_msg_id` re-raises for unrelated tables
- `read_after` returns `[]` when queue tables don't exist
- `read_after` re-raises for unrelated tables

**Integration** (`spec/integration/streams/missing_queue_watermark_spec.rb`, +5 cases against real Postgres):
- `Pgbus::Client#stream_current_msg_id` returns 0 for never-created queue
- `Pgbus::Client#stream_oldest_msg_id` returns nil for never-created queue
- `Pgbus::Client#read_after` returns `[]` for never-created queue
- `Pgbus::Streams::Stream#current_msg_id` (the exact path from the issue backtrace) returns 0 for never-created queue
- After the first broadcast, `current_msg_id` starts returning real msg_ids (lazy-create transition)

Closes #101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stream watermark operations now gracefully handle missing queues, returning empty/neutral results instead of raising errors. Current message ID defaults to 0, oldest message ID to nil, and read operations return empty arrays for streams whose queue tables haven't been created yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->