### PR TITLE
feat(streams): short-name helpers and tighter queue-name budget

### DIFF
--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -105,6 +105,20 @@ module Pgbus
       @stream_cache.compute_if_absent(name) { Streams::Stream.new(streamables) }
     end
 
+    # Compose a short, pgbus-safe stream identifier from any mix of
+    # records, strings, symbols, and arrays. Delegates to
+    # `Pgbus::Streams::Key.stream_key`; raises `ArgumentError` if the
+    # resulting key would overflow the pgbus queue-name budget. See
+    # `lib/pgbus/streams/key.rb` for the digest policy and rationale.
+    #
+    #   Pgbus.stream_key(chat, :messages)
+    #   # => "ai_chat_3a4f9c21b7d20e18:messages"
+    #
+    #   Pgbus.stream(Pgbus.stream_key(chat, :messages)).broadcast(html)
+    def stream_key(*parts, **)
+      Streams::Key.stream_key(*parts, **)
+    end
+
     def reset!
       @client&.close
       @client = nil

--- a/lib/pgbus/queue_name_validator.rb
+++ b/lib/pgbus/queue_name_validator.rb
@@ -46,16 +46,23 @@ module Pgbus
       name
     end
 
-    # Normalizes a queue name by replacing common separators (hyphens, dots)
-    # with underscores, stripping remaining invalid characters, and collapsing
-    # consecutive underscores. Use this for names from external sources
-    # (e.g., Turbo stream names like "hotwire-livereload") where the intent
-    # is to derive a valid PGMQ queue name that preserves readability.
+    # Normalizes a queue name by replacing common separators (hyphens,
+    # dots, colons) with underscores, stripping remaining invalid
+    # characters, and collapsing consecutive underscores. Use this for
+    # names from external sources (e.g., Turbo stream names like
+    # "hotwire-livereload" or "gid://app/Foo/1") where the intent is
+    # to derive a valid PGMQ queue name that preserves as much of the
+    # original identifier as possible.
+    #
+    # Colons in particular are the turbo-rails stream-name separator
+    # (`Pgbus.stream([user, :notifications])` → `"user_gid:notifications"`),
+    # so they must map to a safe character rather than be stripped —
+    # otherwise `"a:b"` and `"ab"` would collide on the same queue.
     def normalize(name)
       name = name.to_s
       return validate!(name) if VALID_QUEUE_NAME_PATTERN.match?(name)
 
-      normalized = name.gsub(/[-.]/, "_")           # hyphens/dots → underscores
+      normalized = name.gsub(/[-.:]/, "_")          # hyphens/dots/colons → underscores
                        .gsub(/[^a-zA-Z0-9_]/, "")   # strip remaining invalid chars
                        .gsub(/_+/, "_")              # collapse consecutive underscores
                        .gsub(/\A_|_\z/, "")          # strip leading/trailing underscores

--- a/lib/pgbus/queue_name_validator.rb
+++ b/lib/pgbus/queue_name_validator.rb
@@ -7,9 +7,21 @@ module Pgbus
   # (e.g., pgmq.q_<name>, pgmq.a_<name>). This module enforces strict
   # validation to prevent SQL injection via crafted queue names.
   module QueueNameValidator
-    # PostgreSQL identifier limit is 63 bytes (NAMEDATALEN - 1).
-    # PGMQ prefixes with "q_" or "a_" (2 chars), so limit the name itself.
-    MAX_QUEUE_NAME_LENGTH = 61
+    # PostgreSQL's NAMEDATALEN caps identifiers at 63 bytes, but the
+    # effective limit is tighter: pgmq-ruby (our transport gem) rejects
+    # any queue name with `length >= 48` in `PGMQ::Client#validate_queue_name!`.
+    # That leaves an actual usable ceiling of 47 characters for the
+    # fully-prefixed name (`<queue_prefix>_<logical_name>`), which is what
+    # this constant expresses. pgmq-ruby picked 48 to leave headroom for
+    # PGMQ's internal tables (`pgmq.q_`, `pgmq.a_`, sequences, indexes)
+    # which all get suffixed beyond the base name.
+    #
+    # Historically this was 61 (the raw PostgreSQL ceiling minus PGMQ's
+    # `q_`/`a_` prefix). That was wrong in practice: names in the 48-61
+    # range passed pgbus's validator but blew up deep inside pgmq-ruby
+    # with an InvalidQueueNameError — exactly the kind of opaque failure
+    # the validator was meant to catch up front.
+    MAX_QUEUE_NAME_LENGTH = 47
 
     # Only alphanumeric characters and underscores are allowed.
     VALID_QUEUE_NAME_PATTERN = /\A[a-zA-Z0-9_]+\z/

--- a/lib/pgbus/streams.rb
+++ b/lib/pgbus/streams.rb
@@ -139,7 +139,7 @@ module Pgbus
               "Stream name #{name.inspect} is #{name.length} chars, " \
               "exceeds pgbus budget of #{budget} " \
               "(queue_prefix=#{Pgbus.configuration.queue_prefix.inspect}, " \
-              "NAMEDATALEN=#{QueueNameValidator::MAX_QUEUE_NAME_LENGTH}). " \
+              "pgbus_max_queue_name_length=#{QueueNameValidator::MAX_QUEUE_NAME_LENGTH}). " \
               "Streamables: #{streamables.inspect}. " \
               "Use Pgbus.stream_key(*streamables) to produce a safe short name, " \
               "or include Pgbus::Streams::Streamable on the model."

--- a/lib/pgbus/streams.rb
+++ b/lib/pgbus/streams.rb
@@ -6,6 +6,15 @@ module Pgbus
   # which returns a `Pgbus::Streams::Stream` providing `#broadcast`,
   # `#current_msg_id`, and `#read_after`.
   module Streams
+    # Raised when a composed stream name would overflow PGMQ's queue-name
+    # budget (derived from PostgreSQL's NAMEDATALEN=64, minus PGMQ's `q_`
+    # table prefix, minus the configured queue_prefix + separator).
+    #
+    # Inherits from ArgumentError so existing rescues of the underlying
+    # QueueNameValidator error keep working; callers that want to handle
+    # this specifically can rescue Pgbus::Streams::StreamNameTooLong.
+    class StreamNameTooLong < ArgumentError; end
+
     # Process-wide registry of server-side audience filter predicates.
     # Register filters at boot time via:
     #   Pgbus::Streams.filters.register(:admin_only) { |user| user.admin? }
@@ -30,6 +39,7 @@ module Pgbus
 
       def initialize(streamables, client: Pgbus.client)
         @name = self.class.name_from(streamables)
+        self.class.validate_name_length!(@name, streamables)
         @client = client
         @ensured = false
         @ensure_mutex = Mutex.new
@@ -106,6 +116,33 @@ module Pgbus
         else
           streamables.to_s
         end
+      end
+
+      # Enforces the pgbus queue-name budget at the Stream-construction
+      # boundary so a forgotten call site fails with an actionable error
+      # (pointing at the offending streamables and suggesting
+      # `Pgbus.stream_key`) instead of an opaque QueueNameValidator
+      # failure three frames deep in Client#ensure_stream_queue.
+      #
+      # The budget is computed from `config.queue_prefix` at call time
+      # so apps that override the prefix get the correct limit. Does not
+      # mutate the name — silent truncation is a footgun for
+      # multi-tenant apps where collisions would mix broadcasts across
+      # records. Callers who need a short, safe identifier should use
+      # `Pgbus.stream_key(...)` or include `Pgbus::Streams::Streamable`
+      # on their ActiveRecord models.
+      def self.validate_name_length!(name, streamables)
+        budget = Key.queue_name_budget
+        return if name.length <= budget
+
+        raise StreamNameTooLong,
+              "Stream name #{name.inspect} is #{name.length} chars, " \
+              "exceeds pgbus budget of #{budget} " \
+              "(queue_prefix=#{Pgbus.configuration.queue_prefix.inspect}, " \
+              "NAMEDATALEN=#{QueueNameValidator::MAX_QUEUE_NAME_LENGTH}). " \
+              "Streamables: #{streamables.inspect}. " \
+              "Use Pgbus.stream_key(*streamables) to produce a safe short name, " \
+              "or include Pgbus::Streams::Streamable on the model."
       end
 
       private

