### PR TITLE
refactor: pre-v1 P2 polish from issue #98

### DIFF
--- a/.flow/STREAMER_DESIGN.md
+++ b/.flow/STREAMER_DESIGN.md
@@ -42,7 +42,7 @@ lib/pgbus/web/streamer.rb                             # Worker-local singleton (
 lib/pgbus/web/streamer/registry.rb                    # Concurrent::Map<stream_name → Set<Connection>>
 lib/pgbus/web/streamer/connection.rb                  # One SSE client (io, cursor, per-io mutex, write_nonblock+deadline)
 lib/pgbus/web/streamer/listener.rb                    # One PG LISTEN connection, NOTIFY → dispatch_queue
-lib/pgbus/web/streamer/dispatcher.rb                  # Consumes dispatch_queue, runs read_after, fans out
+lib/pgbus/web/streamer/stream_event_dispatcher.rb     # Consumes dispatch_queue, runs read_after, fans out
 lib/pgbus/web/streamer/heartbeat.rb                   # Periodic SSE comment + dead-connection sweep
 lib/pgbus/web/streamer/io_writer.rb                   # write_nonblock + deadline, per-io mutex helpers
 lib/pgbus/web/streamer/puma_plugin.rb                 # before_worker_shutdown hook (close all sockets)
@@ -57,7 +57,7 @@ spec/lib/pgbus/web/streamer/registry_spec.rb
 spec/lib/pgbus/web/streamer/connection_spec.rb
 spec/lib/pgbus/web/streamer/io_writer_spec.rb         # write_nonblock semantics, EAGAIN handling, deadline
 spec/lib/pgbus/web/streamer/listener_spec.rb          # LISTEN health check + reconnect
-spec/lib/pgbus/web/streamer/dispatcher_spec.rb
+spec/lib/pgbus/web/streamer/stream_event_dispatcher_spec.rb
 spec/lib/pgbus/streams/cursor_spec.rb
 spec/lib/pgbus/streams/signed_name_spec.rb
 spec/lib/pgbus/streams/envelope_spec.rb

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -30,21 +30,33 @@ module Pgbus
     # Memoized — intentionally never invalidated at runtime. If the
     # pgbus_job_stats migration runs while the app is already running,
     # a restart is required for stat recording to begin.
+    #
+    # We only memoize a *successful* probe. A transient error (PG
+    # hiccup during boot, connection refused during a failover) is
+    # treated as "don't know yet" — the next call retries. Caching
+    # false on the first hiccup would permanently disable job stats
+    # for the process lifetime, which is a worse failure mode than
+    # a few retries. See issue #98 / PR #91 (StreamStat fix).
     def self.table_exists?
       return @table_exists if defined?(@table_exists)
 
       @table_exists = connection.table_exists?(table_name)
-    rescue StandardError
-      @table_exists = false
+    rescue StandardError => e
+      Pgbus.logger.debug { "[Pgbus] Failed to check job stat table: #{e.message}" }
+      false
     end
 
     # Memoized — checks if the latency migration has been applied.
+    # Same transient-error handling as `table_exists?`: a failed
+    # probe is not cached, so a later successful probe can still
+    # enable latency recording.
     def self.latency_columns?
       return @latency_columns if defined?(@latency_columns)
 
       @latency_columns = table_exists? && column_names.include?("enqueue_latency_ms")
-    rescue StandardError
-      @latency_columns = false
+    rescue StandardError => e
+      Pgbus.logger.debug { "[Pgbus] Failed to check job stat latency columns: #{e.message}" }
+      false
     end
 
     # Throughput: jobs per minute bucketed by minute for the last N minutes

--- a/app/models/pgbus/job_stat.rb
+++ b/app/models/pgbus/job_stat.rb
@@ -52,8 +52,9 @@ module Pgbus
     # enable latency recording.
     def self.latency_columns?
       return @latency_columns if defined?(@latency_columns)
+      return false unless table_exists?
 
