### PR TITLE
feat(observability): executor lifecycle logging + zombie message detection

### DIFF
--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -87,7 +87,7 @@ module Pgbus
         handle_failure(message, queue_name, e, payload: payload)
         instrument("pgbus.job_failed", queue: queue_name, job_class: payload&.dig("job_class"), error: e.class.name)
         record_stat(payload, queue_name, "failed", execution_start, message: message)
-        Pgbus.logger.debug { "[Pgbus::Executor] failed #{tag} error=#{e.class}" }
+        Pgbus.logger.debug { "[Pgbus::Executor] failed #{tag} job_class=#{payload&.dig("job_class")} error=#{e.class}" }
         # Don't signal concurrency on transient failure — the job will be retried.
         # Semaphore is released only on success or dead-lettering.
         :failed

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -23,6 +23,7 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus::Executor] start #{tag}" }
 
         payload = JSON.parse(message.message)
+        job_class = payload["job_class"]
         read_count = message.read_ct.to_i
 
         if read_count > config.max_retries
@@ -32,11 +33,9 @@ module Pgbus
           signal_batch_discarded(payload)
           Uniqueness.release_lock(Uniqueness.extract_key(payload))
           record_stat(payload, queue_name, "dead_lettered", execution_start, message: message)
-          Pgbus.logger.debug { "[Pgbus::Executor] dead_lettered #{tag}" }
+          Pgbus.logger.debug { "[Pgbus::Executor] dead_lettered #{tag} job_class=#{job_class}" }
           return :dead_lettered
         end
-
-        job_class = payload["job_class"]
         uniqueness_key = Uniqueness.extract_key(payload)
         uniqueness_strategy = Uniqueness.extract_strategy(payload)
 

--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -19,6 +19,9 @@ module Pgbus
 
       def execute(message, queue_name, source_queue: nil)
         execution_start = monotonic_now
+        tag = "msg_id=#{message.msg_id} queue=#{queue_name} read_ct=#{message.read_ct}"
+        Pgbus.logger.debug { "[Pgbus::Executor] start #{tag}" }
+
         payload = JSON.parse(message.message)
         read_count = message.read_ct.to_i
 
@@ -29,6 +32,7 @@ module Pgbus
           signal_batch_discarded(payload)
           Uniqueness.release_lock(Uniqueness.extract_key(payload))
           record_stat(payload, queue_name, "dead_lettered", execution_start, message: message)
+          Pgbus.logger.debug { "[Pgbus::Executor] dead_lettered #{tag}" }
           return :dead_lettered
         end
 
@@ -53,28 +57,24 @@ module Pgbus
           end
         end
 
+        Pgbus.logger.debug { "[Pgbus::Executor] deserialized #{tag} job_class=#{job_class}" }
         job_succeeded = false
 
-        # Debug-level phase markers. Silent at INFO+, but invaluable when a
-        # fiber interrupt or connection issue loses control flow between phases
-        # (issue #126). Each line identifies msg_id + phase so the gap is
-        # visible in logs: "deserialized" without "archived" means the job
-        # ran but its message was never archived.
         msg_id = message.msg_id.to_i
         Instrumentation.instrument("pgbus.executor.execute", queue: queue_name, job_class: job_class) do
-          Pgbus.logger.debug { "[Pgbus] Executor phase=deserialize msg_id=#{msg_id} job=#{job_class}" }
           job = ::ActiveJob::Base.deserialize(payload)
-          Pgbus.logger.debug { "[Pgbus] Executor phase=perform msg_id=#{msg_id} job=#{job_class}" }
+          Pgbus.logger.debug { "[Pgbus::Executor] running #{tag} job_class=#{job_class}" }
           execute_job(job)
-          Pgbus.logger.debug { "[Pgbus] Executor phase=archive msg_id=#{msg_id} job=#{job_class}" }
+          Pgbus.logger.debug { "[Pgbus::Executor] perform_returned #{tag} job_class=#{job_class}" }
           archive_from(queue_name, msg_id, source_queue: source_queue)
+          Pgbus.logger.debug { "[Pgbus::Executor] archived #{tag} job_class=#{job_class}" }
           FailedEventRecorder.clear!(queue_name: queue_name, msg_id: msg_id)
           job_succeeded = true