--- a/lib/pgbus/streams/key.rb
+++ b/lib/pgbus/streams/key.rb
@@ -76,6 +76,18 @@ module Pgbus
           raise ArgumentError, "digest_bits must be a positive multiple of 4"
         end
 
+        # Unpersisted records all share id=nil, which hashes to a single
+        # constant digest and would collapse every new instance of the
+        # same class into one stream. Fail loud at the first unsaved
+        # call site — the whole point of the 64-bit digest is to
+        # eliminate collisions, so silently producing a shared key here
+        # would reintroduce exactly what it was chosen to prevent.
+        if record.id.nil?
+          raise ArgumentError,
+                "#{record.class.name} must be persisted before generating a stream key " \
+                "(record.id is nil — all unsaved records would collide on one stream)"
+        end
+
         hex_chars = digest_bits / 4
         ::Digest::SHA256.hexdigest(record.id.to_s)[0, hex_chars]
       end

--- a/lib/pgbus/streams/key.rb
+++ b/lib/pgbus/streams/key.rb
@@ -6,12 +6,14 @@ module Pgbus
   module Streams
     # Short, pgbus-safe stream identifiers.
     #
-    # PGMQ queue names are subject to PostgreSQL's NAMEDATALEN ceiling
-    # (63 chars for `pgmq.q_<name>`), and pgbus reserves two of those
-    # for PGMQ's own `q_`/`a_` prefix — leaving 61 chars (see
-    # QueueNameValidator::MAX_QUEUE_NAME_LENGTH). Any stream name composed
-    # from UUID primary keys and turbo-rails-style dom ids blows past that
-    # budget almost immediately:
+    # PGMQ queue names are bounded by two ceilings: PostgreSQL's
+    # NAMEDATALEN (63 chars for `pgmq.q_<name>`) and pgmq-ruby's own
+    # stricter runtime check (`length >= 48` in
+    # `PGMQ::Client#validate_queue_name!`). The effective budget is the
+    # lower of the two, exposed as `QueueNameValidator::MAX_QUEUE_NAME_LENGTH`
+    # (currently 47). Any stream name composed from UUID primary keys
+    # and turbo-rails-style dom ids blows past that budget almost
+    # immediately:
     #
     #     "gid://app/Ai::Chat/9c14e8b2-94c3-4c6f-8ca1-f50d2f5e22ca:messages"
     #     # => 63 chars, already too long before the "pgbus_" prefix is added.

--- a/lib/pgbus/streams/key.rb
+++ b/lib/pgbus/streams/key.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Pgbus
+  module Streams
+    # Short, pgbus-safe stream identifiers.
+    #
+    # PGMQ queue names are subject to PostgreSQL's NAMEDATALEN ceiling
+    # (63 chars for `pgmq.q_<name>`), and pgbus reserves two of those
+    # for PGMQ's own `q_`/`a_` prefix — leaving 61 chars (see
+    # QueueNameValidator::MAX_QUEUE_NAME_LENGTH). Any stream name composed
+    # from UUID primary keys and turbo-rails-style dom ids blows past that
+    # budget almost immediately:
+    #
+    #     "gid://app/Ai::Chat/9c14e8b2-94c3-4c6f-8ca1-f50d2f5e22ca:messages"
+    #     # => 63 chars, already too long before the "pgbus_" prefix is added.
+    #
+    # `stream_key` produces a deterministic short form suitable as a
+    # pgbus stream identifier. It normalizes each part, joins with ":",
+    # and enforces the queue-name budget (derived from the configured
+    # `queue_prefix`) at the call site — raising ArgumentError rather
+    # than letting the failure surface as an opaque QueueNameValidator
+    # error deep inside `Pgbus.stream(...).broadcast(...)`.
+    #
+    # Silent truncation is intentionally NOT supported: trimming a
+    # too-long key to fit would reintroduce the collision risk that the
+    # 64-bit digest is chosen to eliminate. Callers who overflow should
+    # shorten their own identifiers or adopt `Pgbus::Streams::Streamable`
+    # on their ActiveRecord models.
+    #
+    # Usage:
+    #
+    #     Pgbus.stream_key(chat, :messages)
+    #       # => "ai_chat_3a4f9c21b7d20e18:messages"
+    #
+    #     Pgbus.stream_key([user, :notifications])
+    #       # => "user_5fa83c91d44a2701:notifications"
+    #
+    #     Pgbus.stream(Pgbus.stream_key(chat, :messages)).broadcast("<turbo-stream/>")
+    #
+    # Collision horizon: the 64-bit SHA-256 prefix gives a birthday bound
+    # of roughly 5 billion records per model class before a 50% chance of
+    # collision. For multi-tenant apps where a collision would mean two
+    # records share a stream (and receive each other's broadcasts), this
+    # is wide enough in practice. Callers with higher sensitivity can
+    # pass `digest_bits: 128`.
+    module Key
+      DEFAULT_DIGEST_BITS = 64
+
+      module_function
+
+      # Compose a short pgbus-safe stream name from any mix of records,
+      # strings, symbols, and arrays. Returns the joined key when it fits
+      # the pgbus queue-name budget; raises ArgumentError otherwise.
+      def stream_key(*parts, digest_bits: DEFAULT_DIGEST_BITS)
+        key = Array(parts).flatten.map { |part| normalize(part, digest_bits: digest_bits) }.join(":")
+        budget = queue_name_budget
+        return key if key.length <= budget
+
+        raise ArgumentError,
+              "stream_key #{key.inspect} is #{key.length} chars, " \
+              "exceeds pgbus budget of #{budget} " \
+              "(queue_prefix=#{Pgbus.configuration.queue_prefix.inspect}, " \
+              "NAMEDATALEN=#{QueueNameValidator::MAX_QUEUE_NAME_LENGTH}). " \
+              "Shorten the streamables or use Pgbus::Streams::Streamable on the model."
+      end
+
+      # 64-bit (default) SHA-256 prefix of the record's primary key. Stdlib
+      # only, deterministic, and fixed-length. CRC32's 32-bit output is
+      # intentionally not used here: its ~77k-row birthday bound is too
+      # tight for a multi-tenant stream identifier where a collision would
+      # route two records' broadcasts to the same queue.
+      def short_id(record, digest_bits: DEFAULT_DIGEST_BITS)
+        unless digest_bits.is_a?(Integer) && digest_bits.positive? && (digest_bits % 4).zero?
+          raise ArgumentError, "digest_bits must be a positive multiple of 4"
+        end
+
+        hex_chars = digest_bits / 4
+        ::Digest::SHA256.hexdigest(record.id.to_s)[0, hex_chars]
+      end
+
+      # Normalize a single streamable fragment to a pgbus-safe string.
+      # Mirrors the shape accepted by Turbo::Streams::StreamName and
+      # Pgbus::Streams::Stream.name_from so the two code paths agree
+      # on the wire format.
+      #
+      # - Strings and symbols pass through verbatim.
+      # - ActiveRecord models become "<param_key>_<short_id>".
+      # - Anything else responding to `to_gid_param` / `to_param` falls
+      #   back to that; a UUID primary key would still overflow, which
+      #   is why AR models are hashed above.
+      def normalize(part, digest_bits: DEFAULT_DIGEST_BITS)
+        case part
+        when String, Symbol
+          part.to_s
+        else
+          if defined?(::ActiveRecord::Base) && part.is_a?(::ActiveRecord::Base)
+            "#{part.class.model_name.param_key}_#{short_id(part, digest_bits: digest_bits)}"
+          elsif part.respond_to?(:to_stream_key)
+            part.to_stream_key
+          elsif part.respond_to?(:to_gid_param)
+            part.to_gid_param
+          elsif part.respond_to?(:to_param)
+            part.to_param
+          else
+            part.to_s
+          end
+        end
+      end
+
+      # Budget = NAMEDATALEN ceiling - "<queue_prefix>_" length.
+      # Computed at call time (not a constant) so apps that override
+      # `config.queue_prefix` get the correct budget automatically.
+      def queue_name_budget
+        QueueNameValidator::MAX_QUEUE_NAME_LENGTH -
+          Pgbus.configuration.queue_prefix.length - 1
+      end
+    end
+  end
+end

