### PR TITLE
fix(generators): database routing and schema:load autovacuum reapply

### DIFF
--- a/lib/generators/pgbus/add_failed_events_index_generator.rb
+++ b/lib/generators/pgbus/add_failed_events_index_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddFailedEventsIndexGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_failed_events_unique_index.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_failed_events_unique_index.rb"
-        else
-          migration_template "add_failed_events_unique_index.rb.erb",
-                             "db/migrate/add_pgbus_failed_events_unique_index.rb"
-        end
+        migration_template "add_failed_events_unique_index.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_failed_events_unique_index.rb")
       end
 
       def display_post_install
@@ -41,10 +38,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_job_locks_generator.rb
+++ b/lib/generators/pgbus/add_job_locks_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddJobLocksGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_job_locks.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_job_locks.rb"
-        else
-          migration_template "add_job_locks.rb.erb",
-                             "db/migrate/add_pgbus_job_locks.rb"
-        end
+        migration_template "add_job_locks.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_job_locks.rb")
       end
 
       def display_post_install
@@ -42,10 +39,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_job_stats_generator.rb
+++ b/lib/generators/pgbus/add_job_stats_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddJobStatsGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_job_stats.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_job_stats.rb"
-        else
-          migration_template "add_job_stats.rb.erb",
-                             "db/migrate/add_pgbus_job_stats.rb"
-        end
+        migration_template "add_job_stats.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_job_stats.rb")
       end
 
       def display_post_install
@@ -42,10 +39,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_job_stats_latency_generator.rb
+++ b/lib/generators/pgbus/add_job_stats_latency_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddJobStatsLatencyGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_job_stats_latency.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_job_stats_latency.rb"
-        else
-          migration_template "add_job_stats_latency.rb.erb",
-                             "db/migrate/add_pgbus_job_stats_latency.rb"
-        end
+        migration_template "add_job_stats_latency.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_job_stats_latency.rb")
       end
 
       def display_post_install
@@ -42,10 +39,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_job_stats_queue_index_generator.rb
+++ b/lib/generators/pgbus/add_job_stats_queue_index_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddJobStatsQueueIndexGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_job_stats_queue_index.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_job_stats_queue_index.rb"
-        else
-          migration_template "add_job_stats_queue_index.rb.erb",
-                             "db/migrate/add_pgbus_job_stats_queue_index.rb"
-        end
+        migration_template "add_job_stats_queue_index.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_job_stats_queue_index.rb")
       end
 
       def display_post_install
@@ -43,10 +40,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_outbox_generator.rb
+++ b/lib/generators/pgbus/add_outbox_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddOutboxGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_outbox.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_outbox.rb"
-        else
-          migration_template "add_outbox.rb.erb",
-                             "db/migrate/add_pgbus_outbox.rb"
-        end
+        migration_template "add_outbox.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_outbox.rb")
       end
 
       def display_post_install
@@ -42,10 +39,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_presence_generator.rb
+++ b/lib/generators/pgbus/add_presence_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddPresenceGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_presence.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_presence.rb"
-        else
-          migration_template "add_presence.rb.erb",
-                             "db/migrate/add_pgbus_presence.rb"
-        end
+        migration_template "add_presence.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_presence.rb")
       end
 
       def display_post_install
@@ -45,10 +42,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_queue_states_generator.rb
+++ b/lib/generators/pgbus/add_queue_states_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddQueueStatesGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_queue_states.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_queue_states.rb"
-        else
-          migration_template "add_queue_states.rb.erb",
-                             "db/migrate/add_pgbus_queue_states.rb"
-        end
+        migration_template "add_queue_states.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_queue_states.rb")
       end
 
       def display_post_install
@@ -41,10 +38,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_recurring_generator.rb
+++ b/lib/generators/pgbus/add_recurring_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddRecurringGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_recurring_tables.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_recurring_tables.rb"
-        else
-          migration_template "add_recurring_tables.rb.erb",
-                             "db/migrate/add_pgbus_recurring_tables.rb"
-        end
+        migration_template "add_recurring_tables.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_recurring_tables.rb")
       end
 
       def create_recurring_config
@@ -46,10 +43,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/add_stream_stats_generator.rb
+++ b/lib/generators/pgbus/add_stream_stats_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class AddStreamStatsGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "add_stream_stats.rb.erb",
-                             "db/pgbus_migrate/add_pgbus_stream_stats.rb"
-        else
-          migration_template "add_stream_stats.rb.erb",
-                             "db/migrate/add_pgbus_stream_stats.rb"
-        end
+        migration_template "add_stream_stats.rb.erb",
+                           File.join(pgbus_migrate_path, "add_pgbus_stream_stats.rb")
       end
 
       def display_post_install
