### PR TITLE
feat(retry): exponential backoff for VT-based retries

### DIFF
--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -161,6 +161,36 @@ module Pgbus
           error: error,
           retry_count: [message.read_ct.to_i - 1, 0].max
         )
+
+        apply_retry_backoff(message, queue_name, payload)
+      end
+
+      # Extend the message's visibility timeout with exponential backoff
+      # so retries aren't all bunched at the default flat VT interval.
+      # Skipped on the first read (read_ct=1) — that's the initial
+      # attempt, not a retry.
+      def apply_retry_backoff(message, queue_name, payload)
+        attempt = message.read_ct.to_i - 1
+        return if attempt < 1
+
+        job_class = resolve_job_class(payload)
+        delay = if job_class
+                  RetryBackoff.compute_delay_for_job(job_class, attempt: attempt)
+                else
+                  RetryBackoff.compute_delay(attempt: attempt)
+                end
+
+        client.set_visibility_timeout(queue_name, message.msg_id.to_i, vt: delay)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus] Retry backoff VT update failed: #{e.message}" }
+      end
+
+      def resolve_job_class(payload)
+        return unless payload.is_a?(Hash) && payload["job_class"]
+
+        payload["job_class"].constantize
+      rescue NameError
+        nil
       end
 
       def instrument(event_name, payload = {})

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -235,6 +235,11 @@ module Pgbus
       raise ArgumentError, "polling_interval must be > 0" unless polling_interval.is_a?(Numeric) && polling_interval.positive?
       raise ArgumentError, "visibility_timeout must be > 0" unless visibility_timeout.is_a?(Numeric) && visibility_timeout.positive?
       raise ArgumentError, "max_retries must be >= 0" unless max_retries.is_a?(Integer) && max_retries >= 0
+      raise ArgumentError, "retry_backoff must be > 0" unless retry_backoff.is_a?(Numeric) && retry_backoff.positive?
+      raise ArgumentError, "retry_backoff_max must be > 0" unless retry_backoff_max.is_a?(Numeric) && retry_backoff_max.positive?
+      unless retry_backoff_jitter.is_a?(Numeric) && retry_backoff_jitter >= 0 && retry_backoff_jitter <= 1
+        raise ArgumentError, "retry_backoff_jitter must be between 0 and 1"
+      end
 
       Array(workers).each do |w|
         threads = w[:threads] || w["threads"] || 5

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -37,6 +37,10 @@ module Pgbus
     # Dead letter queue
     attr_accessor :max_retries
 
+    # Retry backoff for the VT-based retry path (unhandled exceptions).
+    # Jobs can override these per-class via Pgbus::RetryBackoff::JobMixin.
+    attr_accessor :retry_backoff, :retry_backoff_max, :retry_backoff_jitter
+
     # Priority queues
     attr_accessor :priority_levels, :default_priority
 
@@ -117,6 +121,9 @@ module Pgbus
       @circuit_breaker_enabled = true
 
       @max_retries = 5
+      @retry_backoff = 5          # seconds — first VT-retry delay
+      @retry_backoff_max = 300    # 5 minutes cap
+      @retry_backoff_jitter = 0.15
 
       @priority_levels = nil
       @default_priority = 1