-      @latency_columns = table_exists? && column_names.include?("enqueue_latency_ms")
+      @latency_columns = column_names.include?("enqueue_latency_ms")
     rescue StandardError => e
       Pgbus.logger.debug { "[Pgbus] Failed to check job stat latency columns: #{e.message}" }
       false

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -87,6 +87,11 @@ module Pgbus
 
       WILDCARD_REFRESH_INTERVAL = 30 # seconds
 
+      # Matches the physical queue name inside a "relation \"pgmq.q_foo\" does
+      # not exist" error. Frozen module constant to avoid recompiling the
+      # regex on every queue-missing error in hot fetch/read paths.
+      MISSING_QUEUE_REGEX = /pgmq\.q_(\w+)/
+
       private
 
       def claim_and_execute
@@ -255,8 +260,8 @@ module Pgbus
       # Extract the queue name from the error and remove it from the active list.
       def evict_missing_queues(error)
         prefix = "#{config.queue_prefix}_"
-        if error.message =~ /pgmq\.q_(\w+)/
-          physical_name = Regexp.last_match(1)
+        if (match = MISSING_QUEUE_REGEX.match(error.message))
+          physical_name = match[1]
           logical_name = physical_name.delete_prefix(prefix)
           if @queues.delete(logical_name)
             Pgbus.logger.warn { "[Pgbus] Evicted deleted queue '#{logical_name}' (#{physical_name}) from worker" }

--- a/lib/pgbus/streams.rb
+++ b/lib/pgbus/streams.rb
@@ -38,7 +38,7 @@ module Pgbus
       # Broadcasts a Turbo Stream HTML payload through the pgbus streamer.
       # PGMQ's `message` column is JSONB, so raw HTML strings can't be passed
       # directly. We wrap as `{"html": "..."}` on the way in and unwrap in
-      # Pgbus::Web::Streamer::Dispatcher before delivering to the SSE client.
+      # Pgbus::Web::Streamer::StreamEventDispatcher before delivering to the SSE client.
       # Callers pass a plain HTML string; the wrapping is an implementation
       # detail.
       #

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -875,28 +875,14 @@ module Pgbus
 
       # Extract uniqueness key from a JSON payload string and release its lock.
       def release_lock_for_payload(payload_str)
-        return unless payload_str
-
-        payload = payload_str.is_a?(String) ? JSON.parse(payload_str) : payload_str
-        key = payload[Uniqueness::METADATA_KEY]
+        key = extract_uniqueness_key_from_payload_str(payload_str)
         UniquenessKey.release!(key) if key
-      rescue JSON::ParserError => e
-        Pgbus.logger.debug { "[Pgbus::Web] Error parsing payload for lock release: #{e.message}" }
       end
 
       # Extract uniqueness keys from a collection of formatted messages and
       # release all associated locks in a single query.
       def release_locks_for_messages(messages)
-        keys = messages.filter_map do |m|
-          payload = m[:message]
-          next unless payload
-
-          parsed = payload.is_a?(String) ? JSON.parse(payload) : payload
-          parsed[Uniqueness::METADATA_KEY]
-        rescue JSON::ParserError
-          nil
-        end
-
+        keys = messages.filter_map { |m| extract_uniqueness_key_from_payload_str(m[:message]) }
         UniquenessKey.where(lock_key: keys).delete_all if keys.any?
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error releasing locks for messages: #{e.message}" }
@@ -908,16 +894,26 @@ module Pgbus
           "SELECT payload FROM pgbus_failed_events", "Pgbus Collect Failed Keys"
         )
 
-        keys = rows.to_a.filter_map do |row|
-          payload = JSON.parse(row["payload"])
-          payload[Uniqueness::METADATA_KEY]
-        rescue JSON::ParserError
-          nil
-        end
-
+        keys = rows.to_a.filter_map { |row| extract_uniqueness_key_from_payload_str(row["payload"]) }
         UniquenessKey.where(lock_key: keys).delete_all if keys.any?
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error releasing locks for failed events: #{e.message}" }
+      end
+
+      # Single unwrap point for PGMQ message / failed_event payload strings.
+      # Accepts a raw JSON string or an already-parsed Hash and returns the
+      # uniqueness metadata key, or nil when the payload is blank, unparseable,
+      # or carries no uniqueness metadata. Parse errors are swallowed at debug
+      # level because callers treat missing keys and malformed payloads
+      # identically (no lock to release).
+      def extract_uniqueness_key_from_payload_str(payload_str)
+        return nil unless payload_str
+
+        payload = payload_str.is_a?(String) ? JSON.parse(payload_str) : payload_str
+        payload[Uniqueness::METADATA_KEY]
+      rescue JSON::ParserError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error parsing payload for uniqueness key: #{e.message}" }
+        nil
       end
 
       # Archive the queue message a failed_event row points to. Idempotent —