@@ -44,10 +41,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/install_generator.rb
+++ b/lib/generators/pgbus/install_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class InstallGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -25,13 +27,8 @@ module Pgbus
                          "Migrations go to db/pgbus_migrate/ and schema to db/pgbus_schema.rb"
 
       def create_migration_file
-        if separate_database?
-          migration_template "migration.rb.erb",
-                             "db/pgbus_migrate/create_pgbus_tables.rb"
-        else
-          migration_template "migration.rb.erb",
-                             "db/migrate/create_pgbus_tables.rb"
-        end
+        migration_template "migration.rb.erb",
+                           File.join(pgbus_migrate_path, "create_pgbus_tables.rb")
       end
 
       def create_config_file
@@ -120,10 +117,6 @@ module Pgbus
 
       def database_name
         options[:database]
-      end
-
-      def separate_database?
-        database_name.present?
       end
     end
   end

--- a/lib/generators/pgbus/migrate_job_locks_generator.rb
+++ b/lib/generators/pgbus/migrate_job_locks_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class MigrateJobLocksGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "migrate_job_locks_to_uniqueness_keys.rb.erb",
-                             "db/pgbus_migrate/migrate_pgbus_job_locks_to_uniqueness_keys.rb"
-        else
-          migration_template "migrate_job_locks_to_uniqueness_keys.rb.erb",
-                             "db/migrate/migrate_pgbus_job_locks_to_uniqueness_keys.rb"
-        end
+        migration_template "migrate_job_locks_to_uniqueness_keys.rb.erb",
+                           File.join(pgbus_migrate_path, "migrate_pgbus_job_locks_to_uniqueness_keys.rb")
       end
 
       def display_post_install
@@ -46,10 +43,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/migration_path.rb
+++ b/lib/generators/pgbus/migration_path.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Generators
+    # Shared migration path logic for all pgbus generators.
+    #
+    # When --database is passed, uses Rails' built-in db_migrate_path which
+    # reads migrations_paths from database.yml. This is the standard Rails
+    # multi-database mechanism and respects custom paths like db/pgbus_migrate/.
+    #
+    # Falls back to db/migrate/ when no --database is set (single-database mode).
+    module MigrationPath
+      private
+
+      def pgbus_migrate_path
+        if separate_database?
+          db_migrate_path
+        else
+          "db/migrate"
+        end
+      end
+
+      def separate_database?
+        options[:database].present?
+      end
+    end
+  end
+end

--- a/lib/generators/pgbus/tune_autovacuum_generator.rb
+++ b/lib/generators/pgbus/tune_autovacuum_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class TuneAutovacuumGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "tune_autovacuum.rb.erb",
-                             "db/pgbus_migrate/tune_pgbus_autovacuum.rb"
-        else
-          migration_template "tune_autovacuum.rb.erb",
-                             "db/migrate/tune_pgbus_autovacuum.rb"
-        end
+        migration_template "tune_autovacuum.rb.erb",
+                           File.join(pgbus_migrate_path, "tune_pgbus_autovacuum.rb")
       end
 
       def display_post_install
@@ -45,10 +42,6 @@ module Pgbus
 
       def migration_version
         "[#{ActiveRecord::Migration.current_version}]"
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/generators/pgbus/upgrade_pgmq_generator.rb
+++ b/lib/generators/pgbus/upgrade_pgmq_generator.rb
@@ -2,11 +2,13 @@
 
 require "rails/generators"
 require "rails/generators/active_record"
+require_relative "migration_path"
 
 module Pgbus
   module Generators
     class UpgradePgmqGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
+      include MigrationPath
 
       source_root File.expand_path("templates", __dir__)
 
@@ -18,13 +20,8 @@ module Pgbus
                    desc: "Use a separate database for pgbus tables (e.g. --database=pgbus)"
 
       def create_migration_file
-        if separate_database?
-          migration_template "upgrade_pgmq.rb.erb",
-                             "db/pgbus_migrate/upgrade_pgmq_to_v#{target_version_slug}.rb"
-        else
-          migration_template "upgrade_pgmq.rb.erb",
-                             "db/migrate/upgrade_pgmq_to_v#{target_version_slug}.rb"
-        end
+        migration_template "upgrade_pgmq.rb.erb",
+                           File.join(pgbus_migrate_path, "upgrade_pgmq_to_v#{target_version_slug}.rb")
       end
 
       def display_post_upgrade
