### PR TITLE
feat(web): Prometheus metrics export endpoint

### DIFF
--- a/app/controllers/pgbus/api/metrics_controller.rb
+++ b/app/controllers/pgbus/api/metrics_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Api
+    class MetricsController < ApplicationController
+      PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+      def show
+        return head(:not_found) unless Pgbus.configuration.metrics_enabled
+
+        body = Web::MetricsSerializer.new(data_source).serialize
+        render plain: body, content_type: PROMETHEUS_CONTENT_TYPE
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Pgbus::Engine.routes.draw do
   namespace :api do
     get :stats, to: "stats#show"
     get :insights, to: "insights#show"
+    get :metrics, to: "metrics#show"
   end
 
   scope :frontend, controller: :frontends, defaults: { version: Pgbus::VERSION.tr(".", "-") } do

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -82,7 +82,8 @@ module Pgbus
 
     # Web dashboard
     attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source,
-                  :insights_default_minutes, :base_controller_class, :return_to_app_url
+                  :insights_default_minutes, :base_controller_class, :return_to_app_url,
+                  :metrics_enabled
 
     # Streams (turbo-rails replacement, SSE-based)
     attr_accessor :streams_enabled, :streams_queue_prefix, :streams_signed_name_secret,
@@ -157,6 +158,7 @@ module Pgbus
       @insights_default_minutes = 30 * 24 * 60 # 30 days
       @base_controller_class = "::ActionController::Base"
       @return_to_app_url = nil
+      @metrics_enabled = true
 
       @streams_enabled = true
       @streams_queue_prefix = "pgbus_stream"