--- a/lib/pgbus/web/streamer/heartbeat.rb
+++ b/lib/pgbus/web/streamer/heartbeat.rb
@@ -13,7 +13,7 @@ module Pgbus
       #      SSE clients.
       #
       #   2. Mark connections that have been idle longer than the
-      #      configured idle_timeout as dead. The Dispatcher's next pass
+      #      configured idle_timeout as dead. The StreamEventDispatcher's next pass
       #      picks them up via its disconnect path.
       #
       #   3. Post a DisconnectMessage for any connection already flagged
@@ -97,7 +97,7 @@ module Pgbus
         end
 
         def enqueue_disconnect(connection)
-          @queue << Dispatcher::DisconnectMessage.new(connection: connection)
+          @queue << StreamEventDispatcher::DisconnectMessage.new(connection: connection)
         end
       end
     end

--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -43,7 +43,7 @@ module Pgbus
             health_check_ms: @config.streams_listen_health_check_ms,
             logger: @logger
           )
-          @dispatcher = Dispatcher.new(
+          @dispatcher = StreamEventDispatcher.new(
             client: @client,
             registry: @registry,
             listener: @listener,
@@ -92,7 +92,7 @@ module Pgbus
               return
             end
 
-            @dispatch_queue << Dispatcher::ConnectMessage.new(connection: connection)
+            @dispatch_queue << StreamEventDispatcher::ConnectMessage.new(connection: connection)
           end
         end
 

--- a/lib/pgbus/web/streamer/stream_event_dispatcher.rb
+++ b/lib/pgbus/web/streamer/stream_event_dispatcher.rb
@@ -26,8 +26,12 @@ module Pgbus
       #
       # All state ownership lives on this one thread: the registry is
       # thread-safe (Phase 2.1) but the in-flight buffers are local to
-      # the Dispatcher and accessed only from this thread, so no locks.
-      class Dispatcher
+      # the dispatcher and accessed only from this thread, so no locks.
+      #
+      # Named StreamEventDispatcher (rather than just "Dispatcher") to
+      # disambiguate from Pgbus::Process::Dispatcher, which is an
+      # unrelated worker-side pool coordinator. See issue #98 item 8.
+      class StreamEventDispatcher
         WakeMessage       = Listener::WakeMessage
         ConnectMessage    = Data.define(:connection)
         DisconnectMessage = Data.define(:connection)
@@ -110,7 +114,7 @@ module Pgbus
             # than calling Thread#kill, which leaves IO state corrupt.
             # The orphaned thread will exit on its own once the blocking
             # call returns and it sees @running == false on the next loop.
-            @logger.warn { "[Pgbus::Streamer::Dispatcher] thread did not terminate within 5s" }
+            @logger.warn { "[Pgbus::Streamer::StreamEventDispatcher] thread did not terminate within 5s" }
           end
           @thread = nil
           self
@@ -141,7 +145,7 @@ module Pgbus
             end
           end
         rescue StandardError => e
-          @logger.error { "[Pgbus::Streamer::Dispatcher] crashed: #{e.class}: #{e.message}" }
+          @logger.error { "[Pgbus::Streamer::StreamEventDispatcher] crashed: #{e.class}: #{e.message}" }
           raise
         end
 
@@ -176,7 +180,7 @@ module Pgbus
           when ConnectMessage    then handle_connect(msg)
           when DisconnectMessage then handle_disconnect(msg)
           else
-            @logger.warn { "[Pgbus::Streamer::Dispatcher] unknown message: #{msg.class}" }
+            @logger.warn { "[Pgbus::Streamer::StreamEventDispatcher] unknown message: #{msg.class}" }
           end
         rescue StandardError => e
           # Intentionally swallows per-message failures so one bad
@@ -184,7 +188,7 @@ module Pgbus
           # connected client. The top-level run_loop rescue (below)
           # does re-raise — a crash *between* messages is a real bug
           # and the supervisor should see it.
-          @logger.error { "[Pgbus::Streamer::Dispatcher] handling #{msg.class} raised #{e.class}: #{e.message}" }
+          @logger.error { "[Pgbus::Streamer::StreamEventDispatcher] handling #{msg.class} raised #{e.class}: #{e.message}" }
         end
 
         def handle_wake(msg)
@@ -310,7 +314,7 @@ module Pgbus
           @scanned_cursor.delete(connection)
           cleanup_stream_if_unused(stream)
           connection.mark_dead!
-          @logger.error { "[Pgbus::Streamer::Dispatcher] connect failed for #{connection.id}: #{e.class}: #{e.message}" }
+          @logger.error { "[Pgbus::Streamer::StreamEventDispatcher] connect failed for #{connection.id}: #{e.class}: #{e.message}" }
         end
 
         def handle_disconnect(msg)

--- a/spec/pgbus/job_stat_spec.rb
+++ b/spec/pgbus/job_stat_spec.rb
@@ -115,13 +115,24 @@ RSpec.describe Pgbus::JobStat do
       expect(described_class.latency_columns?).to be false
     end
 
-    it "returns false on error without poisoning the memo" do
+    it "returns false on column_names error without poisoning the memo" do
       allow(described_class).to receive(:table_exists?).and_return(true)
       allow(described_class).to receive(:column_names).and_raise(StandardError, "no db")
 
       expect(described_class.latency_columns?).to be false
       # A transient error must not lock latency_columns? to false
       # for the process lifetime.
+      expect(described_class.instance_variable_defined?(:@latency_columns)).to be false
+    end
+
+    it "returns false when table_exists? transiently fails without poisoning the memo" do
+      # table_exists? returns false due to its own rescue path (transient PG
+      # error), not because the table genuinely doesn't exist. This must NOT
+      # memoize @latency_columns = false — the table may exist on the next
+      # call once the connection recovers.
+      allow(described_class).to receive(:table_exists?).and_return(false)
+
+      expect(described_class.latency_columns?).to be false
       expect(described_class.instance_variable_defined?(:@latency_columns)).to be false
     end
 

--- a/spec/pgbus/job_stat_spec.rb
+++ b/spec/pgbus/job_stat_spec.rb
@@ -71,12 +71,69 @@ RSpec.describe Pgbus::JobStat do
     end
   end
 
+  describe ".table_exists?" do
+    before do
+      # Undo the outer `before` that stubs table_exists? so we exercise
+      # the real memoization logic.
+      allow(described_class).to receive(:table_exists?).and_call_original
+      described_class.remove_instance_variable(:@table_exists) if described_class.instance_variable_defined?(:@table_exists)
+    end
+
+    after do
+      described_class.remove_instance_variable(:@table_exists) if described_class.instance_variable_defined?(:@table_exists)
+    end
+
+    it "returns false on connection error without poisoning the memo" do
+      allow(described_class).to receive(:connection).and_raise(StandardError, "no db")
+
+      expect(described_class.table_exists?).to be false
+      # The failed probe must NOT set @table_exists — otherwise a
+      # transient PG blip during boot permanently disables job stats
+      # for the process lifetime.
+      expect(described_class.instance_variable_defined?(:@table_exists)).to be false
+    end
+
+    it "memoizes a successful probe" do
+      fake_connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+      allow(fake_connection).to receive(:table_exists?).with(described_class.table_name).and_return(true)
+      allow(described_class).to receive(:connection).and_return(fake_connection)
+
+      expect(described_class.table_exists?).to be true
+      # Second call hits the memo, not the connection.
+      expect(described_class.table_exists?).to be true
+      expect(fake_connection).to have_received(:table_exists?).once
+    end
+  end
+
   describe ".latency_columns?" do
     before { described_class.remove_instance_variable(:@latency_columns) if described_class.instance_variable_defined?(:@latency_columns) }
+
+    after { described_class.remove_instance_variable(:@latency_columns) if described_class.instance_variable_defined?(:@latency_columns) }
 
     it "returns false when table does not exist" do
       allow(described_class).to receive(:table_exists?).and_return(false)
       expect(described_class.latency_columns?).to be false
+    end
+
+    it "returns false on error without poisoning the memo" do
+      allow(described_class).to receive(:table_exists?).and_return(true)
+      allow(described_class).to receive(:column_names).and_raise(StandardError, "no db")
+
+      expect(described_class.latency_columns?).to be false
+      # A transient error must not lock latency_columns? to false
+      # for the process lifetime.
+      expect(described_class.instance_variable_defined?(:@latency_columns)).to be false
+    end
+
+    it "memoizes a successful probe" do
+      allow(described_class).to receive_messages(
+        table_exists?: true,
+        column_names: %w[id job_class enqueue_latency_ms]
+      )
+
+      expect(described_class.latency_columns?).to be true
+      expect(described_class.latency_columns?).to be true
+      expect(described_class).to have_received(:column_names).once
     end
   end
 

--- a/spec/pgbus/web/streamer/heartbeat_spec.rb
+++ b/spec/pgbus/web/streamer/heartbeat_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Pgbus::Web::Streamer::Heartbeat do
       heartbeat.tick
 
       msg = dispatch_queue.pop
-      expect(msg).to be_a(Pgbus::Web::Streamer::Dispatcher::DisconnectMessage)
+      expect(msg).to be_a(Pgbus::Web::Streamer::StreamEventDispatcher::DisconnectMessage)
       expect(msg.connection).to be(c1)
     end
 
@@ -97,7 +97,7 @@ RSpec.describe Pgbus::Web::Streamer::Heartbeat do
       expect(c1.dead?).to be true
       expect(c1.comments).to be_empty # idle connections don't get a heartbeat
       msg = dispatch_queue.pop
-      expect(msg).to be_a(Pgbus::Web::Streamer::Dispatcher::DisconnectMessage)
+      expect(msg).to be_a(Pgbus::Web::Streamer::StreamEventDispatcher::DisconnectMessage)
       expect(msg.connection).to be(c1)
     end
 

--- a/spec/pgbus/web/streamer/instance_spec.rb
+++ b/spec/pgbus/web/streamer/instance_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Pgbus::Web::Streamer::Instance do
       streamer.start
       fake_pg.push_timeout
       expect(streamer.listener).to be_a(Pgbus::Web::Streamer::Listener)
-      expect(streamer.dispatcher).to be_a(Pgbus::Web::Streamer::Dispatcher)
+      expect(streamer.dispatcher).to be_a(Pgbus::Web::Streamer::StreamEventDispatcher)
       expect(streamer.heartbeat).to be_a(Pgbus::Web::Streamer::Heartbeat)
     end
 

--- a/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
+++ b/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Pgbus::Web::Streamer::Dispatcher do
+RSpec.describe Pgbus::Web::Streamer::StreamEventDispatcher do
   subject(:dispatcher) do
     described_class.new(
       client: client,
@@ -286,7 +286,7 @@ RSpec.describe Pgbus::Web::Streamer::Dispatcher do
     end
 
     def admin_envelope
-      Pgbus::Web::Streamer::Dispatcher::StreamEnvelope.new(
+      Pgbus::Web::Streamer::StreamEventDispatcher::StreamEnvelope.new(
         msg_id: 100,
         enqueued_at: nil,
         payload: "<turbo-stream>secret</turbo-stream>",
@@ -296,7 +296,7 @@ RSpec.describe Pgbus::Web::Streamer::Dispatcher do
     end
 
     def public_envelope
-      Pgbus::Web::Streamer::Dispatcher::StreamEnvelope.new(
+      Pgbus::Web::Streamer::StreamEventDispatcher::StreamEnvelope.new(
         msg_id: 101,
         enqueued_at: nil,
         payload: "<turbo-stream>everyone</turbo-stream>",


### PR DESCRIPTION
## Summary

Pre-v1 hardening pass from the audit tracking issue. Bundles four small items that each touch different files:

- **P1 #5** (already on this branch) — `JobStat.table_exists?` and `latency_columns?` no longer memoize `false` on transient PG errors. Mirrors the PR #91 fix to `StreamStat`. A PG blip at boot no longer permanently disables job stat recording for the worker's lifetime.
- **P2 #6** — extracted `extract_uniqueness_key_from_payload_str` helper in `lib/pgbus/web/data_source.rb` and rewired `release_lock_for_payload`, `release_locks_for_messages`, `release_locks_for_failed_events` through it. ~40 lines of duplicated `JSON.parse + rescue` gone.
- **P2 #7** — hoisted `/pgmq\.q_(\w+)/` to `MISSING_QUEUE_REGEX` module constant in `lib/pgbus/process/worker.rb`. Also switched from `=~ + Regexp.last_match` to `.match(...)` for a local `MatchData` (no shared thread-local state).
- **P2 #8** — renamed `Pgbus::Web::Streamer::Dispatcher` → `Pgbus::Web::Streamer::StreamEventDispatcher` to stop colliding with `Pgbus::Process::Dispatcher` in log grep and PR reviews. File and spec renamed via `git mv` (95–99% similarity, history preserved). `Pgbus::Process::Dispatcher` is untouched.

**Deferred to follow-up PRs** (per issue #98 scope discussion):
- **P3 #10** Prometheus / StatsD metrics export (~500 LOC, own PR)
- **P3 #11** Retry backoff per job class (~300 LOC, own PR)
- **P2 #9** DedupCache TOCTOU — author recommends leaving (DB unique constraint is authoritative)
- **P3 #12** In-process async mode — author recommends skip
- **P3 #13** Web UI i18n — author recommends skip
- **P1 #1** Worker/capsule pause — not tackled this pass
- **P1 #2** Worker graceful-shutdown SLO docs — docs-only, can follow up
- **P1 #3** `Stream#current_msg_id` render-path caching — needs verification first
- **P1 #4** Split `data_source.rb` — incremental, separate PRs

## Breaking-ish note

Log tags from the streamer dispatcher change:

- before: `[Pgbus::Streamer::Dispatcher]`
- after:  `[Pgbus::Streamer::StreamEventDispatcher]`

Operators with pinned log filters / alert rules on the old tag will need to update. No Ruby-level API surface changes — the class was internal to `Pgbus::Web::Streamer`.

Closes #98 for items 5, 6, 7, 8. Remaining items stay tracked in the issue.

## Test plan

- [x] `bundle exec rubocop` — clean across touched files
- [x] `bundle exec rspec spec/pgbus/web/streamer/` — 111 examples, 0 failures
- [x] `bundle exec rspec spec/pgbus/process/worker_spec.rb` — 39 examples, 0 failures (queue-eviction path still works with the constantised regex)
- [x] `bundle exec rspec spec/pgbus/web/data_source_spec.rb` — 35 examples, 0 failures (all three lock-release paths covered via `#discard_job`, `#discard_failed_event`, `#discard_all_failed`, `#discard_all_enqueued`)
- [x] Full suite delta vs `main`: same 26 pre-existing system/i18n failures on both branches (flaky Capybara + broken i18n normalization — unrelated to this PR)
- [ ] Smoke-test on a running dashboard: open a DLQ page, discard a failed event, verify the uniqueness lock row is gone and the message is archived


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database probe failures no longer permanently poison cached results; transient errors return false and allow retries, improving startup and failover reliability.
  * Improved resilience and clearer debug logging around JSON payload parsing during lock-release and stream-dispatch error paths.

* **Refactor**
  * Stream dispatching component renamed and its message handling updated for clearer logging and wiring (no user-facing behavior changes).

* **Tests**
  * Added and updated tests covering probe memoization, error paths, and streamer message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->