### PR TITLE
feat: add error reporters and JSON log formatter

### DIFF
--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -146,7 +146,9 @@ module Pgbus
       end
 
       def handle_failure(message, queue_name, error, payload: nil)
-        Pgbus.logger.error { "[Pgbus] Job failed: #{error.class}: #{error.message}" }
+        ctx = { queue: queue_name, job_class: payload&.dig("job_class"),
+                msg_id: message.msg_id.to_i, read_ct: message.read_ct.to_i }
+        ErrorReporter.report(error, ctx)
         Pgbus.logger.debug { error.backtrace&.join("\n") }
 
         # Record failure for dashboard visibility.

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -146,7 +146,7 @@ module Pgbus
       end
 
       def handle_failure(message, queue_name, error, payload: nil)
-        ctx = { queue: queue_name, job_class: payload&.dig("job_class"),
+        ctx = { action: "execute_job", queue: queue_name, job_class: payload&.dig("job_class"),
                 msg_id: message.msg_id.to_i, read_ct: message.read_ct.to_i }
         ErrorReporter.report(error, ctx)
         Pgbus.logger.debug { error.backtrace&.join("\n") }

--- a/lib/pgbus/circuit_breaker.rb
+++ b/lib/pgbus/circuit_breaker.rb
@@ -92,7 +92,7 @@ module Pgbus
       @failure_counts.delete(queue_name)
       invalidate_cache(queue_name)
     rescue StandardError => e
-      Pgbus.logger.error { "[Pgbus] Circuit breaker trip failed for #{queue_name}: #{e.message}" }
+      ErrorReporter.report(e, { action: "circuit_breaker_trip", queue: queue_name })
     end
 
     def check_paused(queue_name)

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -59,6 +59,7 @@ module Pgbus
 
     # Logging
     attr_accessor :logger
+    attr_reader :log_format # rubocop:disable Style/AccessorGrouping
 
     # Error reporting — array of callable objects invoked on caught exceptions.
     # Each receives (exception, context_hash) or (exception, context_hash, config).
@@ -144,6 +145,7 @@ module Pgbus
       @allowed_global_id_models = nil # nil = allow all (for backwards compat)
 
       @logger = (defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger) || Logger.new($stdout)
+      @log_format = :text
       @error_reporters = []
 
       @listen_notify = true
@@ -227,6 +229,21 @@ module Pgbus
     def execution_mode_for(worker_config)
       mode = worker_config[:execution_mode] || worker_config["execution_mode"] || execution_mode
       ExecutionPools.normalize_mode(mode)
+    end
+
+    VALID_LOG_FORMATS = %i[text json].freeze
+
+    def log_format=(format)
+      format = format.to_sym
+      unless VALID_LOG_FORMATS.include?(format)
+        raise ArgumentError, "Invalid log_format: #{format}. Must be one of: #{VALID_LOG_FORMATS.join(", ")}"
+      end
+
+      @log_format = format
+      @logger.formatter = case format
+                          when :json then LogFormatter::JSON.new
+                          when :text then LogFormatter::Text.new
+                          end
     end
 
     VALID_PGMQ_SCHEMA_MODES = %i[auto extension embedded].freeze

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -60,6 +60,10 @@ module Pgbus
     # Logging
     attr_accessor :logger
 
+    # Error reporting — array of callable objects invoked on caught exceptions.
+    # Each receives (exception, context_hash) or (exception, context_hash, config).
+    attr_accessor :error_reporters
+
     # LISTEN/NOTIFY. Only the on/off switch is user-facing — the throttle
     # interval is a Postgres-side tuning knob that lives as a constant on
     # Pgbus::Client (NOTIFY_THROTTLE_MS).
@@ -140,6 +144,7 @@ module Pgbus
       @allowed_global_id_models = nil # nil = allow all (for backwards compat)
 
       @logger = (defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger) || Logger.new($stdout)
+      @error_reporters = []
 
       @listen_notify = true
 

--- a/lib/pgbus/error_reporter.rb
+++ b/lib/pgbus/error_reporter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Pgbus
+  # Central error reporting module. Iterates all configured error reporters
+  # and logs the error. Inspired by Sidekiq's error_handlers pattern.
+  #
+  # Usage:
+  #   Pgbus::ErrorReporter.report(exception, { queue: "default" })
+  #
+  # Configuration:
+  #   Pgbus.configure do |c|
+  #     c.error_reporters << ->(ex, ctx) { Appsignal.set_error(ex) { |t| t.set_tags(ctx) } }
+  #   end
+  module ErrorReporter
+    module_function
+
+    def report(exception, context = {}, config: Pgbus.configuration)
+      log_error(exception, context, config: config)
+
+      config.error_reporters.each do |handler|
+        call_handler(handler, exception, context, config)
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        config.logger.error { "[Pgbus] Error reporter raised: #{e.class}: #{e.message}" }
+      end
+    end
+
+    def call_handler(handler, exception, context, config)
+      target = handler.is_a?(Proc) ? handler : handler.method(:call)
+      if target.arity == 3 || (target.arity.negative? && target.parameters.size >= 3)
+        handler.call(exception, context, config)
+      else
+        handler.call(exception, context)
+      end
+    end
+
+    def log_error(exception, context, config:)
+      config.logger.error do
+        msg = "[Pgbus] #{exception.class}: #{exception.message}"
+        msg += " (#{context.inspect})" unless context.empty?
+        msg
+      end
+    end
+  end
+end

--- a/lib/pgbus/error_reporter.rb
+++ b/lib/pgbus/error_reporter.rb
@@ -22,6 +22,10 @@ module Pgbus
       rescue Exception => e # rubocop:disable Lint/RescueException
         config.logger.error { "[Pgbus] Error reporter raised: #{e.class}: #{e.message}" }
       end
+    rescue Exception # rubocop:disable Lint/RescueException
+      # ErrorReporter must never raise — callers sit inside rescue blocks
+      # where an unexpected raise would break fault-tolerance invariants.
+      nil
     end
 
     def call_handler(handler, exception, context, config)

--- a/lib/pgbus/failed_event_recorder.rb
+++ b/lib/pgbus/failed_event_recorder.rb
@@ -32,14 +32,7 @@ module Pgbus
           ]
         )
       rescue StandardError => e
