### PR TITLE
fix(streams): override turbo_stream_from to use pgbus SSE transport

### DIFF
--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -84,6 +84,15 @@ module Pgbus
           # `_` keeps RuboCop's Lint/Void from deleting the line.
           _autoload_trigger = Pgbus::Streams::TurboBroadcastable
           Pgbus::Streams.install_turbo_broadcastable_patch!
+
+          # Subscribe-side patch: override turbo_stream_from to render
+          # <pgbus-stream-source> (SSE) instead of <turbo-cable-stream-source>
+          # (ActionCable). Without this, third-party gems like
+          # hotwire-livereload that call turbo_stream_from in their views
+          # subscribe via ActionCable while the broadcast (patched above)
+          # goes through PGMQ — the message never arrives.
+          _autoload_trigger_override = Pgbus::Streams::TurboStreamOverride
+          Pgbus::Streams.install_turbo_stream_override!
         end
       end
     end

--- a/lib/pgbus/streams/turbo_stream_override.rb
+++ b/lib/pgbus/streams/turbo_stream_override.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Streams
+    # Runtime patch that redirects `turbo_stream_from` (the view helper)
+    # through `pgbus_stream_from` when pgbus streams are enabled. This is
+    # the subscribe-side counterpart to `TurboBroadcastable` (which patches
+    # the publish-side `broadcast_stream_to`).
+    #
+    # Without this patch, third-party gems like hotwire-livereload call
+    # `turbo_stream_from "hotwire-livereload"` in their views, which
+    # renders a `<turbo-cable-stream-source>` element connected to
+    # ActionCable. Meanwhile, the `TurboBroadcastable` patch routes the
+    # broadcast through PGMQ/SSE. Publisher and subscriber end up on
+    # different transports — the message never arrives.
+    #
+    # After this patch, `turbo_stream_from` renders a `<pgbus-stream-source>`
+    # element instead, so both sides use PGMQ/SSE. When `streams_enabled`
+    # is false, the original turbo-rails behavior is preserved via `super`.
+    module TurboStreamOverride
+      def turbo_stream_from(*streamables, **attributes)
+        if Pgbus.configuration.streams_enabled
+          pgbus_stream_from(*streamables, **attributes)
+        else
+          super
+        end
+      end
+    end
+
+    # Apply the patch to Turbo::StreamsHelper. Idempotent: prepending the
+    # same module twice is a no-op. Called from Pgbus::Engine's initializer
+    # when both turbo-rails and pgbus streams are enabled.
+    def self.install_turbo_stream_override!
+      return unless defined?(::Turbo::StreamsHelper)
+      return if ::Turbo::StreamsHelper.ancestors.include?(TurboStreamOverride)
+
+      ::Turbo::StreamsHelper.prepend(TurboStreamOverride)
+    end
+  end
+end