@@ -50,10 +47,6 @@ module Pgbus
 
       def target_version_slug
         target_version.tr(".", "_")
-      end
-
-      def separate_database?
-        options[:database].present?
       end
     end
   end

--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -47,6 +47,7 @@ module Pgbus
     rake_tasks do
       load File.expand_path("../tasks/pgbus_pgmq.rake", __dir__)
       load File.expand_path("../tasks/pgbus_streams.rake", __dir__)
+      load File.expand_path("../tasks/pgbus_autovacuum.rake", __dir__)
     end
 
     initializer "pgbus.i18n" do

--- a/lib/tasks/pgbus_autovacuum.rake
+++ b/lib/tasks/pgbus_autovacuum.rake
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+namespace :pgbus do
+  desc "Apply autovacuum tuning to PGMQ queue/archive tables and high-churn pgbus tables"
+  task tune_autovacuum: :environment do
+    require "pgbus/autovacuum_tuning"
+
+    conn = Pgbus.configuration.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection
+
+    # Only run if pgmq schema exists (tables may not be created yet during
+    # initial setup — the install migration handles tuning itself).
+    pgmq_exists = conn.select_value(
+      "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgmq'"
+    )
+
+    unless pgmq_exists
+      puts "[pgbus] PGMQ schema not found — skipping autovacuum tuning."
+      next
+    end
+
+    puts "[pgbus] Applying autovacuum tuning to PGMQ queue/archive tables..."
+    conn.execute(Pgbus::AutovacuumTuning.sql_for_all_queues)
+
+    puts "[pgbus] Applying autovacuum tuning to high-churn pgbus tables..."
+    conn.execute(Pgbus::AutovacuumTuning.sql_for_high_churn_tables)
+
+    puts "[pgbus] Autovacuum tuning complete."
+  end
+end
+
+# Reapply autovacuum settings after schema:load since Ruby-format schema.rb
+# does not preserve ALTER TABLE ... SET (reloptions). This is a no-op if the
+# tables don't exist yet (IF EXISTS guards in the SQL).
+%w[db:schema:load db:schema:load:pgbus].each do |task_name|
+  next unless Rake::Task.task_defined?(task_name)
+
+  Rake::Task[task_name].enhance do
+    Rake::Task["pgbus:tune_autovacuum"].invoke if Rake::Task.task_defined?("pgbus:tune_autovacuum")
+  end
+end


### PR DESCRIPTION
## Summary

- Extract shared `Pgbus::Generators::MigrationPath` module used by all 14 migration generators
- Replace hardcoded `db/pgbus_migrate/` paths with Rails' built-in `db_migrate_path` which reads `migrations_paths` from `database.yml`
- Add `pgbus:tune_autovacuum` rake task that hooks into `db:schema:load` to reapply autovacuum settings lost by Ruby-format schema dumps

### Problem 1: `--database` routing ignored `database.yml`

All pgbus generators hardcoded migration routing:

```ruby
if separate_database?
  migration_template "...", "db/pgbus_migrate/..."
else
  migration_template "...", "db/migrate/..."
end
```

This ignores `migrations_paths` configured in `database.yml`, so migrations could land in `db/migrate/` when the Rails database config used a different path.

**Fix:** New `MigrationPath` module delegates to Rails' `db_migrate_path` when `--database` is set (-154 lines of duplicated if/else, +84 lines via shared module).

### Problem 2: `db:schema:load` loses autovacuum tuning

Ruby-format `schema.rb` does not preserve `ALTER TABLE ... SET (reloptions)`. Fresh setups via `db:schema:load` lose the autovacuum tuning from the migration.

**Fix:** New `pgbus:tune_autovacuum` rake task hooks into `db:schema:load` (and `db:schema:load:pgbus` for multi-db) to reapply settings automatically. Idempotent and skips gracefully when pgmq schema doesn't exist yet.

## Test plan

- [x] `bundle exec rspec` — 1610 examples, 0 failures
- [x] `bundle exec rubocop` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated migration path logic so generators consistently place pgbus migrations in the unified pgbus migrations directory.

* **New Features**
  * Added a pgbus:tune_autovacuum rake task to tune autovacuum for pgbus/pgmq tables; it is automatically invoked after schema loads when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->