-        # ERROR-level: silent loss of failure-tracking data defeats the
-        # purpose of the dashboard's "Failed Jobs" section. If recording
-        # fails, surface it loudly so the broken state can be diagnosed
-        # rather than silently masked.
-        Pgbus.logger.error do
-          "[Pgbus] Failed to record failed event for queue=#{queue_name} msg_id=#{msg_id}: " \
-            "#{e.class}: #{e.message}"
-        end
+        ErrorReporter.report(e, { action: "record_failed_event", queue: queue_name, msg_id: msg_id })
       end
 
       def clear!(queue_name:, msg_id:)

--- a/lib/pgbus/log_formatter.rb
+++ b/lib/pgbus/log_formatter.rb
@@ -19,6 +19,10 @@ module Pgbus
   module LogFormatter
     module_function
 
+    def tid
+      Thread.current[:pgbus_tid] ||= (Thread.current.object_id ^ ::Process.pid).to_s(36)
+    end
+
     # Thread-local context for structured logging. Works like
     # Sidekiq::Context — any key/value pairs set via with_context
     # appear in the JSON output under the "ctx" key.
@@ -38,14 +42,10 @@ module Pgbus
     # Output: "INFO 2024-01-15T10:30:00.000Z pid=1234 tid=abc queue=default: message\n"
     class Text < ::Logger::Formatter
       def call(severity, time, _progname, message)
-        "#{severity} #{time.utc.iso8601(3)} pid=#{::Process.pid} tid=#{tid}#{format_context}: #{message}\n"
+        "#{severity} #{time.utc.iso8601(3)} pid=#{::Process.pid} tid=#{LogFormatter.tid}#{format_context}: #{message}\n"
       end
 
       private
