### PR TITLE
fix(worker): cap read_multi total so multi-queue fetch cannot overflow pool

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -156,10 +156,17 @@ module Pgbus
     # Read from multiple queues in a single SQL query (UNION ALL).
     # Each returned message includes a queue_name field identifying its source.
     # queue_names should be logical names (prefix is added automatically).
-    def read_multi(queue_names, qty:, vt: nil)
+    #
+    # `qty` is the per-queue cap (pgmq-ruby semantics), so without `limit:` the
+    # caller receives up to `queue_count * qty` messages. Pass `limit:` to cap
+    # the total across all queues — required when feeding a fixed-size pool,
+    # otherwise the pool can overflow on multi-queue reads (issue #123).
+    def read_multi(queue_names, qty:, vt: nil, limit: nil)
       full_names = queue_names.map { |q| config.queue_name(q) }
-      Instrumentation.instrument("pgbus.client.read_multi", queues: full_names, qty: qty) do
-        synchronized { @pgmq.read_multi(full_names, vt: vt || config.visibility_timeout, qty: qty) }
+      Instrumentation.instrument("pgbus.client.read_multi", queues: full_names, qty: qty, limit: limit) do
+        synchronized do
+          @pgmq.read_multi(full_names, vt: vt || config.visibility_timeout, qty: qty, limit: limit)
+        end
       end
     end
 

--- a/lib/pgbus/process/consumer.rb
+++ b/lib/pgbus/process/consumer.rb
@@ -98,8 +98,12 @@ module Pgbus
         # the next read will route to DLQ above.
       end
 
+      # `qty` is the total pool capacity. pgmq-ruby treats `qty:` as per-queue,
+      # so we also pass `limit: qty` to cap the total across all queues —
+      # otherwise we get `queue_count * qty` messages and overflow the
+      # execution pool, crashing the consumer fork (issue #123).
       def fetch_multi_consumer(qty)
-        messages = Pgbus.client.read_multi(@queue_names, qty: qty) || []
+        messages = Pgbus.client.read_multi(@queue_names, qty: qty, limit: qty) || []
         prefix = "#{config.queue_prefix}_"
 
         messages.map do |m|

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -194,8 +194,13 @@ module Pgbus
       # Use pgmq-ruby's read_multi to read from all queues in a single
       # SQL query (UNION ALL). Each returned message carries a queue_name
       # field so we can map it back to the logical queue.
+      #
+      # `qty` is the total pool capacity. pgmq-ruby treats `qty:` as per-queue,
+      # so we also pass `limit: qty` to cap the total across all queues —
+      # otherwise we get `queue_count * qty` messages and overflow the
+      # execution pool, crashing the worker fork (issue #123).
       def fetch_multi(active_queues, qty)
-        messages = Pgbus.client.read_multi(active_queues, qty: qty) || []
+        messages = Pgbus.client.read_multi(active_queues, qty: qty, limit: qty) || []
         prefix = "#{config.queue_prefix}_"
 
         messages.map do |m|

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -279,7 +279,8 @@ RSpec.describe Pgbus::Client do
       expect(mock_pgmq).to have_received(:read_multi).with(
         %w[pgbus_test_default pgbus_test_urgent],
         vt: config.visibility_timeout,
-        qty: 10
+        qty: 10,
+        limit: nil
       )
     end
 
@@ -289,7 +290,19 @@ RSpec.describe Pgbus::Client do
       expect(mock_pgmq).to have_received(:read_multi).with(
         %w[pgbus_test_default],
         vt: 60,
-        qty: 5
+        qty: 5,
+        limit: nil
+      )
+    end
+
+    it "forwards the limit: argument so callers can cap the total across queues" do
+      client.read_multi(%w[default urgent statistics], qty: 5, limit: 5)
+
+      expect(mock_pgmq).to have_received(:read_multi).with(
+        %w[pgbus_test_default pgbus_test_urgent pgbus_test_statistics],
+        vt: config.visibility_timeout,
+        qty: 5,
+        limit: 5
       )
     end
   end

--- a/spec/pgbus/process/consumer_spec.rb
+++ b/spec/pgbus/process/consumer_spec.rb
@@ -106,6 +106,21 @@ RSpec.describe Pgbus::Process::Consumer do
     end
   end
 
