### PR TITLE
feat(streams): Falcon-native streaming body support

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ Without the plugin, Puma closes hijacked SSE sockets abruptly during graceful re
 
 ### Requirements
 
-- **Puma 6.1+ or Falcon.** Streams use `rack.hijack`. Puma 6.1+ supports it via partial hijack (thread-releasing, see [puma/puma#1009](https://github.com/puma/puma/issues/1009)). Falcon supports it via [protocol-rack](https://github.com/socketry/protocol-rack)'s adapter layer — same `env["rack.hijack?"]` + `env["rack.hijack"]` shape as Puma, so `Pgbus::Web::StreamApp` needs no server-specific code paths. Unicorn, Pitchfork, and Passenger return HTTP 501 from the streams endpoint.
+- **Puma 6.1+ or Falcon.** Streams use `rack.hijack` by default. Puma 6.1+ supports it via partial hijack (thread-releasing, see [puma/puma#1009](https://github.com/puma/puma/issues/1009)). Falcon supports both the hijack path (via [protocol-rack](https://github.com/socketry/protocol-rack)'s emulation) and a native streaming body path (`streams_falcon_streaming_body = true`) that integrates with Falcon's fiber scheduler for better backpressure and connection lifecycle management. Unicorn, Pitchfork, and Passenger return HTTP 501 from the streams endpoint.
 - **PostgreSQL LISTEN/NOTIFY.** `config.listen_notify = true` (the default). Stream queues override PGMQ's 250ms NOTIFY throttle to 0 so every broadcast fires individually.
 - **HTTP/2 or HTTP/3 in production.** SSE has a 6-connection-per-origin limit on HTTP/1.1; HTTP/2 lifts it. Falcon supports HTTP/2 natively without a reverse proxy.
 
@@ -725,8 +725,21 @@ Pgbus.configure do |c|
   c.streams_idle_timeout           = 3_600         # close idle connections after 1h
   c.streams_listen_health_check_ms = 250           # PG LISTEN keepalive + ensure_listening ack budget
   c.streams_write_deadline_ms      = 5_000         # write_nonblock deadline
+  c.streams_falcon_streaming_body  = false         # opt-in: Falcon-native streaming body
 end
 ```
+
+#### Falcon-native streaming body (opt-in)
+
+When running on Falcon, enable native streaming body support for better integration with Falcon's fiber scheduler:
+
+```ruby
+c.streams_falcon_streaming_body = true
+```
+
+With this flag, `StreamApp` returns `[200, headers, Writable]` instead of hijacking the socket. Falcon drives the response lifecycle with proper backpressure, connection cleanup, and fiber-scheduled IO. SSE writes go through `Protocol::HTTP::Body::Writable` which is fiber-safe and yields to other fibers when blocked.
+
+Without the flag (default), Falcon uses the same `rack.hijack` path as Puma via protocol-rack's emulation. Both paths are tested and work correctly — the streaming body path is an optimization for Falcon deployments that want tighter scheduler integration.
 
 ### How it works
 

--- a/lib/pgbus/web/stream_app.rb
+++ b/lib/pgbus/web/stream_app.rb
@@ -62,11 +62,15 @@ module Pgbus
         cursor = parse_cursor(env, request)
         return bad_request("invalid cursor: #{cursor}") if cursor.is_a?(String)
 
-        return unsupported_server unless env["rack.hijack?"]
-
         return over_capacity if streamer.registry.size >= config.streams_max_connections
 
-        hijack_and_register(env, stream_name: stream_name, since_id: cursor, context: context)
+        if config.streams_falcon_streaming_body
+          streaming_body_response(stream_name: stream_name, since_id: cursor, context: context)
+        elsif env["rack.hijack?"]
+          hijack_and_register(env, stream_name: stream_name, since_id: cursor, context: context)
+        else
+          unsupported_server
+        end
       rescue StandardError => e
         logger.error { "[Pgbus::StreamApp] #{e.class}: #{e.message}" }
         server_error
@@ -125,6 +129,38 @@ module Pgbus
         streamer.register(connection)
 
         [-1, {}, []]
+      end
+
+      def streaming_body_response(stream_name:, since_id:, context: nil)
+        require "protocol/http/body/writable" unless defined?(::Protocol::HTTP::Body::Writable)
+        require_relative "streamer/falcon_connection" unless defined?(Pgbus::Web::Streamer::FalconConnection)
+
+        body = ::Protocol::HTTP::Body::Writable.new
+
+        body.write(Pgbus::Streams::Envelope.retry_directive(2_000))
+        body.write(Pgbus::Streams::Envelope.comment(
+                     "pgbus stream open since_id=#{since_id} stream=#{stream_name}"
+                   ))
+
+        connection = Pgbus::Web::Streamer::FalconConnection.new(
+          id: SecureRandom.hex(8),
+          stream_name: stream_name,
+          body: body,
+          since_id: since_id,
+          write_deadline_ms: config.streams_write_deadline_ms,
+          context: context
+        )
+        streamer.register(connection)
+
+        [200, sse_headers, body]
+      end
+
+      def sse_headers
+        {
+          "content-type" => "text/event-stream",
+          "cache-control" => "no-cache, no-transform",
+          "x-accel-buffering" => "no"
+        }
       end
 
       def write_headers(io, stream_name:, since_id:)

--- a/lib/pgbus/web/streamer/connection.rb
+++ b/lib/pgbus/web/streamer/connection.rb
@@ -70,6 +70,10 @@ module Pgbus
           result
         end
 
+        def write_sentinel(bytes)
+          @writer.write(self, bytes, deadline_ms: @write_deadline_ms)
+        end
+
         def idle_for
           monotonic - @last_write_at
         end

--- a/lib/pgbus/web/streamer/falcon_connection.rb
+++ b/lib/pgbus/web/streamer/falcon_connection.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Web
+    module Streamer
+      # Connection adapter for Falcon's native streaming body path.
+      # Wraps a Protocol::HTTP::Body::Writable instead of a raw IO socket.
+      #
+      # Satisfies the same duck-type interface as Connection so the
+      # Dispatcher, Heartbeat, and Instance can use either type
+      # interchangeably. Key difference: no IoWriter — writes go
+      # directly to body.write which is backed by Thread::Queue and
+      # is fiber-safe under Falcon's scheduler.
+      class FalconConnection
+        attr_reader :id, :stream_name, :io, :mutex, :last_msg_id_sent, :context
+
+        def initialize(id:, stream_name:, body:, since_id:, write_deadline_ms:, context: nil)
+          @id = id
+          @stream_name = stream_name
+          @body = body
+          @io = body
+          @last_msg_id_sent = since_id.to_i
+          @write_deadline_ms = write_deadline_ms
+          @mutex = Mutex.new
+          @dead = false
+          @closed = false
+          @created_at = monotonic
+          @last_write_at = @created_at
+          @context = context
+        end
+
+        def enqueue(envelopes)
+          written = []
+          envelopes.each do |envelope|
+            next if envelope.msg_id <= @last_msg_id_sent
+
+            bytes = Pgbus::Streams::Envelope.message(
+              id: envelope.msg_id,
+              event: "turbo-stream",
+              data: envelope.payload
+            )
+
+            result = write_to_body(bytes)
+            if result == :ok
+              @last_msg_id_sent = envelope.msg_id
+              @last_write_at = monotonic
+              written << envelope
+            else
+              mark_dead!
+              break
+            end
+          end
+          written
+        end
+
+        def write_comment(text)
+          bytes = Pgbus::Streams::Envelope.comment(text)
+          result = write_to_body(bytes)
+          if result == :ok
+            @last_write_at = monotonic
+          else
+            mark_dead!
+          end
+          result
+        end
+
+        def write_sentinel(bytes)
+          write_to_body(bytes)
+        end
+
+        def close
+          @mutex.synchronize do
+            return if @closed
+
+            @closed = true
+            mark_dead!
+            @body.close_write
+          end
+        rescue StandardError => e
+          Pgbus.logger&.debug { "[Pgbus::Streamer::FalconConnection] close failed: #{e.class}: #{e.message}" }
+        end
+
+        def idle_for
+          monotonic - @last_write_at
+        end
+
+        def dead?
+          @dead || @body.closed?
+        end
+
+        def mark_dead!
+          @dead = true
+        end
+
+        private
+
+        def write_to_body(bytes)
+          @mutex.synchronize do
+            return :closed if @dead || @body.closed?
+
+            @body.write(bytes)
+            :ok
+          end
+        rescue Protocol::HTTP::Body::Writable::Closed
+          :closed
+        end
+
+        def monotonic
+          ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -134,14 +134,9 @@ module Pgbus
             event: "pgbus:shutdown",
             data: '{"reason":"worker_restart"}'
           )
-          deadline_ms = @config.streams_write_deadline_ms
 
           @registry.each_connection do |connection|
-            # IoWriter holds the connection's mutex, so this write is
-            # serialised against any write the dispatcher/heartbeat
-            # might still be performing if their stop hadn't fully
-            # returned yet.
-            safely { IoWriter.write(connection, sentinel_bytes, deadline_ms: deadline_ms) }
+            safely { connection.write_sentinel(sentinel_bytes) }
             safely { connection.close }
           end
         end

--- a/spec/integration/streams/falcon_streaming_body_spec.rb
+++ b/spec/integration/streams/falcon_streaming_body_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative "../../integration_helper"
+require_relative "../../support/falcon_test_harness"
+require_relative "../../support/sse_test_client"
+
+# Integration test that the Falcon-native streaming body path works.
+# When streams_falcon_streaming_body is true, StreamApp returns
+# [200, headers, Writable] instead of hijacking the socket. Falcon
+# drives the response lifecycle via its fiber scheduler.
+#
+# This is separate from falcon_spec.rb which tests the hijack path.
+RSpec.describe "Streams: Falcon native streaming body", :integration do
+  before(:all) do
+    @saved_listen_notify = Pgbus.configuration.listen_notify
+    @saved_signed_name_secret = Pgbus.configuration.streams_signed_name_secret
+    @saved_listen_health_check_ms = Pgbus.configuration.streams_listen_health_check_ms
+    @saved_heartbeat_interval = Pgbus.configuration.streams_heartbeat_interval
+    @saved_write_deadline_ms = Pgbus.configuration.streams_write_deadline_ms
+    @saved_falcon_streaming_body = Pgbus.configuration.streams_falcon_streaming_body
+    Pgbus.configuration.listen_notify = true
+    Pgbus.configuration.streams_signed_name_secret = "a" * 64
+    Pgbus.configuration.streams_listen_health_check_ms = 100
+    Pgbus.configuration.streams_heartbeat_interval = 30
+    Pgbus.configuration.streams_write_deadline_ms = 5_000
+    Pgbus.configuration.streams_falcon_streaming_body = true
+    Pgbus.reset_client!
+  end
+
+  after(:all) do
+    Pgbus.configuration.listen_notify = @saved_listen_notify
+    Pgbus.configuration.streams_signed_name_secret = @saved_signed_name_secret
+    Pgbus.configuration.streams_listen_health_check_ms = @saved_listen_health_check_ms
+    Pgbus.configuration.streams_heartbeat_interval = @saved_heartbeat_interval
+    Pgbus.configuration.streams_write_deadline_ms = @saved_write_deadline_ms
+    Pgbus.configuration.streams_falcon_streaming_body = @saved_falcon_streaming_body
+    Pgbus.reset_client!
+  end
+
+  let(:stream_name) { "fsb_#{SecureRandom.hex(4)}" }
+
+  let(:streamer) do
+    Pgbus::Web::Streamer::Instance.new(
+      client: Pgbus.client,
+      config: Pgbus.configuration,
+      pg_connection: build_pg_listen_connection,
+      logger: Logger.new(IO::NULL)
+    )
+  end
+
+  let(:stream_app) do
+    Pgbus::Web::StreamApp.new(
+      streamer: streamer,
+      config: Pgbus.configuration,
+      logger: Logger.new(IO::NULL)
+    )
+  end
+
+  let(:harness) { SseTestSupport::FalconTestHarness.boot(rack_app: stream_app) }
+
+  before do
+    Pgbus.client.ensure_stream_queue(stream_name)
+    streamer.start
+  end
+
+  after do
+    streamer.shutdown!
+    @booted_harness&.shutdown
+  end
+
+  def signed(name)
+    Pgbus::Streams::SignedName.sign(name)
+  end
+
+  def connect_sse_client(since_id:)
+    @booted_harness = harness
+    url = "#{@booted_harness.url("/#{signed(stream_name)}")}?since=#{since_id}"
+    SseTestSupport::SseTestClient.connect(url: url, timeout: 5)
+  end
+
+  it "delivers broadcasts through Falcon's native streaming body" do
+    stream = Pgbus.stream(stream_name)
+
+    rendered_watermark = stream.current_msg_id
+    stream.broadcast("<turbo-stream>A</turbo-stream>")
+    stream.broadcast("<turbo-stream>B</turbo-stream>")
+
+    client = connect_sse_client(since_id: rendered_watermark)
+    events = client.wait_for_events(count: 2, timeout: 5)
+
+    expect(events.size).to eq(2)
+    expect(events.map(&:data)).to eq([
+                                       "<turbo-stream>A</turbo-stream>",
+                                       "<turbo-stream>B</turbo-stream>"
+                                     ])
+
+    replay_ids = events.map { |e| e.id.to_i }
+    expect(replay_ids).to all(be > rendered_watermark)
+    expect(replay_ids).to eq(replay_ids.sort)
+
+    stream.broadcast("<turbo-stream>C</turbo-stream>")
+    live_events = client.wait_for_events(count: 3, timeout: 5)
+    expect(live_events.size).to eq(3)
+    expect(live_events.last.data).to include(">C<")
+    expect(live_events.last.id.to_i).to be > events.last.id.to_i
+
+    client.close
+  end
+end

--- a/spec/pgbus/web/stream_app_spec.rb
+++ b/spec/pgbus/web/stream_app_spec.rb
@@ -209,4 +209,80 @@ RSpec.describe Pgbus::Web::StreamApp do
       expect(streamer.registered.first.last_msg_id_sent).to eq(200)
     end
   end
+
+  describe "Falcon streaming body path" do
+    before { Pgbus.configuration.streams_falcon_streaming_body = true }
+    after { Pgbus.configuration.streams_falcon_streaming_body = false }
+
+    it "returns [200, sse_headers, Writable] when flag is enabled" do
+      env = get_env("/#{signed("chat")}")
+      status, headers, body = app.call(env)
+
+      expect(status).to eq(200)
+      expect(headers["content-type"]).to eq("text/event-stream")
+      expect(headers["cache-control"]).to eq("no-cache, no-transform")
+      expect(headers["x-accel-buffering"]).to eq("no")
+      expect(body).to be_a(Protocol::HTTP::Body::Writable)
+    ensure
+      body&.close
+    end
+
+    it "registers a FalconConnection with the streamer" do
+      env = get_env("/#{signed("chat")}")
+      _, _, body = app.call(env)
+
+      expect(streamer.registered.length).to eq(1)
+      expect(streamer.registered.first).to be_a(Pgbus::Web::Streamer::FalconConnection)
+      expect(streamer.registered.first.stream_name).to eq("chat")
+    ensure
+      body&.close
+    end
+
+    it "body contains opening SSE frames" do
+      env = get_env("/#{signed("chat")}", "QUERY_STRING" => "since=42")
+      _, _, body = app.call(env)
+
+      # Read the first two chunks (retry directive + opening comment)
+      chunk1 = body.read
+      chunk2 = body.read
+
+      expect(chunk1).to include("retry: 2000")
+      expect(chunk2).to include("since_id=42")
+      expect(chunk2).to include("stream=chat")
+    ensure
+      body&.close
+    end
+
+    it "carries the since_id through to the FalconConnection" do
+      env = get_env("/#{signed("chat")}", "QUERY_STRING" => "since=999")
+      _, _, body = app.call(env)
+
+      expect(streamer.registered.first.last_msg_id_sent).to eq(999)
+    ensure
+      body&.close
+    end
+
+    it "takes priority over rack.hijack? when flag is set" do
+      env = get_env("/#{signed("chat")}", "rack.hijack?" => true)
+      status, _, body = app.call(env)
+
+      # Should return 200 (streaming body), not -1 (hijack sentinel)
+      expect(status).to eq(200)
+      expect(body).to be_a(Protocol::HTTP::Body::Writable)
+    ensure
+      body&.close
+    end
+
+    it "returns 503 when at capacity" do
+      Pgbus.configuration.streams_max_connections = 0
+      env = get_env("/#{signed("chat")}")
+
+      status, headers, _body = app.call(env)
+
+      expect(status).to eq(503)
+      expect(headers["retry-after"]).to eq("2")
+    ensure
+      Pgbus.configuration.streams_max_connections = 2_000
+    end
+  end
 end

--- a/spec/pgbus/web/streamer/connection_spec.rb
+++ b/spec/pgbus/web/streamer/connection_spec.rb
@@ -196,6 +196,24 @@ RSpec.describe Pgbus::Web::Streamer::Connection do
     end
   end
 
+  describe "#write_sentinel" do
+    it "delegates to the writer with the connection's deadline" do
+      result = conn.write_sentinel("sentinel bytes")
+      expect(result).to eq(:ok)
+      expect(writer.writes.last[:bytes]).to eq("sentinel bytes")
+      expect(writer.writes.last[:deadline_ms]).to eq(5_000)
+    end
+
+    it "returns :closed when the writer fails" do
+      failing_writer = writer.class.new(result: :closed)
+      c = described_class.new(
+        id: "c2", stream_name: stream, io: io, since_id: 0,
+        writer: failing_writer, write_deadline_ms: 100
+      )
+      expect(c.write_sentinel("bytes")).to eq(:closed)
+    end
+  end
+
   describe "#idle_for" do
     it "returns seconds since the last successful write" do
       # Simulate a write at t=0, advance the monotonic clock, check idle_for

--- a/spec/pgbus/web/streamer/falcon_connection_spec.rb
+++ b/spec/pgbus/web/streamer/falcon_connection_spec.rb
@@ -158,14 +158,14 @@ RSpec.describe Pgbus::Web::Streamer::FalconConnection do
   describe "#idle_for" do
     it "returns seconds since last write" do
       fake_clock = 0.0
-      allow(::Process).to receive(:clock_gettime)
-        .with(::Process::CLOCK_MONOTONIC).and_return(fake_clock)
+      allow(Process).to receive(:clock_gettime)
+        .with(Process::CLOCK_MONOTONIC).and_return(fake_clock)
 
       conn.enqueue([build_envelope(msg_id: 101)])
 
       fake_clock = 10.0
-      allow(::Process).to receive(:clock_gettime)
-        .with(::Process::CLOCK_MONOTONIC).and_return(fake_clock)
+      allow(Process).to receive(:clock_gettime)
+        .with(Process::CLOCK_MONOTONIC).and_return(fake_clock)
 
       expect(conn.idle_for).to be_within(0.01).of(10.0)
     end

--- a/spec/pgbus/web/streamer/falcon_connection_spec.rb
+++ b/spec/pgbus/web/streamer/falcon_connection_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "protocol/http/body/writable"
+
+RSpec.describe Pgbus::Web::Streamer::FalconConnection do
+  subject(:conn) do
+    described_class.new(
+      id: "fc1",
+      stream_name: stream,
+      body: body,
+      since_id: 100,
+      write_deadline_ms: 5_000
+    )
+  end
+
+  let(:stream) { "chat" }
+  let(:body) { Protocol::HTTP::Body::Writable.new }
+
+  def build_envelope(msg_id:, payload: "<turbo-stream>data</turbo-stream>", visible_to: nil)
+    Pgbus::Web::Streamer::StreamEventDispatcher::StreamEnvelope.new(
+      msg_id: msg_id, enqueued_at: Time.now, payload: payload,
+      source: "q_chat", visible_to: visible_to
+    )
+  end
+
+  describe "#initialize" do
+    it "stores attributes" do
+      expect(conn.id).to eq("fc1")
+      expect(conn.stream_name).to eq("chat")
+      expect(conn.last_msg_id_sent).to eq(100)
+      expect(conn.context).to be_nil
+    end
+
+    it "exposes the body as #io for duck-typing" do
+      expect(conn.io).to eq(body)
+    end
+
+    it "provides a mutex" do
+      expect(conn.mutex).to be_a(Mutex)
+    end
+
+    it "accepts a context" do
+      c = described_class.new(
+        id: "fc2", stream_name: "chat", body: body,
+        since_id: 0, write_deadline_ms: 100, context: :admin
+      )
+      expect(c.context).to eq(:admin)
+    end
+  end
+
+  describe "#enqueue" do
+    it "writes SSE frames to the body and advances the cursor" do
+      envelopes = [build_envelope(msg_id: 101), build_envelope(msg_id: 102)]
+      written = conn.enqueue(envelopes)
+
+      expect(written.size).to eq(2)
+      expect(conn.last_msg_id_sent).to eq(102)
+    end
+
+    it "skips envelopes at or below the cursor" do
+      written = conn.enqueue([build_envelope(msg_id: 99), build_envelope(msg_id: 100)])
+      expect(written).to be_empty
+      expect(conn.last_msg_id_sent).to eq(100)
+    end
+
+    it "writes valid SSE frame format" do
+      conn.enqueue([build_envelope(msg_id: 101, payload: "hello")])
+
+      chunk = body.read
+      expect(chunk).to include("id: 101")
+      expect(chunk).to include("event: turbo-stream")
+      expect(chunk).to include("data: hello")
+    end
+
+    it "marks dead when body is closed" do
+      body.close
+      written = conn.enqueue([build_envelope(msg_id: 101)])
+
+      expect(written).to be_empty
+      expect(conn).to be_dead
+    end
+  end
+
+  describe "#write_comment" do
+    it "writes an SSE comment to the body" do
+      conn.write_comment("heartbeat 123")
+
+      chunk = body.read
+      expect(chunk).to include(": heartbeat 123")
+    end
+
+    it "returns :ok on success" do
+      expect(conn.write_comment("ping")).to eq(:ok)
+    end
+
+    it "marks dead when body is closed" do
+      body.close
+      result = conn.write_comment("ping")
+
+      expect(result).to eq(:closed)
+      expect(conn).to be_dead
+    end
+  end
+
+  describe "#write_sentinel" do
+    it "writes raw bytes to the body" do
+      conn.write_sentinel("sentinel data")
+
+      chunk = body.read
+      expect(chunk).to eq("sentinel data")
+    end
+
+    it "returns :ok on success" do
+      expect(conn.write_sentinel("bytes")).to eq(:ok)
+    end
+
+    it "returns :closed when body is closed" do
+      body.close
+      expect(conn.write_sentinel("bytes")).to eq(:closed)
+    end
+  end
+
+  describe "#close" do
+    it "signals end-of-stream via close_write" do
+      conn.close
+      # After close_write, the body is closed for writing
+      expect(body.closed?).to be true
+    end
+
+    it "marks the connection dead" do
+      conn.close
+      expect(conn).to be_dead
+    end
+
+    it "is idempotent" do
+      conn.close
+      expect { conn.close }.not_to raise_error
+    end
+  end
+
+  describe "#dead?" do
+    it "is false on a fresh connection" do
+      expect(conn).not_to be_dead
+    end
+
+    it "is true after mark_dead!" do
+      conn.mark_dead!
+      expect(conn).to be_dead
+    end
+
+    it "is true when body is externally closed" do
+      body.close
+      expect(conn).to be_dead
+    end
+  end
+
+  describe "#idle_for" do
+    it "returns seconds since last write" do
+      fake_clock = 0.0
+      allow(::Process).to receive(:clock_gettime)
+        .with(::Process::CLOCK_MONOTONIC).and_return(fake_clock)
+
+      conn.enqueue([build_envelope(msg_id: 101)])
+
+      fake_clock = 10.0
+      allow(::Process).to receive(:clock_gettime)
+        .with(::Process::CLOCK_MONOTONIC).and_return(fake_clock)
+
+      expect(conn.idle_for).to be_within(0.01).of(10.0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements the `streams_falcon_streaming_body` config flag (existed as a no-op since v1). When enabled, `StreamApp` returns `[200, headers, Writable]` instead of hijacking the socket, giving Falcon proper fiber-driven SSE streaming.

- **Connection#write_sentinel** — extracted from Instance for type-agnostic shutdown
- **FalconConnection** — wraps `Protocol::HTTP::Body::Writable` with the same duck-type interface as Connection (enqueue, write_comment, write_sentinel, close, dead?, idle_for)
- **StreamApp branching** — `streams_falcon_streaming_body` flag takes priority over `rack.hijack?` (Falcon sets both via protocol-rack emulation)
- **Lazy dependencies** — `protocol-http` and `falcon_connection` loaded at runtime only when the flag is enabled

### Why native streaming body > hijack on Falcon

| Aspect | Hijack (default) | Streaming body (opt-in) |
|--------|-----------------|------------------------|
| IO model | Raw socket, bypasses fiber scheduler | `body.write()`, fiber-yields on backpressure |
| Backpressure | Manual via `write_nonblock` + `IO.select` | Automatic via `Thread::Queue` / Falcon flow control |
| Connection lifecycle | Managed by pgbus code | Managed by Falcon |
| Disconnect detection | `Errno::EPIPE` in IoWriter | `Writable::Closed` exception |

### Configuration

```ruby
Pgbus.configure do |c|
  c.streams_falcon_streaming_body = true  # opt-in for Falcon deployments
end
```

## Test plan

- [x] Connection#write_sentinel spec (2 examples)
- [x] FalconConnection unit tests (21 examples)
- [x] StreamApp streaming body branch tests (6 examples)
- [x] Falcon streaming body integration test (real Falcon + real PGMQ)
- [x] Existing Falcon hijack test still passes
- [x] All 65 streamer unit tests pass
- [x] RuboCop clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in support for Falcon's native streaming body, enabling alternative Server-Sent Event delivery when `streams_falcon_streaming_body` is enabled
  * Applications can now leverage Falcon-specific streaming optimizations without rack.hijack dependency

* **Documentation**
  * Updated compatibility notes to document both hijack and Falcon native streaming body modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->