-
-      def tid
-        Thread.current[:pgbus_tid] ||= (Thread.current.object_id ^ ::Process.pid).to_s(36)
-      end
 
       def format_context
         ctx = LogFormatter.current_context
@@ -75,7 +75,7 @@ module Pgbus
         hash = {
           ts: time.utc.iso8601(3),
           pid: ::Process.pid,
-          tid: tid,
+          tid: LogFormatter.tid,
           lvl: severity
         }
 
@@ -90,12 +90,6 @@ module Pgbus
         hash[:ctx] = ctx unless ctx.empty?
 
         "#{::JSON.generate(hash)}\n"
-      end
-
-      private
-
-      def tid
-        Thread.current[:pgbus_tid] ||= (Thread.current.object_id ^ ::Process.pid).to_s(36)
       end
     end
   end

--- a/lib/pgbus/log_formatter.rb
+++ b/lib/pgbus/log_formatter.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "json"
+require "logger"
+require "time"
+
+module Pgbus
+  # Log formatters for Pgbus, inspired by Sidekiq::Logger::Formatters.
+  #
+  # Usage:
+  #   Pgbus.configure do |c|
+  #     c.logger.formatter = Pgbus::LogFormatter::JSON.new
+  #   end
+  #
+  # Or via the convenience config option:
+  #   Pgbus.configure do |c|
+  #     c.log_format = :json
+  #   end
+  module LogFormatter
+    module_function
+
+    # Thread-local context for structured logging. Works like
+    # Sidekiq::Context — any key/value pairs set via with_context
+    # appear in the JSON output under the "ctx" key.
+    def with_context(hash)
+      orig = current_context.dup
+      current_context.merge!(hash)
+      yield
+    ensure
+      Thread.current[:pgbus_log_context] = orig
+    end
+
+    def current_context
+      Thread.current[:pgbus_log_context] ||= {}
+    end
+
+    # Human-readable text formatter with Pgbus context.
+    # Output: "INFO 2024-01-15T10:30:00.000Z pid=1234 tid=abc queue=default: message\n"
+    class Text < ::Logger::Formatter
+      def call(severity, time, _progname, message)
+        "#{severity} #{time.utc.iso8601(3)} pid=#{::Process.pid} tid=#{tid}#{format_context}: #{message}\n"
+      end
+
+      private
+
+      def tid
+        Thread.current[:pgbus_tid] ||= (Thread.current.object_id ^ ::Process.pid).to_s(36)
+      end
+
+      def format_context
+        ctx = LogFormatter.current_context
+        return "" if ctx.empty?
+
+        " #{ctx.map { |k, v| "#{k}=#{v}" }.join(" ")}"
+      end
+    end
+
+    # JSON formatter for structured logging. Each log line is a single
+    # JSON object followed by a newline. Extracts the [Pgbus::Component]
+    # prefix from messages into a separate "component" field.
+    #
+    # Output fields:
+    #   ts  — ISO 8601 timestamp with milliseconds
+    #   pid — process ID
+    #   tid — thread ID (short hex)
+    #   lvl — severity (DEBUG/INFO/WARN/ERROR/FATAL)
+    #   msg — the log message (with component prefix stripped)
+    #   component — extracted from [Pgbus] or [Pgbus::Foo] prefix (optional)
+    #   ctx — thread-local context hash (optional, only when non-empty)
+    class JSON < ::Logger::Formatter
+      COMPONENT_PREFIX = /\A\[([^\]]+)\]\s*/
+
+      def call(severity, time, _progname, message)
+        msg = message.to_s
+        hash = {
+          ts: time.utc.iso8601(3),
+          pid: ::Process.pid,
+          tid: tid,
+          lvl: severity
+        }
+
+        if (match = msg.match(COMPONENT_PREFIX))
+          hash[:component] = match[1]
+          msg = msg.sub(COMPONENT_PREFIX, "")
+        end
+
+        hash[:msg] = msg
+
+        ctx = LogFormatter.current_context
+        hash[:ctx] = ctx unless ctx.empty?
+
+        "#{::JSON.generate(hash)}\n"
+      end
+
+      private
+
+      def tid
+        Thread.current[:pgbus_tid] ||= (Thread.current.object_id ^ ::Process.pid).to_s(36)
+      end
+    end
+  end
+end