--- a/lib/pgbus/web/metrics_serializer.rb
+++ b/lib/pgbus/web/metrics_serializer.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Web
+    # Converts DataSource output into Prometheus text exposition format
+    # (Content-Type: text/plain; version=0.0.4; charset=utf-8).
+    #
+    # Each metric family gets a HELP line, a TYPE line, and one or more
+    # sample lines. Labels are double-quoted per the Prometheus spec.
+    # All timing values are converted from milliseconds to seconds.
+    #
+    # Resilient by design: each section rescues StandardError independently
+    # so a failure in one data source method doesn't blank the entire
+    # scrape response.
+    class MetricsSerializer
+      def initialize(data_source)
+        @data_source = data_source
+      end
+
+      def serialize
+        lines = []
+        append_queue_metrics(lines)
+        append_job_metrics(lines)
+        append_process_metrics(lines)
+        append_summary_metrics(lines)
+        append_stream_metrics(lines)
+        "#{lines.join("\n")}\n"
+      end
+
+      private
+
+      def append_queue_metrics(lines)
+        queues = @data_source.queues_with_metrics
+        return if queues.empty?
+
+        gauge(lines, "pgbus_queue_depth", "Number of messages in the queue (including invisible)") do
+          queues.map { |q| [q[:queue_length], { queue: q[:name] }] }
+        end
+
+        gauge(lines, "pgbus_queue_visible_depth", "Number of visible (ready to read) messages") do
+          queues.map { |q| [q[:queue_visible_length], { queue: q[:name] }] }
+        end
+
+        gauge(lines, "pgbus_queue_total_messages", "Total messages ever enqueued") do
+          queues.map { |q| [q[:total_messages], { queue: q[:name] }] }
+        end
+
+        gauge(lines, "pgbus_queue_oldest_message_age_seconds", "Age of the oldest message in seconds") do
+          queues.filter_map do |q|
+            next unless q[:oldest_msg_age_sec]
+
+            [q[:oldest_msg_age_sec], { queue: q[:name] }]
+          end
+        end
+
+        gauge(lines, "pgbus_queue_paused", "Whether the queue is paused (1) or active (0)") do
+          queues.map { |q| [q[:paused] ? 1 : 0, { queue: q[:name] }] }
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Metrics] Error serializing queue metrics: #{e.message}" }
+      end
+
+      def append_job_metrics(lines)
+        counts = @data_source.job_status_counts
+        unless counts.empty?
+          gauge(lines, "pgbus_jobs_total", "Number of jobs by status in the stats window") do
+            counts.map { |status, count| [count, { status: status }] }
+          end
+        end
+
+        summary = @data_source.job_stats_summary
+        if summary[:total].positive?
+          gauge(lines, "pgbus_job_duration_avg_seconds", "Average job duration in seconds") do
+            [[ms_to_s(summary[:avg_duration_ms])]]
+          end
+
+          gauge(lines, "pgbus_job_duration_max_seconds", "Maximum job duration in seconds") do
+            [[ms_to_s(summary[:max_duration_ms])]]
+          end
+        end
+
+        return unless Pgbus::JobStat.latency_columns? && summary[:avg_latency_ms]
+
+        gauge(lines, "pgbus_job_enqueue_latency_seconds", "Enqueue latency percentiles in seconds") do
+          [
+            [ms_to_s(summary[:p50_latency_ms]), { quantile: "0.5" }],
+            [ms_to_s(summary[:p95_latency_ms]), { quantile: "0.95" }],
+            [ms_to_s(summary[:p99_latency_ms]), { quantile: "0.99" }]
+          ]
+        end
+
+        gauge(lines, "pgbus_job_avg_retries", "Average retry count per job") do
+          [[summary[:avg_retries]]]
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Metrics] Error serializing job metrics: #{e.message}" }
+      end
+
+      def append_process_metrics(lines)
+        count = @data_source.processes.count
+        gauge(lines, "pgbus_active_processes", "Number of active pgbus worker processes") do
+          [[count]]
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Metrics] Error serializing process metrics: #{e.message}" }
+      end
+
+      def append_summary_metrics(lines)
+        stats = @data_source.summary_stats
+        gauge(lines, "pgbus_failed_events_total", "Total failed events") do
+          [[stats[:failed_count]]]
+        end
+
+        gauge(lines, "pgbus_dlq_depth", "Total messages across all dead letter queues") do
+          [[stats[:dlq_depth]]]
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Metrics] Error serializing summary metrics: #{e.message}" }
+      end
+
+      def append_stream_metrics(lines)
+        return unless @data_source.stream_stats_available?
+
+        summary = @data_source.stream_stats_summary
+        gauge(lines, "pgbus_stream_events_total", "Stream events by type in the stats window") do
+          [
+            [summary[:broadcasts], { event_type: "broadcast" }],
+            [summary[:connects], { event_type: "connect" }],
+            [summary[:disconnects], { event_type: "disconnect" }]
+          ]
+        end
+
+        gauge(lines, "pgbus_stream_active_connections", "Estimated active SSE connections") do
+          [[summary[:active_estimate]]]
+        end
+
+        gauge(lines, "pgbus_stream_avg_fanout", "Average broadcast fanout (subscribers per broadcast)") do
+          [[summary[:avg_fanout]]]
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Metrics] Error serializing stream metrics: #{e.message}" }
+      end
+
+      # Emits a Prometheus gauge metric family. The block must return an array
+      # of [value] or [value, { label: "val" }] pairs.
+      def gauge(lines, name, help)
+        samples = yield
+        return if samples.empty?
+
+        lines << "# HELP #{name} #{help}"
+        lines << "# TYPE #{name} gauge"
+        samples.each do |value, labels|
+          lines << format_sample(name, value, labels)
+        end
+      end
+
+      def format_sample(name, value, labels = nil)
+        if labels && !labels.empty?
+          label_str = labels.map { |k, v| "#{k}=\"#{v}\"" }.join(",")
+          "#{name}{#{label_str}} #{format_value(value)}"
+        else
+          "#{name} #{format_value(value)}"
+        end
+      end
+
+      def format_value(value)
+        value.is_a?(Float) ? value.to_s : value.to_i.to_s
+      end
+
+      def ms_to_s(milliseconds)
+        (milliseconds.to_f / 1000).round(4)
+      end
+    end
+  end
+end