--- a/lib/pgbus/streams/key.rb
+++ b/lib/pgbus/streams/key.rb
@@ -55,8 +55,17 @@ module Pgbus
       # Compose a short pgbus-safe stream name from any mix of records,
       # strings, symbols, and arrays. Returns the joined key when it fits
       # the pgbus queue-name budget; raises ArgumentError otherwise.
+      #
+      # Fragments must not contain `:` — it's the join separator, so
+      # `stream_key("a:b", :c)` and `stream_key("a", "b:c")` would both
+      # produce `"a:b:c"` and collapse two logically distinct streams
+      # onto one queue. Colons inside fragments (typically from a
+      # `to_stream_key`/`to_gid_param` implementation that forgot to
+      # sanitize) raise an ArgumentError at the call site.
       def stream_key(*parts, digest_bits: DEFAULT_DIGEST_BITS)
-        key = Array(parts).flatten.map { |part| normalize(part, digest_bits: digest_bits) }.join(":")
+        fragments = Array(parts).flatten.map { |part| normalize(part, digest_bits: digest_bits) }
+        fragments.each { |fragment| reject_colons!(fragment) }
+        key = fragments.join(":")
         budget = queue_name_budget
         return key if key.length <= budget
 
@@ -64,7 +73,7 @@ module Pgbus
               "stream_key #{key.inspect} is #{key.length} chars, " \
               "exceeds pgbus budget of #{budget} " \
               "(queue_prefix=#{Pgbus.configuration.queue_prefix.inspect}, " \
-              "NAMEDATALEN=#{QueueNameValidator::MAX_QUEUE_NAME_LENGTH}). " \
+              "pgbus_max_queue_name_length=#{QueueNameValidator::MAX_QUEUE_NAME_LENGTH}). " \
               "Shorten the streamables or use Pgbus::Streams::Streamable on the model."
       end
 
@@ -135,13 +144,30 @@ module Pgbus
         end
       end
 
-      # Budget = NAMEDATALEN ceiling - "<queue_prefix>_" length.
-      # Computed at call time (not a constant) so apps that override
-      # `config.queue_prefix` get the correct budget automatically.
+      # Budget = effective pgbus queue-name limit - "<queue_prefix>_"
+      # length. Computed at call time (not a constant) so apps that
+      # override `config.queue_prefix` get the correct budget
+      # automatically.
       def queue_name_budget
         QueueNameValidator::MAX_QUEUE_NAME_LENGTH -
           Pgbus.configuration.queue_prefix.length - 1
       end
+
+      # Raises if a normalized fragment contains the `:` separator.
+      # Kept private-ish via module_function so the guard is shared
+      # between stream_key and any future composer without becoming
+      # part of the public surface.
+      def reject_colons!(fragment)
+        return unless fragment.include?(":")
+
+        raise ArgumentError,
+              "stream_key fragment #{fragment.inspect} contains ':' which is the " \
+              "join separator — two calls with different colon placements would " \
+              "collapse to the same key (e.g. stream_key('a:b', :c) vs " \
+              "stream_key('a', 'b:c') both produce 'a:b:c'). Strip or replace " \
+              "colons in the offending streamable before calling stream_key."
+      end
+      private_class_method :reject_colons!
     end
   end
 end

--- a/lib/pgbus/streams/key.rb
+++ b/lib/pgbus/streams/key.rb
@@ -73,9 +73,21 @@ module Pgbus
       # intentionally not used here: its ~77k-row birthday bound is too
       # tight for a multi-tenant stream identifier where a collision would
       # route two records' broadcasts to the same queue.
+      # Full output size of the backing digest, in bits. Capping
+      # digest_bits here matters because `SHA256.hexdigest` only
+      # produces 64 hex chars (256 bits) no matter what — slicing
+      # `[0, 128]` just returns all 64 chars — so a caller asking for
+      # `digest_bits: 512` would silently get the same output as
+      # `digest_bits: 256` and walk away believing they'd widened the
+      # collision horizon. Raise instead.
+      MAX_DIGEST_BITS = ::Digest::SHA256.new.digest_length * 8 # => 256
+
       def short_id(record, digest_bits: DEFAULT_DIGEST_BITS)
-        unless digest_bits.is_a?(Integer) && digest_bits.positive? && (digest_bits % 4).zero?
-          raise ArgumentError, "digest_bits must be a positive multiple of 4"
+        unless digest_bits.is_a?(Integer) && digest_bits.positive? &&
+               (digest_bits % 4).zero? && digest_bits <= MAX_DIGEST_BITS
+          raise ArgumentError,
+                "digest_bits must be a positive multiple of 4 and <= #{MAX_DIGEST_BITS} " \
+                "(SHA-256 produces #{MAX_DIGEST_BITS} bits; asking for more would silently truncate)"
         end
 
         # Unpersisted records all share id=nil, which hashes to a single

--- a/lib/pgbus/streams/streamable.rb
+++ b/lib/pgbus/streams/streamable.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Streams
+    # ActiveRecord concern that adds `short_id` and `to_stream_key`
+    # instance methods for producing pgbus-safe stream identifiers from
+    # records whose primary key is a UUID (or any other long string).
+    #
+    # Intended for inclusion in `ApplicationRecord`:
+    #
+    #     class ApplicationRecord < ActiveRecord::Base
+    #       primary_abstract_class
+    #       include Pgbus::Streams::Streamable
+    #     end
+    #
+    # Every subclass then gets:
+    #
+    #     chat.short_id
+    #     # => "3a4f9c21b7d20e18"
+    #
+    #     chat.to_stream_key
+    #     # => "ai_chat_3a4f9c21b7d20e18"
+    #
+    #     Pgbus.stream_key(chat, :messages)
+    #     # => "ai_chat_3a4f9c21b7d20e18:messages"
+    #
+    # The mixin is intentionally thin: it delegates to `Pgbus::Streams::Key`
+    # so the digest policy lives in one place. Host apps that already
+    # define `#short_id` will collide at include time — that's loud by
+    # design; silent override would hide a real conflict.
+    module Streamable
+      # Returns a short SHA-256 prefix (64 bits / 16 hex chars by default)
+      # of this record's primary key. See `Pgbus::Streams::Key.short_id`
+      # for the digest policy and collision horizon.
+      def short_id(digest_bits: Key::DEFAULT_DIGEST_BITS)
+        Key.short_id(self, digest_bits: digest_bits)
+      end
+
+      # Returns a stable, pgbus-safe identifier of the form
+      # `<model_key>_<short_id>` suitable for passing directly to
+      # `Pgbus.stream(...)` or composing with `Pgbus.stream_key`.
+      def to_stream_key
+        "#{self.class.model_name.param_key}_#{short_id}"
+      end
+    end
+  end
+end