--- a/lib/pgbus/outbox/poller.rb
+++ b/lib/pgbus/outbox/poller.rb
@@ -65,7 +65,7 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Outbox published #{published} entries" } if published.positive?
         published
       rescue StandardError => e
-        Pgbus.logger.error { "[Pgbus] Outbox poll error: #{e.message}" }
+        ErrorReporter.report(e, { action: "outbox_poll" })
         0
       end
 
@@ -92,7 +92,7 @@ module Pgbus
         entry.update!(published_at: Time.current)
         true
       rescue StandardError => e
-        Pgbus.logger.error { "[Pgbus] Failed to publish outbox entry #{entry.id}: #{e.message}" }
+        ErrorReporter.report(e, { action: "outbox_publish_topic", entry_id: entry.id })
         false
       end
 
@@ -112,7 +112,7 @@ module Pgbus
           group.each { |e| e.update!(published_at: now) }
           succeeded += group.size
         rescue StandardError => e
-          Pgbus.logger.error { "[Pgbus] Failed to batch-publish #{group.size} outbox entries: #{e.message}" }
+          ErrorReporter.report(e, { action: "outbox_batch_publish", queue: queue, batch_size: group.size })
           # Fall back to individual publishing for this group
           group.each { |entry| succeeded += 1 if publish_single_queue(entry) }
         end
@@ -133,7 +133,7 @@ module Pgbus
         entry.update!(published_at: Time.current)
         true
       rescue StandardError => e
-        Pgbus.logger.error { "[Pgbus] Failed to publish outbox entry #{entry.id}: #{e.message}" }
+        ErrorReporter.report(e, { action: "outbox_publish_queue", entry_id: entry.id })
         false
       end
 

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -94,7 +94,7 @@ module Pgbus
         yield
         instance_variable_set(ivar, now)
       rescue StandardError => e