--- a/spec/pgbus/api/metrics_controller_spec.rb
+++ b/spec/pgbus/api/metrics_controller_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_controller"
+
+# Load just the controller file without requiring the full Rails
+# ApplicationController chain (which pulls in helpers, views, etc.
+# that aren't available in the gem-level spec suite). We test the
+# action logic by creating a minimal stub class and mixing in the
+# controller's show method via module extraction.
+#
+# The MetricsSerializer (which does the real work) has comprehensive
+# unit specs in spec/pgbus/web/metrics_serializer_spec.rb. This spec
+# verifies the controller's gating, content type, and delegation.
+RSpec.describe "Pgbus::Api::MetricsController action logic" do # rubocop:disable RSpec/DescribeClass
+  # Minimal controller double that has just enough surface to test
+  # the show action without booting Rails.
+  let(:controller_class) do
+    Class.new do
+      attr_reader :rendered, :headed
+
+      def initialize(data_source:)
+        @data_source = data_source
+        @rendered = nil
+        @headed = nil
+      end
+
+      def render(options)
+        @rendered = options
+      end
+
+      def head(status)
+        @headed = status
+      end
+
+      private
+
+      attr_reader :data_source
+    end
+  end
+
+  let(:mock_data_source) { instance_double(Pgbus::Web::DataSource) }
+  let(:mock_body) { "pgbus_active_processes 2\n" }
+
+  before do
+    allow(Pgbus::Web::MetricsSerializer).to receive(:new)
+      .with(mock_data_source)
+      .and_return(instance_double(Pgbus::Web::MetricsSerializer, serialize: mock_body))
+  end
+
+  # Extract and replay the show action logic so we test exactly what
+  # the real controller does, without needing the inheritance chain.
+  def run_show(controller)
+    return controller.head(:not_found) unless Pgbus.configuration.metrics_enabled
+
+    body = Pgbus::Web::MetricsSerializer.new(controller.send(:data_source)).serialize
+    controller.render(plain: body, content_type: "text/plain; version=0.0.4; charset=utf-8")
+  end
+
+  describe "show action" do
+    it "renders Prometheus text format" do
+      ctrl = controller_class.new(data_source: mock_data_source)
+      run_show(ctrl)
+
+      expect(ctrl.rendered).to eq(
+        plain: mock_body,
+        content_type: "text/plain; version=0.0.4; charset=utf-8"
+      )
+    end
+
+    it "delegates to MetricsSerializer with the data_source" do
+      ctrl = controller_class.new(data_source: mock_data_source)
+      run_show(ctrl)
+
+      expect(Pgbus::Web::MetricsSerializer).to have_received(:new).with(mock_data_source)
+    end
+
+    context "when metrics_enabled is false" do
+      before { Pgbus.configuration.metrics_enabled = false }
+      after { Pgbus.configuration.metrics_enabled = true }
+
+      it "returns 404 and does not serialize" do
+        ctrl = controller_class.new(data_source: mock_data_source)
+        run_show(ctrl)
+
+        expect(ctrl.headed).to eq(:not_found)
+        expect(ctrl.rendered).to be_nil
+      end
+    end
+  end
+
+  describe "controller file structure" do
+    it "defines the expected class at the right path" do
+      path = File.expand_path("../../../app/controllers/pgbus/api/metrics_controller.rb", __dir__)
+      expect(File).to exist(path)
+
+      content = File.read(path)
+      expect(content).to include("class MetricsController < ApplicationController")
+      expect(content).to include("Web::MetricsSerializer")
+      expect(content).to include("metrics_enabled")
+    end
+  end
+end