-          Pgbus.logger.debug { "[Pgbus] Executor phase=succeeded msg_id=#{msg_id} job=#{job_class}" }
         end
 
         instrument("pgbus.job_completed", queue: queue_name, job_class: job_class)
         record_stat(payload, queue_name, "success", execution_start, message: message)
+        Pgbus.logger.debug { "[Pgbus::Executor] done #{tag} job_class=#{job_class}" }
         :success
       rescue *FATAL_EXCEPTIONS
         # Process-fatal: propagate so the supervisor/OS can react.
@@ -88,6 +88,7 @@ module Pgbus
         handle_failure(message, queue_name, e, payload: payload)
         instrument("pgbus.job_failed", queue: queue_name, job_class: payload&.dig("job_class"), error: e.class.name)
         record_stat(payload, queue_name, "failed", execution_start, message: message)
+        Pgbus.logger.debug { "[Pgbus::Executor] failed #{tag} error=#{e.class}" }
         # Don't signal concurrency on transient failure — the job will be retried.
         # Semaphore is released only on success or dead-lettering.
         :failed

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -85,6 +85,10 @@ module Pgbus
     # Requires a matching entry in config/database.yml under the "pgbus" key.
     attr_accessor :connects_to
 
+    # Zombie message detection — logs a warning when a message is redelivered
+    # (read_ct > 1) without any prior failure recorded in pgbus_failed_events.
+    attr_accessor :zombie_detection
+
     # Job stats
     attr_accessor :stats_enabled
     attr_reader :stats_retention # rubocop:disable Style/AccessorGrouping
@@ -159,6 +163,8 @@ module Pgbus
       @recurring_tasks_file = nil
       @skip_recurring = false
       @recurring_execution_retention = 7 * 24 * 3600 # 7 days
+
+      @zombie_detection = true
 
       @stats_enabled = true
       @stats_retention = 30 * 24 * 3600 # 30 days

--- a/lib/pgbus/failed_event_recorder.rb
+++ b/lib/pgbus/failed_event_recorder.rb
@@ -35,6 +35,18 @@ module Pgbus
         ErrorReporter.report(e, { action: "record_failed_event", queue: queue_name, msg_id: msg_id })
       end
 
+      def exists?(queue_name:, msg_id:)
+        result = connection.select_value(
+          "SELECT 1 FROM pgbus_failed_events WHERE queue_name = $1 AND msg_id = $2 LIMIT 1",
+          "FailedEvent Exists",
+          [queue_name, msg_id.to_i]
+        )
+        !result.nil?
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus] FailedEvent exists? check failed: #{e.class}: #{e.message}" }
+        false
+      end
+
       def clear!(queue_name:, msg_id:)
         connection.exec_delete(
           "DELETE FROM pgbus_failed_events WHERE queue_name = $1 AND msg_id = $2",

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -126,6 +126,7 @@ module Pgbus
 
         @rate_counter.increment(:dequeued, tagged_messages.size)
         tagged_messages.each do |queue_name, message, source_queue|
+          detect_zombie(queue_name, message)
           @in_flight.increment
           @pool.post { process_message(message, queue_name, source_queue: source_queue) }
         end
@@ -283,6 +284,21 @@ module Pgbus
           end
         end
         Pgbus.logger.error { "[Pgbus] Queue table missing: #{error.message}" }
+      end
+
+      def detect_zombie(queue_name, message)
+        return unless config.zombie_detection
+        return unless message.read_ct.to_i > 1
+
+        return if FailedEventRecorder.exists?(queue_name: queue_name, msg_id: message.msg_id.to_i)
+
+        Pgbus.logger.warn do
+          "[Pgbus] Zombie message redelivered: queue=#{queue_name} msg_id=#{message.msg_id} " \
+            "read_ct=#{message.read_ct} — previous read did not record a failure. " \
+            "The worker may have crashed mid-execute or the executor silently dropped the job."
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus] Zombie detection failed: #{e.class}: #{e.message}" }
       end
 
       def check_recycle

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -524,6 +524,7 @@ RSpec.describe Pgbus::ActiveJob::Executor do
         output = log_output.string
         expect(output).to include("[Pgbus::Executor] start msg_id=81")
         expect(output).to include("[Pgbus::Executor] dead_lettered msg_id=81")