--- a/spec/pgbus/streams/turbo_stream_override_spec.rb
+++ b/spec/pgbus/streams/turbo_stream_override_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../app/helpers/pgbus/streams_helper" unless defined?(Pgbus::StreamsHelper)
+
+RSpec.describe Pgbus::Streams::TurboStreamOverride do
+  # Fake Turbo::StreamsHelper with the same turbo_stream_from signature
+  # as the real turbo-rails version. We don't load turbo-rails in unit
+  # tests — the override is exercised via a minimal stand-in.
+  let(:fake_turbo_streams_helper) do
+    Module.new do
+      def self.name
+        "Turbo::StreamsHelper"
+      end
+
+      def turbo_stream_from(*_streamables, **attributes)
+        tag = %(<turbo-cable-stream-source channel="Turbo::StreamsChannel")
+        tag += attributes.map { |k, v| %( #{k}="#{v}") }.join
+        "#{tag}></turbo-cable-stream-source>"
+      end
+    end
+  end
+
+  # A view class that includes both Turbo's helper and pgbus's helper,
+  # simulating what a real Rails view stack looks like.
+  let(:view_class) do
+    turbo_mod = fake_turbo_streams_helper
+    Class.new do
+      include turbo_mod
+      include Pgbus::StreamsHelper
+    end
+  end
+
+  let(:view) { view_class.new }
+
+  before do
+    Pgbus.configuration.streams_signed_name_secret = "a" * 64
+    allow_any_instance_of(Pgbus::Streams::Stream).to receive(:current_msg_id).and_return(42)
+    Thread.current[:pgbus_streams_watermark_cache] = nil
+  end
+
+  after do
+    Pgbus.configuration.streams_signed_name_secret = nil
+    Thread.current[:pgbus_streams_watermark_cache] = nil
+  end
+
+  describe ".install_turbo_stream_override!" do
+    it "prepends the override onto Turbo::StreamsHelper" do
+      stub_const("Turbo::StreamsHelper", fake_turbo_streams_helper)
+
+      Pgbus::Streams.install_turbo_stream_override!
+      expect(fake_turbo_streams_helper.ancestors).to include(described_class)
+    end
+
+    it "is idempotent — calling twice does not double-prepend" do
+      stub_const("Turbo::StreamsHelper", fake_turbo_streams_helper)
+
+      Pgbus::Streams.install_turbo_stream_override!
+      Pgbus::Streams.install_turbo_stream_override!
+      expect(fake_turbo_streams_helper.ancestors.count(described_class)).to eq(1)
+    end
+
+    it "is a no-op when Turbo::StreamsHelper is not defined" do
+      hide_const("Turbo::StreamsHelper") if defined?(Turbo::StreamsHelper)
+      expect { Pgbus::Streams.install_turbo_stream_override! }.not_to raise_error
+    end
+  end
+
+  describe "#turbo_stream_from override" do
+    before do
+      turbo_mod = Module.new do
+        def self.signed_stream_verifier_key
+          nil
+        end
+      end
+      stub_const("Turbo", turbo_mod)
+      stub_const("Turbo::StreamsHelper", fake_turbo_streams_helper)
+      Pgbus::Streams.install_turbo_stream_override!
+    end
+
+    let(:patched_view_class) do
+      turbo_mod = fake_turbo_streams_helper
+      Class.new do
+        include turbo_mod
+        include Pgbus::StreamsHelper
+      end
+    end
+
+    let(:patched_view) { patched_view_class.new }
+
+    it "renders <pgbus-stream-source> instead of <turbo-cable-stream-source>" do
+      html = patched_view.turbo_stream_from("hotwire-livereload")
+
+      expect(html).to include("<pgbus-stream-source")
+      expect(html).not_to include("<turbo-cable-stream-source")
+    end
+
+    it "includes the signed-stream-name attribute" do
+      html = patched_view.turbo_stream_from("hotwire-livereload")
+
+      match = html.match(/signed-stream-name="([^"]+)"/)
+      expect(match).not_to be_nil
+      expect(Pgbus::Streams::SignedName.verify!(match[1])).to eq("hotwire-livereload")
+    end
+
+    it "includes the since-id watermark" do
+      html = patched_view.turbo_stream_from("hotwire-livereload")
+      expect(html).to include('since-id="42"')
+    end
+
+    it "works with GlobalID-like objects" do
+      account = double("Account", to_gid_param: "gid://app/Account/7")
+
+      html = patched_view.turbo_stream_from(account)
+
+      match = html.match(/signed-stream-name="([^"]+)"/)
+      expect(Pgbus::Streams::SignedName.verify!(match[1])).to eq("gid://app/Account/7")
+    end
+
+    it "works with multiple streamables joined by colons" do
+      account = double("Account", to_gid_param: "gid://app/Account/7")
+
+      html = patched_view.turbo_stream_from(account, :messages)
+
+      match = html.match(/signed-stream-name="([^"]+)"/)
+      expect(Pgbus::Streams::SignedName.verify!(match[1])).to eq("gid://app/Account/7:messages")
+    end
+
+    it "falls through to original turbo_stream_from when streams are disabled" do
+      Pgbus.configuration.streams_enabled = false
+      html = patched_view.turbo_stream_from("hotwire-livereload")
+
+      expect(html).to include("<turbo-cable-stream-source")
+      expect(html).not_to include("<pgbus-stream-source")
+    ensure
+      Pgbus.configuration.streams_enabled = true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Root cause**: `TurboBroadcastable` patches the publish side (`broadcast_stream_to` → PGMQ), but the subscribe side (`turbo_stream_from` → `<turbo-cable-stream-source>` → ActionCable) was untouched. Third-party gems like hotwire-livereload that call `turbo_stream_from` in their views end up with publisher and subscriber on different transports — the message never arrives.
- **Fix**: `TurboStreamOverride` prepends onto `Turbo::StreamsHelper` and delegates `turbo_stream_from` → `pgbus_stream_from` when `streams_enabled` is true. Falls through to original turbo-rails behavior when disabled.
- Installed via the same engine initializer that installs `TurboBroadcastable`, ensuring both patches are applied atomically.

## Files changed

| File | Change |
|------|--------|
| `lib/pgbus/streams/turbo_stream_override.rb` | New module that overrides `turbo_stream_from` |
| `lib/pgbus/engine.rb` | Wire override into the streams initializer |
| `spec/pgbus/streams/turbo_stream_override_spec.rb` | 9 tests: install idempotency, element rendering, fallback |

## Test plan

- [x] 9 new unit tests for `TurboStreamOverride` (install, override behavior, streams-disabled fallback)
- [x] 108 existing stream specs pass
- [x] 101 system tests pass (Playwright)
- [x] 122 integration tests pass
- [x] RuboCop clean (310 files, 0 offenses)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Turbo Streams integration now supports Server-Sent Events (SSE)-based real-time updates, providing an alternative to the default WebSocket protocol.
  * Streaming functionality is automatically installed at Rails initialization and is configurable.

* **Tests**
  * Added comprehensive test coverage for the new Turbo Streams streaming integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->