### PR TITLE
fix(streams): case-insensitive match for missing PGMQ stream queue

### DIFF
--- a/lib/pgbus/client/read_after.rb
+++ b/lib/pgbus/client/read_after.rb
@@ -81,13 +81,19 @@ module Pgbus
       # OTHER UndefinedTable (wrong schema, typo, operator error) still
       # propagates so real bugs don't get swallowed.
       #
-      # See issue #101.
+      # See issues #101 and #104. The comparison is case-insensitive because
+      # Postgres downcases unquoted identifiers in its error output, while
+      # `sanitized` can contain uppercase characters for GlobalID-keyed streams
+      # (e.g. `pgbus_stream_Z2lkOi8vY29zbW9zL1VzZXIvMQ` from
+      # `pgbus_stream_from Current.user`). A case-sensitive substring match
+      # would miss the downcased relation name and let the exception escape.
       def missing_stream_queue?(error, sanitized)
         pg_error = pg_undefined_table?(error) ? error : error.cause
         return false unless pg_undefined_table?(pg_error)
 
-        message = pg_error.message.to_s
-        message.include?("pgmq.q_#{sanitized}") || message.include?("pgmq.a_#{sanitized}")
+        message = pg_error.message.to_s.downcase
+        needle = sanitized.downcase
+        message.include?("pgmq.q_#{needle}") || message.include?("pgmq.a_#{needle}")
       end
 
       def pg_undefined_table?(error)

--- a/lib/pgbus/client/read_after.rb
+++ b/lib/pgbus/client/read_after.rb
@@ -87,13 +87,18 @@ module Pgbus
       # (e.g. `pgbus_stream_Z2lkOi8vY29zbW9zL1VzZXIvMQ` from
       # `pgbus_stream_from Current.user`). A case-sensitive substring match
       # would miss the downcased relation name and let the exception escape.
+      #
+      # The regex uses `\b` word boundaries so `pgmq.q_<needle>` doesn't
+      # accidentally match longer related identifiers like
+      # `pgmq.q_<needle>_archive` — a PGMQ internal object we'd want to
+      # propagate as a real error rather than silently swallow.
       def missing_stream_queue?(error, sanitized)
         pg_error = pg_undefined_table?(error) ? error : error.cause
         return false unless pg_undefined_table?(pg_error)
 
         message = pg_error.message.to_s.downcase
-        needle = sanitized.downcase
-        message.include?("pgmq.q_#{needle}") || message.include?("pgmq.a_#{needle}")
+        needle = Regexp.escape(sanitized.downcase)
+        message.match?(/\bpgmq\.(?:q|a)_#{needle}\b/)
       end
 
       def pg_undefined_table?(error)

--- a/spec/pgbus/client/read_after_spec.rb
+++ b/spec/pgbus/client/read_after_spec.rb
@@ -190,6 +190,23 @@ RSpec.describe Pgbus::Client::ReadAfter do
       expect(client.stream_current_msg_id("chat")).to eq(0)
     end
 
+    # GlobalID-keyed streams (`pgbus_stream_from Current.user`) produce sanitized
+    # queue names like `pgbus_test_stream_Z2lkOi8vY29zbW9zL1VzZXIvMQ` — base64
+    # always contains uppercase letters. Postgres downcases unquoted identifiers
+    # in its error messages, so a naive case-sensitive substring match on the
+    # mixed-case sanitized name never fires and the PG::UndefinedTable bubbles
+    # up to the host app. See issue #104 (regression from #103).
+    it "returns 0 for a mixed-case GlobalID-style stream name when Postgres downcases the identifier" do
+      # Simulate Postgres downcasing: our SQL sent `...pgmq.q_pgbus_test_stream_Z2lk...`,
+      # the error reports `...pgmq.q_pgbus_test_stream_z2lk...`.
+      allow(raw_conn).to receive(:exec)
+        .and_raise(PG::UndefinedTable.new(
+                     'relation "pgmq.q_pgbus_test_stream_z2lkoi8vy29zbw9zl1vzzxivmq" does not exist'
+                   ))
+
+      expect(client.stream_current_msg_id("stream_Z2lkOi8vY29zbW9zL1VzZXIvMQ")).to eq(0)
+    end
+
     it "re-raises PG::UndefinedTable for unrelated tables" do
       allow(raw_conn).to receive(:exec)
         .and_raise(PG::UndefinedTable.new('relation "public.some_other_table" does not exist'))

--- a/spec/pgbus/client/read_after_spec.rb
+++ b/spec/pgbus/client/read_after_spec.rb
@@ -214,6 +214,16 @@ RSpec.describe Pgbus::Client::ReadAfter do
       expect { client.stream_current_msg_id("chat") }.to raise_error(PG::UndefinedTable)
     end
 
+    # The rescue must not accidentally swallow errors about a table whose name
+    # merely starts with our stream's q_/a_ identifier — only the exact queue
+    # and archive tables count as "missing stream queue". See PR #106 review.
+    it "re-raises PG::UndefinedTable for a longer table name that merely shares a prefix" do
+      allow(raw_conn).to receive(:exec)
+        .and_raise(PG::UndefinedTable.new('relation "pgmq.q_pgbus_test_chat_archive_v2" does not exist'))
+
+      expect { client.stream_current_msg_id("chat") }.to raise_error(PG::UndefinedTable)
+    end
+
     it "re-raises other PG errors" do
       allow(raw_conn).to receive(:exec).and_raise(PG::ConnectionBad.new("server closed"))
 


### PR DESCRIPTION
## Summary

The 0.6.2 rescue for missing PGMQ stream queues (#103) was case-sensitive, so it never fired for GlobalID-keyed streams like `pgbus_stream_from Current.user`. Postgres downcases unquoted identifiers in its error messages, while the sanitized queue name passed in from the caller keeps its original mixed case (base64 GlobalIDs always contain uppercase), so `message.include?("pgmq.q_#{sanitized}")` returned `false` and the `PG::UndefinedTable` escaped to the host app on every fresh database.

- `lib/pgbus/client/read_after.rb` — downcase both the PG error message and the sanitized needle inside `missing_stream_queue?` before the substring check. The `pgmq.q_` / `pgmq.a_` prefix is preserved, so unrelated missing tables still propagate.
- `spec/pgbus/client/read_after_spec.rb` — adds a regression test that simulates the exact scenario: a mixed-case sanitized name sent to Postgres, an all-lowercase identifier in the resulting error. Fails on `main`, passes with the fix.

Closes #104

## Test plan

- [x] `bundle exec rspec spec/pgbus/client/read_after_spec.rb` (21 examples, 0 failures)
- [x] `bundle exec rubocop lib/pgbus/client/read_after.rb spec/pgbus/client/read_after_spec.rb` (clean)
- [x] New regression spec fails on `main` before the fix (verified by running it with the old `missing_stream_queue?`)
- [x] Existing `#101` regression specs (all-lowercase stream names, unrelated `PG::UndefinedTable`, wrapped `ActiveRecord::StatementInvalid`) still pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust detection of missing stream queues: matching is now case-insensitive and avoids false positives on similarly named relations, preventing spurious errors.

* **Tests**
  * Added tests covering uppercase-style stream identifiers and negative cases to ensure correct behavior when unrelated tables share name prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->