+        expect(output).to include("job_class=TestJob")
       end
 
       it "emits debug log on failure" do

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -477,6 +477,75 @@ RSpec.describe Pgbus::ActiveJob::Executor do
       end
     end
 
+    describe "lifecycle debug logging" do
+      let(:message) { build_message_double(msg_id: 80, message: message_json, read_ct: 1) }
+      let(:log_output) { StringIO.new }
+
+      before do
+        config.logger = Logger.new(log_output, level: Logger::DEBUG)
+      end
+
+      after do
+        config.logger = Logger.new($stdout)
+      end
+
+      it "emits debug logs at each phase on success" do
+        executor.execute(message, queue_name)
+
+        output = log_output.string
+        expect(output).to include("[Pgbus::Executor] start msg_id=80")
+        expect(output).to include("[Pgbus::Executor] deserialized msg_id=80")
+        expect(output).to include("[Pgbus::Executor] running msg_id=80")
+        expect(output).to include("[Pgbus::Executor] perform_returned msg_id=80")
+        expect(output).to include("[Pgbus::Executor] archived msg_id=80")
+        expect(output).to include("[Pgbus::Executor] done msg_id=80")
+      end
+
+      it "includes queue and read_ct in the tag" do
+        executor.execute(message, queue_name)
+
+        output = log_output.string
+        expect(output).to include("queue=default")
+        expect(output).to include("read_ct=1")
+      end
+
+      it "includes job_class after deserialization" do
+        executor.execute(message, queue_name)
+
+        output = log_output.string
+        expect(output).to include("job_class=TestJob")
+      end
+
+      it "emits debug logs for dead letter path" do
+        dlq_message = build_message_double(msg_id: 81, message: message_json, read_ct: config.max_retries + 1)
+
+        executor.execute(dlq_message, queue_name)
+
+        output = log_output.string
+        expect(output).to include("[Pgbus::Executor] start msg_id=81")
+        expect(output).to include("[Pgbus::Executor] dead_lettered msg_id=81")
+      end
+
+      it "emits debug log on failure" do
+        allow(job_double).to receive(:perform_now).and_raise(StandardError, "boom")
+
+        executor.execute(message, queue_name)
+
+        output = log_output.string
+        expect(output).to include("[Pgbus::Executor] start msg_id=80")
+        expect(output).to include("[Pgbus::Executor] failed msg_id=80")
+      end
+
+      it "does not evaluate debug blocks when logger level is above debug" do
+        config.logger = Logger.new(log_output, level: Logger::INFO)
+
+        executor.execute(message, queue_name)
+
+        output = log_output.string
+        expect(output).not_to include("[Pgbus::Executor]")
+      end
+    end
+
     describe "retry backoff (VT-based retry path)" do
       let(:message) { build_message_double(msg_id: 50, message: message_json, read_ct: 2) }
 

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -481,12 +481,15 @@ RSpec.describe Pgbus::ActiveJob::Executor do
       let(:message) { build_message_double(msg_id: 80, message: message_json, read_ct: 1) }
       let(:log_output) { StringIO.new }
 
+      let(:previous_logger) { config.logger }
+
       before do
+        previous_logger # memoize before overwriting
         config.logger = Logger.new(log_output, level: Logger::DEBUG)
       end
 
       after do
-        config.logger = Logger.new($stdout)
+        config.logger = previous_logger
       end
 
       it "emits debug logs at each phase on success" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe Pgbus::Configuration do
       expect(config.streams_stats_enabled).to be false
     end
 
+    it "has zombie_detection enabled by default" do
+      expect(config.zombie_detection).to be true
+    end
+
     it "has insights_default_minutes of 30 days" do
       expect(config.insights_default_minutes).to eq(30 * 24 * 60)
     end

--- a/spec/pgbus/failed_event_recorder_spec.rb
+++ b/spec/pgbus/failed_event_recorder_spec.rb
@@ -63,6 +63,35 @@ RSpec.describe Pgbus::FailedEventRecorder do
     end
   end
 