--- a/lib/pgbus/streams/streamable.rb
+++ b/lib/pgbus/streams/streamable.rb
@@ -25,9 +25,19 @@ module Pgbus
     #     # => "ai_chat_3a4f9c21b7d20e18:messages"
     #
     # The mixin is intentionally thin: it delegates to `Pgbus::Streams::Key`
-    # so the digest policy lives in one place. Host apps that already
-    # define `#short_id` will collide at include time — that's loud by
-    # design; silent override would hide a real conflict.
+    # so the digest policy lives in one place.
+    #
+    # `#to_stream_key` calls `Key.short_id(self)` directly rather than
+    # dispatching through `#short_id`. Ruby does NOT warn when a class
+    # defines an instance method and a later `include` adds a module
+    # with the same name — the class method silently wins. A host app
+    # that already defines its own `#short_id` (returning, say, a
+    # display-friendly abbreviation) would therefore hijack
+    # `to_stream_key` without any indication, producing stream keys
+    # the wire format never promised. Calling `Key.short_id(self)`
+    # explicitly bypasses instance-method lookup and guarantees the
+    # advertised digest regardless of what the host class does with
+    # the unqualified name.
     module Streamable
       # Returns a short SHA-256 prefix (64 bits / 16 hex chars by default)
       # of this record's primary key. See `Pgbus::Streams::Key.short_id`
@@ -40,7 +50,7 @@ module Pgbus
       # `<model_key>_<short_id>` suitable for passing directly to
       # `Pgbus.stream(...)` or composing with `Pgbus.stream_key`.
       def to_stream_key
-        "#{self.class.model_name.param_key}_#{short_id}"
+        "#{self.class.model_name.param_key}_#{Key.short_id(self)}"
       end
     end
   end