--- a/lib/pgbus/retry_backoff.rb
+++ b/lib/pgbus/retry_backoff.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Pgbus
+  # Computes exponential backoff delays for the VT-based retry path
+  # (unhandled exceptions that fall through ActiveJob's retry_on).
+  #
+  # The formula mirrors the CircuitBreaker pattern already used
+  # elsewhere in pgbus: base * 2^(attempt-1), capped at max,
+  # with optional jitter to prevent thundering-herd retries.
+  #
+  # Jobs can override the global config via the pgbus_retry_backoff
+  # class-level DSL (see JobMixin below).
+  module RetryBackoff
+    # Mixin for ActiveJob classes to declare per-job backoff config.
+    #
+    #   class ImportJob < ApplicationJob
+    #     include Pgbus::RetryBackoff::JobMixin
+    #     pgbus_retry_backoff base: 15, max: 120, jitter: 0.2
+    #   end
+    module JobMixin
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def pgbus_retry_backoff(base: nil, max: nil, jitter: nil)
+          @pgbus_retry_backoff = {
+            base: base,
+            max: max,
+            jitter: jitter
+          }.compact.freeze
+        end
+
+        def pgbus_retry_backoff_config
+          @pgbus_retry_backoff
+        end
+      end
+    end
+
+    class << self
+      # Compute delay for a specific job class, falling back to global
+      # config for any options not overridden at the job level.
+      def compute_delay_for_job(job_class, attempt:, jitter: nil)
+        overrides = (job_class.respond_to?(:pgbus_retry_backoff_config) &&
+                    job_class.pgbus_retry_backoff_config) || {}
+
+        config = Pgbus.configuration
+        compute_delay(
+          attempt: attempt,
+          base: overrides[:base] || config.retry_backoff,
+          max: overrides[:max] || config.retry_backoff_max,
+          jitter: jitter || overrides[:jitter] || config.retry_backoff_jitter
+        )
+      end
+
+      # Core backoff computation.
+      #
+      # @param attempt [Integer] 1-based retry attempt number (read_ct - 1)
+      # @param base [Numeric] base delay in seconds (default: config.retry_backoff)
+      # @param max [Numeric] maximum delay cap (default: config.retry_backoff_max)
+      # @param jitter [Numeric] jitter factor 0..1 (default: config.retry_backoff_jitter)
+      # @return [Integer] delay in seconds
+      def compute_delay(attempt:, base: nil, max: nil, jitter: nil)
+        config = Pgbus.configuration
+        base ||= config.retry_backoff
+        max ||= config.retry_backoff_max
+        jitter = config.retry_backoff_jitter if jitter.nil?
+
+        exponent = [attempt - 1, 0].max
+        delay = base * (2**exponent)
+        delay = [delay, max].min
+
+        apply_jitter(delay, jitter)
+      end
+
+      private
+
+      def apply_jitter(delay, jitter)
+        return delay.to_i if jitter.nil? || jitter.zero?
+
+        spread = delay * jitter
+        jittered = delay + rand(-spread..spread)
+        [jittered.round, 0].max
+      end
+    end
+  end
+end

--- a/lib/pgbus/retry_backoff.rb
+++ b/lib/pgbus/retry_backoff.rb
@@ -22,6 +22,12 @@ module Pgbus
 
       class_methods do
         def pgbus_retry_backoff(base: nil, max: nil, jitter: nil)