+  describe ".exists?" do
+    it "returns true when a failed event row exists" do
+      allow(mock_connection).to receive(:select_value).and_return(1)
+
+      result = described_class.exists?(queue_name: "default", msg_id: 42)
+
+      expect(result).to be true
+      expect(mock_connection).to have_received(:select_value).with(
+        a_string_matching(/SELECT 1 FROM pgbus_failed_events/),
+        "FailedEvent Exists",
+        ["default", 42]
+      )
+    end
+
+    it "returns false when no failed event row exists" do
+      allow(mock_connection).to receive(:select_value).and_return(nil)
+
+      result = described_class.exists?(queue_name: "default", msg_id: 42)
+
+      expect(result).to be false
+    end
+
+    it "returns false on database errors" do
+      allow(mock_connection).to receive(:select_value).and_raise(ActiveRecord::StatementInvalid, "table missing")
+
+      expect(described_class.exists?(queue_name: "default", msg_id: 42)).to be false
+    end
+  end
+
   describe ".clear!" do
     it "deletes the failed event for the given queue and msg_id" do
       allow(mock_connection).to receive(:exec_delete)

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -432,6 +432,8 @@ RSpec.describe Pgbus::Process::Worker do
 
         worker.send(:claim_and_execute)
 
+        expect(Pgbus::FailedEventRecorder).to have_received(:exists?)
+          .with(queue_name: "default", msg_id: 99)
         zombie_log = warn_messages.find { |m| m.include?("Zombie message redelivered") }
         expect(zombie_log).to include("msg_id=99")
         expect(zombie_log).to include("read_ct=2")

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -407,6 +407,72 @@ RSpec.describe Pgbus::Process::Worker do
     end
   end
 
+  describe "zombie message detection" do
+    let(:wake_signal) { worker.instance_variable_get(:@wake_signal) }
+
+    before do
+      allow(wake_signal).to receive(:wait)
+      allow(Pgbus::FailedEventRecorder).to receive(:exists?).and_return(false)
+    end
+
+    context "when zombie_detection is enabled (default)" do
+      it "logs a warning for redelivered messages with no prior failure" do
+        msg = build_message_double(msg_id: 99, message: '{"job_class":"TestJob"}', read_ct: 2)
+        allow(mock_client).to receive(:read_batch).and_return([msg])
+        allow(pool).to receive(:post).and_yield
+        allow(executor).to receive(:execute).and_return(:success)
+
+        expect(Pgbus.logger).to receive(:warn).at_least(:once) do |&block|
+          log_msg = block.call
+          expect(log_msg).to include("Zombie message redelivered")
+          expect(log_msg).to include("msg_id=99")
+          expect(log_msg).to include("read_ct=2")
+        end
+
+        worker.send(:claim_and_execute)
+      end
+
+      it "does not warn for first-time messages (read_ct=1)" do
+        msg = build_message_double(msg_id: 100, message: '{"job_class":"TestJob"}', read_ct: 1)
+        allow(mock_client).to receive(:read_batch).and_return([msg])
+        allow(pool).to receive(:post).and_yield
+        allow(executor).to receive(:execute).and_return(:success)
+
+        expect(Pgbus.logger).not_to receive(:warn).with(/Zombie/)
+
+        worker.send(:claim_and_execute)
+      end
+
+      it "does not warn when a prior failure is recorded" do
+        msg = build_message_double(msg_id: 101, message: '{"job_class":"TestJob"}', read_ct: 2)
+        allow(mock_client).to receive(:read_batch).and_return([msg])
+        allow(pool).to receive(:post).and_yield
+        allow(executor).to receive(:execute).and_return(:success)
+        allow(Pgbus::FailedEventRecorder).to receive(:exists?).and_return(true)
+
+        expect(Pgbus.logger).not_to receive(:warn).with(/Zombie/)
+
+        worker.send(:claim_and_execute)
+      end
+    end
+
+    context "when zombie_detection is disabled" do
+      before { worker.config.zombie_detection = false }
+      after { worker.config.zombie_detection = true }
+
+      it "does not check for zombie messages" do
+        msg = build_message_double(msg_id: 102, message: '{"job_class":"TestJob"}', read_ct: 3)
+        allow(mock_client).to receive(:read_batch).and_return([msg])
+        allow(pool).to receive(:post).and_yield
+        allow(executor).to receive(:execute).and_return(:success)
+
+        worker.send(:claim_and_execute)
+
+        expect(Pgbus::FailedEventRecorder).not_to have_received(:exists?)
+      end
+    end
+  end
+
   describe "consumer priority" do
     it "defaults to 0" do
       expect(worker.stats[:consumer_priority]).to eq(0)

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -416,20 +416,25 @@ RSpec.describe Pgbus::Process::Worker do
     end
 
     context "when zombie_detection is enabled (default)" do