-        Pgbus.logger.error { "[Pgbus] Dispatcher maintenance error: #{e.message}" }
+        ErrorReporter.report(e, { action: "dispatcher_maintenance", task: ivar.to_s.delete_prefix("@last_").delete_suffix("_at") })
       end
 
       def cleanup_processed_events

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -83,7 +83,7 @@ module Pgbus
         @forks[pid] = { type: :worker, config: worker_config }
         Pgbus.logger.info { "[Pgbus] Forked worker pid=#{pid} queues=#{queues.join(",")} mode=#{exec_mode}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
-        Pgbus.logger.error { "[Pgbus] Fork failed for worker: #{e.message}" }
+        ErrorReporter.report(e, { action: "fork_worker", queues: queues })
       end
 
       def fork_dispatcher
@@ -103,7 +103,7 @@ module Pgbus
         @forks[pid] = { type: :dispatcher }
         Pgbus.logger.info { "[Pgbus] Forked dispatcher pid=#{pid}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
-        Pgbus.logger.error { "[Pgbus] Fork failed for dispatcher: #{e.message}" }
+        ErrorReporter.report(e, { action: "fork_dispatcher" })
       end
 
       def boot_scheduler
@@ -132,7 +132,7 @@ module Pgbus
         @forks[pid] = { type: :scheduler }
         Pgbus.logger.info { "[Pgbus] Forked scheduler pid=#{pid}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
-        Pgbus.logger.error { "[Pgbus] Fork failed for scheduler: #{e.message}" }
+        ErrorReporter.report(e, { action: "fork_scheduler" })
       end
 
       def recurring_tasks_configured?
@@ -186,7 +186,7 @@ module Pgbus
         @forks[pid] = { type: :consumer, config: consumer_config }
         Pgbus.logger.info { "[Pgbus] Forked consumer pid=#{pid} topics=#{topics.join(",")}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
-        Pgbus.logger.error { "[Pgbus] Fork failed for consumer: #{e.message}" }
+        ErrorReporter.report(e, { action: "fork_consumer", topics: topics })
       end
 
       def boot_outbox_poller
@@ -212,7 +212,7 @@ module Pgbus
         @forks[pid] = { type: :outbox_poller }
         Pgbus.logger.info { "[Pgbus] Forked outbox poller pid=#{pid}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
-        Pgbus.logger.error { "[Pgbus] Fork failed for outbox poller: #{e.message}" }
+        ErrorReporter.report(e, { action: "fork_outbox_poller" })
       end
 
       def monitor_loop
@@ -282,7 +282,7 @@ module Pgbus
       def bootstrap_queues
         Pgbus.client.ensure_all_queues
       rescue StandardError => e
-        Pgbus.logger.error { "[Pgbus] Failed to bootstrap queues: #{e.message}" }
+        ErrorReporter.report(e, { action: "bootstrap_queues" })
       end
 
       def load_rails_app

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -151,7 +151,7 @@ module Pgbus
         if undefined_queue_table_error?(e)
           evict_missing_queues(e)
         else
-          Pgbus.logger.error { "[Pgbus] Error fetching messages: #{e.message}" }
+          ErrorReporter.report(e, { action: "fetch_messages", queues: active_queues })
         end
         []
       end
@@ -223,7 +223,7 @@ module Pgbus
         @jobs_failed.increment
         @rate_counter.increment(:failed)
         @circuit_breaker.record_failure(queue_name)
-        Pgbus.logger.error { "[Pgbus] Unhandled error processing message: #{e.message}" }
+        ErrorReporter.report(e, { action: "process_message", queue: queue_name })
       ensure
         @in_flight.decrement
       end

--- a/spec/pgbus/configuration_error_reporters_spec.rb
+++ b/spec/pgbus/configuration_error_reporters_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Configuration do
+  subject(:config) { described_class.new }
+
+  describe "#error_reporters" do
+    it "defaults to an empty array" do
+      expect(config.error_reporters).to eq([])
+    end
+
+    it "accepts callable objects" do
+      reporter = ->(ex, ctx) { [ex, ctx] }
+      config.error_reporters << reporter
+
+      expect(config.error_reporters).to contain_exactly(reporter)
+    end
+
+    it "can be replaced entirely" do
+      reporter = ->(ex, ctx) { [ex, ctx] }
+      config.error_reporters = [reporter]
+
+      expect(config.error_reporters).to contain_exactly(reporter)
+    end
+  end
+end

--- a/spec/pgbus/configuration_log_format_spec.rb
+++ b/spec/pgbus/configuration_log_format_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Configuration do
+  subject(:config) { described_class.new }
+
+  describe "#log_format" do
+    it "defaults to :text" do
+      expect(config.log_format).to eq(:text)
+    end
+
+    it "can be set to :json" do
+      config.log_format = :json
+
+      expect(config.log_format).to eq(:json)
+      expect(config.logger.formatter).to be_a(Pgbus::LogFormatter::JSON)
+    end
+
+    it "can be set to :text" do
+      config.log_format = :json
+      config.log_format = :text
+
+      expect(config.log_format).to eq(:text)
+      expect(config.logger.formatter).to be_a(Pgbus::LogFormatter::Text)
+    end
+
+    it "raises for invalid formats" do
+      expect { config.log_format = :xml }.to raise_error(ArgumentError, /Invalid log_format/)
+    end
+
+    it "accepts string values" do
+      config.log_format = "json"
+
+      expect(config.log_format).to eq(:json)
+    end
+  end
+end

--- a/spec/pgbus/error_reporter_spec.rb
+++ b/spec/pgbus/error_reporter_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::ErrorReporter do
+  let(:config) { Pgbus::Configuration.new }
+  let(:error) { StandardError.new("test failure") }
+  let(:context) { { queue: "default", job_class: "MyJob" } }
+
+  before do
+    config.logger = Logger.new(IO::NULL)
+    allow(config.logger).to receive(:error)
+  end
+
+  describe ".report" do
+    context "with no reporters configured" do
+      it "logs the error and does not raise" do
+        described_class.report(error, context, config: config)
+
+        expect(config.logger).to have_received(:error)
+      end
+    end
+
+    context "with a single reporter" do
+      it "calls the reporter with exception and context" do
+        reported = []
+        config.error_reporters << ->(ex, ctx) { reported << [ex, ctx] }
+
+        described_class.report(error, context, config: config)
+
+        expect(reported.size).to eq(1)
+        expect(reported.first[0]).to eq(error)
+        expect(reported.first[1]).to include(queue: "default")
+      end
+    end
+
+    context "with multiple reporters" do
+      it "calls all reporters" do
+        called = []
+        config.error_reporters << ->(_ex, _ctx) { called << :first }
+        config.error_reporters << ->(_ex, _ctx) { called << :second }
+
+        described_class.report(error, context, config: config)
+
+        expect(called).to eq(%i[first second])
+      end
+    end
+
+    context "when a reporter raises" do
+      it "continues to the next reporter and logs the handler error" do
+        called = []
+        config.error_reporters << ->(_ex, _ctx) { raise "handler boom" }
+        config.error_reporters << ->(_ex, _ctx) { called << :second }
+
+        described_class.report(error, context, config: config)
+
+        expect(called).to eq([:second])
+        expect(config.logger).to have_received(:error).at_least(:twice)
+      end
+    end
+
+    context "when reporter accepts 3 arguments (with config)" do
+      it "passes config as the third argument" do
+        received_config = nil
+        config.error_reporters << ->(_ex, _ctx, cfg) { received_config = cfg }
+
+        described_class.report(error, context, config: config)
+
+        expect(received_config).to eq(config)
+      end
+    end
+  end
+end

--- a/spec/pgbus/error_reporter_spec.rb
+++ b/spec/pgbus/error_reporter_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe Pgbus::ErrorReporter do
       end
     end
 
+    context "when the logger itself raises" do
+      it "does not propagate — report must never raise" do
+        broken_logger = Logger.new(IO::NULL)
+        allow(broken_logger).to receive(:error).and_raise(RuntimeError, "logger broken")
+        config.logger = broken_logger
+
+        expect { described_class.report(error, context, config: config) }.not_to raise_error
+      end
+    end
+
     context "when reporter accepts 3 arguments (with config)" do
       it "passes config as the third argument" do
         received_config = nil

--- a/spec/pgbus/log_formatter_spec.rb
+++ b/spec/pgbus/log_formatter_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+
+RSpec.describe Pgbus::LogFormatter do
+  describe Pgbus::LogFormatter::Text do
+    subject(:formatter) { described_class.new }
+
+    it "formats a basic message" do
+      output = formatter.call("INFO", Time.now, "Pgbus", "test message")
+
+      expect(output).to include("INFO")
+      expect(output).to include("test message")
+      expect(output).to end_with("\n")
+    end
+
+    it "includes timestamp, pid, and tid" do
+      output = formatter.call("WARN", Time.now, "Pgbus", "hello")
+
+      expect(output).to include("pid=#{Process.pid}")
+      expect(output).to include("tid=")
+    end
+  end
+
+  describe Pgbus::LogFormatter::JSON do
+    subject(:formatter) { described_class.new }
+
+    it "outputs valid JSON with a trailing newline" do
+      output = formatter.call("INFO", Time.now.utc, "Pgbus", "test message")
+
+      expect(output).to end_with("\n")
+      parsed = JSON.parse(output)
+      expect(parsed).to be_a(Hash)
+    end
+
+    it "includes standard fields" do
+      time = Time.now.utc
+      output = formatter.call("ERROR", time, "Pgbus", "boom")
+      parsed = JSON.parse(output)
+
+      expect(parsed["ts"]).to eq(time.iso8601(3))
+      expect(parsed["pid"]).to eq(Process.pid)
+      expect(parsed["tid"]).to be_a(String)
+      expect(parsed["lvl"]).to eq("ERROR")
+      expect(parsed["msg"]).to eq("boom")
+    end
+
+    it "extracts the [Pgbus] component prefix into a separate field" do
+      output = formatter.call("INFO", Time.now.utc, "Pgbus", "[Pgbus] Starting server")
+      parsed = JSON.parse(output)
+
+      expect(parsed["component"]).to eq("Pgbus")
+      expect(parsed["msg"]).to eq("Starting server")
+    end
+
+    it "extracts nested component prefixes like [Pgbus::Web]" do
+      output = formatter.call("ERROR", Time.now.utc, "Pgbus", "[Pgbus::Web] Error fetching data")
+      parsed = JSON.parse(output)
+
+      expect(parsed["component"]).to eq("Pgbus::Web")
+      expect(parsed["msg"]).to eq("Error fetching data")
+    end
+
+    it "includes ctx when provided via thread-local context" do
+      Pgbus::LogFormatter.with_context(queue: "default", job_class: "MyJob") do
+        output = formatter.call("INFO", Time.now.utc, "Pgbus", "processing")
+        parsed = JSON.parse(output)
+
+        expect(parsed["ctx"]).to eq("queue" => "default", "job_class" => "MyJob")
+      end
+    end
+
+    it "omits ctx when context is empty" do
+      output = formatter.call("INFO", Time.now.utc, "Pgbus", "hello")
+      parsed = JSON.parse(output)
+
+      expect(parsed).not_to have_key("ctx")
+    end
+  end
+
+  describe ".with_context" do
+    it "merges context for the duration of the block" do
+      inner_ctx = nil
+
+      described_class.with_context(queue: "default") do
+        described_class.with_context(job_class: "MyJob") do
+          inner_ctx = described_class.current_context.dup
+        end
+      end
+
+      expect(inner_ctx).to eq(queue: "default", job_class: "MyJob")
+      expect(described_class.current_context).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Error Reporter** (`Pgbus::ErrorReporter`): Configurable array of callable error reporters (`config.error_reporters`) that receive `(exception, context_hash)` at every critical rescue site. Inspired by Sidekiq's `error_handlers` pattern. Lets users route exceptions to APM services (Appsignal, Sentry, Honeybadger, etc.) instead of only logging them.
- **JSON Log Formatter** (`Pgbus::LogFormatter::JSON`): Structured JSON log output with separate fields for `ts`, `pid`, `tid`, `lvl`, `msg`, `component`, and optional `ctx`. Extracts `[Pgbus]` / `[Pgbus::Web]` prefixes into a dedicated `component` field so `msg` stays clean. Also adds `Pgbus::LogFormatter::Text` for consistent text output.
- **Log Context** (`Pgbus::LogFormatter.with_context`): Thread-local context hash that appears in JSON output under `ctx`, similar to `Sidekiq::Context`.

### Error Reporter Configuration

```ruby
Pgbus.configure do |c|
  c.error_reporters << ->(ex, ctx) {
    Appsignal.set_error(ex) { |t| t.set_tags(ctx) }
  }
end
```

### JSON Logging Configuration

```ruby
Pgbus.configure do |c|
  c.log_format = :json
end
```

### Wired Into

Error reporters are called at all critical rescue sites:
- ActiveJob executor (job failures)
- Worker (fetch + process errors)
- Dispatcher (maintenance task failures)
- Supervisor (fork failures)
- Circuit breaker (trip failures)
- Outbox poller (publish failures)
- Failed event recorder (recording failures)

Non-critical paths (dashboard queries, stat recording, debug-level catches) remain log-only.

## Test plan

- [x] `bundle exec rspec` — 1632 examples, 0 failures (excluding pre-existing system test failures)
- [x] `bundle exec rubocop` — no offenses
- [ ] Verify JSON formatter output in a Rails app with `config.log_format = :json`
- [ ] Verify error reporter integration with Appsignal/Sentry in staging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable log format (text or JSON) with improved, thread-aware log context.
  * Centralized, fault‑tolerant error reporting with pluggable handlers and structured context.
  * Core runtime components now send errors to the centralized reporter for more consistent observability.

* **Tests**
  * Added specs covering configuration, log formatters, and error reporter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->