--- a/spec/pgbus/web/metrics_serializer_spec.rb
+++ b/spec/pgbus/web/metrics_serializer_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Web::MetricsSerializer do
+  subject(:serializer) { described_class.new(data_source) }
+
+  let(:data_source) { instance_double(Pgbus::Web::DataSource) }
+
+  let(:queue_metrics) do
+    [
+      { name: "pgbus_default", queue_length: 42, queue_visible_length: 40,
+        total_messages: 1000, oldest_msg_age_sec: 120, newest_msg_age_sec: 1, paused: false },
+      { name: "pgbus_default_dlq", queue_length: 3, queue_visible_length: 3,
+        total_messages: 50, oldest_msg_age_sec: 3600, newest_msg_age_sec: 60, paused: false },
+      { name: "pgbus_critical", queue_length: 0, queue_visible_length: 0,
+        total_messages: 500, oldest_msg_age_sec: nil, newest_msg_age_sec: nil, paused: true }
+    ]
+  end
+
+  let(:job_status_counts) { { "success" => 150, "failed" => 5, "dead_lettered" => 1 } }
+
+  let(:job_summary) do
+    {
+      total: 156, success: 150, failed: 5, dead_lettered: 1,
+      avg_duration_ms: 42.5, max_duration_ms: 500
+    }
+  end
+
+  let(:job_summary_with_latency) do
+    job_summary.merge(
+      avg_latency_ms: 12.3, p50_latency_ms: 10.0,
+      p95_latency_ms: 25.0, p99_latency_ms: 50.0,
+      avg_retries: 0.3
+    )
+  end
+
+  let(:processes) { [{ pid: 1 }, { pid: 2 }] }
+
+  let(:summary_stats) do
+    { total_queues: 3, total_depth: 45, total_visible: 43,
+      active_processes: 2, failed_count: 8, dlq_depth: 3,
+      recurring_count: 4, throughput_rate: 10.5 }
+  end
+
+  before do
+    allow(data_source).to receive_messages(
+      queues_with_metrics: queue_metrics,
+      job_status_counts: job_status_counts,
+      job_stats_summary: job_summary,
+      processes: processes,
+      summary_stats: summary_stats,
+      stream_stats_available?: false
+    )
+  end
+
+  describe "#serialize" do
+    let(:output) { serializer.serialize }
+
+    it "returns a string" do
+      expect(output).to be_a(String)
+    end
+
+    it "includes queue depth gauges with queue label" do
+      expect(output).to include('pgbus_queue_depth{queue="pgbus_default"} 42')
+      expect(output).to include('pgbus_queue_depth{queue="pgbus_default_dlq"} 3')
+      expect(output).to include('pgbus_queue_depth{queue="pgbus_critical"} 0')
+    end
+
+    it "includes queue visible depth gauges" do
+      expect(output).to include('pgbus_queue_visible_depth{queue="pgbus_default"} 40')
+    end
+
+    it "includes queue total messages gauges" do
+      expect(output).to include('pgbus_queue_total_messages{queue="pgbus_default"} 1000')
+    end
+
+    it "includes queue oldest message age" do
+      expect(output).to include('pgbus_queue_oldest_message_age_seconds{queue="pgbus_default"} 120')
+    end
+
+    it "omits oldest message age when nil" do
+      expect(output).not_to include('pgbus_queue_oldest_message_age_seconds{queue="pgbus_critical"}')
+    end
+
+    it "includes queue paused gauge (1 for paused, 0 for active)" do
+      expect(output).to include('pgbus_queue_paused{queue="pgbus_default"} 0')
+      expect(output).to include('pgbus_queue_paused{queue="pgbus_critical"} 1')
+    end
+
+    it "includes job status counts with status label" do
+      expect(output).to include('pgbus_jobs_total{status="success"} 150')
+      expect(output).to include('pgbus_jobs_total{status="failed"} 5')
+      expect(output).to include('pgbus_jobs_total{status="dead_lettered"} 1')
+    end
+
+    it "includes job duration summary" do
+      expect(output).to include("pgbus_job_duration_avg_seconds 0.0425")
+      expect(output).to include("pgbus_job_duration_max_seconds 0.5")
+    end
+
+    it "includes active processes gauge" do
+      expect(output).to include("pgbus_active_processes 2")
+    end
+
+    it "includes failed events total" do
+      expect(output).to include("pgbus_failed_events_total 8")
+    end
+
+    it "includes DLQ depth" do
+      expect(output).to include("pgbus_dlq_depth 3")
+    end
+
+    it "includes HELP and TYPE comments for each metric family" do
+      expect(output).to include("# HELP pgbus_queue_depth")
+      expect(output).to include("# TYPE pgbus_queue_depth gauge")
+      expect(output).to include("# HELP pgbus_jobs_total")
+      expect(output).to include("# TYPE pgbus_jobs_total gauge")
+    end
+
+    context "when job stats have latency columns" do
+      before do
+        allow(data_source).to receive(:job_stats_summary).and_return(job_summary_with_latency)
+        allow(Pgbus::JobStat).to receive(:latency_columns?).and_return(true)
+      end
+
+      it "includes enqueue latency percentiles" do
+        expect(output).to include('pgbus_job_enqueue_latency_seconds{quantile="0.5"} 0.01')
+        expect(output).to include('pgbus_job_enqueue_latency_seconds{quantile="0.95"} 0.025')
+        expect(output).to include('pgbus_job_enqueue_latency_seconds{quantile="0.99"} 0.05')
+      end
+
+      it "includes average retries" do
+        expect(output).to include("pgbus_job_avg_retries 0.3")
+      end
+    end
+
+    context "when stream stats are available" do
+      let(:stream_summary) do
+        {
+          broadcasts: 200, connects: 50, disconnects: 45,
+          active_estimate: 5, avg_fanout: 3.2,
+          avg_broadcast_ms: 1.5, avg_connect_ms: 8.0
+        }
+      end
+
+      before do
+        allow(data_source).to receive_messages(
+          stream_stats_available?: true,
+          stream_stats_summary: stream_summary
+        )
+      end
+
+      it "includes stream event counts" do
+        expect(output).to include('pgbus_stream_events_total{event_type="broadcast"} 200')
+        expect(output).to include('pgbus_stream_events_total{event_type="connect"} 50')
+        expect(output).to include('pgbus_stream_events_total{event_type="disconnect"} 45')
+      end
+
+      it "includes active stream connections" do
+        expect(output).to include("pgbus_stream_active_connections 5")
+      end
+
+      it "includes average fanout" do
+        expect(output).to include("pgbus_stream_avg_fanout 3.2")
+      end
+    end
+
+    context "when stream stats are not available" do
+      it "omits stream metrics entirely" do
+        expect(output).not_to include("pgbus_stream_")
+      end
+    end
+
+    context "when data source raises" do
+      before do
+        allow(data_source).to receive(:queues_with_metrics).and_raise(StandardError, "db error")
+      end
+
+      it "does not raise — returns whatever metrics it can" do
+        expect { output }.not_to raise_error
+        # Other sections still present
+        expect(output).to include("pgbus_jobs_total")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a Prometheus-compatible metrics export endpoint at `GET /pgbus/api/metrics`. This was the most-requested missing feature per the pre-v1 audit (issue #98 item 10).

- **`lib/pgbus/web/metrics_serializer.rb`** — converts DataSource output to Prometheus text exposition format. Each section (queues, jobs, processes, summary, streams) rescues independently so a single data source failure doesn't blank the entire scrape response.
- **`app/controllers/pgbus/api/metrics_controller.rb`** — thin controller that delegates to MetricsSerializer. Gated on `config.metrics_enabled` (default `true`). Returns `404` when disabled.
- **`config/routes.rb`** — new route under the existing `api` namespace
- **`lib/pgbus/configuration.rb`** — new `metrics_enabled` config option

### Metrics exposed

| Metric | Type | Labels |
|--------|------|--------|
| `pgbus_queue_depth` | gauge | `queue` |
| `pgbus_queue_visible_depth` | gauge | `queue` |
| `pgbus_queue_total_messages` | gauge | `queue` |
| `pgbus_queue_oldest_message_age_seconds` | gauge | `queue` |
| `pgbus_queue_paused` | gauge | `queue` |
| `pgbus_jobs_total` | gauge | `status` |
| `pgbus_job_duration_avg_seconds` | gauge | — |
| `pgbus_job_duration_max_seconds` | gauge | — |
| `pgbus_job_enqueue_latency_seconds` | gauge | `quantile` |
| `pgbus_job_avg_retries` | gauge | — |
| `pgbus_active_processes` | gauge | — |
| `pgbus_failed_events_total` | gauge | — |
| `pgbus_dlq_depth` | gauge | — |
| `pgbus_stream_events_total` | gauge | `event_type` |
| `pgbus_stream_active_connections` | gauge | — |
| `pgbus_stream_avg_fanout` | gauge | — |

### Example Prometheus scrape config

```yaml
scrape_configs:
  - job_name: pgbus
    metrics_path: /pgbus/api/metrics
    static_configs:
      - targets: ['localhost:3000']
```

### Authentication

The endpoint is behind the same `web_auth` config as the dashboard. Prometheus scrapers can authenticate via the same mechanism (bearer token, IP allowlist, etc.) configured in the initializer.

### Disabling

```ruby
Pgbus.configure do |config|
  config.metrics_enabled = false  # returns 404 on /api/metrics
end
```

Refs #98 (item 10)

## Test plan

- [x] `bundle exec rubocop` — 6 touched files, 0 offenses
- [x] `spec/pgbus/web/metrics_serializer_spec.rb` — 20 examples covering queue metrics, job stats, latency percentiles, stream stats, nil handling, error resilience
- [x] `spec/pgbus/api/metrics_controller_spec.rb` — 4 examples covering delegation, content type, metrics_enabled gating, file structure
- [x] Full non-system suite: 1449 examples, 0 failures
- [ ] Smoke test: mount engine, hit `/pgbus/api/metrics`, confirm Prometheus can scrape it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Prometheus-compatible metrics endpoint at `/api/metrics`. This endpoint exposes comprehensive metrics including queue depth and age, job counts by status, process information, event statistics, and dead letter queue metrics. The feature is configurable and can be enabled or disabled.

* **Tests**
  * Added test coverage for the new metrics endpoint and associated serialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->