+          raise ArgumentError, "retry_backoff base must be > 0" if !base.nil? && (!base.is_a?(Numeric) || base <= 0)
+          raise ArgumentError, "retry_backoff max must be > 0" if !max.nil? && (!max.is_a?(Numeric) || max <= 0)
+          if !jitter.nil? && (!jitter.is_a?(Numeric) || jitter.negative? || jitter > 1)
+            raise ArgumentError, "retry_backoff jitter must be between 0 and 1"
+          end
+
           @pgbus_retry_backoff = {
             base: base,
             max: max,
@@ -68,7 +74,7 @@ module Pgbus
         delay = base * (2**exponent)
         delay = [delay, max].min
 
-        apply_jitter(delay, jitter)
+        [apply_jitter(delay, jitter), max].min
       end
 
       private

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -428,5 +428,47 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         expect(Pgbus::Uniqueness).not_to have_received(:release_lock)
       end
     end
+
+    describe "retry backoff (VT-based retry path)" do
+      let(:message) { build_message_double(msg_id: 50, message: message_json, read_ct: 2) }
+
+      before do
+        allow(job_double).to receive(:perform_now).and_raise(StandardError, "transient")
+      end
+
+      it "extends the visibility timeout with exponential backoff on failure" do
+        executor.execute(message, queue_name)
+
+        # read_ct=2 → attempt=1 (first retry), base=5 → delay=5
+        expect(mock_client).to have_received(:set_visibility_timeout).with(
+          queue_name, 50, vt: a_value_between(4, 6)
+        )
+      end
+
+      it "increases backoff with higher read_ct" do
+        msg = build_message_double(msg_id: 51, message: message_json, read_ct: 4)
+
+        executor.execute(msg, queue_name)
+
+        # read_ct=4 → attempt=3, base=5 → 5*2^2=20
+        expect(mock_client).to have_received(:set_visibility_timeout).with(
+          queue_name, 51, vt: a_value_between(17, 23)
+        )
+      end
+
+      it "does not set VT on first read (read_ct=1)" do
+        msg = build_message_double(msg_id: 52, message: message_json, read_ct: 1)
+
+        executor.execute(msg, queue_name)
+
+        expect(mock_client).not_to have_received(:set_visibility_timeout)
+      end
+
+      it "does not blow up if set_visibility_timeout raises" do
+        allow(mock_client).to receive(:set_visibility_timeout).and_raise(StandardError, "pg gone")
+
+        expect { executor.execute(message, queue_name) }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -812,6 +812,28 @@ RSpec.describe Pgbus::Configuration do
       config.insights_default_minutes = 90.5
       expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
     end
+
+    it "rejects negative retry_backoff" do
+      config.retry_backoff = -1
+      expect { config.validate! }.to raise_error(ArgumentError, /retry_backoff must be > 0/)
+    end
+
+    it "rejects nil retry_backoff_max" do
+      config.retry_backoff_max = nil
+      expect { config.validate! }.to raise_error(ArgumentError, /retry_backoff_max must be > 0/)
+    end
+
+    it "rejects jitter > 1" do
+      config.retry_backoff_jitter = 1.5
+      expect { config.validate! }.to raise_error(ArgumentError, /retry_backoff_jitter must be between 0 and 1/)
+    end
+
+    it "accepts valid backoff settings" do
+      config.retry_backoff = 10
+      config.retry_backoff_max = 600
+      config.retry_backoff_jitter = 0.2
+      expect { config.validate! }.not_to raise_error
+    end
   end
 
   describe "#connection_options" do

--- a/spec/pgbus/retry_backoff_spec.rb
+++ b/spec/pgbus/retry_backoff_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::RetryBackoff do
+  describe ".compute_delay" do
+    context "with global config defaults" do
+      it "returns base delay on first retry (attempt=1)" do
+        delay = described_class.compute_delay(attempt: 1, jitter: 0)
+        expect(delay).to eq(5)
+      end
+
+      it "doubles the delay on each subsequent attempt" do
+        delays = (1..4).map { |n| described_class.compute_delay(attempt: n, jitter: 0) }
+        expect(delays).to eq([5, 10, 20, 40])
+      end
+
+      it "caps at retry_backoff_max" do
+        delay = described_class.compute_delay(attempt: 10, jitter: 0)
+        expect(delay).to eq(Pgbus.configuration.retry_backoff_max)
+      end
+
+      it "applies jitter when non-zero" do
+        delays = Array.new(100) { described_class.compute_delay(attempt: 1) }
+        # With default jitter (0.15), all delays should be within ±15% of base
+        base = Pgbus.configuration.retry_backoff
+        min_expected = (base * (1 - Pgbus.configuration.retry_backoff_jitter)).floor
+        max_expected = (base * (1 + Pgbus.configuration.retry_backoff_jitter)).ceil
+        expect(delays).to all(be_between(min_expected, max_expected))
+      end
+
+      it "never returns a negative delay" do
+        delay = described_class.compute_delay(attempt: 0, jitter: 0)
+        expect(delay).to be >= 0
+      end
+    end
+
+    context "with custom config" do
+      it "uses provided base and max" do
+        delay = described_class.compute_delay(
+          attempt: 3, base: 10, max: 50, jitter: 0
+        )
+        # 10 * 2^(3-1) = 40, capped at 50
+        expect(delay).to eq(40)
+      end
+
+      it "caps at custom max" do
+        delay = described_class.compute_delay(
+          attempt: 4, base: 10, max: 50, jitter: 0
+        )
+        # 10 * 2^(4-1) = 80, capped at 50
+        expect(delay).to eq(50)
+      end
+    end
+
+    context "with per-job-class override" do
+      let(:job_class) do
+        klass = Class.new
+        klass.extend(Pgbus::RetryBackoff::JobMixin::ClassMethods)
+        klass.pgbus_retry_backoff(base: 15, max: 120, jitter: 0)
+        klass
+      end
+
+      it "reads backoff config from the job class" do
+        delay = described_class.compute_delay_for_job(job_class, attempt: 2)
+        # 15 * 2^(2-1) = 30
+        expect(delay).to eq(30)
+      end
+
+      it "caps at the job-level max" do
+        delay = described_class.compute_delay_for_job(job_class, attempt: 5)
+        # 15 * 2^4 = 240, capped at 120
+        expect(delay).to eq(120)
+      end
+    end
+
+    context "with a job class that has no override" do
+      let(:plain_job_class) { Class.new }
+
+      it "falls back to global config" do
+        delay = described_class.compute_delay_for_job(plain_job_class, attempt: 1, jitter: 0)
+        expect(delay).to eq(Pgbus.configuration.retry_backoff)
+      end
+    end
+  end
+end

--- a/spec/pgbus/retry_backoff_spec.rb
+++ b/spec/pgbus/retry_backoff_spec.rb
@@ -82,5 +82,39 @@ RSpec.describe Pgbus::RetryBackoff do
         expect(delay).to eq(Pgbus.configuration.retry_backoff)
       end
     end
+
+    context "with jitter near the cap" do
+      it "never exceeds max even with jitter" do
+        max = 10
+        delays = Array.new(200) { described_class.compute_delay(attempt: 10, base: 5, max: max, jitter: 0.5) }
+        expect(delays).to all(be <= max)
+      end
+    end
+
+    context "with invalid per-job DSL values" do
+      it "rejects a negative base" do
+        klass = Class.new
+        klass.extend(Pgbus::RetryBackoff::JobMixin::ClassMethods)
+        expect { klass.pgbus_retry_backoff(base: -1) }.to raise_error(ArgumentError, /base must be > 0/)
+      end
+
+      it "rejects a string base" do
+        klass = Class.new
+        klass.extend(Pgbus::RetryBackoff::JobMixin::ClassMethods)
+        expect { klass.pgbus_retry_backoff(base: "5") }.to raise_error(ArgumentError, /base must be > 0/)
+      end
+
+      it "rejects jitter > 1" do
+        klass = Class.new
+        klass.extend(Pgbus::RetryBackoff::JobMixin::ClassMethods)
+        expect { klass.pgbus_retry_backoff(jitter: 2) }.to raise_error(ArgumentError, /jitter must be between 0 and 1/)
+      end
+
+      it "accepts valid values" do
+        klass = Class.new
+        klass.extend(Pgbus::RetryBackoff::JobMixin::ClassMethods)
+        expect { klass.pgbus_retry_backoff(base: 10, max: 60, jitter: 0.3) }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds exponential backoff for the PGMQ-level VT-based retry path (unhandled exceptions that fall through ActiveJob's `retry_on`). Previously every retry waited the same flat 30s visibility timeout — now retries follow an exponential curve.

### Key finding during research

ActiveJob's `retry_on` **already works correctly** with pgbus. When `retry_on` matches an exception, Rails calls `adapter.enqueue_at()` internally, creating a new PGMQ message with the computed delay. The original message gets archived. No changes needed for that path.

The feature gap was specifically the **VT-based fallback retry** path — when exceptions are NOT caught by `retry_on`, the message stays in the queue and becomes visible again after a flat `visibility_timeout` (default 30s). This PR adds exponential backoff for that path.

### How it works

After `handle_failure` records the failed event, the executor calls `set_visibility_timeout` with:

```
base * 2^(attempt-1), capped at max, with jitter
```

Default curve with `retry_backoff=5`, `retry_backoff_max=300`, `max_retries=5`:

| Attempt | Delay |
|---------|-------|
| 1st retry | ~5s |
| 2nd retry | ~10s |
| 3rd retry | ~20s |
| 4th retry | ~40s |
| 5th retry | ~80s |
| → DLQ | — |

### Per-job-class override

```ruby
class ImportJob < ApplicationJob
  include Pgbus::RetryBackoff::JobMixin
  pgbus_retry_backoff base: 15, max: 120, jitter: 0.2
end
```

The executor resolves the job class from the payload at failure time and reads per-class config. Falls back to global config when no override is declared.

### Global configuration

```ruby
Pgbus.configure do |config|
  config.retry_backoff = 5        # base delay in seconds (default)
  config.retry_backoff_max = 300  # cap in seconds (default)
  config.retry_backoff_jitter = 0.15  # jitter factor (default)
end
```

### Files changed

- `lib/pgbus/retry_backoff.rb` — backoff calculator module + `JobMixin` DSL
- `lib/pgbus/active_job/executor.rb` — `apply_retry_backoff` in failure path
- `lib/pgbus/configuration.rb` — three new config options with defaults
- `spec/pgbus/retry_backoff_spec.rb` — 10 examples (exponential curve, cap, jitter, per-job override, fallback)
- `spec/pgbus/active_job/executor_spec.rb` — 4 new examples (VT set on retry, increasing backoff, skip on first read, resilience)

Refs #98 (item 11)

## Test plan

- [x] `bundle exec rubocop` — 5 touched files, 0 offenses
- [x] `spec/pgbus/retry_backoff_spec.rb` — 10 examples, 0 failures
- [x] `spec/pgbus/active_job/executor_spec.rb` — 36 examples (32 existing + 4 new), 0 failures
- [x] Full non-system suite: 1472 examples, 0 failures
- [ ] Smoke test: enqueue a job that raises, verify VT increases exponentially via `SELECT vt FROM pgmq.q_<queue> WHERE msg_id = ?`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable exponential backoff for retry delays with global settings for base, max cap, and jitter.
  * Per-job class override for retry backoff values.
* **Bug Fixes / Reliability**
  * Applying visibility-timeout delays on retries is now performed safely; failures updating visibility timeout are logged and do not interrupt job failure handling.
* **Tests**
  * Added specs covering backoff computation, per-job overrides, validation, and VT-based retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->