### PR TITLE
feat(streams): add config.streams_path for decoupled SSE endpoint URL

### DIFF
--- a/app/helpers/pgbus/streams_helper.rb
+++ b/app/helpers/pgbus/streams_helper.rb
@@ -98,7 +98,7 @@ module Pgbus
     #      engine's url_helpers aren't wired in.
     def pgbus_stream_src(signed_name)
       base = Pgbus.configuration.streams_path
-      return "#{base}/#{signed_name}" if base
+      return "#{base.delete_suffix("/")}/#{signed_name}" if base
 
       base = Pgbus::Engine.routes.url_helpers.streams_path
       "#{base}/#{signed_name}"

--- a/app/helpers/pgbus/streams_helper.rb
+++ b/app/helpers/pgbus/streams_helper.rb
@@ -75,22 +75,34 @@ module Pgbus
       end
     end
 
-    # Build the SSE endpoint URL by asking the engine where its
-    # `:streams` mount point lives, then appending the signed name.
-    # The base comes from Pgbus::Engine.routes.url_helpers.streams_path
-    # so the URL follows whatever mount point the host app chose for
-    # the engine ("/pgbus", "/admin/dashboard", etc.). A
-    # `NoMethodError` fallback covers the test-only context where
-    # the helper is included in a plain class outside a Rails
-    # request and the engine's url_helpers aren't wired in.
+    # Build the SSE endpoint URL for the given signed stream name.
+    #
+    # Resolution order:
+    #   1. `config.streams_path` — explicit override, useful when the
+    #      engine is mounted behind an auth constraint but the SSE
+    #      endpoint is mounted publicly at a separate path:
+    #
+    #        # config/routes.rb
+    #        authenticate :user, ->(u) { u.admin? } do
+    #          mount Pgbus::Engine => "/admin/jobs"
+    #        end
+    #        mount Pgbus::Web::StreamApp.new => "/pgbus/streams"
+    #
+    #        # config/initializers/pgbus.rb
+    #        Pgbus.configure { |c| c.streams_path = "/pgbus/streams" }
+    #
+    #   2. Engine route helper — derives the path from wherever the
+    #      host app mounted the engine.
+    #
+    #   3. Fallback `/pgbus/streams` — test-only context where the
+    #      engine's url_helpers aren't wired in.
     def pgbus_stream_src(signed_name)
+      base = Pgbus.configuration.streams_path
+      return "#{base}/#{signed_name}" if base
+
       base = Pgbus::Engine.routes.url_helpers.streams_path
       "#{base}/#{signed_name}"
     rescue NameError
-      # NameError covers both uninitialized-constant (Pgbus::Engine
-      # not loaded, e.g. plain-Ruby unit specs) and NoMethodError
-      # (a NameError subclass) when the routes helper chain isn't
-      # wired in.
       "/pgbus/streams/#{signed_name}"
     end
 

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -90,7 +90,7 @@ module Pgbus
                   :metrics_enabled
 
     # Streams (turbo-rails replacement, SSE-based)
-    attr_accessor :streams_enabled, :streams_queue_prefix, :streams_signed_name_secret,
+    attr_accessor :streams_enabled, :streams_path, :streams_queue_prefix, :streams_signed_name_secret,
                   :streams_default_retention, :streams_retention, :streams_heartbeat_interval,
                   :streams_max_connections, :streams_idle_timeout, :streams_listen_health_check_ms,
                   :streams_write_deadline_ms, :streams_falcon_streaming_body,
@@ -168,6 +168,7 @@ module Pgbus
       @metrics_enabled = true
 
       @streams_enabled = true
+      @streams_path = nil
       @streams_queue_prefix = "pgbus_stream"
       @streams_signed_name_secret = nil
       @streams_default_retention = 5 * 60 # 5 minutes

--- a/spec/pgbus/streams_helper_spec.rb
+++ b/spec/pgbus/streams_helper_spec.rb
@@ -115,6 +115,17 @@ RSpec.describe Pgbus::StreamsHelper do
       Pgbus.configuration.streams_path = nil
     end
 
+    it "normalizes a trailing slash on config.streams_path" do
+      Pgbus.configuration.streams_path = "/pgbus/streams/"
+      html = view.pgbus_stream_from("chat")
+
+      match = html.match(/src="([^"]+)"/)
+      expect(match[1]).not_to include("//")
+      expect(match[1]).to start_with("/pgbus/streams/")
+    ensure
+      Pgbus.configuration.streams_path = nil
+    end
+
     it "builds the src URL from the engine's url_helpers so custom mounts work" do
       # The helper delegates src construction to a private
       # pgbus_stream_src(signed_name) method that asks

--- a/spec/pgbus/streams_helper_spec.rb
+++ b/spec/pgbus/streams_helper_spec.rb
@@ -105,6 +105,16 @@ RSpec.describe Pgbus::StreamsHelper do
       expect(html).to include("&quot;&gt;evil&lt;")
     end
 
+    it "uses config.streams_path when set, bypassing engine mount detection" do
+      Pgbus.configuration.streams_path = "/pgbus/streams"
+      html = view.pgbus_stream_from("chat")
+
+      match = html.match(/src="([^"]+)"/)
+      expect(match[1]).to start_with("/pgbus/streams/")
+    ensure
+      Pgbus.configuration.streams_path = nil
+    end
+
     it "builds the src URL from the engine's url_helpers so custom mounts work" do
       # The helper delegates src construction to a private
       # pgbus_stream_src(signed_name) method that asks


### PR DESCRIPTION
## Summary

- Adds `config.streams_path` option (default: `nil`) that lets host apps override the URL emitted by `pgbus_stream_src`
- When the engine is mounted behind an auth constraint (e.g. `AdminConstraint` at `/admin/jobs`), the derived streams URL is unreachable for non-admin users — this config eliminates the need for monkey-patches
- Resolution order: `config.streams_path` > engine route helper > fallback `/pgbus/streams`

### Usage

```ruby
# config/routes.rb
authenticate :user, ->(u) { u.admin? } do
  mount Pgbus::Engine => "/admin/jobs"
end
mount Pgbus::Web::StreamApp.new => "/pgbus/streams"

# config/initializers/pgbus.rb
Pgbus.configure { |c| c.streams_path = "/pgbus/streams" }
```

## Test plan

- [x] Existing `streams_helper_spec.rb` tests pass (19 examples)
- [x] New test verifies `config.streams_path` bypasses engine mount detection
- [x] Default behavior (nil) unchanged — engine route helper still used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `streams_path` configuration option, allowing customization of the base URL path used by server-sent event (SSE) streams with intelligent fallback to default paths when unconfigured.

* **Tests**
  * Added test coverage for the new configuration option, verifying proper path resolution and default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->