+      let(:warn_messages) { [] }
+
+      before do
+        allow(Pgbus.logger).to receive(:warn) do |&block|
+          warn_messages << block.call if block
+        end
+      end
+
       it "logs a warning for redelivered messages with no prior failure" do
         msg = build_message_double(msg_id: 99, message: '{"job_class":"TestJob"}', read_ct: 2)
         allow(mock_client).to receive(:read_batch).and_return([msg])
         allow(pool).to receive(:post).and_yield
         allow(executor).to receive(:execute).and_return(:success)
 
-        expect(Pgbus.logger).to receive(:warn).at_least(:once) do |&block|
-          log_msg = block.call
-          expect(log_msg).to include("Zombie message redelivered")
-          expect(log_msg).to include("msg_id=99")
-          expect(log_msg).to include("read_ct=2")
-        end
-
         worker.send(:claim_and_execute)
+
+        zombie_log = warn_messages.find { |m| m.include?("Zombie message redelivered") }
+        expect(zombie_log).to include("msg_id=99")
+        expect(zombie_log).to include("read_ct=2")
       end
 
       it "does not warn for first-time messages (read_ct=1)" do
@@ -438,9 +443,9 @@ RSpec.describe Pgbus::Process::Worker do
         allow(pool).to receive(:post).and_yield
         allow(executor).to receive(:execute).and_return(:success)
 
-        expect(Pgbus.logger).not_to receive(:warn).with(/Zombie/)
-
         worker.send(:claim_and_execute)
+
+        expect(warn_messages).not_to include(a_string_matching(/Zombie/))
       end
 
       it "does not warn when a prior failure is recorded" do
@@ -450,9 +455,9 @@ RSpec.describe Pgbus::Process::Worker do
         allow(executor).to receive(:execute).and_return(:success)
         allow(Pgbus::FailedEventRecorder).to receive(:exists?).and_return(true)
 
-        expect(Pgbus.logger).not_to receive(:warn).with(/Zombie/)
-
         worker.send(:claim_and_execute)
+
+        expect(warn_messages).not_to include(a_string_matching(/Zombie/))
       end
     end
 


### PR DESCRIPTION
## Summary

- **Executor lifecycle debug logs**: Added ~8 `Pgbus.logger.debug { ... }` lines in `Executor#execute` at each phase transition (`start`, `deserialized`, `running`, `perform_returned`, `archived`, `done`, `failed`, `dead_lettered`). Each line is tagged with `msg_id`, `queue`, `read_ct`, and `job_class`. Zero overhead when debug is off since blocks are only evaluated at debug level.

- **Zombie message detection**: Added `detect_zombie` in `Worker#claim_and_execute` that checks for `read_ct > 1` without a matching `pgbus_failed_events` row. Emits a WARN log when detected. Gated behind `config.zombie_detection` (default: `true`).

- **`FailedEventRecorder.exists?`**: New class method for the zombie detection lookup — simple `SELECT 1 ... LIMIT 1` query with error-safe fallback to `false`.

Closes #127

## Test plan

- [x] `FailedEventRecorder.exists?` — returns true/false, handles DB errors gracefully (3 specs)
- [x] `Configuration#zombie_detection` — defaults to true (1 spec)
- [x] Executor lifecycle logging — emits debug at each phase, includes correct tags, silent at INFO level (6 specs)
- [x] Zombie detection — warns on redelivery without failure, silent for read_ct=1, silent when failure exists, disabled when config off (4 specs)
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rspec` — 1713 examples, 0 failures (excluding pre-existing system test failures)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zombie message detection: warns when a message is redelivered without a prior failure record; enabled by default via a new configuration flag.
  * Enhanced execution lifecycle debug logging for job processing (start, deserialized, running, perform returned, archived, success/failure) with contextual tags; suppressed at higher log levels.

* **Tests**
  * Added specs for zombie detection behavior and execution lifecycle debug logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->