+  describe "fetch_multi_consumer (private)" do
+    let(:consumer) { described_class.new(topics: ["orders.#"]) }
+
+    before do
+      consumer.instance_variable_set(:@queue_names, %w[q_orders q_payments q_shipping])
+    end
+
+    it "caps the total across queues at qty so the execution pool cannot overflow (issue #123)" do
+      allow(mock_client).to receive(:read_multi).and_return([])
+      consumer.send(:fetch_multi_consumer, 3)
+      expect(mock_client).to have_received(:read_multi)
+        .with(%w[q_orders q_payments q_shipping], qty: 3, limit: 3)
+    end
+  end
+
   describe "pattern_overlaps? (private)" do
     let(:consumer) { described_class.new(topics: ["orders.#"]) }
 

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -135,10 +135,10 @@ RSpec.describe Pgbus::Process::Worker do
     context "with multiple queues" do
       let(:worker) { described_class.new(queues: %w[default priority], threads: 4) }
 
-      it "uses read_multi to fetch from all queues in a single call" do
+      it "uses read_multi to fetch from all queues in a single call, capping the total with limit:" do
         allow(mock_client).to receive(:read_multi).and_return([])
         worker.send(:fetch_messages, 4)
-        expect(mock_client).to have_received(:read_multi).with(%w[default priority], qty: 4)
+        expect(mock_client).to have_received(:read_multi).with(%w[default priority], qty: 4, limit: 4)
       end
 
       it "tags each message with its source queue from the queue_name field" do
@@ -152,6 +152,17 @@ RSpec.describe Pgbus::Process::Worker do
 
         results = worker.send(:fetch_messages, 4)
         expect(results).to eq([["default", msg1], ["priority", msg2]])
+      end
+    end
+
+    context "with three or more queues under backpressure (regression: issue #123)" do
+      let(:worker) { described_class.new(queues: %w[default low statistics], threads: 5) }
+
+      it "caps the total across queues at qty so the execution pool cannot overflow" do
+        allow(mock_client).to receive(:read_multi).and_return([])
+        worker.send(:fetch_messages, 5)
+        expect(mock_client).to have_received(:read_multi)
+          .with(%w[default low statistics], qty: 5, limit: 5)
       end
     end
 
@@ -321,7 +332,7 @@ RSpec.describe Pgbus::Process::Worker do
         allow(mock_client).to receive(:read_multi).and_return([])
 
         worker.send(:claim_and_execute)
-        expect(mock_client).to have_received(:read_multi).with(%w[default events], qty: 5)
+        expect(mock_client).to have_received(:read_multi).with(%w[default events], qty: 5, limit: 5)
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes the `"Execution pool is at capacity"` crash-loop reported in #123.

pgmq-ruby's `PGMQ::Client#read_multi` treats `qty:` as **per-queue**; without `limit:` it returns up to `queue_count × qty` messages. `Pgbus::Process::Worker#fetch_multi` was passing `qty` equal to the pool's idle capacity and iterating every returned message into `@pool.post`, so the first over-capacity post raised and killed the worker fork. Messages sat in PGMQ with their VT ticking, the supervisor restarted the fork, VT expired, and the same batch crash-looped. Observed: P50 latency jumped from 140ms to 4.5min and `READS` climbed monotonically on recurring jobs.

Changes:

- `Pgbus::Client#read_multi` now accepts and forwards `limit:` to pgmq-ruby (and threads it into the `pgbus.client.read_multi` instrumentation payload).
- `Pgbus::Process::Worker#fetch_multi` passes `limit: qty` so the total across queues is capped at the pool's actual capacity.
- `Pgbus::Process::Consumer#fetch_multi_consumer` — same fix; it had the identical bug for multi-queue event consumers.

The single-queue path (`read_batch`) and `fetch_prioritized` were already correct.

Closes #123

## Test plan

- [x] `bundle exec rspec spec/pgbus/client_spec.rb spec/pgbus/process/worker_spec.rb spec/pgbus/process/consumer_spec.rb` — all green
- [x] Regression spec for issue #123 in `worker_spec.rb`: 3 queues + qty=5 asserts `read_multi` is called with `qty: 5, limit: 5` (without the fix this would overflow the pool once real messages flow)
- [x] Regression spec in `consumer_spec.rb`: `fetch_multi_consumer` over 3 queues caps total at `qty`
- [x] Existing `#read_multi` client specs updated to assert `limit:` is forwarded (defaults to `nil` for existing callers)
- [x] `bundle exec rubocop` clean on changed files
- [x] Full non-system suite: 1695 examples, 0 failures (system spec failures are pre-existing Capybara/turbo-frame flakes unrelated to this change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional message fetch limit parameter to control total messages retrieved when consuming from multiple queues simultaneously.

* **Improvements**
  * Consumer and worker processes now enforce total message fetch caps across all queues to prevent execution pool overflow and maintain system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->