### PR TITLE
fix(streams): normalize queue names with hyphens/dots instead of rejecting

### DIFF
--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -191,8 +191,7 @@ module Pgbus
 
     def queue_name(name)
       full = "#{queue_prefix}_#{name}"
-      QueueNameValidator.validate!(full)
-      full
+      QueueNameValidator.normalize(full)
     end
 
     def dead_letter_queue_name(name)

--- a/lib/pgbus/queue_name_validator.rb
+++ b/lib/pgbus/queue_name_validator.rb
@@ -34,6 +34,23 @@ module Pgbus
       name
     end
 
+    # Normalizes a queue name by replacing common separators (hyphens, dots)
+    # with underscores, stripping remaining invalid characters, and collapsing
+    # consecutive underscores. Use this for names from external sources
+    # (e.g., Turbo stream names like "hotwire-livereload") where the intent
+    # is to derive a valid PGMQ queue name that preserves readability.
+    def normalize(name)
+      name = name.to_s
+      return validate!(name) if VALID_QUEUE_NAME_PATTERN.match?(name)
+
+      normalized = name.gsub(/[-.]/, "_")           # hyphens/dots → underscores
+                       .gsub(/[^a-zA-Z0-9_]/, "")   # strip remaining invalid chars
+                       .gsub(/_+/, "_")              # collapse consecutive underscores
+                       .gsub(/\A_|_\z/, "")          # strip leading/trailing underscores
+      validate!(normalized)
+      normalized
+    end
+
     # Sanitizes a queue name by removing invalid characters, then validates.
     # Use this for names from untrusted sources (e.g., URL params).
     def sanitize!(name)

--- a/spec/pgbus/client/ensure_stream_queue_spec.rb
+++ b/spec/pgbus/client/ensure_stream_queue_spec.rb
@@ -65,8 +65,14 @@ RSpec.describe Pgbus::Client::EnsureStreamQueue do
     end
 
     it "normalizes stream names with invalid characters via QueueNameValidator" do
-      # After normalization: "nope; DROP TABLE" → "nopeDROPTABLE" (safe for SQL)
+      received_sql = nil
+      allow(raw_conn).to receive(:exec) do |sql|
+        received_sql = sql
+      end
+
       expect { client.ensure_stream_queue("nope; DROP TABLE") }.not_to raise_error
+      expect(received_sql).to match(/pgmq\.a_pgbus_test_nopeDROPTABLE/i)
+      expect(received_sql).not_to include(";")
     end
   end
 end

--- a/spec/pgbus/client/ensure_stream_queue_spec.rb
+++ b/spec/pgbus/client/ensure_stream_queue_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Pgbus::Client::EnsureStreamQueue do
       expect(raw_conn).to have_received(:exec).twice
     end
 
-    it "rejects unsanitised stream names via QueueNameValidator" do
-      expect { client.ensure_stream_queue("nope; DROP TABLE") }
-        .to raise_error(ArgumentError)
+    it "normalizes stream names with invalid characters via QueueNameValidator" do
+      # After normalization: "nope; DROP TABLE" → "nopeDROPTABLE" (safe for SQL)
+      expect { client.ensure_stream_queue("nope; DROP TABLE") }.not_to raise_error
     end
   end
 end

--- a/spec/pgbus/client/read_after_spec.rb
+++ b/spec/pgbus/client/read_after_spec.rb
@@ -78,9 +78,10 @@ RSpec.describe Pgbus::Client::ReadAfter do
       expect(client.read_after("chat", after_id: 9999)).to eq([])
     end
 
-    it "rejects unsanitised stream names via QueueNameValidator" do
-      expect { client.read_after("bad'; DROP TABLE", after_id: 0) }
-        .to raise_error(ArgumentError)
+    it "normalizes stream names with invalid characters via QueueNameValidator" do
+      # After normalization: "bad'; DROP TABLE" → "badDROPTABLE" (safe for SQL)
+      allow(raw_conn).to receive(:exec_params).and_return(double("PG::Result", to_a: []))
+      expect { client.read_after("bad'; DROP TABLE", after_id: 0) }.not_to raise_error
     end
 
     it "passes after_id and limit as positional bind parameters" do
@@ -159,8 +160,12 @@ RSpec.describe Pgbus::Client::ReadAfter do
       expect(client.stream_current_msg_id("chat")).to eq(0)
     end
 
-    it "rejects unsafe queue names" do
-      expect { client.stream_current_msg_id("nope; DROP") }.to raise_error(ArgumentError)
+    it "normalizes unsafe queue names instead of rejecting" do
+      # After normalization: "nope; DROP" → "nopeDROP" (safe for SQL)
+      result = double("PG::Result")
+      allow(result).to receive(:first).and_return({ "max" => "0" })
+      allow(raw_conn).to receive(:exec).and_return(result)
+      expect { client.stream_current_msg_id("nope; DROP") }.not_to raise_error
     end
 
     # A fresh database has not yet created pgmq.q_<stream> — the queue is

--- a/spec/pgbus/client/read_after_spec.rb
+++ b/spec/pgbus/client/read_after_spec.rb
@@ -79,9 +79,16 @@ RSpec.describe Pgbus::Client::ReadAfter do
     end
 
     it "normalizes stream names with invalid characters via QueueNameValidator" do
-      # After normalization: "bad'; DROP TABLE" → "badDROPTABLE" (safe for SQL)
-      allow(raw_conn).to receive(:exec_params).and_return(double("PG::Result", to_a: []))
+      received_sql = nil
+      allow(raw_conn).to receive(:exec_params) do |sql, _params|
+        received_sql = sql
+        double("PG::Result", to_a: [])
+      end
+
       expect { client.read_after("bad'; DROP TABLE", after_id: 0) }.not_to raise_error
