### PR TITLE
fix(bootstrap): make enable_notify_insert idempotent to prevent deadlocks

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -457,10 +457,46 @@ module Pgbus
         synchronized do
           @pgmq.create(full_name)
           tune_autovacuum(full_name)
-          @pgmq.enable_notify_insert(full_name, throttle_interval_ms: NOTIFY_THROTTLE_MS) if config.listen_notify
+          enable_notify_if_needed(full_name, NOTIFY_THROTTLE_MS)
         end
         true
       end
+    end
+
+    def enable_notify_if_needed(full_name, throttle_ms)
+      return unless config.listen_notify
+      return if notify_trigger_current?(full_name, throttle_ms)
+
+      @pgmq.enable_notify_insert(full_name, throttle_interval_ms: throttle_ms)
+    end
+
+    # Check whether the NOTIFY trigger already exists on this queue with the
+    # expected throttle interval. When it does, we can skip the destructive
+    # DROP TRIGGER + CREATE TRIGGER cycle that causes deadlocks when multiple
+    # forked processes race during bootstrap.
+    def notify_trigger_current?(full_name, throttle_ms)
+      with_raw_connection do |conn|
+        result = conn.exec_params(<<~SQL, [full_name, throttle_ms])
+          SELECT 1
+          FROM pg_trigger t
+          JOIN pg_class c ON t.tgrelid = c.oid
+          JOIN pg_namespace n ON c.relnamespace = n.oid
+          WHERE n.nspname = 'pgmq'
+            AND c.relname = pgmq.format_table_name($1, 'q')
+            AND t.tgname = 'trigger_notify_queue_insert_listeners'
+            AND EXISTS (
+              SELECT 1 FROM pgmq.notify_insert_throttle
+              WHERE queue_name = $1
+                AND throttle_interval_ms = $2
+            )
+          LIMIT 1
+        SQL
+        result.ntuples.positive?
+      end
+    rescue StandardError
+      # If we can't check (e.g. pgmq schema not fully ready), fall back to
+      # the unconditional path — same behavior as before this fix.
+      false
     end
 
     def tune_autovacuum(queue_name)

--- a/lib/pgbus/client/ensure_stream_queue.rb
+++ b/lib/pgbus/client/ensure_stream_queue.rb
@@ -27,7 +27,9 @@ module Pgbus
         # sensitive and need every broadcast to fire a NOTIFY, even
         # when several are batched within a single millisecond.
         # Override the throttle to 0 specifically for stream queues.
-        synchronized { @pgmq.enable_notify_insert(full_name, throttle_interval_ms: 0) } if config.listen_notify
+        # Use the idempotent path to avoid deadlocks when multiple
+        # processes race to set up the same stream queue.
+        synchronized { enable_notify_if_needed(full_name, 0) }
 
         # CREATE INDEX IF NOT EXISTS is idempotent in Postgres but still
         # requires a roundtrip and a brief ACCESS SHARE lock on the archive

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -21,6 +21,14 @@ module Pgbus
 
         Pgbus.logger.info { "[Pgbus] Supervisor starting pid=#{::Process.pid}" }
 
+        # Bootstrap queues once in the parent process before forking children.
+        # This avoids the deadlock that occurs when multiple forked children
+        # race to call enable_notify_insert (DROP TRIGGER + CREATE TRIGGER)
+        # concurrently on the same queue tables. Children still call
+        # bootstrap_queues post-fork but the idempotent check in
+        # notify_trigger_current? makes those calls cheap no-ops.
+        bootstrap_queues
+
         boot_processes
         monitor_loop
       ensure

--- a/spec/pgbus/client/ensure_stream_queue_spec.rb
+++ b/spec/pgbus/client/ensure_stream_queue_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Pgbus::Client::EnsureStreamQueue do
     end)
     allow(client).to receive(:with_raw_connection).and_yield(raw_conn)
     allow(client).to receive(:ensure_queue)
+    # Stub notify trigger check — runs raw SQL which needs a real PG connection.
+    allow(client).to receive(:notify_trigger_current?).and_return(false)
   end
 
   let(:config) do

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Pgbus::Client do
     c.instance_variable_set(:@schema_ensured, true)
     # Stub autovacuum tuning — runs raw SQL which needs a real PG connection.
     allow(c).to receive(:tune_autovacuum)
+    # Stub notify trigger check — runs raw SQL which needs a real PG connection.
+    # Tests that exercise this method explicitly override this stub.
+    allow(c).to receive(:notify_trigger_current?).and_return(false)
     c
   end
 
@@ -114,6 +117,7 @@ RSpec.describe Pgbus::Client do
 
     it "enables LISTEN/NOTIFY when listen_notify is true" do
       config.listen_notify = true
+      allow(client).to receive(:notify_trigger_current?).and_return(false)
       client.ensure_queue("jobs")
 
       expect(mock_pgmq).to have_received(:enable_notify_insert).with("pgbus_test_jobs", throttle_interval_ms: Pgbus::Client::NOTIFY_THROTTLE_MS)
