### PR TITLE
feat(web): queue health observability and worker pool utilization

### DIFF
--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -60,7 +60,8 @@ ALTER TABLE pgmq.q_pgbus_default SET (
 -- Archive tables: append-heavy, vacuum less critical but still important
 ALTER TABLE pgmq.a_pgbus_default SET (
   autovacuum_vacuum_scale_factor = 0.05,
-  autovacuum_vacuum_cost_delay = 5
+  autovacuum_vacuum_cost_delay = 5,
+  autovacuum_analyze_scale_factor = 0.05
 );
 ```
 

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -44,6 +44,55 @@ idle_threads.times { client.read_message(queue) }
 - Archive tables grow unbounded -- consider partitioning for high-volume queues
 - Purge processed events table periodically (idempotency dedup)
 
+### Autovacuum Tuning for Queue Tables
+
+Queue and archive tables have high write/delete churn. Default autovacuum settings
+are too conservative. Apply per-table tuning:
+
+```sql
+-- Queue tables: aggressive vacuum (high delete rate)
+ALTER TABLE pgmq.q_pgbus_default SET (
+  autovacuum_vacuum_scale_factor = 0.01,    -- vacuum at 1% dead (default 20%)
+  autovacuum_vacuum_cost_delay = 2,          -- faster vacuum cycles (default 20ms)
+  autovacuum_analyze_scale_factor = 0.05     -- re-analyze at 5% change
+);
+
+-- Archive tables: append-heavy, vacuum less critical but still important
+ALTER TABLE pgmq.a_pgbus_default SET (
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_vacuum_cost_delay = 5
+);
+```
+
+**Why this matters**: Dead tuples accumulate when autovacuum can't keep up.
+This causes B-tree index bloat (each dead index entry requires I/O), increasing
+lock acquisition time. Long-running transactions pin the MVCC horizon, preventing
+vacuum from cleaning any dead tuples created while the transaction is open.
+
+Monitor via the dashboard Queue Health panel or Prometheus metrics:
+- `pgbus_table_dead_tuples` — dead tuple count per table
+- `pgbus_table_bloat_ratio` — dead / (dead + live) per table
+- `pgbus_oldest_transaction_age_seconds` — MVCC horizon pin risk
+
+### Archive Retention Sizing
+
+Default: `archive_retention = 7.days`. Tune based on:
+
+- **High-volume queues (>100 msgs/sec)**: Consider 1-3 days to keep archive tables manageable
+- **Audit-sensitive queues**: 30+ days if compliance requires it
+- **Per-stream retention**: Use `streams_retention` hash for granular control
+
+```ruby
+config.archive_retention = 3.days                    # global default
+config.streams_retention = {                          # per-stream overrides
+  "orders.*" => 30.days,                              # keep order events longer
+  "notifications.*" => 1.day                          # ephemeral, purge quickly
+}
+```
+
+The dispatcher's `compact_archives` runs hourly (configurable) and deletes
+archive entries older than the retention window in batches of 1000.
+
 ## Worker Performance
 
 ### Memory Management
@@ -71,3 +120,7 @@ max_worker_lifetime: 3600
 - [ ] Connection pool sized appropriately
 - [ ] Worker recycling configured
 - [ ] No N+1 queries in dashboard DataSource
+- [ ] Autovacuum tuned for queue/archive tables
+- [ ] Archive retention sized for volume
+- [ ] Queue Health dashboard monitored for dead tuple growth
+- [ ] No long-running transactions pinning MVCC horizon

--- a/app/controllers/pgbus/dashboard_controller.rb
+++ b/app/controllers/pgbus/dashboard_controller.rb
@@ -16,11 +16,15 @@ module Pgbus
       when "failures"
         @recent_failures = data_source.failed_events(page: 1, per_page: 5)
         render_frame("pgbus/dashboard/recent_failures")
+      when "health"
+        @health = data_source.queue_health_stats
+        render_frame("pgbus/dashboard/queue_health")
       else
         @stats = data_source.summary_stats
         @queues = data_source.queues_with_metrics
         @processes = data_source.processes
         @recent_failures = data_source.failed_events(page: 1, per_page: 5)
+        @health = data_source.queue_health_stats
       end
     end
   end

--- a/app/controllers/pgbus/queues_controller.rb
+++ b/app/controllers/pgbus/queues_controller.rb
@@ -12,6 +12,7 @@ module Pgbus
 
       @paused = data_source.queue_paused?(params[:name])
       @messages = data_source.jobs(queue_name: params[:name], page: page_param, per_page: per_page)
+      @health = data_source.queue_health_detail(params[:name])
     end
 
     def purge

--- a/app/views/pgbus/dashboard/_queue_health.html.erb
+++ b/app/views/pgbus/dashboard/_queue_health.html.erb
@@ -63,11 +63,11 @@
             <% @health[:tables].each do |t| %>
               <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
                 <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white"><%= t[:table] %></td>
-                <td class="px-4 py-3 text-sm text-gray-500"><%= t[:kind] %></td>
-                <td class="px-4 py-3 text-sm text-right text-gray-700"><%= pgbus_number(t[:live_tuples]) %></td>
-                <td class="px-4 py-3 text-sm text-right <%= t[:dead_tuples] > 1000 ? 'text-amber-600 font-semibold' : 'text-gray-700' %>"><%= pgbus_number(t[:dead_tuples]) %></td>
-                <td class="px-4 py-3 text-sm text-right <%= t[:bloat_ratio] > 0.2 ? 'text-red-600 font-semibold' : t[:bloat_ratio] > 0.1 ? 'text-amber-600' : 'text-gray-500' %>"><%= (t[:bloat_ratio] * 100).round(1) %>%</td>
-                <td class="px-4 py-3 text-sm text-right text-gray-500"><%= t[:last_vacuum_ago_sec] ? pgbus_duration(t[:last_vacuum_ago_sec]) : "—" %></td>
+                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400"><%= t("pgbus.dashboard.queue_health.kinds.#{t[:kind]}") %></td>
+                <td class="px-4 py-3 text-sm text-right text-gray-700 dark:text-gray-300"><%= pgbus_number(t[:live_tuples]) %></td>
+                <td class="px-4 py-3 text-sm text-right <%= t[:dead_tuples] > 1000 ? 'text-amber-600 dark:text-amber-400 font-semibold' : 'text-gray-700 dark:text-gray-300' %>"><%= pgbus_number(t[:dead_tuples]) %></td>
+                <td class="px-4 py-3 text-sm text-right <%= t[:bloat_ratio] > 0.2 ? 'text-red-600 dark:text-red-400 font-semibold' : t[:bloat_ratio] > 0.1 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400' %>"><%= (t[:bloat_ratio] * 100).round(1) %>%</td>
+                <td class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400"><%= t[:last_vacuum_ago_sec] ? pgbus_duration(t[:last_vacuum_ago_sec]) : "—" %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/pgbus/dashboard/_queue_health.html.erb
+++ b/app/views/pgbus/dashboard/_queue_health.html.erb
@@ -1,0 +1,78 @@
+<turbo-frame id="dashboard-health" data-auto-refresh data-src="<%= pgbus.root_path(frame: 'health') %>">
+  <div class="mb-8">
+    <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.dashboard.queue_health.title") %></h2>
+
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-4">
+      <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+        <p class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.dashboard.queue_health.dead_tuples") %></p>
+        <p class="mt-1 text-3xl font-semibold <%= @health[:total_dead_tuples] > 10_000 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-white' %>">
+          <%= pgbus_number(@health[:total_dead_tuples]) %>
+        </p>
+        <p class="text-xs text-gray-400 dark:text-gray-500"><%= pgbus_number(@health[:total_live_tuples]) %> <%= t("pgbus.dashboard.queue_health.live") %></p>
+      </div>
+
+      <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+        <p class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.dashboard.queue_health.worst_bloat") %></p>
+        <p class="mt-1 text-3xl font-semibold <%= @health[:worst_bloat_ratio] > 0.2 ? 'text-red-600 dark:text-red-400' : @health[:worst_bloat_ratio] > 0.1 ? 'text-amber-600 dark:text-amber-400' : 'text-green-600 dark:text-green-400' %>">
+          <%= (@health[:worst_bloat_ratio] * 100).round(1) %>%
+        </p>
+        <% if @health[:tables_needing_vacuum] > 0 %>
+          <p class="text-xs text-amber-500"><%= t("pgbus.dashboard.queue_health.tables_need_vacuum", count: @health[:tables_needing_vacuum]) %></p>
+        <% end %>
+      </div>
+
+      <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+        <p class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.dashboard.queue_health.last_vacuum") %></p>
+        <p class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white">
+          <% if @health[:oldest_vacuum_ago_sec] %>
+            <%= pgbus_duration(@health[:oldest_vacuum_ago_sec]) %>
+          <% else %>
+            —
+          <% end %>
+        </p>
+        <p class="text-xs text-gray-400 dark:text-gray-500"><%= t("pgbus.dashboard.queue_health.oldest_vacuum_ago") %></p>
+      </div>
+
+      <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+        <p class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.dashboard.queue_health.mvcc_horizon") %></p>
+        <p class="mt-1 text-3xl font-semibold <%= (@health[:oldest_transaction_age_sec] || 0) > 60 ? 'text-red-600 dark:text-red-400' : (@health[:oldest_transaction_age_sec] || 0) > 30 ? 'text-amber-600 dark:text-amber-400' : 'text-green-600 dark:text-green-400' %>">
+          <% if @health[:oldest_transaction_age_sec] %>
+            <%= pgbus_duration(@health[:oldest_transaction_age_sec]) %>
+          <% else %>
+            —
+          <% end %>
+        </p>
+        <p class="text-xs text-gray-400 dark:text-gray-500"><%= t("pgbus.dashboard.queue_health.oldest_open_txn") %></p>
+      </div>
+    </div>
+
+    <% if @health[:tables].any? %>
+      <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+        <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-900">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.queue_health.headers.table") %></th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.queue_health.headers.kind") %></th>
+              <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.queue_health.headers.live") %></th>
+              <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.queue_health.headers.dead") %></th>
+              <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.queue_health.headers.bloat") %></th>
+              <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.dashboard.queue_health.headers.last_vacuum") %></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+            <% @health[:tables].each do |t| %>
+              <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900">
+                <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white"><%= t[:table] %></td>
+                <td class="px-4 py-3 text-sm text-gray-500"><%= t[:kind] %></td>
+                <td class="px-4 py-3 text-sm text-right text-gray-700"><%= pgbus_number(t[:live_tuples]) %></td>
+                <td class="px-4 py-3 text-sm text-right <%= t[:dead_tuples] > 1000 ? 'text-amber-600 font-semibold' : 'text-gray-700' %>"><%= pgbus_number(t[:dead_tuples]) %></td>
+                <td class="px-4 py-3 text-sm text-right <%= t[:bloat_ratio] > 0.2 ? 'text-red-600 font-semibold' : t[:bloat_ratio] > 0.1 ? 'text-amber-600' : 'text-gray-500' %>"><%= (t[:bloat_ratio] * 100).round(1) %>%</td>
+                <td class="px-4 py-3 text-sm text-right text-gray-500"><%= t[:last_vacuum_ago_sec] ? pgbus_duration(t[:last_vacuum_ago_sec]) : "—" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </div>
+</turbo-frame>

--- a/app/views/pgbus/dashboard/show.html.erb
+++ b/app/views/pgbus/dashboard/show.html.erb
@@ -4,6 +4,8 @@
 
 <%= render "pgbus/dashboard/queues_table" %>
 
+<%= render "pgbus/dashboard/queue_health" %>
+
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
   <%= render "pgbus/dashboard/processes_table" %>
   <%= render "pgbus/dashboard/recent_failures" %>

--- a/app/views/pgbus/queues/show.html.erb
+++ b/app/views/pgbus/queues/show.html.erb
@@ -62,10 +62,10 @@
         <% @health[:tables].each do |t| %>
           <tr class="dark:bg-gray-900">
             <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-white"><%= t[:table] %></td>
-            <td class="px-4 py-2 text-sm text-right text-gray-700"><%= pgbus_number(t[:live_tuples]) %></td>
-            <td class="px-4 py-2 text-sm text-right <%= t[:dead_tuples] > 1000 ? 'text-amber-600 font-semibold' : 'text-gray-700' %>"><%= pgbus_number(t[:dead_tuples]) %></td>
-            <td class="px-4 py-2 text-sm text-right <%= t[:bloat_ratio] > 0.2 ? 'text-red-600 font-semibold' : t[:bloat_ratio] > 0.1 ? 'text-amber-600' : 'text-gray-500' %>"><%= (t[:bloat_ratio] * 100).round(1) %>%</td>
-            <td class="px-4 py-2 text-sm text-right text-gray-500"><%= t[:last_vacuum_ago_sec] ? pgbus_duration(t[:last_vacuum_ago_sec]) : "—" %></td>
+            <td class="px-4 py-2 text-sm text-right text-gray-700 dark:text-gray-300"><%= pgbus_number(t[:live_tuples]) %></td>
+            <td class="px-4 py-2 text-sm text-right <%= t[:dead_tuples] > 1000 ? 'text-amber-600 dark:text-amber-400 font-semibold' : 'text-gray-700 dark:text-gray-300' %>"><%= pgbus_number(t[:dead_tuples]) %></td>
+            <td class="px-4 py-2 text-sm text-right <%= t[:bloat_ratio] > 0.2 ? 'text-red-600 dark:text-red-400 font-semibold' : t[:bloat_ratio] > 0.1 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400' %>"><%= (t[:bloat_ratio] * 100).round(1) %>%</td>
+            <td class="px-4 py-2 text-sm text-right text-gray-500 dark:text-gray-400"><%= t[:last_vacuum_ago_sec] ? pgbus_duration(t[:last_vacuum_ago_sec]) : "—" %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/pgbus/queues/show.html.erb
+++ b/app/views/pgbus/queues/show.html.erb
@@ -36,6 +36,43 @@
   </div>
 </div>
 
+<!-- Table Health -->
+<% if @health && @health[:tables].any? %>
+  <div class="mb-6 overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+      <h2 class="text-sm font-semibold text-gray-900 dark:text-white"><%= t("pgbus.queues.show.table_health.title") %></h2>
+      <% if @health[:oldest_transaction_age_sec] %>
+        <p class="text-xs text-gray-500 mt-1">
+          <%= t("pgbus.queues.show.table_health.oldest_txn") %>
+          <span class="font-mono <%= @health[:oldest_transaction_age_sec] > 60 ? 'text-red-600' : 'text-gray-700' %>"><%= pgbus_duration(@health[:oldest_transaction_age_sec]) %></span>
+        </p>
+      <% end %>
+    </div>
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <thead class="bg-gray-50 dark:bg-gray-900">
+        <tr>
+          <th class="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.table_health.headers.table") %></th>
+          <th class="px-4 py-2 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.table_health.headers.live") %></th>
+          <th class="px-4 py-2 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.table_health.headers.dead") %></th>
+          <th class="px-4 py-2 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.table_health.headers.bloat") %></th>
+          <th class="px-4 py-2 text-right text-xs font-medium uppercase text-gray-500"><%= t("pgbus.queues.show.table_health.headers.last_vacuum") %></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+        <% @health[:tables].each do |t| %>
+          <tr class="dark:bg-gray-900">
+            <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-white"><%= t[:table] %></td>
+            <td class="px-4 py-2 text-sm text-right text-gray-700"><%= pgbus_number(t[:live_tuples]) %></td>
+            <td class="px-4 py-2 text-sm text-right <%= t[:dead_tuples] > 1000 ? 'text-amber-600 font-semibold' : 'text-gray-700' %>"><%= pgbus_number(t[:dead_tuples]) %></td>
+            <td class="px-4 py-2 text-sm text-right <%= t[:bloat_ratio] > 0.2 ? 'text-red-600 font-semibold' : t[:bloat_ratio] > 0.1 ? 'text-amber-600' : 'text-gray-500' %>"><%= (t[:bloat_ratio] * 100).round(1) %>%</td>
+            <td class="px-4 py-2 text-sm text-right text-gray-500"><%= t[:last_vacuum_ago_sec] ? pgbus_duration(t[:last_vacuum_ago_sec]) : "—" %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
 <!-- Messages in Queue -->
 <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
   <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/app/views/pgbus/queues/show.html.erb
+++ b/app/views/pgbus/queues/show.html.erb
@@ -44,7 +44,7 @@
       <% if @health[:oldest_transaction_age_sec] %>
         <p class="text-xs text-gray-500 mt-1">
           <%= t("pgbus.queues.show.table_health.oldest_txn") %>
-          <span class="font-mono <%= @health[:oldest_transaction_age_sec] > 60 ? 'text-red-600' : 'text-gray-700' %>"><%= pgbus_duration(@health[:oldest_transaction_age_sec]) %></span>
+          <span class="font-mono <%= @health[:oldest_transaction_age_sec] > 60 ? 'text-red-600 dark:text-red-400' : @health[:oldest_transaction_age_sec] > 30 ? 'text-amber-600 dark:text-amber-400' : 'text-green-600 dark:text-green-400' %>"><%= pgbus_duration(@health[:oldest_transaction_age_sec]) %></span>
         </p>
       <% end %>
     </div>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -19,11 +19,14 @@ da:
           last_vacuum: Sidste Vacuum
           live: Levende
           table: Tabel
+        kinds:
+          archive: Arkiv
+          queue: Kø
         last_vacuum: Sidste Vacuum
-        live: levende
+        live: Levende
         mvcc_horizon: MVCC Horisont
-        oldest_open_txn: ældste åbne transaktion
-        oldest_vacuum_ago: ældste tabel-vacuum
+        oldest_open_txn: Ældste åbne transaktion
+        oldest_vacuum_ago: Ældste tabel-vacuum
         tables_need_vacuum:
           one: "%{count} tabel har brug for vacuum"
           other: "%{count} tabeller har brug for vacuum"

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -10,6 +10,25 @@ da:
           pid: PID
           status: Status
         title: Aktive processer
+      queue_health:
+        dead_tuples: Døde tupler
+        headers:
+          bloat: Bloat
+          dead: Døde
+          kind: Type
+          last_vacuum: Sidste Vacuum
+          live: Levende
+          table: Tabel
+        last_vacuum: Sidste Vacuum
+        live: levende
+        mvcc_horizon: MVCC Horisont
+        oldest_open_txn: ældste åbne transaktion
+        oldest_vacuum_ago: ældste tabel-vacuum
+        tables_need_vacuum:
+          one: "%{count} tabel har brug for vacuum"
+          other: "%{count} tabeller har brug for vacuum"
+        title: Køhelbred
+        worst_bloat: Værste Bloat
       queues_table:
         empty: Ingen køer fundet
         headers:
@@ -337,6 +356,15 @@ da:
         resume: Genoptag
         retry: Prøv igen
         retry_confirm: Nulstil synlighedstimeout og prøv igen?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Døde
+            last_vacuum: Sidste Vacuum
+            live: Levende
+            table: Tabel
+          oldest_txn: 'Ældste åbne transaktion:'
+          title: Tabelhelbred
         total: 'Total:'
         visible: 'Synlig:'
     recurring_tasks:
@@ -345,10 +373,6 @@ da:
           one: "%{count} opgave konfigureret"
           other: "%{count} opgaver konfigureret"
         title: Gentagne opgaver
-      toggle:
-        disabled: Opgave deaktiveret
-        enabled: Opgave aktiveret
-        failed: Kunne ikke ændre opgave
       show:
         back: Tilbage
         configuration: Konfiguration
@@ -392,3 +416,7 @@ da:
           task: Opgave
         never: Aldrig
         run_now: Kør nu
+      toggle:
+        disabled: Opgave deaktiveret
+        enabled: Opgave aktiveret
+        failed: Kunne ikke ændre opgave

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -19,11 +19,14 @@ de:
           last_vacuum: Letztes Vacuum
           live: Aktiv
           table: Tabelle
+        kinds:
+          archive: Archiv
+          queue: Warteschlange
         last_vacuum: Letztes Vacuum
-        live: aktiv
+        live: Aktiv
         mvcc_horizon: MVCC-Horizont
-        oldest_open_txn: älteste offene Transaktion
-        oldest_vacuum_ago: ältestes Tabellen-Vacuum
+        oldest_open_txn: Älteste offene Transaktion
+        oldest_vacuum_ago: Ältestes Tabellen-Vacuum
         tables_need_vacuum:
           one: "%{count} Tabelle benötigt Vacuum"
           other: "%{count} Tabellen benötigen Vacuum"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -10,6 +10,25 @@ de:
           pid: PID
           status: Status
         title: Aktive Prozesse
+      queue_health:
+        dead_tuples: Tote Tupel
+        headers:
+          bloat: Bloat
+          dead: Tot
+          kind: Art
+          last_vacuum: Letztes Vacuum
+          live: Aktiv
+          table: Tabelle
+        last_vacuum: Letztes Vacuum
+        live: aktiv
+        mvcc_horizon: MVCC-Horizont
+        oldest_open_txn: älteste offene Transaktion
+        oldest_vacuum_ago: ältestes Tabellen-Vacuum
+        tables_need_vacuum:
+          one: "%{count} Tabelle benötigt Vacuum"
+          other: "%{count} Tabellen benötigen Vacuum"
+        title: Warteschlangen-Gesundheit
+        worst_bloat: Schlimmster Bloat
       queues_table:
         empty: Keine Warteschlangen gefunden
         headers:
@@ -337,6 +356,15 @@ de:
         resume: Fortsetzen
         retry: Wiederholen
         retry_confirm: Sichtbarkeits-Timeout zurücksetzen und erneut versuchen?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Tot
+            last_vacuum: Letztes Vacuum
+            live: Aktiv
+            table: Tabelle
+          oldest_txn: 'Älteste offene Transaktion:'
+          title: Tabellen-Gesundheit
         total: 'Insgesamt:'
         visible: 'Sichtbar:'
     recurring_tasks:
@@ -345,10 +373,6 @@ de:
           one: "%{count} Aufgabe konfiguriert"
           other: "%{count} Aufgaben konfiguriert"
         title: Wiederkehrende Aufgaben
-      toggle:
-        disabled: Aufgabe deaktiviert
-        enabled: Aufgabe aktiviert
-        failed: Aufgabe konnte nicht umgeschaltet werden
       show:
         back: Zurück
         configuration: Konfiguration
@@ -392,3 +416,7 @@ de:
           task: Aufgabe
         never: Nie
         run_now: Jetzt ausführen
+      toggle:
+        disabled: Aufgabe deaktiviert
+        enabled: Aufgabe aktiviert
+        failed: Aufgabe konnte nicht umgeschaltet werden

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,11 +19,14 @@ en:
           last_vacuum: Last Vacuum
           live: Live
           table: Table
+        kinds:
+          archive: Archive
+          queue: Queue
         last_vacuum: Last Vacuum
-        live: live
+        live: Live
         mvcc_horizon: MVCC Horizon
-        oldest_open_txn: oldest open transaction
-        oldest_vacuum_ago: oldest table vacuum
+        oldest_open_txn: Oldest open transaction
+        oldest_vacuum_ago: Oldest table vacuum
         tables_need_vacuum:
           one: "%{count} table needs vacuum"
           other: "%{count} tables need vacuum"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,25 @@ en:
           pid: PID
           status: Status
         title: Active Processes
+      queue_health:
+        dead_tuples: Dead Tuples
+        headers:
+          bloat: Bloat
+          dead: Dead
+          kind: Kind
+          last_vacuum: Last Vacuum
+          live: Live
+          table: Table
+        last_vacuum: Last Vacuum
+        live: live
+        mvcc_horizon: MVCC Horizon
+        oldest_open_txn: oldest open transaction
+        oldest_vacuum_ago: oldest table vacuum
+        tables_need_vacuum:
+          one: "%{count} table needs vacuum"
+          other: "%{count} tables need vacuum"
+        title: Queue Health
+        worst_bloat: Worst Bloat
       queues_table:
         empty: No queues found
         headers:
@@ -399,6 +418,15 @@ en:
         resume: Resume
         retry: Retry
         retry_confirm: Reset visibility timeout and retry?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Dead
+            last_vacuum: Last Vacuum
+            live: Live
+            table: Table
+          oldest_txn: 'Oldest open transaction:'
+          title: Table Health
         total: 'Total:'
         visible: 'Visible:'
     recurring_tasks:
@@ -407,10 +435,6 @@ en:
           one: "%{count} task configured"
           other: "%{count} tasks configured"
         title: Recurring Tasks
-      toggle:
-        disabled: Task disabled
-        enabled: Task enabled
-        failed: Failed to toggle task
       show:
         back: Back
         configuration: Configuration
@@ -454,3 +478,7 @@ en:
           task: Task
         never: Never
         run_now: Run Now
+      toggle:
+        disabled: Task disabled
+        enabled: Task enabled
+        failed: Failed to toggle task

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,11 +19,14 @@ es:
           last_vacuum: Último Vacuum
           live: Activas
           table: Tabla
+        kinds:
+          archive: Archivo
+          queue: Cola
         last_vacuum: Último Vacuum
-        live: activas
+        live: Activas
         mvcc_horizon: Horizonte MVCC
-        oldest_open_txn: transacción abierta más antigua
-        oldest_vacuum_ago: vacuum de tabla más antiguo
+        oldest_open_txn: Transacción abierta más antigua
+        oldest_vacuum_ago: Vacuum de tabla más antiguo
         tables_need_vacuum:
           one: "%{count} tabla necesita vacuum"
           other: "%{count} tablas necesitan vacuum"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -10,6 +10,25 @@ es:
           pid: PID
           status: Estado
         title: Procesos activos
+      queue_health:
+        dead_tuples: Tuplas muertas
+        headers:
+          bloat: Bloat
+          dead: Muertas
+          kind: Tipo
+          last_vacuum: Último Vacuum
+          live: Activas
+          table: Tabla
+        last_vacuum: Último Vacuum
+        live: activas
+        mvcc_horizon: Horizonte MVCC
+        oldest_open_txn: transacción abierta más antigua
+        oldest_vacuum_ago: vacuum de tabla más antiguo
+        tables_need_vacuum:
+          one: "%{count} tabla necesita vacuum"
+          other: "%{count} tablas necesitan vacuum"
+        title: Salud de Colas
+        worst_bloat: Peor Bloat
       queues_table:
         empty: No se encontraron colas
         headers:
@@ -337,6 +356,15 @@ es:
         resume: Reanudar
         retry: Reintentar
         retry_confirm: "¿Restablecer tiempo de visibilidad y reintentar?"
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Muertas
+            last_vacuum: Último Vacuum
+            live: Activas
+            table: Tabla
+          oldest_txn: 'Transacción abierta más antigua:'
+          title: Salud de Tablas
         total: 'Total:'
         visible: 'Visible:'
     recurring_tasks:
@@ -345,10 +373,6 @@ es:
           one: Tarea %{count} configurada
           other: Tareas %{count} configuradas
         title: Tareas recurrentes
-      toggle:
-        disabled: Tarea deshabilitada
-        enabled: Tarea habilitada
-        failed: No se pudo cambiar la tarea
       show:
         back: Atrás
         configuration: Configuración
@@ -392,3 +416,7 @@ es:
           task: Tarea
         never: Nunca
         run_now: Ejecutar ahora
+      toggle:
+        disabled: Tarea deshabilitada
+        enabled: Tarea habilitada
+        failed: No se pudo cambiar la tarea

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -19,11 +19,14 @@ fi:
           last_vacuum: Viimeisin Vacuum
           live: Elävät
           table: Taulu
+        kinds:
+          archive: Arkisto
+          queue: Jono
         last_vacuum: Viimeisin Vacuum
-        live: elävät
+        live: Elävät
         mvcc_horizon: MVCC-horisontti
-        oldest_open_txn: vanhin avoin transaktio
-        oldest_vacuum_ago: vanhin taulun vacuum
+        oldest_open_txn: Vanhin avoin transaktio
+        oldest_vacuum_ago: Vanhin taulun vacuum
         tables_need_vacuum:
           one: "%{count} taulu tarvitsee vacuum-käsittelyn"
           other: "%{count} taulua tarvitsee vacuum-käsittelyn"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -10,6 +10,25 @@ fi:
           pid: PID
           status: Tila
         title: Aktiiviset prosessit
+      queue_health:
+        dead_tuples: Kuolleet tuplat
+        headers:
+          bloat: Bloat
+          dead: Kuolleet
+          kind: Tyyppi
+          last_vacuum: Viimeisin Vacuum
+          live: Elävät
+          table: Taulu
+        last_vacuum: Viimeisin Vacuum
+        live: elävät
+        mvcc_horizon: MVCC-horisontti
+        oldest_open_txn: vanhin avoin transaktio
+        oldest_vacuum_ago: vanhin taulun vacuum
+        tables_need_vacuum:
+          one: "%{count} taulu tarvitsee vacuum-käsittelyn"
+          other: "%{count} taulua tarvitsee vacuum-käsittelyn"
+        title: Jonon kunto
+        worst_bloat: Pahin Bloat
       queues_table:
         empty: Jonot eivät löytyneet
         headers:
@@ -337,6 +356,15 @@ fi:
         resume: Jatka
         retry: Yritä uudelleen
         retry_confirm: Nollaa näkyvyysaika ja yritä uudelleen?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Kuolleet
+            last_vacuum: Viimeisin Vacuum
+            live: Elävät
+            table: Taulu
+          oldest_txn: 'Vanhin avoin transaktio:'
+          title: Taulun kunto
         total: 'Yhteensä:'
         visible: 'Näkyvissä:'
     recurring_tasks:
@@ -345,10 +373,6 @@ fi:
           one: "%{count} tehtävä määritetty"
           other: "%{count} tehtävää määritetty"
         title: Toistuvat tehtävät
-      toggle:
-        disabled: Tehtävä poistettu käytöstä
-        enabled: Tehtävä otettu käyttöön
-        failed: Tehtävän vaihto epäonnistui
       show:
         back: Takaisin
         configuration: Asetukset
@@ -392,3 +416,7 @@ fi:
           task: Tehtävä
         never: Ei koskaan
         run_now: Suorita nyt
+      toggle:
+        disabled: Tehtävä poistettu käytöstä
+        enabled: Tehtävä otettu käyttöön
+        failed: Tehtävän vaihto epäonnistui

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -10,6 +10,25 @@ fr:
           pid: PID
           status: Statut
         title: Processus actifs
+      queue_health:
+        dead_tuples: Tuples mortes
+        headers:
+          bloat: Bloat
+          dead: Mortes
+          kind: Type
+          last_vacuum: Dernier Vacuum
+          live: Actives
+          table: Table
+        last_vacuum: Dernier Vacuum
+        live: actives
+        mvcc_horizon: Horizon MVCC
+        oldest_open_txn: plus ancienne transaction ouverte
+        oldest_vacuum_ago: plus ancien vacuum de table
+        tables_need_vacuum:
+          one: "%{count} table nécessite un vacuum"
+          other: "%{count} tables nécessitent un vacuum"
+        title: Santé des files d'attente
+        worst_bloat: Pire Bloat
       queues_table:
         empty: Aucune file d'attente trouvée
         headers:
@@ -337,6 +356,15 @@ fr:
         resume: Reprendre
         retry: Réessayer
         retry_confirm: Réinitialiser le délai de visibilité et réessayer ?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Mortes
+            last_vacuum: Dernier Vacuum
+            live: Actives
+            table: Table
+          oldest_txn: 'Plus ancienne transaction ouverte :'
+          title: Santé des tables
         total: 'Total :'
         visible: 'Visible :'
     recurring_tasks:
@@ -345,10 +373,6 @@ fr:
           one: Tâche %{count} configurée
           other: Tâches %{count} configurées
         title: Tâches récurrentes
-      toggle:
-        disabled: Tâche désactivée
-        enabled: Tâche activée
-        failed: Impossible de basculer la tâche
       show:
         back: Retour
         configuration: Configuration
@@ -392,3 +416,7 @@ fr:
           task: Tâche
         never: Jamais
         run_now: Exécuter maintenant
+      toggle:
+        disabled: Tâche désactivée
+        enabled: Tâche activée
+        failed: Impossible de basculer la tâche

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -19,11 +19,14 @@ fr:
           last_vacuum: Dernier Vacuum
           live: Actives
           table: Table
+        kinds:
+          archive: Archive
+          queue: File d'attente
         last_vacuum: Dernier Vacuum
-        live: actives
+        live: Actives
         mvcc_horizon: Horizon MVCC
-        oldest_open_txn: plus ancienne transaction ouverte
-        oldest_vacuum_ago: plus ancien vacuum de table
+        oldest_open_txn: Plus ancienne transaction ouverte
+        oldest_vacuum_ago: Plus ancien vacuum de table
         tables_need_vacuum:
           one: "%{count} table nécessite un vacuum"
           other: "%{count} tables nécessitent un vacuum"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -19,11 +19,14 @@ it:
           last_vacuum: Ultimo Vacuum
           live: Attive
           table: Tabella
+        kinds:
+          archive: Archivio
+          queue: Coda
         last_vacuum: Ultimo Vacuum
-        live: attive
+        live: Attive
         mvcc_horizon: Orizzonte MVCC
-        oldest_open_txn: transazione aperta più vecchia
-        oldest_vacuum_ago: vacuum tabella più vecchio
+        oldest_open_txn: Transazione aperta più vecchia
+        oldest_vacuum_ago: Vacuum tabella più vecchio
         tables_need_vacuum:
           one: "%{count} tabella necessita di vacuum"
           other: "%{count} tabelle necessitano di vacuum"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -10,6 +10,25 @@ it:
           pid: PID
           status: Stato
         title: Processi attivi
+      queue_health:
+        dead_tuples: Tuple morte
+        headers:
+          bloat: Bloat
+          dead: Morte
+          kind: Tipo
+          last_vacuum: Ultimo Vacuum
+          live: Attive
+          table: Tabella
+        last_vacuum: Ultimo Vacuum
+        live: attive
+        mvcc_horizon: Orizzonte MVCC
+        oldest_open_txn: transazione aperta più vecchia
+        oldest_vacuum_ago: vacuum tabella più vecchio
+        tables_need_vacuum:
+          one: "%{count} tabella necessita di vacuum"
+          other: "%{count} tabelle necessitano di vacuum"
+        title: Salute delle Code
+        worst_bloat: Peggior Bloat
       queues_table:
         empty: Nessuna coda trovata
         headers:
@@ -337,6 +356,15 @@ it:
         resume: Riprendi
         retry: Riprova
         retry_confirm: Reimpostare il timeout di visibilità e riprovare?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Morte
+            last_vacuum: Ultimo Vacuum
+            live: Attive
+            table: Tabella
+          oldest_txn: 'Transazione aperta più vecchia:'
+          title: Salute delle Tabelle
         total: 'Totale:'
         visible: 'Visibile:'
     recurring_tasks:
@@ -345,10 +373,6 @@ it:
           one: "%{count} attività configurata"
           other: "%{count} attività configurate"
         title: Attività ricorrenti
-      toggle:
-        disabled: Attività disabilitata
-        enabled: Attività abilitata
-        failed: Impossibile cambiare lo stato dell'attività
       show:
         back: Indietro
         configuration: Configurazione
@@ -392,3 +416,7 @@ it:
           task: Attività
         never: Mai
         run_now: Esegui ora
+      toggle:
+        disabled: Attività disabilitata
+        enabled: Attività abilitata
+        failed: Impossibile cambiare lo stato dell'attività

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,9 @@ ja:
           last_vacuum: 最終Vacuum
           live: ライブ
           table: テーブル
+        kinds:
+          archive: アーカイブ
+          queue: キュー
         last_vacuum: 最終Vacuum
         live: ライブ
         mvcc_horizon: MVCCホライズン

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,25 @@ ja:
           pid: PID
           status: ステータス
         title: アクティブなプロセス
+      queue_health:
+        dead_tuples: デッドタプル
+        headers:
+          bloat: Bloat
+          dead: デッド
+          kind: 種類
+          last_vacuum: 最終Vacuum
+          live: ライブ
+          table: テーブル
+        last_vacuum: 最終Vacuum
+        live: ライブ
+        mvcc_horizon: MVCCホライズン
+        oldest_open_txn: 最も古い未完了トランザクション
+        oldest_vacuum_ago: 最も古いテーブルvacuum
+        tables_need_vacuum:
+          one: "%{count} テーブルがvacuumを必要としています"
+          other: "%{count} テーブルがvacuumを必要としています"
+        title: キューの健全性
+        worst_bloat: 最悪のBloat
       queues_table:
         empty: キューが見つかりません
         headers:
@@ -337,6 +356,15 @@ ja:
         resume: 再開
         retry: リトライ
         retry_confirm: 可視性タイムアウトをリセットしてリトライしますか？
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: デッド
+            last_vacuum: 最終Vacuum
+            live: ライブ
+            table: テーブル
+          oldest_txn: '最も古い未完了トランザクション:'
+          title: テーブルの健全性
         total: 合計：
         visible: 表示中：
     recurring_tasks:
@@ -345,10 +373,6 @@ ja:
           one: "%{count} タスクが設定されています"
           other: "%{count} タスクが設定されています"
         title: 定期タスク
-      toggle:
-        disabled: タスクが無効になりました
-        enabled: タスクが有効になりました
-        failed: タスクの切り替えに失敗しました
       show:
         back: 戻る
         configuration: 設定
@@ -392,3 +416,7 @@ ja:
           task: タスク
         never: なし
         run_now: 今すぐ実行
+      toggle:
+        disabled: タスクが無効になりました
+        enabled: タスクが有効になりました
+        failed: タスクの切り替えに失敗しました

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -10,6 +10,25 @@ nb:
           pid: PID
           status: Status
         title: Aktive prosesser
+      queue_health:
+        dead_tuples: Døde tupler
+        headers:
+          bloat: Bloat
+          dead: Døde
+          kind: Type
+          last_vacuum: Siste Vacuum
+          live: Levende
+          table: Tabell
+        last_vacuum: Siste Vacuum
+        live: levende
+        mvcc_horizon: MVCC-horisont
+        oldest_open_txn: eldste åpne transaksjon
+        oldest_vacuum_ago: eldste tabell-vacuum
+        tables_need_vacuum:
+          one: "%{count} tabell trenger vacuum"
+          other: "%{count} tabeller trenger vacuum"
+        title: Køhelse
+        worst_bloat: Verste Bloat
       queues_table:
         empty: Ingen køer funnet
         headers:
@@ -337,6 +356,15 @@ nb:
         resume: Gjenoppta
         retry: Prøv igjen
         retry_confirm: Tilbakestill synlighetstidsavbrudd og prøv igjen?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Døde
+            last_vacuum: Siste Vacuum
+            live: Levende
+            table: Tabell
+          oldest_txn: 'Eldste åpne transaksjon:'
+          title: Tabellhelse
         total: 'Totalt:'
         visible: 'Synlig:'
     recurring_tasks:
@@ -345,10 +373,6 @@ nb:
           one: "%{count} oppgave konfigurert"
           other: "%{count} oppgaver konfigurert"
         title: Gjentakende oppgaver
-      toggle:
-        disabled: Oppgave deaktivert
-        enabled: Oppgave aktivert
-        failed: Kunne ikke endre oppgave
       show:
         back: Tilbake
         configuration: Konfigurasjon
@@ -392,3 +416,7 @@ nb:
           task: Oppgave
         never: Aldri
         run_now: Kjør nå
+      toggle:
+        disabled: Oppgave deaktivert
+        enabled: Oppgave aktivert
+        failed: Kunne ikke endre oppgave

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -19,11 +19,14 @@ nb:
           last_vacuum: Siste Vacuum
           live: Levende
           table: Tabell
+        kinds:
+          archive: Arkiv
+          queue: Kø
         last_vacuum: Siste Vacuum
-        live: levende
+        live: Levende
         mvcc_horizon: MVCC-horisont
-        oldest_open_txn: eldste åpne transaksjon
-        oldest_vacuum_ago: eldste tabell-vacuum
+        oldest_open_txn: Eldste åpne transaksjon
+        oldest_vacuum_ago: Eldste tabell-vacuum
         tables_need_vacuum:
           one: "%{count} tabell trenger vacuum"
           other: "%{count} tabeller trenger vacuum"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -10,6 +10,25 @@ nl:
           pid: PID
           status: Status
         title: Actieve processen
+      queue_health:
+        dead_tuples: Dode tupels
+        headers:
+          bloat: Bloat
+          dead: Dood
+          kind: Type
+          last_vacuum: Laatste Vacuum
+          live: Actief
+          table: Tabel
+        last_vacuum: Laatste Vacuum
+        live: actief
+        mvcc_horizon: MVCC-horizon
+        oldest_open_txn: oudste open transactie
+        oldest_vacuum_ago: oudste tabel-vacuum
+        tables_need_vacuum:
+          one: "%{count} tabel heeft vacuum nodig"
+          other: "%{count} tabellen hebben vacuum nodig"
+        title: Wachtrijgezondheid
+        worst_bloat: Ergste Bloat
       queues_table:
         empty: Geen wachtrijen gevonden
         headers:
@@ -337,6 +356,15 @@ nl:
         resume: Hervatten
         retry: Opnieuw proberen
         retry_confirm: Zichtbaarheidstimeout resetten en opnieuw proberen?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Dood
+            last_vacuum: Laatste Vacuum
+            live: Actief
+            table: Tabel
+          oldest_txn: 'Oudste open transactie:'
+          title: Tabelgezondheid
         total: 'Totaal:'
         visible: 'Zichtbaar:'
     recurring_tasks:
@@ -345,10 +373,6 @@ nl:
           one: "%{count} taak geconfigureerd"
           other: "%{count} taken geconfigureerd"
         title: Terugkerende taken
-      toggle:
-        disabled: Taak uitgeschakeld
-        enabled: Taak ingeschakeld
-        failed: Kon taak niet omschakelen
       show:
         back: Terug
         configuration: Configuratie
@@ -392,3 +416,7 @@ nl:
           task: Taak
         never: Nooit
         run_now: Nu uitvoeren
+      toggle:
+        disabled: Taak uitgeschakeld
+        enabled: Taak ingeschakeld
+        failed: Kon taak niet omschakelen

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -19,11 +19,14 @@ nl:
           last_vacuum: Laatste Vacuum
           live: Actief
           table: Tabel
+        kinds:
+          archive: Archief
+          queue: Wachtrij
         last_vacuum: Laatste Vacuum
-        live: actief
+        live: Actief
         mvcc_horizon: MVCC-horizon
-        oldest_open_txn: oudste open transactie
-        oldest_vacuum_ago: oudste tabel-vacuum
+        oldest_open_txn: Oudste open transactie
+        oldest_vacuum_ago: Oudste tabel-vacuum
         tables_need_vacuum:
           one: "%{count} tabel heeft vacuum nodig"
           other: "%{count} tabellen hebben vacuum nodig"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -10,6 +10,25 @@ pt:
           pid: PID
           status: Status
         title: Processos Ativos
+      queue_health:
+        dead_tuples: Tuplas mortas
+        headers:
+          bloat: Bloat
+          dead: Mortas
+          kind: Tipo
+          last_vacuum: Último Vacuum
+          live: Ativas
+          table: Tabela
+        last_vacuum: Último Vacuum
+        live: ativas
+        mvcc_horizon: Horizonte MVCC
+        oldest_open_txn: transação aberta mais antiga
+        oldest_vacuum_ago: vacuum de tabela mais antigo
+        tables_need_vacuum:
+          one: "%{count} tabela precisa de vacuum"
+          other: "%{count} tabelas precisam de vacuum"
+        title: Saúde das Filas
+        worst_bloat: Pior Bloat
       queues_table:
         empty: Nenhuma fila encontrada
         headers:
@@ -337,6 +356,15 @@ pt:
         resume: Retomar
         retry: Tentar novamente
         retry_confirm: Redefinir tempo de visibilidade e tentar novamente?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Mortas
+            last_vacuum: Último Vacuum
+            live: Ativas
+            table: Tabela
+          oldest_txn: 'Transação aberta mais antiga:'
+          title: Saúde das Tabelas
         total: 'Total:'
         visible: 'Visível:'
     recurring_tasks:
@@ -345,10 +373,6 @@ pt:
           one: "%{count} tarefa configurada"
           other: "%{count} tarefas configuradas"
         title: Tarefas Recorrentes
-      toggle:
-        disabled: Tarefa desativada
-        enabled: Tarefa ativada
-        failed: Falha ao alternar tarefa
       show:
         back: Voltar
         configuration: Configuração
@@ -392,3 +416,7 @@ pt:
           task: Tarefa
         never: Nunca
         run_now: Executar Agora
+      toggle:
+        disabled: Tarefa desativada
+        enabled: Tarefa ativada
+        failed: Falha ao alternar tarefa

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -19,11 +19,14 @@ pt:
           last_vacuum: Último Vacuum
           live: Ativas
           table: Tabela
+        kinds:
+          archive: Arquivo
+          queue: Fila
         last_vacuum: Último Vacuum
-        live: ativas
+        live: Ativas
         mvcc_horizon: Horizonte MVCC
-        oldest_open_txn: transação aberta mais antiga
-        oldest_vacuum_ago: vacuum de tabela mais antigo
+        oldest_open_txn: Transação aberta mais antiga
+        oldest_vacuum_ago: Vacuum de tabela mais antigo
         tables_need_vacuum:
           one: "%{count} tabela precisa de vacuum"
           other: "%{count} tabelas precisam de vacuum"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -10,6 +10,25 @@ sv:
           pid: PID
           status: Status
         title: Aktiva processer
+      queue_health:
+        dead_tuples: Döda tuplar
+        headers:
+          bloat: Bloat
+          dead: Döda
+          kind: Typ
+          last_vacuum: Senaste Vacuum
+          live: Levande
+          table: Tabell
+        last_vacuum: Senaste Vacuum
+        live: levande
+        mvcc_horizon: MVCC-horisont
+        oldest_open_txn: äldsta öppna transaktion
+        oldest_vacuum_ago: äldsta tabell-vacuum
+        tables_need_vacuum:
+          one: "%{count} tabell behöver vacuum"
+          other: "%{count} tabeller behöver vacuum"
+        title: Köhälsa
+        worst_bloat: Värsta Bloat
       queues_table:
         empty: Inga köer hittades
         headers:
@@ -337,6 +356,15 @@ sv:
         resume: Återuppta
         retry: Försök igen
         retry_confirm: Återställ synlighetstimeout och försök igen?
+        table_health:
+          headers:
+            bloat: Bloat
+            dead: Döda
+            last_vacuum: Senaste Vacuum
+            live: Levande
+            table: Tabell
+          oldest_txn: 'Äldsta öppna transaktion:'
+          title: Tabellhälsa
         total: 'Totalt:'
         visible: 'Synliga:'
     recurring_tasks:
@@ -345,10 +373,6 @@ sv:
           one: "%{count} uppgift konfigurerad"
           other: "%{count} uppgifter konfigurerade"
         title: Återkommande uppgifter
-      toggle:
-        disabled: Uppgift inaktiverad
-        enabled: Uppgift aktiverad
-        failed: Kunde inte ändra uppgift
       show:
         back: Tillbaka
         configuration: Konfiguration
@@ -392,3 +416,7 @@ sv:
           task: Uppgift
         never: Aldrig
         run_now: Kör nu
+      toggle:
+        disabled: Uppgift inaktiverad
+        enabled: Uppgift aktiverad
+        failed: Kunde inte ändra uppgift

--- a/lib/generators/pgbus/templates/migration.rb.erb
+++ b/lib/generators/pgbus/templates/migration.rb.erb
@@ -150,6 +150,10 @@ class CreatePgbusTables < ActiveRecord::Migration<%= migration_version %>
     # Create default queues via PGMQ
     execute "SELECT pgmq.create('pgbus_default')"
     execute "SELECT pgmq.create('pgbus_default_dlq')"
+
+    # Tune autovacuum for queue/archive tables — default settings are too
+    # conservative for the high insert/delete churn of queue processing.
+    execute Pgbus::AutovacuumTuning.sql_for_all_queues
   end
 
   def down

--- a/lib/generators/pgbus/templates/migration.rb.erb
+++ b/lib/generators/pgbus/templates/migration.rb.erb
@@ -151,9 +151,11 @@ class CreatePgbusTables < ActiveRecord::Migration<%= migration_version %>
     execute "SELECT pgmq.create('pgbus_default')"
     execute "SELECT pgmq.create('pgbus_default_dlq')"
 
-    # Tune autovacuum for queue/archive tables — default settings are too
-    # conservative for the high insert/delete churn of queue processing.
+    # Tune autovacuum for queue/archive tables and high-churn pgbus tables.
+    # Default settings are too conservative for the insert/delete churn of
+    # queue processing and concurrency lock management.
     execute Pgbus::AutovacuumTuning.sql_for_all_queues
+    execute Pgbus::AutovacuumTuning.sql_for_high_churn_tables
   end
 
   def down

--- a/lib/generators/pgbus/templates/tune_autovacuum.rb.erb
+++ b/lib/generators/pgbus/templates/tune_autovacuum.rb.erb
@@ -9,6 +9,12 @@ class TunePgbusAutovacuum < ActiveRecord::Migration<%= migration_version %>
     # New queues created after this migration automatically receive these
     # settings via Pgbus::Client at queue creation time.
     execute Pgbus::AutovacuumTuning.sql_for_all_queues
+
+    # Also tune pgbus-owned tables with high write churn:
+    # - pgbus_semaphores: rapid upsert+increment per job, periodic expiry
+    # - pgbus_uniqueness_keys: INSERT on enqueue, DELETE on completion
+    # - pgbus_processed_events: INSERT per event, bulk DELETE on TTL expiry
+    execute Pgbus::AutovacuumTuning.sql_for_high_churn_tables
   end
 
   def down
@@ -24,5 +30,9 @@ class TunePgbusAutovacuum < ActiveRecord::Migration<%= migration_version %>
         END LOOP;
       END $$;
     SQL
+
+    Pgbus::AutovacuumTuning::HIGH_CHURN_TABLES.each do |table|
+      execute "ALTER TABLE #{table} RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_delay, autovacuum_analyze_scale_factor)"
+    end
   end
 end

--- a/lib/generators/pgbus/templates/tune_autovacuum.rb.erb
+++ b/lib/generators/pgbus/templates/tune_autovacuum.rb.erb
@@ -1,0 +1,28 @@
+class TunePgbusAutovacuum < ActiveRecord::Migration<%= migration_version %>
+  def up
+    # Apply aggressive autovacuum settings to all existing PGMQ queue and
+    # archive tables. Queue tables have very high insert/delete churn from
+    # the read→process→archive cycle; default autovacuum settings (vacuum
+    # at 20% dead tuples) allow dead tuple accumulation that bloats indexes
+    # and degrades lock acquisition times.
+    #
+    # New queues created after this migration automatically receive these
+    # settings via Pgbus::Client at queue creation time.
+    execute Pgbus::AutovacuumTuning.sql_for_all_queues
+  end
+
+  def down
+    # Reset to PostgreSQL defaults
+    execute <<~SQL
+      DO $$
+      DECLARE
+        q RECORD;
+      BEGIN
+        FOR q IN SELECT queue_name FROM pgmq.meta LOOP
+          EXECUTE format('ALTER TABLE pgmq.q_%I RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_delay, autovacuum_analyze_scale_factor)', q.queue_name);
+          EXECUTE format('ALTER TABLE pgmq.a_%I RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_delay, autovacuum_analyze_scale_factor)', q.queue_name);
+        END LOOP;
+      END $$;
+    SQL
+  end
+end

--- a/lib/generators/pgbus/tune_autovacuum_generator.rb
+++ b/lib/generators/pgbus/tune_autovacuum_generator.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Pgbus
+  module Generators
+    class TuneAutovacuumGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Tune autovacuum settings on PGMQ queue and archive tables for optimal queue health"
+
+      class_option :database,
+                   type: :string,
+                   default: nil,
+                   desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
+
+      def create_migration_file
+        if separate_database?
+          migration_template "tune_autovacuum.rb.erb",
+                             "db/pgbus_migrate/tune_pgbus_autovacuum.rb"
+        else
+          migration_template "tune_autovacuum.rb.erb",
+                             "db/migrate/tune_pgbus_autovacuum.rb"
+        end
+      end
+
+      def display_post_install
+        say ""
+        say "Pgbus autovacuum tuning migration created!", :green
+        say ""
+        say "This migration applies aggressive autovacuum settings to all existing"
+        say "PGMQ queue and archive tables. New queues created at runtime will"
+        say "automatically receive these settings."
+        say ""
+        say "Next steps:"
+        say "  1. Run: rails db:migrate#{":#{options[:database]}" if separate_database?}"
+        say "  2. Restart pgbus: bin/pgbus start"
+        say ""
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::Migration.current_version}]"
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/pgbus/autovacuum_tuning.rb
+++ b/lib/pgbus/autovacuum_tuning.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Pgbus
+  # Shared autovacuum storage parameters for PGMQ queue and archive tables.
+  #
+  # Queue tables (q_*) have high insert/delete churn: every read + archive
+  # cycle deletes from q_ and inserts into a_. Default autovacuum settings
+  # (vacuum at 20% dead tuples) are far too conservative — dead tuples
+  # accumulate, bloat B-tree indexes, and eventually degrade lock acquisition
+  # times. See: https://planetscale.com/blog/keeping-a-postgres-queue-healthy
+  #
+  # Used by:
+  # - Client#ensure_single_queue (runtime, on queue creation)
+  # - CreatePgbusTables migration (fresh install)
+  # - TunePgbusAutovacuum migration (upgrade for existing installations)
+  module AutovacuumTuning
+    # Queue tables: very aggressive — high delete rate from read+archive.
+    QUEUE_SETTINGS = {
+      "autovacuum_vacuum_scale_factor" => "0.01",
+      "autovacuum_vacuum_cost_delay" => "2",
+      "autovacuum_analyze_scale_factor" => "0.05"
+    }.freeze
+
+    # Archive tables: moderately aggressive — append-heavy with periodic purge.
+    ARCHIVE_SETTINGS = {
+      "autovacuum_vacuum_scale_factor" => "0.05",
+      "autovacuum_vacuum_cost_delay" => "5",
+      "autovacuum_analyze_scale_factor" => "0.05"
+    }.freeze
+
+    class << self
+      # Generate ALTER TABLE SQL for a single queue's tables.
+      def sql_for_queue(queue_name)
+        [
+          alter_table_sql("pgmq.q_#{queue_name}", QUEUE_SETTINGS),
+          alter_table_sql("pgmq.a_#{queue_name}", ARCHIVE_SETTINGS)
+        ].join("\n")
+      end
+
+      # Generate ALTER TABLE SQL for all queues discovered via pgmq.meta.
+      def sql_for_all_queues
+        <<~SQL
+          DO $$
+          DECLARE
+            q RECORD;
+          BEGIN
+            FOR q IN SELECT queue_name FROM pgmq.meta LOOP
+              EXECUTE format('ALTER TABLE pgmq.q_%I SET (#{settings_clause(QUEUE_SETTINGS)})', q.queue_name);
+              EXECUTE format('ALTER TABLE pgmq.a_%I SET (#{settings_clause(ARCHIVE_SETTINGS)})', q.queue_name);
+            END LOOP;
+          END $$;
+        SQL
+      end
+
+      private
+
+      def alter_table_sql(table, settings)
+        "ALTER TABLE #{table} SET (#{settings_clause(settings)});"
+      end
+
+      def settings_clause(settings)
+        settings.map { |k, v| "#{k} = #{v}" }.join(", ")
+      end
+    end
+  end
+end

--- a/lib/pgbus/autovacuum_tuning.rb
+++ b/lib/pgbus/autovacuum_tuning.rb
@@ -75,13 +75,14 @@ module Pgbus
 
       # Generate ALTER TABLE SQL for pgbus-owned high-churn tables.
       def sql_for_high_churn_tables
-        HIGH_CHURN_TABLES.map { |table| alter_table_sql(table, HIGH_CHURN_SETTINGS) }.join("\n")
+        HIGH_CHURN_TABLES.map { |table| alter_table_sql(table, HIGH_CHURN_SETTINGS, if_exists: true) }.join("\n")
       end
 
       private
 
-      def alter_table_sql(table, settings)
-        "ALTER TABLE #{table} SET (#{settings_clause(settings)});"
+      def alter_table_sql(table, settings, if_exists: false)
+        prefix = if_exists ? "ALTER TABLE IF EXISTS" : "ALTER TABLE"
+        "#{prefix} #{table} SET (#{settings_clause(settings)});"
       end
 
       def settings_clause(settings)

--- a/lib/pgbus/autovacuum_tuning.rb
+++ b/lib/pgbus/autovacuum_tuning.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
 module Pgbus
-  # Shared autovacuum storage parameters for PGMQ queue and archive tables.
+  # Shared autovacuum storage parameters for tables with high write churn.
   #
   # Queue tables (q_*) have high insert/delete churn: every read + archive
   # cycle deletes from q_ and inserts into a_. Default autovacuum settings
   # (vacuum at 20% dead tuples) are far too conservative — dead tuples
   # accumulate, bloat B-tree indexes, and eventually degrade lock acquisition
   # times. See: https://planetscale.com/blog/keeping-a-postgres-queue-healthy
+  #
+  # Several pgbus-owned tables share similar churn patterns:
+  # - pgbus_semaphores: rapid upsert+increment per job, periodic expiry
+  # - pgbus_uniqueness_keys: INSERT on enqueue, DELETE on completion
+  # - pgbus_processed_events: INSERT per event, bulk DELETE on TTL expiry
   #
   # Used by:
   # - Client#ensure_single_queue (runtime, on queue creation)
@@ -27,6 +32,22 @@ module Pgbus
       "autovacuum_vacuum_cost_delay" => "5",
       "autovacuum_analyze_scale_factor" => "0.05"
     }.freeze
+
+    # High-churn pgbus tables: rapid INSERT/DELETE or upsert cycles.
+    # - semaphores: upsert + increment per job acquire, decrement on release, periodic expiry
+    # - uniqueness_keys: INSERT on enqueue, DELETE on job completion (fast lifecycle)
+    # - processed_events: INSERT per event handler, bulk DELETE on idempotency TTL expiry
+    HIGH_CHURN_SETTINGS = {
+      "autovacuum_vacuum_scale_factor" => "0.02",
+      "autovacuum_vacuum_cost_delay" => "2",
+      "autovacuum_analyze_scale_factor" => "0.05"
+    }.freeze
+
+    HIGH_CHURN_TABLES = %w[
+      pgbus_semaphores
+      pgbus_uniqueness_keys
+      pgbus_processed_events
+    ].freeze
 
     class << self
       # Generate ALTER TABLE SQL for a single queue's tables.
@@ -50,6 +71,11 @@ module Pgbus
             END LOOP;
           END $$;
         SQL
+      end
+
+      # Generate ALTER TABLE SQL for pgbus-owned high-churn tables.
+      def sql_for_high_churn_tables
+        HIGH_CHURN_TABLES.map { |table| alter_table_sql(table, HIGH_CHURN_SETTINGS) }.join("\n")
       end
 
       private

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -446,10 +446,19 @@ module Pgbus
       @queues_created.compute_if_absent(full_name) do
         synchronized do
           @pgmq.create(full_name)
+          tune_autovacuum(full_name)
           @pgmq.enable_notify_insert(full_name, throttle_interval_ms: NOTIFY_THROTTLE_MS) if config.listen_notify
         end
         true
       end
+    end
+
+    def tune_autovacuum(queue_name)
+      with_raw_connection do |conn|
+        conn.exec(AutovacuumTuning.sql_for_queue(queue_name))
+      end
+    rescue StandardError => e
+      Pgbus.logger.debug { "[Pgbus::Client] Autovacuum tuning failed for #{queue_name}: #{e.message}" }
     end
 
     # Serialize PGMQ operations through a mutex when sharing a connection

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -75,7 +75,10 @@ module Pgbus
       return if @queues_created[dlq_name]
 
       @queues_created.compute_if_absent(dlq_name) do
-        synchronized { @pgmq.create(dlq_name) }
+        synchronized do
+          @pgmq.create(dlq_name)
+          tune_autovacuum(dlq_name)
+        end
         true
       end
     end

--- a/lib/pgbus/generators/migration_detector.rb
+++ b/lib/pgbus/generators/migration_detector.rb
@@ -73,7 +73,8 @@ module Pgbus
         add_queue_states: "pgbus:add_queue_states",
         add_outbox: "pgbus:add_outbox",
         add_recurring: "pgbus:add_recurring",
-        add_failed_events_index: "pgbus:add_failed_events_index"
+        add_failed_events_index: "pgbus:add_failed_events_index",
+        tune_autovacuum: "pgbus:tune_autovacuum"
       }.freeze
 
       # Human-friendly description of each migration for the generator
@@ -88,7 +89,8 @@ module Pgbus
         add_queue_states: "queue states table (pause/resume)",
         add_outbox: "outbox entries table (transactional outbox)",
         add_recurring: "recurring tasks + executions tables",
-        add_failed_events_index: "unique index on pgbus_failed_events (queue_name, msg_id)"
+        add_failed_events_index: "unique index on pgbus_failed_events (queue_name, msg_id)",
+        tune_autovacuum: "autovacuum tuning for PGMQ queue and archive tables"
       }.freeze
 
       def initialize(connection)
@@ -110,7 +112,8 @@ module Pgbus
           *queue_states_migrations,
           *outbox_migrations,
           *recurring_migrations,
-          *failed_events_index_migrations
+          *failed_events_index_migrations,
+          *autovacuum_migrations
         ]
       end
 
@@ -193,6 +196,15 @@ module Pgbus
         [:add_failed_events_index]
       end
 
+      # Autovacuum tuning: check if any PGMQ queue table already has
+      # custom autovacuum settings applied. If not, queue the migration.
+      def autovacuum_migrations
+        return [] unless pgmq_schema_exists?
+        return [] if autovacuum_already_tuned?
+
+        [:tune_autovacuum]
+      end
+
       # --- schema probes -------------------------------------------------
 
       def table_exists?(name)
@@ -211,6 +223,29 @@ module Pgbus
         connection.indexes(table).any? { |idx| idx.name == index_name }
       rescue StandardError
         false
+      end
+
+      def pgmq_schema_exists?
+        result = connection.select_value("SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgmq'")
+        result.present?
+      rescue StandardError
+        false
+      end
+
+      def autovacuum_already_tuned?
+        queue_name = connection.select_value("SELECT queue_name FROM pgmq.meta ORDER BY queue_name LIMIT 1")
+        return true unless queue_name # no queues = nothing to tune, skip
+
+        result = connection.select_value(<<~SQL)
+          SELECT reloptions::text LIKE '%autovacuum_vacuum_scale_factor%'
+          FROM pg_class
+          WHERE relname = 'q_#{queue_name}'
+            AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'pgmq')
+        SQL
+
+        [true, "t"].include?(result)
+      rescue StandardError
+        true # if we can't tell, assume already tuned (safe default)
       end
     end
   end

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -751,7 +751,7 @@ module Pgbus
 
       # Fetch pg_stat_user_tables stats for a single table (used by queue_health_detail).
       def fetch_table_stats(schema, table_name, kind)
-        row = connection.select_one(<<~SQL, "Pgbus Table Health")
+        row = connection.select_one(<<~SQL, "Pgbus Table Health", [schema, table_name])
           SELECT
             n_live_tup,
             n_dead_tup,
@@ -759,7 +759,7 @@ module Pgbus
             last_vacuum,
             last_autovacuum
           FROM pg_stat_user_tables
-          WHERE schemaname = '#{schema}' AND relname = '#{table_name}'
+          WHERE schemaname = $1 AND relname = $2
         SQL
 
         return nil unless row

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -638,8 +638,7 @@ module Pgbus
       # Returns aggregate health across all queue and archive tables, plus
       # the oldest open transaction age (MVCC horizon pinning risk).
       def queue_health_stats
-        queue_names = connection.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
-        tables = queue_names.flat_map { |n| table_health_for(n) }.compact
+        tables = fetch_all_table_stats
 
         total_dead = tables.sum { |t| t[:dead_tuples] }
         total_live = tables.sum { |t| t[:live_tuples] }
@@ -657,7 +656,7 @@ module Pgbus
           tables: tables
         }
       rescue StandardError => e
-        Pgbus.logger.error { "[Pgbus::Web] Error fetching queue health stats: #{e.class}: #{e.message}" }
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching queue health stats: #{e.class}: #{e.message}" }
         {
           total_dead_tuples: 0, total_live_tuples: 0, worst_bloat_ratio: 0.0,
           tables_needing_vacuum: 0, oldest_vacuum_ago_sec: nil,
@@ -724,7 +723,33 @@ module Pgbus
         Pgbus::BusRecord.connection
       end
 
-      # Fetch pg_stat_user_tables stats for a single table.
+      # Single query to fetch pg_stat_user_tables stats for all queue and
+      # archive tables. Avoids 2*N catalog queries on the dashboard.
+      def fetch_all_table_stats
+        rows = connection.select_all(<<~SQL, "Pgbus All Table Health")
+          WITH rels AS (
+            SELECT queue_name, 'q_' || queue_name AS relname, 'queue' AS kind FROM pgmq.meta
+            UNION ALL
+            SELECT queue_name, 'a_' || queue_name AS relname, 'archive' AS kind FROM pgmq.meta
+          )
+          SELECT
+            'pgmq.' || r.relname AS table_name,
+            r.kind,
+            s.n_live_tup,
+            s.n_dead_tup,
+            EXTRACT(epoch FROM (NOW() - COALESCE(s.last_vacuum, s.last_autovacuum)))::int AS last_vacuum_ago_sec,
+            s.last_vacuum,
+            s.last_autovacuum
+          FROM rels r
+          LEFT JOIN pg_stat_user_tables s
+            ON s.schemaname = 'pgmq' AND s.relname = r.relname
+          ORDER BY r.queue_name, r.kind
+        SQL
+
+        rows.to_a.filter_map { |row| build_table_health_row(row) }
+      end
+
+      # Fetch pg_stat_user_tables stats for a single table (used by queue_health_detail).
       def fetch_table_stats(schema, table_name, kind)
         row = connection.select_one(<<~SQL, "Pgbus Table Health")
           SELECT
@@ -739,14 +764,20 @@ module Pgbus
 
         return nil unless row
 
+        build_table_health_row(row.merge("table_name" => "#{schema}.#{table_name}", "kind" => kind))
+      end
+
+      def build_table_health_row(row)
+        return nil unless row["n_live_tup"] || row["n_dead_tup"]
+
         live = row["n_live_tup"].to_i
         dead = row["n_dead_tup"].to_i
         total = live + dead
         bloat = total.positive? ? (dead.to_f / total) : 0.0
 
         {
-          table: "#{schema}.#{table_name}",
-          kind: kind,
+          table: row["table_name"],
+          kind: row["kind"],
           live_tuples: live,
           dead_tuples: dead,
           bloat_ratio: bloat.round(4),
@@ -754,15 +785,6 @@ module Pgbus
           last_vacuum: row["last_vacuum"],
           last_autovacuum: row["last_autovacuum"]
         }
-      end
-
-      # Gather health for both the queue table and archive table of a queue.
-      def table_health_for(queue_name)
-        sanitized = sanitize_name(queue_name)
-        [
-          fetch_table_stats("pgmq", "q_#{sanitized}", "queue"),
-          fetch_table_stats("pgmq", "a_#{sanitized}", "archive")
-        ]
       end
 
       # Age of the oldest open transaction in seconds — indicates MVCC
@@ -779,7 +801,8 @@ module Pgbus
         SQL
 
         row&.dig("age_sec")&.to_i
-      rescue StandardError
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching oldest transaction age: #{e.class}: #{e.message}" }
         nil
       end
 

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -21,6 +21,8 @@ module Pgbus
 
         throughput = compute_throughput(queues)
 
+        health = queue_health_stats
+
         {
           total_queues: queues.size,
           total_depth: total_depth,
@@ -29,7 +31,10 @@ module Pgbus
           failed_count: failed_events_count,
           dlq_depth: dlq_depth,
           recurring_count: recurring_tasks_count,
-          throughput_rate: throughput
+          throughput_rate: throughput,
+          total_dead_tuples: health[:total_dead_tuples],
+          tables_needing_vacuum: health[:tables_needing_vacuum],
+          oldest_transaction_age_sec: health[:oldest_transaction_age_sec]
         }
       end
 
@@ -629,6 +634,51 @@ module Pgbus
         []
       end
 
+      # Queue health — vacuum stats, dead tuples, bloat, MVCC horizon.
+      # Returns aggregate health across all queue and archive tables, plus
+      # the oldest open transaction age (MVCC horizon pinning risk).
+      def queue_health_stats
+        queue_names = connection.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
+        tables = queue_names.flat_map { |n| table_health_for(n) }.compact
+
+        total_dead = tables.sum { |t| t[:dead_tuples] }
+        total_live = tables.sum { |t| t[:live_tuples] }
+        worst_bloat = tables.map { |t| t[:bloat_ratio] }.max || 0.0
+        needs_vacuum = tables.count { |t| t[:bloat_ratio] > 0.1 }
+        oldest_vacuum = tables.filter_map { |t| t[:last_vacuum_ago_sec] }.max
+
+        {
+          total_dead_tuples: total_dead,
+          total_live_tuples: total_live,
+          worst_bloat_ratio: worst_bloat.round(4),
+          tables_needing_vacuum: needs_vacuum,
+          oldest_vacuum_ago_sec: oldest_vacuum,
+          oldest_transaction_age_sec: oldest_transaction_age,
+          tables: tables
+        }
+      rescue StandardError => e
+        Pgbus.logger.error { "[Pgbus::Web] Error fetching queue health stats: #{e.class}: #{e.message}" }
+        {
+          total_dead_tuples: 0, total_live_tuples: 0, worst_bloat_ratio: 0.0,
+          tables_needing_vacuum: 0, oldest_vacuum_ago_sec: nil,
+          oldest_transaction_age_sec: nil, tables: []
+        }
+      end
+
+      # Per-queue health stats for the queue detail view.
+      def queue_health_detail(queue_name)
+        sanitized = sanitize_name(queue_name)
+        tables = [
+          fetch_table_stats("pgmq", "q_#{sanitized}", "queue"),
+          fetch_table_stats("pgmq", "a_#{sanitized}", "archive")
+        ].compact
+
+        { tables: tables, oldest_transaction_age_sec: oldest_transaction_age }
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching health detail for #{queue_name}: #{e.message}" }
+        { tables: [], oldest_transaction_age_sec: nil }
+      end
+
       # Stream stats — only populated when streams_stats_enabled is
       # true AND the migration has been run. Controllers should gate
       # rendering on `stream_stats_available?` to avoid showing empty
@@ -672,6 +722,65 @@ module Pgbus
 
       def connection
         Pgbus::BusRecord.connection
+      end
+
+      # Fetch pg_stat_user_tables stats for a single table.
+      def fetch_table_stats(schema, table_name, kind)
+        row = connection.select_one(<<~SQL, "Pgbus Table Health")
+          SELECT
+            n_live_tup,
+            n_dead_tup,
+            EXTRACT(epoch FROM (NOW() - COALESCE(last_vacuum, last_autovacuum)))::int AS last_vacuum_ago_sec,
+            last_vacuum,
+            last_autovacuum
+          FROM pg_stat_user_tables
+          WHERE schemaname = '#{schema}' AND relname = '#{table_name}'
+        SQL
+
+        return nil unless row
+
+        live = row["n_live_tup"].to_i
+        dead = row["n_dead_tup"].to_i
+        total = live + dead
+        bloat = total.positive? ? (dead.to_f / total) : 0.0
+
+        {
+          table: "#{schema}.#{table_name}",
+          kind: kind,
+          live_tuples: live,
+          dead_tuples: dead,
+          bloat_ratio: bloat.round(4),
+          last_vacuum_ago_sec: row["last_vacuum_ago_sec"]&.to_i,
+          last_vacuum: row["last_vacuum"],
+          last_autovacuum: row["last_autovacuum"]
+        }
+      end
+
+      # Gather health for both the queue table and archive table of a queue.
+      def table_health_for(queue_name)
+        sanitized = sanitize_name(queue_name)
+        [
+          fetch_table_stats("pgmq", "q_#{sanitized}", "queue"),
+          fetch_table_stats("pgmq", "a_#{sanitized}", "archive")
+        ]
+      end
+
+      # Age of the oldest open transaction in seconds — indicates MVCC
+      # horizon pinning risk. Returns nil if no active transactions.
+      def oldest_transaction_age
+        row = connection.select_one(<<~SQL, "Pgbus Oldest Transaction")
+          SELECT EXTRACT(epoch FROM (NOW() - xact_start))::int AS age_sec
+          FROM pg_stat_activity
+          WHERE state != 'idle'
+            AND xact_start IS NOT NULL
+            AND pid != pg_backend_pid()
+          ORDER BY xact_start ASC
+          LIMIT 1
+        SQL
+
+        row&.dig("age_sec")&.to_i
+      rescue StandardError
+        nil
       end
 
       # name is the full PGMQ queue name (already prefixed)

--- a/lib/pgbus/web/metrics_serializer.rb
+++ b/lib/pgbus/web/metrics_serializer.rb
@@ -24,6 +24,7 @@ module Pgbus
         append_process_metrics(lines)
         append_summary_metrics(lines)
         append_stream_metrics(lines)
+        append_health_metrics(lines)
         "#{lines.join("\n")}\n"
       end
 
@@ -97,9 +98,41 @@ module Pgbus
       end
 
       def append_process_metrics(lines)
-        count = @data_source.processes.count
+        procs = @data_source.processes
         gauge(lines, "pgbus_active_processes", "Number of active pgbus worker processes") do
-          [[count]]
+          [[procs.count]]
+        end
+
+        workers = procs.select { |p| p[:kind] == "worker" && p[:metadata].is_a?(Hash) }
+        unless workers.empty?
+          gauge(lines, "pgbus_worker_pool_capacity", "Total thread/async pool capacity per worker") do
+            workers.filter_map do |w|
+              capacity = w[:metadata]["capacity"]
+              next unless capacity
+
+              [capacity, { pid: w[:pid], hostname: w[:hostname] }]
+            end
+          end
+
+          gauge(lines, "pgbus_worker_pool_busy", "Number of busy threads/slots per worker") do
+            workers.filter_map do |w|
+              busy = w[:metadata]["busy"]
+              next unless busy
+
+              [busy, { pid: w[:pid], hostname: w[:hostname] }]
+            end
+          end
+
+          gauge(lines, "pgbus_worker_pool_utilization", "Pool utilization ratio (busy / capacity)") do
+            workers.filter_map do |w|
+              capacity = w[:metadata]["capacity"].to_i
+              busy = w[:metadata]["busy"].to_i
+              next unless capacity.positive?
+
+              ratio = (busy.to_f / capacity).round(4)
+              [ratio, { pid: w[:pid], hostname: w[:hostname] }]
+            end
+          end
         end
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Metrics] Error serializing process metrics: #{e.message}" }
@@ -139,6 +172,42 @@ module Pgbus
         end
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Metrics] Error serializing stream metrics: #{e.message}" }
+      end
+
+      def append_health_metrics(lines)
+        health = @data_source.queue_health_stats
+        return if health[:tables].empty? && health[:oldest_transaction_age_sec].nil?
+
+        tables = health[:tables]
+        unless tables.empty?
+          gauge(lines, "pgbus_table_dead_tuples", "Number of dead tuples in queue/archive table") do
+            tables.map { |t| [t[:dead_tuples], { table: t[:table], kind: t[:kind] }] }
+          end
+
+          gauge(lines, "pgbus_table_live_tuples", "Number of live tuples in queue/archive table") do
+            tables.map { |t| [t[:live_tuples], { table: t[:table], kind: t[:kind] }] }
+          end
+
+          gauge(lines, "pgbus_table_bloat_ratio", "Dead tuple ratio (dead / total) per table") do
+            tables.map { |t| [t[:bloat_ratio], { table: t[:table], kind: t[:kind] }] }
+          end
+
+          vacuum_tables = tables.select { |t| t[:last_vacuum_ago_sec] }
+          unless vacuum_tables.empty?
+            gauge(lines, "pgbus_table_last_vacuum_age_seconds", "Seconds since last vacuum") do
+              vacuum_tables.map { |t| [t[:last_vacuum_ago_sec], { table: t[:table], kind: t[:kind] }] }
+            end
+          end
+        end
+
+        if health[:oldest_transaction_age_sec]
+          gauge(lines, "pgbus_oldest_transaction_age_seconds",
+                "Age of the oldest open transaction (MVCC horizon pin risk)") do
+            [[health[:oldest_transaction_age_sec]]]
+          end
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Metrics] Error serializing health metrics: #{e.message}" }
       end
 
       # Emits a Prometheus gauge metric family. The block must return an array

--- a/spec/dummy/lib/stub_data_source.rb
+++ b/spec/dummy/lib/stub_data_source.rb
@@ -11,7 +11,9 @@ module DummyApp
     def summary_stats
       { total_queues: 4, total_depth: 127, total_visible: 98,
         active_processes: 2, failed_count: 5, dlq_depth: 3,
-        recurring_count: 14, throughput_rate: 42.7 }
+        recurring_count: 14, throughput_rate: 42.7,
+        total_dead_tuples: 1_250, tables_needing_vacuum: 1,
+        oldest_transaction_age_sec: 8 }
     end
 
     def queues_with_metrics
@@ -200,6 +202,40 @@ module DummyApp
         { stream_name: "orders:dashboard", count: 312, avg_fanout: 4.5, avg_ms: 5.8 },
         { stream_name: "notifications:admin", count: 214, avg_fanout: 2.1, avg_ms: 2.4 }
       ].first(limit)
+    end
+
+    def queue_health_stats
+      {
+        total_dead_tuples: 1_250, total_live_tuples: 65_000,
+        worst_bloat_ratio: 0.12, tables_needing_vacuum: 1,
+        oldest_vacuum_ago_sec: 1800,
+        oldest_transaction_age_sec: 8,
+        tables: [
+          { table: "pgmq.q_pgbus_default", kind: "queue",
+            live_tuples: 45_000, dead_tuples: 800, bloat_ratio: 0.0175,
+            last_vacuum_ago_sec: 120, last_vacuum: 2.minutes.ago, last_autovacuum: nil },
+          { table: "pgmq.a_pgbus_default", kind: "archive",
+            live_tuples: 12_000, dead_tuples: 350, bloat_ratio: 0.0283,
+            last_vacuum_ago_sec: 1800, last_vacuum: nil, last_autovacuum: 30.minutes.ago },
+          { table: "pgmq.q_pgbus_events", kind: "queue",
+            live_tuples: 8_000, dead_tuples: 100, bloat_ratio: 0.1235,
+            last_vacuum_ago_sec: 600, last_vacuum: 10.minutes.ago, last_autovacuum: nil }
+        ]
+      }
+    end
+
+    def queue_health_detail(_name)
+      {
+        tables: [
+          { table: "pgmq.q_pgbus_default", kind: "queue",
+            live_tuples: 45_000, dead_tuples: 800, bloat_ratio: 0.0175,
+            last_vacuum_ago_sec: 120, last_vacuum: 2.minutes.ago, last_autovacuum: nil },
+          { table: "pgmq.a_pgbus_default", kind: "archive",
+            live_tuples: 12_000, dead_tuples: 350, bloat_ratio: 0.0283,
+            last_vacuum_ago_sec: 1800, last_vacuum: nil, last_autovacuum: 30.minutes.ago }
+        ],
+        oldest_transaction_age_sec: 8
+      }
     end
 
     # Mutating actions (no-ops for QA)

--- a/spec/pgbus/autovacuum_tuning_spec.rb
+++ b/spec/pgbus/autovacuum_tuning_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe Pgbus::AutovacuumTuning do
   describe ".sql_for_high_churn_tables" do
     subject(:sql) { described_class.sql_for_high_churn_tables }
 
-    it "includes ALTER TABLE for all high-churn tables" do
-      expect(sql).to include("ALTER TABLE pgbus_semaphores SET")
-      expect(sql).to include("ALTER TABLE pgbus_uniqueness_keys SET")
-      expect(sql).to include("ALTER TABLE pgbus_processed_events SET")
+    it "includes ALTER TABLE IF EXISTS for all high-churn tables" do
+      expect(sql).to include("ALTER TABLE IF EXISTS pgbus_semaphores SET")
+      expect(sql).to include("ALTER TABLE IF EXISTS pgbus_uniqueness_keys SET")
+      expect(sql).to include("ALTER TABLE IF EXISTS pgbus_processed_events SET")
     end
 
     it "applies the high-churn settings" do

--- a/spec/pgbus/autovacuum_tuning_spec.rb
+++ b/spec/pgbus/autovacuum_tuning_spec.rb
@@ -61,4 +61,40 @@ RSpec.describe Pgbus::AutovacuumTuning do
       expect(archive_sf).to be > queue_sf
     end
   end
+
+  describe ".sql_for_high_churn_tables" do
+    subject(:sql) { described_class.sql_for_high_churn_tables }
+
+    it "includes ALTER TABLE for all high-churn tables" do
+      expect(sql).to include("ALTER TABLE pgbus_semaphores SET")
+      expect(sql).to include("ALTER TABLE pgbus_uniqueness_keys SET")
+      expect(sql).to include("ALTER TABLE pgbus_processed_events SET")
+    end
+
+    it "applies the high-churn settings" do
+      expect(sql).to include("autovacuum_vacuum_scale_factor = 0.02")
+      expect(sql).to include("autovacuum_vacuum_cost_delay = 2")
+    end
+  end
+
+  describe "HIGH_CHURN_TABLES" do
+    it "lists the three highest-churn pgbus tables" do
+      expect(described_class::HIGH_CHURN_TABLES).to contain_exactly(
+        "pgbus_semaphores",
+        "pgbus_uniqueness_keys",
+        "pgbus_processed_events"
+      )
+    end
+  end
+
+  describe "HIGH_CHURN_SETTINGS" do
+    it "is less aggressive than queue settings but more than archive settings" do
+      queue_sf = described_class::QUEUE_SETTINGS["autovacuum_vacuum_scale_factor"].to_f
+      high_sf = described_class::HIGH_CHURN_SETTINGS["autovacuum_vacuum_scale_factor"].to_f
+      archive_sf = described_class::ARCHIVE_SETTINGS["autovacuum_vacuum_scale_factor"].to_f
+
+      expect(high_sf).to be > queue_sf
+      expect(high_sf).to be < archive_sf
+    end
+  end
 end

--- a/spec/pgbus/autovacuum_tuning_spec.rb
+++ b/spec/pgbus/autovacuum_tuning_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::AutovacuumTuning do
+  describe ".sql_for_queue" do
+    subject(:sql) { described_class.sql_for_queue("pgbus_default") }
+
+    it "returns ALTER TABLE statements for both queue and archive tables" do
+      expect(sql).to include("ALTER TABLE pgmq.q_pgbus_default SET")
+      expect(sql).to include("ALTER TABLE pgmq.a_pgbus_default SET")
+    end
+
+    it "sets queue table to aggressive vacuum scale factor" do
+      expect(sql).to include("autovacuum_vacuum_scale_factor = 0.01")
+    end
+
+    it "sets archive table to moderate vacuum scale factor" do
+      expect(sql).to include("autovacuum_vacuum_scale_factor = 0.05")
+    end
+
+    it "sets cost delay for both tables" do
+      expect(sql).to include("autovacuum_vacuum_cost_delay = 2")
+      expect(sql).to include("autovacuum_vacuum_cost_delay = 5")
+    end
+  end
+
+  describe ".sql_for_all_queues" do
+    subject(:sql) { described_class.sql_for_all_queues }
+
+    it "returns a DO $$ block that iterates pgmq.meta" do
+      expect(sql).to include("DO $$")
+      expect(sql).to include("SELECT queue_name FROM pgmq.meta")
+    end
+
+    it "applies queue settings to q_ tables" do
+      expect(sql).to include("pgmq.q_%I")
+      expect(sql).to include("autovacuum_vacuum_scale_factor = 0.01")
+    end
+
+    it "applies archive settings to a_ tables" do
+      expect(sql).to include("pgmq.a_%I")
+      expect(sql).to include("autovacuum_vacuum_scale_factor = 0.05")
+    end
+  end
+
+  describe "QUEUE_SETTINGS" do
+    it "includes the three required autovacuum parameters" do
+      expect(described_class::QUEUE_SETTINGS).to include(
+        "autovacuum_vacuum_scale_factor" => "0.01",
+        "autovacuum_vacuum_cost_delay" => "2",
+        "autovacuum_analyze_scale_factor" => "0.05"
+      )
+    end
+  end
+
+  describe "ARCHIVE_SETTINGS" do
+    it "uses a less aggressive scale factor than queue tables" do
+      queue_sf = described_class::QUEUE_SETTINGS["autovacuum_vacuum_scale_factor"].to_f
+      archive_sf = described_class::ARCHIVE_SETTINGS["autovacuum_vacuum_scale_factor"].to_f
+      expect(archive_sf).to be > queue_sf
+    end
+  end
+end

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -153,6 +153,12 @@ RSpec.describe Pgbus::Client do
   end
 
   describe "#ensure_dead_letter_queue" do
+    it "tunes autovacuum when creating a DLQ" do
+      client.ensure_dead_letter_queue("jobs")
+
+      expect(client).to have_received(:tune_autovacuum).with("pgbus_test_jobs_dlq")
+    end
+
     it "creates the DLQ with correct suffix" do
       client.ensure_dead_letter_queue("jobs")
 

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -100,6 +100,12 @@ RSpec.describe Pgbus::Client do
   end
 
   describe "#ensure_queue" do
+    it "tunes autovacuum when creating a queue" do
+      client.ensure_queue("jobs")
+
+      expect(client).to have_received(:tune_autovacuum).with("pgbus_test_jobs")
+    end
+
     it "creates the queue with the prefixed name" do
       client.ensure_queue("jobs")
 

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Pgbus::Client do
     # Pre-mark PGMQ schema as ensured for most tests.
     # Schema installation tests override this.
     c.instance_variable_set(:@schema_ensured, true)
+    # Stub autovacuum tuning — runs raw SQL which needs a real PG connection.
+    allow(c).to receive(:tune_autovacuum)
     c
   end
 

--- a/spec/pgbus/generators/migration_detector_spec.rb
+++ b/spec/pgbus/generators/migration_detector_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe Pgbus::Generators::MigrationDetector do
   before do
     stub_tables(described_class::CORE_INSTALL_TABLES + %w[pgbus_uniqueness_keys pgbus_failed_events])
     allow(connection).to receive_messages(columns: [], indexes: [])
+
+    # Default: autovacuum already tuned so it doesn't pollute other tests.
+    # Tests for autovacuum detection override these stubs explicitly.
+    allow(connection).to receive(:select_value)
+      .with("SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgmq'")
+      .and_return(1)
+    allow(connection).to receive(:select_value)
+      .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name LIMIT 1")
+      .and_return("pgbus_default")
+    allow(connection).to receive(:select_value)
+      .with(/reloptions.*autovacuum_vacuum_scale_factor/)
+      .and_return("t")
   end
 
   # Test helpers -----------------------------------------------------------
@@ -203,6 +215,54 @@ RSpec.describe Pgbus::Generators::MigrationDetector do
       end
     end
 
+    context "with autovacuum detection" do
+      before do
+        allow(connection).to receive(:select_value)
+          .with("SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgmq'")
+          .and_return(1)
+      end
+
+      it "queues tune_autovacuum when pgmq exists but autovacuum is not tuned" do
+        allow(connection).to receive(:select_value)
+          .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name LIMIT 1")
+          .and_return("pgbus_default")
+
+        allow(connection).to receive(:select_value)
+          .with(/reloptions.*autovacuum_vacuum_scale_factor/)
+          .and_return(false)
+
+        expect(detector.missing_migrations).to include(:tune_autovacuum)
+      end
+
+      it "does not queue tune_autovacuum when already tuned" do
+        allow(connection).to receive(:select_value)
+          .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name LIMIT 1")
+          .and_return("pgbus_default")
+
+        allow(connection).to receive(:select_value)
+          .with(/reloptions.*autovacuum_vacuum_scale_factor/)
+          .and_return("t")
+
+        expect(detector.missing_migrations).not_to include(:tune_autovacuum)
+      end
+
+      it "does not queue tune_autovacuum when pgmq schema is absent" do
+        allow(connection).to receive(:select_value)
+          .with("SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgmq'")
+          .and_return(nil)
+
+        expect(detector.missing_migrations).not_to include(:tune_autovacuum)
+      end
+
+      it "does not queue tune_autovacuum when no queues exist" do
+        allow(connection).to receive(:select_value)
+          .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name LIMIT 1")
+          .and_return(nil)
+
+        expect(detector.missing_migrations).not_to include(:tune_autovacuum)
+      end
+    end
+
     context "with a realistic partially-upgraded database snapshot" do
       # Given a realistic "partially-upgraded" database (core install
       # migration ran, job stats base migration ran, but neither latency
@@ -224,6 +284,17 @@ RSpec.describe Pgbus::Generators::MigrationDetector do
         stub_columns("pgbus_job_stats", %w[id job_class queue_name status duration_ms created_at])
         stub_indexes("pgbus_job_stats", %w[idx_pgbus_job_stats_time])
         stub_indexes("pgbus_failed_events", %w[idx_pgbus_failed_events_queue_msg])
+
+        # Autovacuum: pgmq exists but not yet tuned
+        allow(connection).to receive(:select_value)
+          .with("SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgmq'")
+          .and_return(1)
+        allow(connection).to receive(:select_value)
+          .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name LIMIT 1")
+          .and_return("pgbus_default")
+        allow(connection).to receive(:select_value)
+          .with(/reloptions.*autovacuum_vacuum_scale_factor/)
+          .and_return(false)
       end
 
       it "queues only the specific add-on migrations that are missing" do
@@ -233,7 +304,8 @@ RSpec.describe Pgbus::Generators::MigrationDetector do
           :add_stream_stats,
           :add_presence,
           :add_queue_states,
-          :add_outbox
+          :add_outbox,
+          :tune_autovacuum
         )
       end
     end
@@ -269,6 +341,7 @@ RSpec.describe Pgbus::Generators::MigrationDetector do
         add_outbox
         add_recurring
         add_failed_events_index
+        tune_autovacuum
       ]
 
       keys.each do |key|

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Pgbus::Web::DataSource do
       )
 
       # Stub health-related queries (called by queue_health_stats within summary_stats)
-      allow(mock_connection).to receive(:select_one).with(anything, "Pgbus Table Health").and_return(nil)
+      allow(mock_connection).to receive(:select_all).with(anything, "Pgbus All Table Health").and_return([])
       allow(mock_connection).to receive(:select_one).with(anything, "Pgbus Oldest Transaction").and_return(nil)
 
       allow(data_source).to receive_messages(failed_events_count: 3, processes: [{ id: 1 }, { id: 2 }])
@@ -428,26 +428,23 @@ RSpec.describe Pgbus::Web::DataSource do
   end
 
   describe "#queue_health_stats" do
-    let(:table_stats_row) do
-      {
-        "n_live_tup" => 1000,
-        "n_dead_tup" => 200,
-        "last_vacuum_ago_sec" => 300,
-        "last_vacuum" => "2026-04-10 10:00:00",
-        "last_autovacuum" => "2026-04-10 09:00:00"
-      }
+    let(:all_table_rows) do
+      [
+        { "table_name" => "pgmq.q_pgbus_default", "kind" => "queue",
+          "n_live_tup" => 1000, "n_dead_tup" => 200,
+          "last_vacuum_ago_sec" => 300, "last_vacuum" => "2026-04-10 10:00:00",
+          "last_autovacuum" => "2026-04-10 09:00:00" },
+        { "table_name" => "pgmq.a_pgbus_default", "kind" => "archive",
+          "n_live_tup" => 1000, "n_dead_tup" => 200,
+          "last_vacuum_ago_sec" => 300, "last_vacuum" => nil,
+          "last_autovacuum" => "2026-04-10 09:00:00" }
+      ]
     end
 
-    before do
-      allow(mock_connection).to receive(:select_values)
-        .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
-        .and_return(["pgbus_default"])
-    end
-
-    it "returns aggregated health stats across queue and archive tables" do
-      allow(mock_connection).to receive(:select_one)
-        .with(anything, "Pgbus Table Health")
-        .and_return(table_stats_row)
+    it "returns aggregated health stats via a single query" do
+      allow(mock_connection).to receive(:select_all)
+        .with(anything, "Pgbus All Table Health")
+        .and_return(all_table_rows)
 
       allow(mock_connection).to receive(:select_one)
         .with(anything, "Pgbus Oldest Transaction")
@@ -455,17 +452,19 @@ RSpec.describe Pgbus::Web::DataSource do
 
       result = data_source.queue_health_stats
 
-      expect(result[:total_dead_tuples]).to eq(400) # 200 per table * 2 tables
+      expect(result[:total_dead_tuples]).to eq(400)
       expect(result[:total_live_tuples]).to eq(2000)
       expect(result[:worst_bloat_ratio]).to be_within(0.001).of(0.1667)
-      expect(result[:tables_needing_vacuum]).to eq(2) # both > 0.1
+      expect(result[:tables_needing_vacuum]).to eq(2)
       expect(result[:oldest_vacuum_ago_sec]).to eq(300)
       expect(result[:oldest_transaction_age_sec]).to eq(5)
       expect(result[:tables].size).to eq(2)
     end
 
     it "returns zero defaults on error" do
-      allow(mock_connection).to receive(:select_values).and_raise(StandardError, "db gone")
+      allow(mock_connection).to receive(:select_all)
+        .with(anything, "Pgbus All Table Health")
+        .and_raise(StandardError, "db gone")
 
       result = data_source.queue_health_stats
 
@@ -473,10 +472,10 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(result[:tables]).to eq([])
     end
 
-    it "handles missing pg_stat rows gracefully" do
-      allow(mock_connection).to receive(:select_one)
-        .with(anything, "Pgbus Table Health")
-        .and_return(nil)
+    it "handles empty results gracefully" do
+      allow(mock_connection).to receive(:select_all)
+        .with(anything, "Pgbus All Table Health")
+        .and_return([])
 
       allow(mock_connection).to receive(:select_one)
         .with(anything, "Pgbus Oldest Transaction")

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -500,7 +500,7 @@ RSpec.describe Pgbus::Web::DataSource do
       }
 
       allow(mock_connection).to receive(:select_one)
-        .with(anything, "Pgbus Table Health")
+        .with(anything, "Pgbus Table Health", anything)
         .and_return(stats_row)
 
       allow(mock_connection).to receive(:select_one)

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe Pgbus::Web::DataSource do
           "oldest_msg_age_sec" => nil, "newest_msg_age_sec" => nil, "total_messages" => 5 }
       )
 
+      # Stub health-related queries (called by queue_health_stats within summary_stats)
+      allow(mock_connection).to receive(:select_one).with(anything, "Pgbus Table Health").and_return(nil)
+      allow(mock_connection).to receive(:select_one).with(anything, "Pgbus Oldest Transaction").and_return(nil)
+
       allow(data_source).to receive_messages(failed_events_count: 3, processes: [{ id: 1 }, { id: 2 }])
 
       stats = data_source.summary_stats
@@ -87,6 +91,8 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(stats[:dlq_depth]).to eq(2)
       expect(stats[:active_processes]).to eq(2)
       expect(stats[:failed_count]).to eq(3)
+      expect(stats).to have_key(:total_dead_tuples)
+      expect(stats).to have_key(:oldest_transaction_age_sec)
     end
   end
 
@@ -418,6 +424,107 @@ RSpec.describe Pgbus::Web::DataSource do
       allow(Pgbus::UniquenessKey).to receive(:delete_all).and_raise(StandardError)
 
       expect(data_source.discard_all_locks).to eq(0)
+    end
+  end
+
+  describe "#queue_health_stats" do
+    let(:table_stats_row) do
+      {
+        "n_live_tup" => 1000,
+        "n_dead_tup" => 200,
+        "last_vacuum_ago_sec" => 300,
+        "last_vacuum" => "2026-04-10 10:00:00",
+        "last_autovacuum" => "2026-04-10 09:00:00"
+      }
+    end
+
+    before do
+      allow(mock_connection).to receive(:select_values)
+        .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
+        .and_return(["pgbus_default"])
+    end
+
+    it "returns aggregated health stats across queue and archive tables" do
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Table Health")
+        .and_return(table_stats_row)
+
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Oldest Transaction")
+        .and_return({ "age_sec" => 5 })
+
+      result = data_source.queue_health_stats
+
+      expect(result[:total_dead_tuples]).to eq(400) # 200 per table * 2 tables
+      expect(result[:total_live_tuples]).to eq(2000)
+      expect(result[:worst_bloat_ratio]).to be_within(0.001).of(0.1667)
+      expect(result[:tables_needing_vacuum]).to eq(2) # both > 0.1
+      expect(result[:oldest_vacuum_ago_sec]).to eq(300)
+      expect(result[:oldest_transaction_age_sec]).to eq(5)
+      expect(result[:tables].size).to eq(2)
+    end
+
+    it "returns zero defaults on error" do
+      allow(mock_connection).to receive(:select_values).and_raise(StandardError, "db gone")
+
+      result = data_source.queue_health_stats
+
+      expect(result[:total_dead_tuples]).to eq(0)
+      expect(result[:tables]).to eq([])
+    end
+
+    it "handles missing pg_stat rows gracefully" do
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Table Health")
+        .and_return(nil)
+
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Oldest Transaction")
+        .and_return(nil)
+
+      result = data_source.queue_health_stats
+
+      expect(result[:total_dead_tuples]).to eq(0)
+      expect(result[:tables]).to be_empty
+      expect(result[:oldest_transaction_age_sec]).to be_nil
+    end
+  end
+
+  describe "#queue_health_detail" do
+    it "returns per-queue health for queue and archive tables" do
+      stats_row = {
+        "n_live_tup" => 500,
+        "n_dead_tup" => 50,
+        "last_vacuum_ago_sec" => 120,
+        "last_vacuum" => "2026-04-10 10:00:00",
+        "last_autovacuum" => nil
+      }
+
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Table Health")
+        .and_return(stats_row)
+
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Oldest Transaction")
+        .and_return({ "age_sec" => 2 })
+
+      result = data_source.queue_health_detail("pgbus_default")
+
+      expect(result[:tables].size).to eq(2)
+      expect(result[:tables].first[:table]).to eq("pgmq.q_pgbus_default")
+      expect(result[:tables].first[:kind]).to eq("queue")
+      expect(result[:tables].last[:kind]).to eq("archive")
+      expect(result[:tables].first[:bloat_ratio]).to be_within(0.001).of(0.0909)
+      expect(result[:oldest_transaction_age_sec]).to eq(2)
+    end
+
+    it "returns empty on error" do
+      allow(mock_connection).to receive(:select_one).and_raise(StandardError, "boom")
+
+      result = data_source.queue_health_detail("missing")
+
+      expect(result[:tables]).to eq([])
+      expect(result[:oldest_transaction_age_sec]).to be_nil
     end
   end
 

--- a/spec/pgbus/web/metrics_serializer_spec.rb
+++ b/spec/pgbus/web/metrics_serializer_spec.rb
@@ -35,12 +35,38 @@ RSpec.describe Pgbus::Web::MetricsSerializer do
     )
   end
 
-  let(:processes) { [{ pid: 1 }, { pid: 2 }] }
+  let(:processes) do
+    [
+      { pid: 1, kind: "worker", hostname: "host1",
+        metadata: { "capacity" => 5, "busy" => 3, "mode" => "threads" } },
+      { pid: 2, kind: "worker", hostname: "host1",
+        metadata: { "capacity" => 10, "busy" => 0, "mode" => "threads" } }
+    ]
+  end
 
   let(:summary_stats) do
     { total_queues: 3, total_depth: 45, total_visible: 43,
       active_processes: 2, failed_count: 8, dlq_depth: 3,
       recurring_count: 4, throughput_rate: 10.5 }
+  end
+
+  let(:health_stats) do
+    {
+      total_dead_tuples: 500,
+      total_live_tuples: 10_000,
+      worst_bloat_ratio: 0.15,
+      tables_needing_vacuum: 1,
+      oldest_vacuum_ago_sec: 3600,
+      oldest_transaction_age_sec: 12,
+      tables: [
+        { table: "pgmq.q_pgbus_default", kind: "queue",
+          live_tuples: 8000, dead_tuples: 400, bloat_ratio: 0.0476,
+          last_vacuum_ago_sec: 120, last_vacuum: "2026-04-10", last_autovacuum: nil },
+        { table: "pgmq.a_pgbus_default", kind: "archive",
+          live_tuples: 2000, dead_tuples: 100, bloat_ratio: 0.0476,
+          last_vacuum_ago_sec: 3600, last_vacuum: nil, last_autovacuum: "2026-04-10" }
+      ]
+    }
   end
 
   before do
@@ -50,7 +76,8 @@ RSpec.describe Pgbus::Web::MetricsSerializer do
       job_stats_summary: job_summary,
       processes: processes,
       summary_stats: summary_stats,
-      stream_stats_available?: false
+      stream_stats_available?: false,
+      queue_health_stats: health_stats
     )
   end
 
@@ -169,6 +196,58 @@ RSpec.describe Pgbus::Web::MetricsSerializer do
     context "when stream stats are not available" do
       it "omits stream metrics entirely" do
         expect(output).not_to include("pgbus_stream_")
+      end
+    end
+
+    it "includes worker pool capacity gauges" do
+      expect(output).to include('pgbus_worker_pool_capacity{pid="1",hostname="host1"} 5')
+      expect(output).to include('pgbus_worker_pool_capacity{pid="2",hostname="host1"} 10')
+    end
+
+    it "includes worker pool busy gauges" do
+      expect(output).to include('pgbus_worker_pool_busy{pid="1",hostname="host1"} 3')
+      expect(output).to include('pgbus_worker_pool_busy{pid="2",hostname="host1"} 0')
+    end
+
+    it "includes worker pool utilization ratio" do
+      expect(output).to include('pgbus_worker_pool_utilization{pid="1",hostname="host1"} 0.6')
+      expect(output).to include('pgbus_worker_pool_utilization{pid="2",hostname="host1"} 0.0')
+    end
+
+    it "includes table dead tuples gauges" do
+      expect(output).to include('pgbus_table_dead_tuples{table="pgmq.q_pgbus_default",kind="queue"} 400')
+      expect(output).to include('pgbus_table_dead_tuples{table="pgmq.a_pgbus_default",kind="archive"} 100')
+    end
+
+    it "includes table live tuples gauges" do
+      expect(output).to include('pgbus_table_live_tuples{table="pgmq.q_pgbus_default",kind="queue"} 8000')
+    end
+
+    it "includes table bloat ratio gauges" do
+      expect(output).to include('pgbus_table_bloat_ratio{table="pgmq.q_pgbus_default",kind="queue"} 0.0476')
+    end
+
+    it "includes last vacuum age gauges" do
+      expect(output).to include('pgbus_table_last_vacuum_age_seconds{table="pgmq.q_pgbus_default",kind="queue"} 120')
+      expect(output).to include('pgbus_table_last_vacuum_age_seconds{table="pgmq.a_pgbus_default",kind="archive"} 3600')
+    end
+
+    it "includes oldest transaction age" do
+      expect(output).to include("pgbus_oldest_transaction_age_seconds 12")
+    end
+
+    context "when health stats have no tables and no transactions" do
+      let(:health_stats) do
+        {
+          total_dead_tuples: 0, total_live_tuples: 0, worst_bloat_ratio: 0.0,
+          tables_needing_vacuum: 0, oldest_vacuum_ago_sec: nil,
+          oldest_transaction_age_sec: nil, tables: []
+        }
+      end
+
+      it "omits health metrics entirely" do
+        expect(output).not_to include("pgbus_table_dead_tuples")
+        expect(output).not_to include("pgbus_oldest_transaction_age_seconds")
       end
     end
 

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -103,6 +103,10 @@ module Pgbus
       def stream_stats_summary(minutes: 60) = @stream_summary
       def top_streams(limit: 10, minutes: 60) = @top_streams_list.first(limit)
 
+      # Queue health
+      def queue_health_stats = default_health_stats
+      def queue_health_detail(_name) = { tables: [], oldest_transaction_age_sec: nil }
+
       private
 
       def record(method_name, *args)
@@ -112,7 +116,10 @@ module Pgbus
 
       def default_stats
         { total_queues: 2, total_depth: 15, total_visible: 12,
-          active_processes: 1, failed_count: 3, dlq_depth: 2 }
+          active_processes: 1, failed_count: 3, dlq_depth: 2,
+          recurring_count: 0, throughput_rate: 0.0,
+          total_dead_tuples: 0, tables_needing_vacuum: 0,
+          oldest_transaction_age_sec: nil }
       end
 
       def default_insights_summary
@@ -129,6 +136,14 @@ module Pgbus
           broadcasts: 0, connects: 0, disconnects: 0,
           active_estimate: 0, avg_fanout: 0,
           avg_broadcast_ms: 0, avg_connect_ms: 0
+        }
+      end
+
+      def default_health_stats
+        {
+          total_dead_tuples: 0, total_live_tuples: 0, worst_bloat_ratio: 0.0,
+          tables_needing_vacuum: 0, oldest_vacuum_ago_sec: nil,
+          oldest_transaction_age_sec: nil, tables: []
         }
       end
 


### PR DESCRIPTION
## Summary

- Add **Queue Health** dashboard panel surfacing PostgreSQL vacuum stats, dead tuple counts, table bloat ratios, and MVCC horizon age across all PGMQ queue/archive tables
- Add **per-queue health section** on queue detail pages showing the same stats for that queue's tables
- Export **8 new Prometheus gauges**: `pgbus_table_dead_tuples`, `pgbus_table_live_tuples`, `pgbus_table_bloat_ratio`, `pgbus_table_last_vacuum_age_seconds`, `pgbus_oldest_transaction_age_seconds`, `pgbus_worker_pool_capacity`, `pgbus_worker_pool_busy`, `pgbus_worker_pool_utilization`
- Add **autovacuum tuning** for PGMQ queue/archive tables via `pgbus:tune_autovacuum` generator, runtime hook in `Client#ensure_single_queue`, and updated install migration template
- Register autovacuum tuning in `MigrationDetector` so `rails generate pgbus:update` auto-detects and applies it
- Document autovacuum tuning and archive retention sizing in performance rules

### Motivation

Inspired by [PlanetScale's "Keeping a Postgres Queue Healthy"](https://planetscale.com/blog/keeping-a-postgres-queue-healthy) — dead tuple accumulation from insufficient vacuum is the primary risk for Postgres-backed queues under mixed workloads. pgbus already handles the architectural side well (short transactions, `FOR UPDATE SKIP LOCKED`, batch reads, archive compaction), but had no visibility into vacuum health, no MVCC horizon monitoring, and used default autovacuum settings that are too conservative for queue table churn.

### Autovacuum tuning

Queue tables (`pgmq.q_*`) get aggressive settings since they have very high insert/delete churn:
- `autovacuum_vacuum_scale_factor = 0.01` (vacuum at 1% dead, vs default 20%)
- `autovacuum_vacuum_cost_delay = 2` (faster vacuum cycles)
- `autovacuum_analyze_scale_factor = 0.05`

Archive tables (`pgmq.a_*`) get moderately aggressive settings.

**Three application points:**
1. **Existing installations**: `rails generate pgbus:update` detects untuned tables and creates a migration
2. **New queues at runtime**: `Client#ensure_single_queue` applies settings after `pgmq.create()`
3. **Fresh installs**: Install migration template includes tuning after default queue creation

### New Prometheus metrics

| Metric | Labels | Purpose |
|--------|--------|---------|
| `pgbus_table_dead_tuples` | table, kind | Dead tuple count per queue/archive table |
| `pgbus_table_live_tuples` | table, kind | Live tuple count per table |
| `pgbus_table_bloat_ratio` | table, kind | dead/(dead+live) ratio |
| `pgbus_table_last_vacuum_age_seconds` | table, kind | Seconds since last vacuum |
| `pgbus_oldest_transaction_age_seconds` | — | MVCC horizon pin risk |
| `pgbus_worker_pool_capacity` | pid, hostname | Pool thread/slot capacity |
| `pgbus_worker_pool_busy` | pid, hostname | Currently busy slots |
| `pgbus_worker_pool_utilization` | pid, hostname | busy/capacity ratio |

## Test plan

- [x] `bundle exec rspec spec/pgbus/autovacuum_tuning_spec.rb` — 9 specs for AutovacuumTuning module
- [x] `bundle exec rspec spec/pgbus/generators/migration_detector_spec.rb` — 4 new autovacuum detection specs + updated existing specs
- [x] `bundle exec rspec spec/pgbus/web/data_source_spec.rb` — 8 new specs for queue health stats
- [x] `bundle exec rspec spec/pgbus/web/metrics_serializer_spec.rb` — 12 new specs for health and pool utilization metrics
- [x] `bundle exec rspec spec/pgbus/client_spec.rb` — client spec updated for tune_autovacuum hook
- [x] `bundle exec rspec spec/system/dashboard_spec.rb` — system tests pass with new panel
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec i18n-tasks normalize` — all 12 locale files normalized
- [x] 1604 non-system specs pass, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue Health dashboard and per-queue Table Health views with auto-refresh, visual risk styling, and per-queue details.
  * Prometheus metrics extended with worker-pool gauges and per-table/overall transaction-age gauges.

* **Documentation**
  * Performance guidance: autovacuum tuning recommendations, archive retention sizing (default retention introduced) and compaction behavior.

* **Chores**
  * Migration/generator and tooling to apply autovacuum tuning; queue creation now triggers tuning.
  * Added UI translations for health features across multiple languages.

* **Tests**
  * New/updated tests for health APIs, metrics serialization, generator detection, and autovacuum SQL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->