+      expect(received_sql).to match(/pgmq\.q_pgbus_test_badDROPTABLE/i)
+      expect(received_sql).to match(/pgmq\.a_pgbus_test_badDROPTABLE/i)
+      expect(received_sql).not_to include(";")
     end
 
     it "passes after_id and limit as positional bind parameters" do
@@ -161,11 +168,18 @@ RSpec.describe Pgbus::Client::ReadAfter do
     end
 
     it "normalizes unsafe queue names instead of rejecting" do
-      # After normalization: "nope; DROP" → "nopeDROP" (safe for SQL)
       result = double("PG::Result")
       allow(result).to receive(:first).and_return({ "max" => "0" })
-      allow(raw_conn).to receive(:exec).and_return(result)
+
+      received_sql = nil
+      allow(raw_conn).to receive(:exec) do |sql|
+        received_sql = sql
+        result
+      end
+
       expect { client.stream_current_msg_id("nope; DROP") }.not_to raise_error
+      expect(received_sql).to match(/pgmq\.q_pgbus_test_nopeDROP/i)
+      expect(received_sql).not_to include(";")
     end
 
     # A fresh database has not yet created pgmq.q_<stream> — the queue is

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -114,6 +114,14 @@ RSpec.describe Pgbus::Configuration do
     it "prefixes the queue name" do
       expect(config.queue_name("critical")).to eq("pgbus_critical")
     end
+
+    it "normalizes hyphens to underscores" do
+      expect(config.queue_name("hotwire-livereload")).to eq("pgbus_hotwire_livereload")
+    end
+
+    it "normalizes dots to underscores" do
+      expect(config.queue_name("my.queue")).to eq("pgbus_my_queue")
+    end
   end
 
   describe "#dead_letter_queue_name" do

--- a/spec/pgbus/queue_name_validator_spec.rb
+++ b/spec/pgbus/queue_name_validator_spec.rb
@@ -43,6 +43,37 @@ RSpec.describe Pgbus::QueueNameValidator do
     end
   end
 
+  describe ".normalize" do
+    it "replaces hyphens with underscores" do
+      expect(described_class.normalize("hotwire-livereload")).to eq("hotwire_livereload")
+    end
+
+    it "replaces dots with underscores" do
+      expect(described_class.normalize("my.queue.name")).to eq("my_queue_name")
+    end
+
+    it "collapses consecutive underscores after replacement" do
+      expect(described_class.normalize("my--queue")).to eq("my_queue")
+    end
+
+    it "strips leading/trailing underscores after replacement" do
+      expect(described_class.normalize("-leading")).to eq("leading")
+      expect(described_class.normalize("trailing-")).to eq("trailing")
+    end
+
+    it "strips characters that are not alphanumeric, hyphens, dots, or underscores" do
+      expect(described_class.normalize("queue!@#name")).to eq("queuename")
+    end
+
+    it "passes through already-valid names unchanged" do
+      expect(described_class.normalize("pgbus_default")).to eq("pgbus_default")
+    end
+
+    it "raises when normalized result is blank" do
+      expect { described_class.normalize("---!!!") }.to raise_error(ArgumentError, /cannot be blank/)
+    end
+  end
+
   describe ".sanitize!" do
     it "strips invalid characters and returns the result" do
       expect(described_class.sanitize!("my-queue.name!")).to eq("myqueuename")

--- a/spec/pgbus/security_spec.rb
+++ b/spec/pgbus/security_spec.rb
@@ -82,11 +82,12 @@ RSpec.describe "Security" do
       expect(config.queue_name("default")).to eq("pgbus_default")
     end
 
-    it "rejects queue names with special characters" do
+    it "normalizes queue names with special characters instead of rejecting" do
       config = Pgbus::Configuration.new
       config.queue_prefix = "pgbus"
 
-      expect { config.queue_name("my;queue") }.to raise_error(ArgumentError)
+      # Semicolons are stripped, hyphens/dots become underscores — safe for SQL
+      expect(config.queue_name("my;queue")).to eq("pgbus_myqueue")
     end
   end
 


### PR DESCRIPTION
## Summary

- Add `QueueNameValidator.normalize` that replaces hyphens/dots with underscores, strips invalid chars, and collapses consecutive underscores
- Change `Configuration#queue_name` to use `normalize` instead of `validate!`, making it the single normalization chokepoint for both publisher and subscriber paths
- Fast-path short-circuit when name already matches valid pattern (preserves allocation budget)

**Root cause**: `hotwire-livereload` gem broadcasts to a stream named `"hotwire-livereload"`. Pgbus's Turbo Streams patch intercepts this and tries to create a PGMQ queue named `"pgbus_hotwire-livereload"`, but `QueueNameValidator.validate!` rejects hyphens. Now it normalizes to `"pgbus_hotwire_livereload"` instead.

**Security**: `normalize` calls `validate!` internally, and `read_after`/`stream_current_msg_id` retain their additional `sanitize!` defense-in-depth layer. SQL injection via crafted stream names remains impossible.

## Test plan

- [x] `QueueNameValidator.normalize` specs: hyphens, dots, collapse, strip, passthrough, blank
- [x] `Configuration#queue_name` specs: hyphens and dots normalized
- [x] Security spec updated: special chars normalized not rejected
- [x] `ensure_stream_queue` and `read_after` specs updated for normalization behavior
- [x] Allocation budget spec passes (fast-path avoids extra allocations)
- [x] Full suite: 1433 examples, 0 failures
- [x] Rubocop: 291 files, no offenses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue names containing special characters are now automatically normalized. Hyphens and dots are converted to underscores, other invalid characters are removed, and leading and trailing underscores are stripped to generate valid identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->