@@ -124,6 +128,22 @@ RSpec.describe Pgbus::Client do
       client.ensure_queue("jobs")
 
       expect(mock_pgmq).not_to have_received(:enable_notify_insert)
+    end
+
+    it "skips enable_notify_insert when trigger already exists with correct throttle" do
+      config.listen_notify = true
+      allow(client).to receive(:notify_trigger_current?).with("pgbus_test_jobs", Pgbus::Client::NOTIFY_THROTTLE_MS).and_return(true)
+      client.ensure_queue("jobs")
+
+      expect(mock_pgmq).not_to have_received(:enable_notify_insert)
+    end
+
+    it "calls enable_notify_insert when trigger exists but throttle differs" do
+      config.listen_notify = true
+      allow(client).to receive(:notify_trigger_current?).with("pgbus_test_jobs", Pgbus::Client::NOTIFY_THROTTLE_MS).and_return(false)
+      client.ensure_queue("jobs")
+
+      expect(mock_pgmq).to have_received(:enable_notify_insert).with("pgbus_test_jobs", throttle_interval_ms: Pgbus::Client::NOTIFY_THROTTLE_MS)
     end
 
     it "is idempotent — only creates the queue once" do

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -150,6 +150,43 @@ RSpec.describe Pgbus::Process::Supervisor do
     end
   end
 
+  describe "pre-fork bootstrap" do
+    let(:supervisor) { described_class.new }
+    let(:mock_client) { build_mock_client }
+
+    before do
+      allow(Pgbus).to receive(:client).and_return(mock_client)
+      allow(mock_client).to receive(:ensure_all_queues)
+    end
+
+    it "calls bootstrap_queues before boot_processes" do
+      call_order = []
+      allow(supervisor).to receive(:bootstrap_queues) { call_order << :bootstrap }
+      allow(supervisor).to receive(:boot_processes) { call_order << :boot }
+      allow(supervisor).to receive(:setup_signals)
+      allow(supervisor).to receive(:start_heartbeat)
+      allow(supervisor).to receive(:monitor_loop)
+      allow(supervisor).to receive(:shutdown)
+
+      supervisor.run
+
+      expect(call_order).to eq(%i[bootstrap boot])
+    end
+
+    it "rescues bootstrap errors in the parent without aborting" do
+      allow(supervisor).to receive(:bootstrap_queues).and_call_original
+      allow(mock_client).to receive(:ensure_all_queues).and_raise(StandardError, "pg down")
+      allow(supervisor).to receive(:boot_processes)
+      allow(supervisor).to receive(:setup_signals)
+      allow(supervisor).to receive(:start_heartbeat)
+      allow(supervisor).to receive(:monitor_loop)
+      allow(supervisor).to receive(:shutdown)
+      allow(Pgbus.logger).to receive(:error)
+
+      expect { supervisor.run }.not_to raise_error
+    end
+  end
+
   describe "recurring_tasks_configured? (private)" do
     let(:supervisor) { described_class.new }
 


### PR DESCRIPTION
## Summary

Fixes the deadlock that occurs when multiple forked child processes (workers, dispatcher, scheduler) race to call `enable_notify_insert` during supervisor boot. The pgmq function unconditionally does `DROP TRIGGER + CREATE TRIGGER`, which requires `AccessExclusiveLock` and deadlocks when two processes target the same queue table.

**Two changes:**

1. **Idempotent notify trigger check** (`notify_trigger_current?`) — queries `pg_trigger` + `pgmq.notify_insert_throttle` to see if the trigger already exists at the correct throttle interval. When it matches, the destructive `DROP+CREATE` is skipped entirely. Falls back to the unconditional path on any error (e.g. schema not yet ready).

2. **Pre-fork bootstrap** — the supervisor now calls `bootstrap_queues` in the parent process *before* forking children. Children still call it post-fork, but the idempotent check makes those calls cheap no-ops.

Both `ensure_single_queue` and `ensure_stream_queue` use the same idempotent path via `enable_notify_if_needed`.

Closes #125

## Test plan

- [x] New spec: skips `enable_notify_insert` when trigger+throttle already match
- [x] New spec: calls `enable_notify_insert` when throttle differs
- [x] New spec: supervisor calls `bootstrap_queues` before `boot_processes`
- [x] New spec: supervisor rescues bootstrap errors in parent without aborting
- [x] All 107 affected specs pass (0 failures)
- [x] RuboCop clean on all changed files
- [x] Pre-existing failures (i18n, system specs) confirmed unrelated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue initialization efficiency by skipping redundant trigger enablement when already configured.
  * Enhanced concurrent queue initialization to prevent deadlocks in multi-process environments.
  * Supervisor now bootstraps queues earlier during startup for more reliable initialization.

* **Tests**
  * Added test coverage for trigger state validation and concurrent initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->