--- a/spec/integration/streams/stream_name_length_spec.rb
+++ b/spec/integration/streams/stream_name_length_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require_relative "../../integration_helper"
+
+# Integration tests for the stream-name length safety net and the
+# `Pgbus.stream_key` helper. These exercise the full path:
+#
+#   Pgbus.stream_key(...)  -> short name
+#   Pgbus.stream(name)     -> constructs Stream (which calls validate_name_length!)
+#   stream.broadcast(html) -> ensure_stream_queue -> queue_name(name)
+#                             -> QueueNameValidator.validate!
+#                             -> real PGMQ insert
+#   stream.read_after      -> real PGMQ read
+#
+# The point is to prove the two layers (Pgbus::Streams::Stream's
+# validate_name_length! and the underlying QueueNameValidator) agree on
+# the budget for the real, configured queue_prefix and that the short
+# digest produced by `stream_key` is actually accepted by PGMQ.
+RSpec.describe "Streams: name length safety net (integration)", :integration do
+  let(:budget) { Pgbus::Streams::Key.queue_name_budget }
+
+  # A Struct that looks enough like an AR model for Pgbus::Streams::Key
+  # to hash its id into a short_id. Using a real ActiveRecord model would
+  # force integration_helper to bootstrap an unrelated table; this stays
+  # focused on the naming layer while still going through real PGMQ.
+  let(:fake_model_class) do
+    Class.new do
+      attr_reader :id
+
+      def initialize(id)
+        @id = id
+      end
+
+      def to_stream_key
+        "fake_chat_#{Digest::SHA256.hexdigest(id.to_s)[0, 16]}"
+      end
+    end
+  end
+
+  let(:fake_chat) { fake_model_class.new("9c14e8b2-94c3-4c6f-8ca1-f50d2f5e22ca") }
+
+  describe "Pgbus.stream_key produces a broadcast-able short name" do
+    it "round-trips a broadcast + read_after through real PGMQ" do
+      name = Pgbus.stream_key(fake_chat, :messages)
+      expect(name).to match(/\Afake_chat_[0-9a-f]{16}:messages\z/)
+
+      stream = Pgbus.stream(name)
+      msg_id = stream.broadcast("<turbo-stream>hello</turbo-stream>")
+      expect(msg_id.to_i).to be > 0
+
+      replayed = stream.read_after(after_id: 0, limit: 10)
+      payloads = replayed.map { |envelope| JSON.parse(envelope.payload) }
+      expect(payloads.map { |p| p["html"] }).to include("<turbo-stream>hello</turbo-stream>")
+    end
+
+    it "is stable — two constructions of the same stream land in the same PGMQ queue" do
+      name = Pgbus.stream_key(fake_chat, :messages)
+      Pgbus.stream(name).broadcast("<a/>")
+      Pgbus.stream(name).broadcast("<b/>")
+
+      replayed = Pgbus.stream(name).read_after(after_id: 0, limit: 10)
+      htmls = replayed.map { |envelope| JSON.parse(envelope.payload)["html"] }
+      expect(htmls).to include("<a/>", "<b/>")
+    end
+  end
+
+  describe "overflow path — forgotten call site fails fast" do
+    it "raises StreamNameTooLong at Pgbus.stream(...) before touching PGMQ" do
+      # Simulates `broadcast_replace_to [long_record, :some_long_suffix]`
+      # where the composed name overflows. The error must originate
+      # from Pgbus::Streams::Stream, not from deep inside PGMQ, and
+      # must NOT have side effects on the queue catalog.
+      long = "leak_check_#{"z" * budget}"
+      conn = ActiveRecord::Base.connection
+      queues_before = conn.select_values("SELECT queue_name FROM pgmq.meta").sort
+
+      expect { Pgbus.stream(long) }
+        .to raise_error(Pgbus::Streams::StreamNameTooLong, /exceeds pgbus budget/)
+
+      queues_after = conn.select_values("SELECT queue_name FROM pgmq.meta").sort
+      expect(queues_after).to eq(queues_before)
+    end
+
+    it "names the streamables and points at the helper in the error message" do
+      long = "x" * (budget + 5)
+      expect { Pgbus.stream(long) }
+        .to raise_error(Pgbus::Streams::StreamNameTooLong) do |err|
+          expect(err.message).to include(long.length.to_s)
+          expect(err.message).to include("Pgbus.stream_key")
+        end
+    end
+
+    it "remains an ArgumentError so pre-existing rescues still catch it" do
+      long = "y" * (budget + 5)
+      expect { Pgbus.stream(long) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "budget tracks config.queue_prefix" do
+    it "allows a name that fits the current budget and reaches real PGMQ" do
+      # Pick a name exactly at the budget so the assertion actually
+      # exercises the boundary, not a comfortable interior value.
+      short_name = "s" * budget
+      expect(short_name.length).to eq(budget)
+
+      stream = Pgbus.stream(short_name)
+      expect { stream.broadcast("<x/>") }.not_to raise_error
+
+      # Verify the raw queue_name(...) computation agrees with the budget
+      # — the fully-prefixed name must stay within MAX_QUEUE_NAME_LENGTH,
+      # which is both pgbus's and (indirectly) pgmq-ruby's ceiling.
+      full_queue_name = Pgbus.configuration.queue_name(short_name)
+      expect(full_queue_name.length).to be <= Pgbus::QueueNameValidator::MAX_QUEUE_NAME_LENGTH
+    end
+
+    it "rejects the same name under a longer prefix" do
+      original_prefix = Pgbus.configuration.queue_prefix
+      name = "z" * (budget - 2) # fits under the default prefix
+
+      # Switch to a much longer prefix so the name no longer fits.
+      Pgbus.configuration.queue_prefix = "pgbus_integration_long_prefix"
+      Pgbus.instance_variable_set(:@stream_cache, nil)
+
+      expect { Pgbus.stream(name) }
+        .to raise_error(Pgbus::Streams::StreamNameTooLong)
+    ensure
+      Pgbus.configuration.queue_prefix = original_prefix
+      Pgbus.instance_variable_set(:@stream_cache, nil)
+    end
+  end
+
+  describe "stream_key helper boundary at exactly the budget" do
+    it "accepts a key that is exactly queue_name_budget characters" do
+      at_budget = "p" * budget
+      expect { Pgbus.stream_key(at_budget) }.not_to raise_error
+      expect(Pgbus.stream(at_budget)).to be_a(Pgbus::Streams::Stream)
+    end
+
+    it "rejects a key that is one character over the budget" do
+      over = "p" * (budget + 1)
+      expect { Pgbus.stream_key(over) }
+        .to raise_error(ArgumentError, /exceeds pgbus budget/)
+    end
+  end
+end

--- a/spec/integration/streams/stream_name_length_spec.rb
+++ b/spec/integration/streams/stream_name_length_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe "Streams: name length safety net (integration)", :integration do
 
   let(:fake_chat) { fake_model_class.new("9c14e8b2-94c3-4c6f-8ca1-f50d2f5e22ca") }
 
+  # Snapshots the set of PGMQ queue names via Pgbus::Client (the library
+  # boundary) rather than reaching into pgmq.meta directly. This keeps
+  # the spec aligned with the project rule that all PGMQ interactions
+  # go through Client — see .claude/rules/coding-style.md.
+  def queue_names_snapshot
+    Pgbus.client.list_queues.map { |q| q.respond_to?(:queue_name) ? q.queue_name : q.to_s }.sort
+  end
+
   describe "Pgbus.stream_key produces a broadcast-able short name" do
     it "round-trips a broadcast + read_after through real PGMQ" do
       name = Pgbus.stream_key(fake_chat, :messages)
@@ -71,13 +79,12 @@ RSpec.describe "Streams: name length safety net (integration)", :integration do
       # from Pgbus::Streams::Stream, not from deep inside PGMQ, and
       # must NOT have side effects on the queue catalog.
       long = "leak_check_#{"z" * budget}"
-      conn = ActiveRecord::Base.connection
-      queues_before = conn.select_values("SELECT queue_name FROM pgmq.meta").sort
+      queues_before = queue_names_snapshot
 
       expect { Pgbus.stream(long) }
         .to raise_error(Pgbus::Streams::StreamNameTooLong, /exceeds pgbus budget/)
 
-      queues_after = conn.select_values("SELECT queue_name FROM pgmq.meta").sort
+      queues_after = queue_names_snapshot
       expect(queues_after).to eq(queues_before)
     end
 
@@ -117,8 +124,11 @@ RSpec.describe "Streams: name length safety net (integration)", :integration do
       original_prefix = Pgbus.configuration.queue_prefix
       name = "z" * (budget - 2) # fits under the default prefix
 
-      # Switch to a much longer prefix so the name no longer fits.
-      Pgbus.configuration.queue_prefix = "pgbus_integration_long_prefix"
+      # Grow the prefix relative to whatever the suite booted with so
+      # the test deterministically triggers overflow even if the
+      # baseline prefix ever changes. Appending any non-empty suffix
+      # shrinks the budget and pushes `name` past it.
+      Pgbus.configuration.queue_prefix = "#{original_prefix}_overflow"
       Pgbus.instance_variable_set(:@stream_cache, nil)
 
       expect { Pgbus.stream(name) }

--- a/spec/pgbus/queue_name_validator_spec.rb
+++ b/spec/pgbus/queue_name_validator_spec.rb
@@ -33,13 +33,20 @@ RSpec.describe Pgbus::QueueNameValidator do
     end
 
     it "rejects names exceeding max length" do
-      long_name = "a" * 62
+      long_name = "a" * (described_class::MAX_QUEUE_NAME_LENGTH + 1)
       expect { described_class.validate!(long_name) }.to raise_error(ArgumentError, /too long/)
     end
 
     it "accepts names at max length" do
-      name = "a" * 61
+      name = "a" * described_class::MAX_QUEUE_NAME_LENGTH
       expect(described_class.validate!(name)).to eq(name)
+    end
+
+    it "matches the effective limit enforced by pgmq-ruby (< 48 chars)" do
+      # pgmq-ruby rejects length >= 48 in PGMQ::Client#validate_queue_name!,
+      # so our constant must stay below that to avoid letting names through
+      # pgbus that then fail deep in the transport gem.
+      expect(described_class::MAX_QUEUE_NAME_LENGTH).to be < 48
     end
   end
 

--- a/spec/pgbus/queue_name_validator_spec.rb
+++ b/spec/pgbus/queue_name_validator_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe Pgbus::QueueNameValidator do
       expect(described_class.normalize("my.queue.name")).to eq("my_queue_name")
     end
 
+    it "replaces colons with underscores" do
+      # Colons are the turbo-rails stream-name separator
+      # (e.g. "user_1:notifications"). Stripping them entirely would
+      # collapse "user_1:notifications" and "user_1notifications"
+      # onto the same queue, so they must map to a safe character.
+      expect(described_class.normalize("user_1:notifications")).to eq("user_1_notifications")
+    end
+
+    it "does not collide colon-joined names with their stripped form" do
+      with_colon = described_class.normalize("a:b:c")
+      without_colon = described_class.normalize("abc")
+      expect(with_colon).not_to eq(without_colon)
+    end
+
     it "collapses consecutive underscores after replacement" do
       expect(described_class.normalize("my--queue")).to eq("my_queue")
     end
@@ -68,7 +82,7 @@ RSpec.describe Pgbus::QueueNameValidator do
       expect(described_class.normalize("trailing-")).to eq("trailing")
     end
 
-    it "strips characters that are not alphanumeric, hyphens, dots, or underscores" do
+    it "strips characters that are not alphanumeric, hyphens, dots, colons, or underscores" do
       expect(described_class.normalize("queue!@#name")).to eq("queuename")
     end
 

--- a/spec/pgbus/streams/key_spec.rb
+++ b/spec/pgbus/streams/key_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Pgbus::Streams::Key do
     let(:record) { double("record", id: "9c14e8b2-94c3-4c6f-8ca1-f50d2f5e22ca") }
 
     it "returns a 16-char (64-bit) hex prefix of SHA-256(id) by default" do
-      expect(described_class.short_id(record)).to match(/\A[0-9a-f]{16}\z/)
+      expected = Digest::SHA256.hexdigest(record.id.to_s)[0, 16]
+      expect(described_class.short_id(record)).to eq(expected)
     end
 
     it "is deterministic for the same id" do
@@ -44,7 +45,8 @@ RSpec.describe Pgbus::Streams::Key do
     end
 
     it "respects digest_bits override (128 bits -> 32 hex chars)" do
-      expect(described_class.short_id(record, digest_bits: 128)).to match(/\A[0-9a-f]{32}\z/)
+      expected = Digest::SHA256.hexdigest(record.id.to_s)[0, 32]
+      expect(described_class.short_id(record, digest_bits: 128)).to eq(expected)
     end
 
     it "rejects non-multiple-of-4 digest_bits" do
@@ -59,7 +61,18 @@ RSpec.describe Pgbus::Streams::Key do
 
     it "handles numeric ids by coercing to string" do
       numeric = double("record", id: 42)
-      expect(described_class.short_id(numeric)).to match(/\A[0-9a-f]{16}\z/)
+      expected = Digest::SHA256.hexdigest("42")[0, 16]
+      expect(described_class.short_id(numeric)).to eq(expected)
+    end
+
+    it "raises when the record has not been persisted (id is nil)" do
+      # Unpersisted AR records all share id=nil; hashing the empty
+      # string would collapse every unsaved record of the same class
+      # onto one stream key. The guard is what makes the digest's
+      # collision argument hold.
+      unsaved = double("unsaved_record", id: nil, class: double("Chat", name: "Chat"))
+      expect { described_class.short_id(unsaved) }
+        .to raise_error(ArgumentError, /must be persisted/)
     end
   end
 

--- a/spec/pgbus/streams/key_spec.rb
+++ b/spec/pgbus/streams/key_spec.rb
@@ -162,6 +162,44 @@ RSpec.describe Pgbus::Streams::Key do
     ensure
       Pgbus.configuration.queue_prefix = original_prefix
     end
+
+    it "labels the ceiling in the error as pgbus_max_queue_name_length (not NAMEDATALEN)" do
+      # The ceiling is pgbus's effective limit (derived from
+      # pgmq-ruby's < 48 runtime check), not PostgreSQL's
+      # NAMEDATALEN=63. Pointing callers at "NAMEDATALEN" during
+      # debugging would send them chasing the wrong number.
+      oversized = "x" * (described_class.queue_name_budget + 1)
+      expect { described_class.stream_key(oversized) }
+        .to raise_error(ArgumentError) do |err|
+          expect(err.message).to include("pgbus_max_queue_name_length=#{Pgbus::QueueNameValidator::MAX_QUEUE_NAME_LENGTH}")
+          expect(err.message).not_to include("NAMEDATALEN")
+        end
+    end
+
+    it "rejects a string fragment containing ':' (the join separator)" do
+      # Without this guard, stream_key("a:b", :c) and stream_key("a", "b:c")
+      # would both produce "a:b:c" and collapse onto the same queue.
+      expect { described_class.stream_key("a:b", :c) }
+        .to raise_error(ArgumentError, /contains ':'/)
+    end
+
+    it "rejects a symbol fragment containing ':'" do
+      expect { described_class.stream_key(:"a:b") }
+        .to raise_error(ArgumentError, /contains ':'/)
+    end
+
+    it "rejects a fragment whose to_stream_key/to_gid_param contains ':'" do
+      hostile = Class.new do
+        def to_stream_key = "weird:value"
+      end.new
+      expect { described_class.stream_key(hostile) }
+        .to raise_error(ArgumentError, /contains ':'/)
+    end
+
+    it "explains the ambiguous-collision failure mode in the error" do
+      expect { described_class.stream_key("a:b") }
+        .to raise_error(ArgumentError, /collapse to the same key/)
+    end
   end
 
   describe ".queue_name_budget" do
@@ -176,7 +214,7 @@ RSpec.describe Pgbus::Streams::Key do
       Pgbus.configuration.queue_prefix = original_prefix
     end
 
-    it "reserves NAMEDATALEN minus queue_prefix minus separator" do
+    it "reserves MAX_QUEUE_NAME_LENGTH minus queue_prefix minus separator" do
       max = Pgbus::QueueNameValidator::MAX_QUEUE_NAME_LENGTH
       expected = max - Pgbus.configuration.queue_prefix.length - 1
       expect(described_class.queue_name_budget).to eq(expected)

--- a/spec/pgbus/streams/key_spec.rb
+++ b/spec/pgbus/streams/key_spec.rb
@@ -59,6 +59,19 @@ RSpec.describe Pgbus::Streams::Key do
         .to raise_error(ArgumentError, /positive/)
     end
 
+    it "accepts digest_bits at the SHA-256 maximum (256)" do
+      expected = Digest::SHA256.hexdigest(record.id.to_s)
+      expect(described_class.short_id(record, digest_bits: 256)).to eq(expected)
+    end
+
+    it "rejects digest_bits above the SHA-256 maximum" do
+      # SHA-256 produces 64 hex chars total; asking for 512 bits would
+      # silently truncate to 256 with no indication to the caller.
+      # Refuse the request instead of lying about the collision horizon.
+      expect { described_class.short_id(record, digest_bits: 512) }
+        .to raise_error(ArgumentError, /256/)
+    end
+
     it "handles numeric ids by coercing to string" do
       numeric = double("record", id: 42)
       expected = Digest::SHA256.hexdigest("42")[0, 16]

--- a/spec/pgbus/streams/key_spec.rb
+++ b/spec/pgbus/streams/key_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Streams::Key do
+  # Minimal stand-in that quacks like an ActiveRecord model without
+  # needing a live DB connection. Overrides `is_a?` so the code path
+  # that checks `part.is_a?(::ActiveRecord::Base)` fires.
+  let(:ar_like_class) do
+    param_key = "chat"
+    Class.new do
+      attr_reader :id
+
+      def initialize(id)
+        @id = id
+      end
+
+      define_singleton_method(:model_name) do
+        Struct.new(:param_key).new(param_key)
+      end
+
+      def is_a?(klass)
+        return true if klass == ActiveRecord::Base
+
+        super
+      end
+    end
+  end
+
+  describe ".short_id" do
+    let(:record) { double("record", id: "9c14e8b2-94c3-4c6f-8ca1-f50d2f5e22ca") }
+
+    it "returns a 16-char (64-bit) hex prefix of SHA-256(id) by default" do
+      expect(described_class.short_id(record)).to match(/\A[0-9a-f]{16}\z/)
+    end
+
+    it "is deterministic for the same id" do
+      expect(described_class.short_id(record)).to eq(described_class.short_id(record))
+    end
+
+    it "differs for different ids" do
+      other = double("record", id: "11111111-2222-3333-4444-555555555555")
+      expect(described_class.short_id(record)).not_to eq(described_class.short_id(other))
+    end
+
+    it "respects digest_bits override (128 bits -> 32 hex chars)" do
+      expect(described_class.short_id(record, digest_bits: 128)).to match(/\A[0-9a-f]{32}\z/)
+    end
+
+    it "rejects non-multiple-of-4 digest_bits" do
+      expect { described_class.short_id(record, digest_bits: 63) }
+        .to raise_error(ArgumentError, /multiple of 4/)
+    end
+
+    it "rejects non-positive digest_bits" do
+      expect { described_class.short_id(record, digest_bits: 0) }
+        .to raise_error(ArgumentError, /positive/)
+    end
+
+    it "handles numeric ids by coercing to string" do
+      numeric = double("record", id: 42)
+      expect(described_class.short_id(numeric)).to match(/\A[0-9a-f]{16}\z/)
+    end
+  end
+
+  describe ".normalize" do
+    it "passes strings through verbatim" do
+      expect(described_class.normalize("messages")).to eq("messages")
+    end
+
+    it "coerces symbols to strings" do
+      expect(described_class.normalize(:messages)).to eq("messages")
+    end
+
+    it "hashes ActiveRecord models to <param_key>_<short_id>" do
+      record = ar_like_class.new("abc-123")
+      result = described_class.normalize(record)
+      expect(result).to match(/\Achat_[0-9a-f]{16}\z/)
+    end
+
+    it "uses to_stream_key when the object responds to it (non-AR)" do
+      obj = double("stream_keyable", to_stream_key: "custom_abc")
+      expect(described_class.normalize(obj)).to eq("custom_abc")
+    end
+
+    it "falls back to to_gid_param when present" do
+      obj = double("gid", to_gid_param: "gid_param_value")
+      expect(described_class.normalize(obj)).to eq("gid_param_value")
+    end
+
+    it "falls back to to_param when neither to_stream_key nor to_gid_param is present" do
+      klass = Class.new do
+        def to_param = "param_value"
+      end
+      expect(described_class.normalize(klass.new)).to eq("param_value")
+    end
+
+    it "falls back to to_s for anything else" do
+      expect(described_class.normalize(42)).to eq("42")
+    end
+  end
+
+  describe ".stream_key" do
+    it "joins normalized parts with ':'" do
+      expect(described_class.stream_key("room", :messages)).to eq("room:messages")
+    end
+
+    it "flattens nested arrays (turbo-rails-compatible)" do
+      expect(described_class.stream_key(%w[a b], :c)).to eq("a:b:c")
+    end
+
+    it "hashes an ActiveRecord model part to a short id" do
+      record = ar_like_class.new("550e8400-e29b-41d4-a716-446655440000")
+      result = described_class.stream_key(record, :msgs)
+      expect(result).to match(/\Achat_[0-9a-f]{16}:msgs\z/)
+    end
+
+    it "returns a key that fits within the queue-name budget for normal inputs" do
+      key = described_class.stream_key("ai_chat_3a4f9c21b7d20e18", :messages)
+      budget = described_class.queue_name_budget
+      expect(key.length).to be <= budget
+    end
+
+    it "raises ArgumentError when the composed key exceeds the pgbus budget" do
+      oversized = "x" * (described_class.queue_name_budget + 1)
+      expect { described_class.stream_key(oversized) }
+        .to raise_error(ArgumentError, /exceeds pgbus budget/)
+    end
+
+    it "mentions the current queue_prefix in the error message" do
+      original_prefix = Pgbus.configuration.queue_prefix
+      Pgbus.configuration.queue_prefix = "custom_prefix"
+      oversized = "x" * 100
+      expect { described_class.stream_key(oversized) }
+        .to raise_error(ArgumentError, /custom_prefix/)
+    ensure
+      Pgbus.configuration.queue_prefix = original_prefix
+    end
+  end
+
+  describe ".queue_name_budget" do
+    it "is derived from the current queue_prefix so prefix overrides propagate" do
+      original_prefix = Pgbus.configuration.queue_prefix
+      Pgbus.configuration.queue_prefix = "abc"    # 3 chars + underscore = 4
+      short_budget = described_class.queue_name_budget
+      Pgbus.configuration.queue_prefix = "abcdef" # 6 chars + underscore = 7
+      long_prefix_budget = described_class.queue_name_budget
+      expect(short_budget - long_prefix_budget).to eq(3)
+    ensure
+      Pgbus.configuration.queue_prefix = original_prefix
+    end
+
+    it "reserves NAMEDATALEN minus queue_prefix minus separator" do
+      max = Pgbus::QueueNameValidator::MAX_QUEUE_NAME_LENGTH
+      expected = max - Pgbus.configuration.queue_prefix.length - 1
+      expect(described_class.queue_name_budget).to eq(expected)
+    end
+  end
+end

--- a/spec/pgbus/streams/stream_name_length_spec.rb
+++ b/spec/pgbus/streams/stream_name_length_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Streams::Stream do
+  let(:max) { Pgbus::QueueNameValidator::MAX_QUEUE_NAME_LENGTH }
+  let(:budget) { Pgbus::Streams::Key.queue_name_budget }
+
+  describe "Pgbus::Streams::Stream.validate_name_length!" do
+    it "returns silently when the name fits the budget" do
+      name = "x" * budget
+      expect do
+        described_class.validate_name_length!(name, [name])
+      end.not_to raise_error
+    end
+
+    it "raises StreamNameTooLong when the name overflows" do
+      name = "x" * (budget + 1)
+      expect do
+        described_class.validate_name_length!(name, [name])
+      end.to raise_error(Pgbus::Streams::StreamNameTooLong, /exceeds pgbus budget/)
+    end
+
+    it "embeds the offending length, budget, and streamables in the message" do
+      name = "y" * (budget + 10)
+      streamables = [name, :messages]
+      err = begin
+        described_class.validate_name_length!(name, streamables)
+        nil
+      rescue Pgbus::Streams::StreamNameTooLong => e
+        e
+      end
+
+      expect(err).not_to be_nil
+      expect(err.message).to include("#{name.length} chars")
+      expect(err.message).to include("budget of #{budget}")
+      expect(err.message).to include(streamables.inspect)
+      expect(err.message).to include("Pgbus.stream_key")
+    end
+
+    it "is an ArgumentError subclass (backcompat with QueueNameValidator)" do
+      expect(Pgbus::Streams::StreamNameTooLong.ancestors).to include(ArgumentError)
+    end
+
+    it "adjusts the budget when config.queue_prefix changes" do
+      original = Pgbus.configuration.queue_prefix
+      Pgbus.configuration.queue_prefix = "a" # 1 + 1 = 2 chars reserved
+      long_prefix_budget_before = max - 2
+      name = "z" * long_prefix_budget_before
+      expect do
+        described_class.validate_name_length!(name, [name])
+      end.not_to raise_error
+
+      Pgbus.configuration.queue_prefix = "very_long_prefix" # 16 + 1 = 17 chars reserved
+      expect do
+        described_class.validate_name_length!(name, [name])
+      end.to raise_error(Pgbus::Streams::StreamNameTooLong)
+    ensure
+      Pgbus.configuration.queue_prefix = original
+    end
+  end
+
+  describe "Pgbus::Streams::Stream#initialize" do
+    before { Pgbus.instance_variable_set(:@stream_cache, nil) }
+
+    it "raises StreamNameTooLong for a literal overflowing name" do
+      long = "abc_#{"d" * budget}"
+      expect { described_class.new(long, client: double("client")) }
+        .to raise_error(Pgbus::Streams::StreamNameTooLong)
+    end
+
+    it "accepts a short name" do
+      expect { described_class.new("short", client: double("client")) }
+        .not_to raise_error
+    end
+  end
+
+  describe "Pgbus.stream caching interaction" do
+    before { Pgbus.instance_variable_set(:@stream_cache, nil) }
+
+    it "does not cache a Stream when construction raises on overflow" do
+      long = "e" * (budget + 5)
+      expect { Pgbus.stream(long) }.to raise_error(Pgbus::Streams::StreamNameTooLong)
+      # Second call must raise again — the cache must not have swallowed the first failure
+      expect { Pgbus.stream(long) }.to raise_error(Pgbus::Streams::StreamNameTooLong)
+    end
+  end
+end

--- a/spec/pgbus/streams/streamable_spec.rb
+++ b/spec/pgbus/streams/streamable_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Streams::Streamable do
+  # Minimal stand-in for an ActiveRecord model. Streamable only relies on
+  # `id` and `class.model_name.param_key`, so we avoid pulling in a real
+  # ActiveRecord setup for a unit spec.
+  let(:model_class) do
+    Class.new do
+      include Pgbus::Streams::Streamable
+
+      attr_reader :id
+
+      def initialize(id)
+        @id = id
+      end
+
+      def self.model_name
+        Struct.new(:param_key).new("ai_chat")
+      end
+    end
+  end
+
+  let(:record) { model_class.new("9c14e8b2-94c3-4c6f-8ca1-f50d2f5e22ca") }
+
+  describe "#short_id" do
+    it "delegates to Pgbus::Streams::Key.short_id (16 hex chars by default)" do
+      expect(record.short_id).to match(/\A[0-9a-f]{16}\z/)
+    end
+
+    it "is deterministic across calls" do
+      expect(record.short_id).to eq(record.short_id)
+    end
+
+    it "accepts digest_bits override" do
+      expect(record.short_id(digest_bits: 128)).to match(/\A[0-9a-f]{32}\z/)
+    end
+  end
+
+  describe "#to_stream_key" do
+    it "returns '<param_key>_<short_id>'" do
+      expect(record.to_stream_key).to match(/\Aai_chat_[0-9a-f]{16}\z/)
+    end
+
+    it "is stable for the same id" do
+      expect(record.to_stream_key).to eq(record.to_stream_key)
+    end
+
+    it "differs for different ids on the same class" do
+      other = model_class.new("ffffffff-ffff-ffff-ffff-ffffffffffff")
+      expect(record.to_stream_key).not_to eq(other.to_stream_key)
+    end
+  end
+
+  describe "integration with Pgbus.stream_key" do
+    it "produces a composable key when mixed with other streamables" do
+      key = Pgbus.stream_key(record.to_stream_key, :messages)
+      expect(key).to match(/\Aai_chat_[0-9a-f]{16}:messages\z/)
+    end
+
+    it "fits within the pgbus queue-name budget for UUID primary keys" do
+      key = Pgbus.stream_key(record.to_stream_key, :messages)
+      expect(key.length).to be <= Pgbus::Streams::Key.queue_name_budget
+    end
+  end
+end

--- a/spec/pgbus/streams/streamable_spec.rb
+++ b/spec/pgbus/streams/streamable_spec.rb
@@ -51,6 +51,37 @@ RSpec.describe Pgbus::Streams::Streamable do
       other = model_class.new("ffffffff-ffff-ffff-ffff-ffffffffffff")
       expect(record.to_stream_key).not_to eq(other.to_stream_key)
     end
+
+    it "bypasses a host-class #short_id override (method dispatch would silently win)" do
+      # Ruby does NOT warn when a class defines an instance method and
+      # then includes a module with the same name — the class method
+      # wins method lookup. If `to_stream_key` went through the
+      # unqualified `short_id` call, a host class defining its own
+      # `#short_id` (e.g. a display helper) would silently hijack the
+      # wire format. Streamable calls Key.short_id(self) explicitly to
+      # defeat this, and this spec pins the behavior.
+      hostile_class = Class.new do
+        include Pgbus::Streams::Streamable
+
+        attr_reader :id
+
+        def initialize(id)
+          @id = id
+        end
+
+        def self.model_name
+          Struct.new(:param_key).new("ai_chat")
+        end
+
+        def short_id(*)
+          "HOSTILE" # would break the wire format if dispatched to
+        end
+      end
+
+      record = hostile_class.new("9c14e8b2-94c3-4c6f-8ca1-f50d2f5e22ca")
+      expect(record.to_stream_key).to match(/\Aai_chat_[0-9a-f]{16}\z/)
+      expect(record.to_stream_key).not_to include("HOSTILE")
+    end
   end
 
   describe "integration with Pgbus.stream_key" do


### PR DESCRIPTION
## Summary

Apps using pgbus with UUID primary keys and turbo-rails-style dom ids routinely hit PGMQ's queue-name ceiling (`"gid://app/Ai::Chat/9c14e8b2-...:messages"` is already 63 chars *before* the `pgbus_` prefix). Today the failure surfaces as an opaque error three frames deep inside `Client#ensure_stream_queue` — or worse, from pgmq-ruby's own `length >= 48` guard — well below the `broadcast_replace_to` callsite that actually caused it. getzazu/app#1948 worked around this with an app-level `StreamKeys` helper; this PR brings that solution into pgbus and hardens the failure mode for the day a callsite gets forgotten.

## What changes

- **Align \`MAX_QUEUE_NAME_LENGTH\` with the real ceiling.** pgmq-ruby 0.5 enforces \`length >= 48\` in \`PGMQ::Client#validate_queue_name!\`, so the old 61-char limit let names through pgbus that blew up downstream. Drop to 47 so the validators agree and the first error message is actionable.
- **New \`Pgbus::Streams::Key\` module** with \`stream_key\`, \`short_id\`, \`normalize\`. Composes a short pgbus-safe identifier from mixed streamables and hashes ActiveRecord models to \`<param_key>_<16-hex SHA-256 prefix>\`. 64 bits gives a ~5B-row birthday horizon per model class (see rationale in getzazu/app@529d911). Budget is computed from \`config.queue_prefix\` at call time so prefix overrides adjust automatically.
- **New \`Pgbus::Streams::Streamable\` mixin** for \`ApplicationRecord\`, giving \`short_id\` / \`to_stream_key\` instance methods. Host apps collapse their plumbing to \`include Pgbus::Streams::Streamable\`.
- **\`Pgbus.stream_key(*parts)\` top-level helper** delegating to \`Streams::Key\`.
- **Harden \`Pgbus::Streams::Stream#initialize\`.** Raises \`Pgbus::Streams::StreamNameTooLong\` (an \`ArgumentError\` subclass for backcompat) with the offending streamables, computed budget, and a pointer at \`Pgbus.stream_key\`. Fires before PGMQ is touched, so a forgotten call site leaves no trace in the queue catalog.

## Design decisions

- **No silent truncation.** Trimming a too-long key to fit would reintroduce the exact collision risk the 64-bit digest was chosen to eliminate. In a multi-tenant app, a collision means two records share a stream and receive each other's broadcasts — a real data leak.
- **Budget is computed, not constant.** The app-level workaround hardcoded \`PGBUS_QUEUE_PREFIX = "pgbus_"\`, which silently produces the wrong budget for any app that sets \`config.queue_prefix\` to something else. The helper reads the live config.
- **\`StreamNameTooLong < ArgumentError\`** so pre-existing rescues of \`ArgumentError\` around broadcast still work.

## Migration for getzazu/app

Once this ships, the app-level \`StreamKeys\` module can collapse to:

\`\`\`ruby
# app/models/application_record.rb
class ApplicationRecord < ActiveRecord::Base
  primary_abstract_class
  include Pgbus::Streams::Streamable
end

# app/models/concerns/stream_keys.rb
module StreamKeys
  def self.stream_key(*parts) = Pgbus.stream_key(*parts)
end
\`\`\`

…and eventually every \`StreamKeys.stream_key(...)\` callsite can be replaced with \`Pgbus.stream_key(...)\` directly.

## Test plan

- [x] Unit specs for \`Pgbus::Streams::Key\` — digest determinism, \`digest_bits\` validation, \`normalize\` shapes (string/symbol/AR/to_stream_key/to_gid_param/to_param/to_s), budget computation, overflow raises, error message content.
- [x] Unit specs for \`Pgbus::Streams::Streamable\` — \`short_id\`, \`to_stream_key\`, composition with \`Pgbus.stream_key\`.
- [x] Unit specs for the \`Stream#initialize\` length guard — fits/overflows, error message content, streamable echoed back, \`ArgumentError\` backcompat, budget adjusts when \`queue_prefix\` changes, cache is not polluted on overflow.
- [x] Integration specs against real PGMQ — happy-path broadcast + \`read_after\` round trip using \`stream_key\`; overflow raises \`StreamNameTooLong\` before touching PGMQ (verified via \`pgmq.meta\` snapshot); budget tracks \`queue_prefix\` end-to-end; exact boundary behavior at \`queue_name_budget\`.
- [x] \`bundle exec rspec spec/pgbus/\` — 1497 examples, 0 failures.
- [x] \`bundle exec rspec spec/integration/streams/\` — 34 examples, 0 failures.
- [x] \`bundle exec rubocop\` — clean across all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public stream-key helper and a model mixin for stable, transport-safe short stream identifiers; composed names now fail fast with a clear StreamNameTooLong error when too long.

* **Improvements**
  * Tightened acceptable queue-name length and normalized colon handling to avoid collisions.

* **Bug Fixes**
  * Prevented failed name constructions from being cached.

* **Tests**
  * Added end-to-end and unit tests covering key generation, boundaries, caching, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->