### PR TITLE
feat(testing): EventBus test primitives — matchers, assertions, inline execution

### DIFF
--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -39,6 +39,7 @@ module Pgbus
         )
         loader.ignore("#{__dir__}/generators")
         loader.ignore("#{__dir__}/active_job")
+        loader.ignore("#{__dir__}/pgbus/testing")
         # lib/puma/plugin/pgbus_streams.rb is a Puma plugin — it's required
         # explicitly by the user from config/puma.rb via `plugin :pgbus_streams`.
         # Without this ignore, Zeitwerk scans lib/puma/ under the pgbus loader

--- a/lib/pgbus/event_bus/publisher.rb
+++ b/lib/pgbus/event_bus/publisher.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 module Pgbus
   module EventBus
     module Publisher

--- a/lib/pgbus/event_bus/publisher.rb
+++ b/lib/pgbus/event_bus/publisher.rb
@@ -21,7 +21,7 @@ module Pgbus
 
           Pgbus::Testing.store.push_event(event)
 
-          if Pgbus::Testing.inline?
+          if Pgbus::Testing.inline? && delay.to_i <= 0
             Pgbus::EventBus::Registry.instance.handlers_for(routing_key).each do |subscriber|
               subscriber.handler_class.new.handle(event)
             end

--- a/lib/pgbus/event_bus/publisher.rb
+++ b/lib/pgbus/event_bus/publisher.rb
@@ -7,6 +7,27 @@ module Pgbus
 
       def publish(routing_key, payload, headers: nil, delay: 0)
         event_data = build_event_data(payload)
+
+        if defined?(Pgbus::Testing) && !Pgbus::Testing.disabled?
+          event = Pgbus::Event.new(
+            event_id: event_data["event_id"],
+            payload: event_data["payload"],
+            published_at: event_data["published_at"] ? Time.parse(event_data["published_at"]) : nil,
+            routing_key: routing_key,
+            headers: headers
+          )
+
+          Pgbus::Testing.store.push_event(event)
+
+          if Pgbus::Testing.inline?
+            Pgbus::EventBus::Registry.instance.handlers_for(routing_key).each do |subscriber|
+              subscriber.handler_class.new.handle(event)
+            end
+          end
+
+          return event_data
+        end
+
         Pgbus.client.publish_to_topic(routing_key, event_data, headers: headers, delay: delay)
       end
 

--- a/lib/pgbus/testing.rb
+++ b/lib/pgbus/testing.rb
@@ -18,39 +18,6 @@ module Pgbus
     MODES = %i[fake inline disabled].freeze
     MODE_KEY = :__pgbus_test_mode
 
-    class << self
-      def mode!(mode, &block)
-        raise ArgumentError, "Unknown mode: #{mode}. Valid modes: #{MODES.join(", ")}" unless MODES.include?(mode)
-
-        unless block
-          Thread.main[MODE_KEY] = mode
-          return
-        end
-
-        old = Thread.current[MODE_KEY]
-        Thread.current[MODE_KEY] = mode
-        yield
-      ensure
-        Thread.current[MODE_KEY] = old if block
-      end
-
-      def mode
-        Thread.current[MODE_KEY] || Thread.main[MODE_KEY] || :disabled
-      end
-
-      def fake!(&) = mode!(:fake, &)
-      def inline!(&) = mode!(:inline, &)
-      def disabled!(&) = mode!(:disabled, &)
-
-      def fake?     = mode == :fake
-      def inline?   = mode == :inline
-      def disabled? = mode == :disabled
-
-      def store
-        @store ||= EventStore.new
-      end
-    end
-
     # Thread-safe in-memory store for events captured in fake/inline mode.
     class EventStore
       def initialize
@@ -88,6 +55,40 @@ module Pgbus
           end
         end
       end
+    end
+
+    # Eagerly initialize the store so concurrent access never races on creation.
+    @store = EventStore.new
+
+    class << self
+      def mode!(mode, &block)
+        raise ArgumentError, "Unknown mode: #{mode}. Valid modes: #{MODES.join(", ")}" unless MODES.include?(mode)
+
+        unless block
+          Thread.main[MODE_KEY] = mode
+          return
+        end
+
+        old = Thread.current[MODE_KEY]
+        Thread.current[MODE_KEY] = mode
+        yield
+      ensure
+        Thread.current[MODE_KEY] = old if block
+      end
+
+      def mode
+        Thread.current[MODE_KEY] || Thread.main[MODE_KEY] || :disabled
+      end
+
+      def fake!(&) = mode!(:fake, &)
+      def inline!(&) = mode!(:inline, &)
+      def disabled!(&) = mode!(:disabled, &)
+
+      def fake?     = mode == :fake
+      def inline?   = mode == :inline
+      def disabled? = mode == :disabled
+
+      attr_reader :store
     end
   end
 end

--- a/lib/pgbus/testing.rb
+++ b/lib/pgbus/testing.rb
@@ -46,13 +46,18 @@ module Pgbus
       end
 
       # Dispatch all stored events to their matching handlers, then clear.
+      # Events are removed one at a time after successful dispatch so that
+      # a handler exception leaves unprocessed events in the store.
       def drain!
-        events_to_drain = @mutex.synchronize { @events.dup.tap { @events.clear } }
+        loop do
+          event = @mutex.synchronize { @events.first }
+          break unless event
 
-        events_to_drain.each do |event|
           Pgbus::EventBus::Registry.instance.handlers_for(event.routing_key).each do |subscriber|
             subscriber.handler_class.new.handle(event)
           end
+
+          @mutex.synchronize { @events.shift }
         end
       end
     end

--- a/lib/pgbus/testing.rb
+++ b/lib/pgbus/testing.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "pgbus"
+
+module Pgbus
+  # Test helpers for Pgbus EventBus. Opt-in via explicit require — never
+  # autoloaded by Zeitwerk so this code never leaks into production.
+  #
+  #   require "pgbus/testing"          # core only
+  #   require "pgbus/testing/rspec"    # RSpec matchers + auto-config
+  #   require "pgbus/testing/minitest" # Minitest assertions
+  #
+  # Three modes:
+  #   :fake     — capture published events in an in-memory store (default for tests)
+  #   :inline   — capture AND immediately dispatch to matching handlers
+  #   :disabled — pass through to the real publisher (production behavior)
+  module Testing
+    MODES = %i[fake inline disabled].freeze
+    MODE_KEY = :__pgbus_test_mode
+
+    class << self
+      def mode!(mode, &block)
+        raise ArgumentError, "Unknown mode: #{mode}. Valid modes: #{MODES.join(", ")}" unless MODES.include?(mode)
+
+        unless block
+          Thread.main[MODE_KEY] = mode
+          return
+        end
+
+        old = Thread.current[MODE_KEY]
+        Thread.current[MODE_KEY] = mode
+        yield
+      ensure
+        Thread.current[MODE_KEY] = old if block
+      end
+
+      def mode
+        Thread.current[MODE_KEY] || Thread.main[MODE_KEY] || :disabled
+      end
+
+      def fake!(&) = mode!(:fake, &)
+      def inline!(&) = mode!(:inline, &)
+      def disabled!(&) = mode!(:disabled, &)
+
+      def fake?     = mode == :fake
+      def inline?   = mode == :inline
+      def disabled? = mode == :disabled
+
+      def store
+        @store ||= EventStore.new
+      end
+    end
+
+    # Thread-safe in-memory store for events captured in fake/inline mode.
+    class EventStore
+      def initialize
+        @mutex = Mutex.new
+        @events = []
+      end
+
+      def push_event(event)
+        @mutex.synchronize { @events << event }
+      end
+
+      def events(routing_key: nil)
+        @mutex.synchronize do
+          result = @events.dup
+          result = result.select { |e| e.routing_key == routing_key } if routing_key
+          result
+        end
+      end
+
+      def size
+        @mutex.synchronize { @events.size }
+      end
+
+      def clear!
+        @mutex.synchronize { @events.clear }
+      end
+
+      # Dispatch all stored events to their matching handlers, then clear.
+      def drain!
+        events_to_drain = @mutex.synchronize { @events.dup.tap { @events.clear } }
+
+        events_to_drain.each do |event|
+          Pgbus::EventBus::Registry.instance.handlers_for(event.routing_key).each do |subscriber|
+            subscriber.handler_class.new.handle(event)
+          end
+        end
+      end
+    end
+  end
+end
+
+require_relative "testing/assertions"

--- a/lib/pgbus/testing/assertions.rb
+++ b/lib/pgbus/testing/assertions.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Testing
+    # Framework-agnostic assertion helpers. Included by both RSpec and Minitest
+    # integrations. Can also be included directly in any test class.
+    #
+    #   include Pgbus::Testing::Assertions
+    #
+    #   assert_pgbus_published(count: 1, routing_key: "orders.created") do
+    #     Order.create!(...)
+    #   end
+    module Assertions
+      def pgbus_published_events(routing_key: nil)
+        Pgbus::Testing.store.events(routing_key: routing_key)
+      end
+
+      def assert_pgbus_published(count:, routing_key: nil)
+        before = pgbus_published_events(routing_key: routing_key).size
+        yield
+        after = pgbus_published_events(routing_key: routing_key).size
+        actual = after - before
+
+        return if actual == count
+
+        suffix = routing_key ? " matching #{routing_key.inspect}" : ""
+        raise_assertion("Expected #{count} event(s) published#{suffix}, got #{actual}")
+      end
+
+      def assert_no_pgbus_published(routing_key: nil)
+        before = pgbus_published_events(routing_key: routing_key).size
+        yield
+        after = pgbus_published_events(routing_key: routing_key).size
+        actual = after - before
+
+        return if actual.zero?
+
+        suffix = routing_key ? " matching #{routing_key.inspect}" : ""
+        raise_assertion("Expected no events published#{suffix}, got #{actual}")
+      end
+
+      # Execute the block, capturing events, then dispatch all captured events
+      # to their registered handlers.
+      def perform_published_events
+        yield
+        Pgbus::Testing.store.drain!
+      end
+
+      private
+
+      def raise_assertion(message)
+        # Use Minitest::Assertion if available, otherwise a generic RuntimeError
+        raise Minitest::Assertion, message if defined?(Minitest::Assertion)
+
+        raise message
+      end
+    end
+  end
+end

--- a/lib/pgbus/testing/minitest.rb
+++ b/lib/pgbus/testing/minitest.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../testing"
+
+module Pgbus
+  module Testing
+    # Minitest integration for Pgbus test helpers.
+    #
+    # Include in your test_helper.rb:
+    #
+    #   require "pgbus/testing/minitest"
+    #
+    #   class ActiveSupport::TestCase
+    #     include Pgbus::Testing::MinitestHelpers
+    #   end
+    #
+    # This provides:
+    #   - Automatic fake mode + store clearing per test
+    #   - assert_pgbus_published / assert_no_pgbus_published
+    #   - perform_published_events
+    #   - pgbus_published_events
+    module MinitestHelpers
+      include Pgbus::Testing::Assertions
+
+      def before_setup
+        Pgbus::Testing.fake!
+        Pgbus::Testing.store.clear!
+        super
+      end
+    end
+  end
+end

--- a/lib/pgbus/testing/rspec.rb
+++ b/lib/pgbus/testing/rspec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "../testing"
+
+RSpec::Matchers.define :have_published_event do |expected_routing_key|
+  supports_block_expectations
+
+  chain(:with_payload) { |payload| @expected_payload = payload }
+  chain(:with_headers) { |headers| @expected_headers = headers }
+  chain(:exactly)      { |count|   @expected_count = count }
+
+  match do |block|
+    @before = Pgbus::Testing.store.events(routing_key: expected_routing_key).dup
+    block.call
+    @after = Pgbus::Testing.store.events(routing_key: expected_routing_key)
+    @new_events = @after - @before
+
+    return false if @new_events.empty?
+
+    return false if @expected_count && @new_events.size != @expected_count
+
+    if @expected_payload
+      @new_events = @new_events.select { |e| values_match?(@expected_payload, e.payload) }
+      return false if @new_events.empty?
+    end
+
+    if @expected_headers
+      @new_events = @new_events.select { |e| values_match?(@expected_headers, e.headers) }
+      return false if @new_events.empty?
+    end
+
+    true
+  end
+
+  match_when_negated do |block|
+    @before = Pgbus::Testing.store.events(routing_key: expected_routing_key).dup
+    block.call
+    @after = Pgbus::Testing.store.events(routing_key: expected_routing_key)
+    @new_events = @after - @before
+    @new_events.empty?
+  end
+
+  failure_message do
+    parts = ["expected block to publish a #{expected_routing_key.inspect} event"]
+    parts << "with payload #{@expected_payload.inspect}" if @expected_payload
+    parts << "with headers #{@expected_headers.inspect}" if @expected_headers
+    parts << "exactly #{@expected_count} time(s)" if @expected_count
+
+    published = @new_events&.size || 0
+    parts << "but #{published} matching event(s) were published"
+
+    if published.positive? && @expected_payload
+      actual_payloads = @after.map(&:payload)
+      parts << "actual payloads: #{actual_payloads.inspect}"
+    end
+
+    parts.join(", ")
+  end
+
+  failure_message_when_negated do
+    "expected block not to publish a #{expected_routing_key.inspect} event, but #{@new_events.size} were published"
+  end
+end
+
+RSpec.configure do |config|
+  config.include Pgbus::Testing::Assertions
+end

--- a/lib/pgbus/testing/rspec.rb
+++ b/lib/pgbus/testing/rspec.rb
@@ -17,8 +17,6 @@ RSpec::Matchers.define :have_published_event do |expected_routing_key|
 
     return false if @new_events.empty?
 
-    return false if @expected_count && @new_events.size != @expected_count
-
     if @expected_payload
       @new_events = @new_events.select { |e| values_match?(@expected_payload, e.payload) }
       return false if @new_events.empty?
@@ -29,6 +27,8 @@ RSpec::Matchers.define :have_published_event do |expected_routing_key|
       return false if @new_events.empty?
     end
 
+    return false if @expected_count && @new_events.size != @expected_count
+
     true
   end
 
@@ -37,7 +37,16 @@ RSpec::Matchers.define :have_published_event do |expected_routing_key|
     block.call
     @after = Pgbus::Testing.store.events(routing_key: expected_routing_key)
     @new_events = @after - @before
-    @new_events.empty?
+
+    @new_events = @new_events.select { |e| values_match?(@expected_payload, e.payload) } if @expected_payload
+
+    @new_events = @new_events.select { |e| values_match?(@expected_headers, e.headers) } if @expected_headers
+
+    if @expected_count
+      @new_events.size != @expected_count
+    else
+      @new_events.empty?
+    end
   end
 
   failure_message do

--- a/spec/pgbus/testing/assertions_spec.rb
+++ b/spec/pgbus/testing/assertions_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pgbus/testing"
+
+RSpec.describe Pgbus::Testing::Assertions do
+  include described_class
+
+  before do
+    Pgbus::Testing.fake!
+    Pgbus::Testing.store.clear!
+    allow(Pgbus).to receive(:client).and_return(double("Pgbus::Client", publish_to_topic: nil))
+  end
+
+  after do
+    Pgbus::Testing.disabled!
+    Pgbus::Testing.store.clear!
+  end
+
+  describe "#pgbus_published_events" do
+    it "returns all published events" do
+      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+      Pgbus::EventBus::Publisher.publish("orders.shipped", { "id" => 2 })
+
+      expect(pgbus_published_events.size).to eq(2)
+    end
+
+    it "filters by routing_key" do
+      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+      Pgbus::EventBus::Publisher.publish("orders.shipped", { "id" => 2 })
+
+      result = pgbus_published_events(routing_key: "orders.created")
+      expect(result.size).to eq(1)
+      expect(result.first.routing_key).to eq("orders.created")
+    end
+  end
+
+  describe "#assert_pgbus_published" do
+    it "passes when expected events are published" do
+      expect {
+        assert_pgbus_published(count: 1, routing_key: "orders.created") do
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+        end
+      }.not_to raise_error
+    end
+
+    it "fails when count doesn't match" do
+      expect {
+        assert_pgbus_published(count: 2, routing_key: "orders.created") do
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+        end
+      }.to raise_error(/Expected 2 event\(s\) published.*got 1/)
+    end
+
+    it "only counts events published within the block" do
+      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 0 })
+
+      expect {
+        assert_pgbus_published(count: 1) do
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+        end
+      }.not_to raise_error
+    end
+  end
+
+  describe "#assert_no_pgbus_published" do
+    it "passes when no events are published" do
+      expect {
+        assert_no_pgbus_published { "no-op" }
+      }.not_to raise_error
+    end
+
+    it "fails when events are published" do
+      expect {
+        assert_no_pgbus_published do
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+        end
+      }.to raise_error(/Expected no events published.*got 1/)
+    end
+  end
+
+  describe "#perform_published_events" do
+    let(:handler_class) do
+      Class.new(Pgbus::EventBus::Handler) do
+        class << self
+          attr_accessor :handled_events
+        end
+        self.handled_events = []
+
+        def handle(event)
+          self.class.handled_events << event
+        end
+      end.tap { |klass| stub_const("TestPerformHandler", klass) }
+    end
+
+    before do
+      Pgbus::EventBus::Registry.instance.clear!
+      handler_class.handled_events = []
+    end
+
+    after do
+      Pgbus::EventBus::Registry.instance.clear!
+    end
+
+    it "publishes events and then dispatches them to handlers" do
+      Pgbus::EventBus::Registry.instance.subscribe("orders.created", handler_class)
+
+      perform_published_events do
+        Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 42 })
+      end
+
+      expect(handler_class.handled_events.size).to eq(1)
+      expect(handler_class.handled_events.first["id"]).to eq(42)
+    end
+  end
+end

--- a/spec/pgbus/testing/assertions_spec.rb
+++ b/spec/pgbus/testing/assertions_spec.rb
@@ -37,51 +37,51 @@ RSpec.describe Pgbus::Testing::Assertions do
 
   describe "#assert_pgbus_published" do
     it "passes when expected events are published" do
-      expect {
+      expect do
         assert_pgbus_published(count: 1, routing_key: "orders.created") do
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
         end
-      }.not_to raise_error
+      end.not_to raise_error
     end
 
     it "fails when count doesn't match" do
-      expect {
+      expect do
         assert_pgbus_published(count: 2, routing_key: "orders.created") do
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
         end
-      }.to raise_error(/Expected 2 event\(s\) published.*got 1/)
+      end.to raise_error(/Expected 2 event\(s\) published.*got 1/)
     end
 
     it "only counts events published within the block" do
       Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 0 })
 
-      expect {
+      expect do
         assert_pgbus_published(count: 1) do
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
         end
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 
   describe "#assert_no_pgbus_published" do
     it "passes when no events are published" do
-      expect {
+      expect do
         assert_no_pgbus_published { "no-op" }
-      }.not_to raise_error
+      end.not_to raise_error
     end
 
     it "fails when events are published" do
-      expect {
+      expect do
         assert_no_pgbus_published do
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
         end
-      }.to raise_error(/Expected no events published.*got 1/)
+      end.to raise_error(/Expected no events published.*got 1/)
     end
   end
 
   describe "#perform_published_events" do
     let(:handler_class) do
-      Class.new(Pgbus::EventBus::Handler) do
+      klass = Class.new(Pgbus::EventBus::Handler) do
         class << self
           attr_accessor :handled_events
         end
@@ -90,7 +90,9 @@ RSpec.describe Pgbus::Testing::Assertions do
         def handle(event)
           self.class.handled_events << event
         end
-      end.tap { |klass| stub_const("TestPerformHandler", klass) }
+      end
+      stub_const("TestPerformHandler", klass)
+      klass
     end
 
     before do

--- a/spec/pgbus/testing/minitest_spec.rb
+++ b/spec/pgbus/testing/minitest_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pgbus/testing/minitest"
+
+# Verify that Minitest module can be loaded and includes the right methods.
+# We don't actually run Minitest here — we just verify the module structure
+# is correct and mixable.
+RSpec.describe Pgbus::Testing::MinitestHelpers do
+  it "includes assertion methods from Assertions" do
+    expect(described_class.instance_methods).to include(:assert_pgbus_published)
+    expect(described_class.instance_methods).to include(:assert_no_pgbus_published)
+    expect(described_class.instance_methods).to include(:pgbus_published_events)
+    expect(described_class.instance_methods).to include(:perform_published_events)
+  end
+
+  it "includes setup/teardown hooks" do
+    expect(described_class.instance_methods).to include(:before_setup)
+  end
+end

--- a/spec/pgbus/testing/publisher_hook_spec.rb
+++ b/spec/pgbus/testing/publisher_hook_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "pgbus/testing"
 
-RSpec.describe "Publisher test mode hook" do
+RSpec.describe Pgbus::EventBus::Publisher do
   include PgmqDoubles
 
   let(:mock_client) { build_mock_client }
@@ -22,7 +22,7 @@ RSpec.describe "Publisher test mode hook" do
     before { Pgbus::Testing.fake! }
 
     it "captures the event without calling PGMQ" do
-      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+      described_class.publish("orders.created", { "id" => 1 })
 
       expect(mock_client).not_to have_received(:publish_to_topic)
       expect(Pgbus::Testing.store.events.size).to eq(1)
@@ -34,7 +34,7 @@ RSpec.describe "Publisher test mode hook" do
     end
 
     it "captures headers" do
-      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 }, headers: { "x-trace" => "abc" })
+      described_class.publish("orders.created", { "id" => 1 }, headers: { "x-trace" => "abc" })
 
       event = Pgbus::Testing.store.events.first
       expect(event.headers).to eq("x-trace" => "abc")
@@ -43,7 +43,7 @@ RSpec.describe "Publisher test mode hook" do
 
   describe "inline mode" do
     let(:handler_class) do
-      Class.new(Pgbus::EventBus::Handler) do
+      klass = Class.new(Pgbus::EventBus::Handler) do
         class << self
           attr_accessor :handled_events
         end
@@ -52,7 +52,9 @@ RSpec.describe "Publisher test mode hook" do
         def handle(event)
           self.class.handled_events << event
         end
-      end.tap { |klass| stub_const("TestInlineHandler", klass) }
+      end
+      stub_const("TestInlineHandler", klass)
+      klass
     end
 
     before do
@@ -67,7 +69,7 @@ RSpec.describe "Publisher test mode hook" do
 
     it "captures the event AND dispatches to handlers" do
       Pgbus::EventBus::Registry.instance.subscribe("orders.created", handler_class)
-      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 42 })
+      described_class.publish("orders.created", { "id" => 42 })
 
       expect(mock_client).not_to have_received(:publish_to_topic)
       expect(Pgbus::Testing.store.events.size).to eq(1)
@@ -80,7 +82,7 @@ RSpec.describe "Publisher test mode hook" do
     before { Pgbus::Testing.disabled! }
 
     it "passes through to the real publisher" do
-      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+      described_class.publish("orders.created", { "id" => 1 })
 
       expect(mock_client).to have_received(:publish_to_topic)
       expect(Pgbus::Testing.store.events).to be_empty

--- a/spec/pgbus/testing/publisher_hook_spec.rb
+++ b/spec/pgbus/testing/publisher_hook_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pgbus/testing"
+
+RSpec.describe "Publisher test mode hook" do
+  include PgmqDoubles
+
+  let(:mock_client) { build_mock_client }
+
+  before do
+    allow(Pgbus).to receive(:client).and_return(mock_client)
+    Pgbus::Testing.store.clear!
+  end
+
+  after do
+    Pgbus::Testing.disabled!
+    Pgbus::Testing.store.clear!
+  end
+
+  describe "fake mode" do
+    before { Pgbus::Testing.fake! }
+
+    it "captures the event without calling PGMQ" do
+      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+
+      expect(mock_client).not_to have_received(:publish_to_topic)
+      expect(Pgbus::Testing.store.events.size).to eq(1)
+
+      event = Pgbus::Testing.store.events.first
+      expect(event.routing_key).to eq("orders.created")
+      expect(event.payload).to eq("id" => 1)
+      expect(event.event_id).to be_a(String)
+    end
+
+    it "captures headers" do
+      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 }, headers: { "x-trace" => "abc" })
+
+      event = Pgbus::Testing.store.events.first
+      expect(event.headers).to eq("x-trace" => "abc")
+    end
+  end
+
+  describe "inline mode" do
+    let(:handler_class) do
+      Class.new(Pgbus::EventBus::Handler) do
+        class << self
+          attr_accessor :handled_events
+        end
+        self.handled_events = []
+
+        def handle(event)
+          self.class.handled_events << event
+        end
+      end.tap { |klass| stub_const("TestInlineHandler", klass) }
+    end
+
+    before do
+      Pgbus::Testing.inline!
+      Pgbus::EventBus::Registry.instance.clear!
+      handler_class.handled_events = []
+    end
+
+    after do
+      Pgbus::EventBus::Registry.instance.clear!
+    end
+
+    it "captures the event AND dispatches to handlers" do
+      Pgbus::EventBus::Registry.instance.subscribe("orders.created", handler_class)
+      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 42 })
+
+      expect(mock_client).not_to have_received(:publish_to_topic)
+      expect(Pgbus::Testing.store.events.size).to eq(1)
+      expect(handler_class.handled_events.size).to eq(1)
+      expect(handler_class.handled_events.first.payload).to eq("id" => 42)
+    end
+  end
+
+  describe "disabled mode" do
+    before { Pgbus::Testing.disabled! }
+
+    it "passes through to the real publisher" do
+      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+
+      expect(mock_client).to have_received(:publish_to_topic)
+      expect(Pgbus::Testing.store.events).to be_empty
+    end
+  end
+end

--- a/spec/pgbus/testing/publisher_hook_spec.rb
+++ b/spec/pgbus/testing/publisher_hook_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe Pgbus::EventBus::Publisher do
       expect(handler_class.handled_events.size).to eq(1)
       expect(handler_class.handled_events.first.payload).to eq("id" => 42)
     end
+
+    it "captures but does not dispatch delayed events" do
+      Pgbus::EventBus::Registry.instance.subscribe("orders.created", handler_class)
+      described_class.publish("orders.created", { "id" => 99 }, delay: 300)
+
+      expect(Pgbus::Testing.store.events.size).to eq(1)
+      expect(handler_class.handled_events).to be_empty
+    end
   end
 
   describe "disabled mode" do

--- a/spec/pgbus/testing/rspec_spec.rb
+++ b/spec/pgbus/testing/rspec_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pgbus/testing/rspec"
+
+RSpec.describe "RSpec matchers" do
+  before do
+    Pgbus::Testing.fake!
+    Pgbus::Testing.store.clear!
+    allow(Pgbus).to receive(:client).and_return(double("Pgbus::Client", publish_to_topic: nil))
+  end
+
+  after do
+    Pgbus::Testing.disabled!
+    Pgbus::Testing.store.clear!
+  end
+
+  describe "have_published_event" do
+    it "matches when an event with the routing key is published" do
+      expect {
+        Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+      }.to have_published_event("orders.created")
+    end
+
+    it "fails when no event with the routing key is published" do
+      expect {
+        expect {
+          Pgbus::EventBus::Publisher.publish("orders.shipped", { "id" => 1 })
+        }.to have_published_event("orders.created")
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
+
+    it "supports negation" do
+      expect {
+        Pgbus::EventBus::Publisher.publish("orders.shipped", { "id" => 1 })
+      }.not_to have_published_event("orders.created")
+    end
+
+    describe ".with_payload" do
+      it "matches payload with hash_including" do
+        expect {
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1, "total" => 99 })
+        }.to have_published_event("orders.created").with_payload(hash_including("id" => 1))
+      end
+
+      it "matches exact payload" do
+        expect {
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+        }.to have_published_event("orders.created").with_payload("id" => 1)
+      end
+
+      it "fails when payload doesn't match" do
+        expect {
+          expect {
+            Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+          }.to have_published_event("orders.created").with_payload("id" => 2)
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+    end
+
+    describe ".with_headers" do
+      it "matches headers" do
+        expect {
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 }, headers: { "x-trace" => "abc" })
+        }.to have_published_event("orders.created").with_headers(hash_including("x-trace" => "abc"))
+      end
+    end
+
+    it "only counts events published within the block" do
+      Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 0 })
+
+      expect {
+        Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+      }.to have_published_event("orders.created").with_payload("id" => 1)
+    end
+
+    describe ".exactly" do
+      it "matches exact count" do
+        expect {
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 2 })
+        }.to have_published_event("orders.created").exactly(2)
+      end
+
+      it "fails when count doesn't match" do
+        expect {
+          expect {
+            Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+          }.to have_published_event("orders.created").exactly(2)
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+    end
+  end
+end

--- a/spec/pgbus/testing/rspec_spec.rb
+++ b/spec/pgbus/testing/rspec_spec.rb
@@ -3,16 +3,16 @@
 require "spec_helper"
 require "pgbus/testing/rspec"
 
-RSpec.describe "RSpec matchers" do
+RSpec.describe Pgbus::Testing do
   before do
-    Pgbus::Testing.fake!
-    Pgbus::Testing.store.clear!
+    described_class.fake!
+    described_class.store.clear!
     allow(Pgbus).to receive(:client).and_return(double("Pgbus::Client", publish_to_topic: nil))
   end
 
   after do
-    Pgbus::Testing.disabled!
-    Pgbus::Testing.store.clear!
+    described_class.disabled!
+    described_class.store.clear!
   end
 
   describe "have_published_event" do

--- a/spec/pgbus/testing/rspec_spec.rb
+++ b/spec/pgbus/testing/rspec_spec.rb
@@ -17,77 +17,107 @@ RSpec.describe "RSpec matchers" do
 
   describe "have_published_event" do
     it "matches when an event with the routing key is published" do
-      expect {
+      expect do
         Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
-      }.to have_published_event("orders.created")
+      end.to have_published_event("orders.created")
     end
 
     it "fails when no event with the routing key is published" do
-      expect {
-        expect {
+      expect do
+        expect do
           Pgbus::EventBus::Publisher.publish("orders.shipped", { "id" => 1 })
-        }.to have_published_event("orders.created")
-      }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+        end.to have_published_event("orders.created")
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
 
     it "supports negation" do
-      expect {
+      expect do
         Pgbus::EventBus::Publisher.publish("orders.shipped", { "id" => 1 })
-      }.not_to have_published_event("orders.created")
+      end.not_to have_published_event("orders.created")
     end
 
     describe ".with_payload" do
       it "matches payload with hash_including" do
-        expect {
+        expect do
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1, "total" => 99 })
-        }.to have_published_event("orders.created").with_payload(hash_including("id" => 1))
+        end.to have_published_event("orders.created").with_payload(hash_including("id" => 1))
       end
 
       it "matches exact payload" do
-        expect {
+        expect do
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
-        }.to have_published_event("orders.created").with_payload("id" => 1)
+        end.to have_published_event("orders.created").with_payload("id" => 1)
       end
 
       it "fails when payload doesn't match" do
-        expect {
-          expect {
+        expect do
+          expect do
             Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
-          }.to have_published_event("orders.created").with_payload("id" => 2)
-        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+          end.to have_published_event("orders.created").with_payload("id" => 2)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
     end
 
     describe ".with_headers" do
       it "matches headers" do
-        expect {
+        expect do
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 }, headers: { "x-trace" => "abc" })
-        }.to have_published_event("orders.created").with_headers(hash_including("x-trace" => "abc"))
+        end.to have_published_event("orders.created").with_headers(hash_including("x-trace" => "abc"))
       end
     end
 
     it "only counts events published within the block" do
       Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 0 })
 
-      expect {
+      expect do
         Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
-      }.to have_published_event("orders.created").with_payload("id" => 1)
+      end.to have_published_event("orders.created").with_payload("id" => 1)
     end
 
     describe ".exactly" do
       it "matches exact count" do
-        expect {
+        expect do
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
           Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 2 })
-        }.to have_published_event("orders.created").exactly(2)
+        end.to have_published_event("orders.created").exactly(2)
       end
 
       it "fails when count doesn't match" do
-        expect {
-          expect {
+        expect do
+          expect do
             Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
-          }.to have_published_event("orders.created").exactly(2)
-        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+          end.to have_published_event("orders.created").exactly(2)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+
+      it "counts only events matching payload when chained with .with_payload" do
+        expect do
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 2 })
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+        end.to have_published_event("orders.created").with_payload("id" => 1).exactly(2)
+      end
+    end
+
+    describe "negation with chained constraints" do
+      it "passes when events exist but payload doesn't match" do
+        expect do
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+        end.not_to have_published_event("orders.created").with_payload("id" => 99)
+      end
+
+      it "fails when events match payload" do
+        expect do
+          expect do
+            Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 })
+          end.not_to have_published_event("orders.created").with_payload("id" => 1)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+
+      it "passes when events exist but headers don't match" do
+        expect do
+          Pgbus::EventBus::Publisher.publish("orders.created", { "id" => 1 }, headers: { "x" => "a" })
+        end.not_to have_published_event("orders.created").with_headers("x" => "z")
       end
     end
   end

--- a/spec/pgbus/testing_spec.rb
+++ b/spec/pgbus/testing_spec.rb
@@ -179,6 +179,24 @@ RSpec.describe Pgbus::Testing do
         expect { store.drain! }.not_to raise_error
         expect(store.events).to be_empty
       end
+
+      it "preserves unprocessed events when a handler raises" do
+        failing_handler = Class.new(Pgbus::EventBus::Handler) do
+          def handle(_event)
+            raise "boom"
+          end
+        end
+        stub_const("TestFailingHandler", failing_handler)
+
+        Pgbus::EventBus::Registry.instance.subscribe("fail.me", failing_handler)
+        Pgbus::EventBus::Registry.instance.subscribe("orders.created", handler_class)
+
+        store.push_event(Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "fail.me"))
+        store.push_event(Pgbus::Event.new(event_id: "e2", payload: {}, routing_key: "orders.created"))
+
+        expect { store.drain! }.to raise_error(RuntimeError, "boom")
+        expect(store.events.map(&:event_id)).to eq(%w[e1 e2])
+      end
     end
   end
 end

--- a/spec/pgbus/testing_spec.rb
+++ b/spec/pgbus/testing_spec.rb
@@ -5,8 +5,8 @@ require "pgbus/testing"
 
 RSpec.describe Pgbus::Testing do
   after do
-    described_class.disabled!
-    described_class.store.clear!
+    Pgbus::Testing.disabled! # rubocop:disable RSpec/DescribedClass
+    Pgbus::Testing.store.clear! # rubocop:disable RSpec/DescribedClass
   end
 
   describe ".mode!" do
@@ -87,96 +87,98 @@ RSpec.describe Pgbus::Testing do
       expect(described_class.store).to equal(described_class.store)
     end
   end
-end
 
-RSpec.describe Pgbus::Testing::EventStore do
-  subject(:store) { described_class.new }
+  describe Pgbus::Testing::EventStore do
+    subject(:store) { described_class.new }
 
-  describe "#push_event" do
-    it "stores an event" do
-      event = Pgbus::Event.new(event_id: "e1", payload: { "a" => 1 }, routing_key: "orders.created")
-      store.push_event(event)
+    describe "#push_event" do
+      it "stores an event" do
+        event = Pgbus::Event.new(event_id: "e1", payload: { "a" => 1 }, routing_key: "orders.created")
+        store.push_event(event)
 
-      expect(store.events).to contain_exactly(event)
-    end
-  end
-
-  describe "#events" do
-    it "returns events filtered by routing_key" do
-      e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "orders.created")
-      e2 = Pgbus::Event.new(event_id: "e2", payload: {}, routing_key: "orders.shipped")
-      store.push_event(e1)
-      store.push_event(e2)
-
-      expect(store.events(routing_key: "orders.created")).to contain_exactly(e1)
+        expect(store.events).to contain_exactly(event)
+      end
     end
 
-    it "returns all events when no filter" do
-      e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "orders.created")
-      e2 = Pgbus::Event.new(event_id: "e2", payload: {}, routing_key: "orders.shipped")
-      store.push_event(e1)
-      store.push_event(e2)
+    describe "#events" do
+      it "returns events filtered by routing_key" do
+        e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "orders.created")
+        e2 = Pgbus::Event.new(event_id: "e2", payload: {}, routing_key: "orders.shipped")
+        store.push_event(e1)
+        store.push_event(e2)
 
-      expect(store.events).to contain_exactly(e1, e2)
+        expect(store.events(routing_key: "orders.created")).to contain_exactly(e1)
+      end
+
+      it "returns all events when no filter" do
+        e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "orders.created")
+        e2 = Pgbus::Event.new(event_id: "e2", payload: {}, routing_key: "orders.shipped")
+        store.push_event(e1)
+        store.push_event(e2)
+
+        expect(store.events).to contain_exactly(e1, e2)
+      end
+
+      it "returns a copy so mutations don't affect the store" do
+        e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "x")
+        store.push_event(e1)
+
+        store.events.clear
+        expect(store.events).to contain_exactly(e1)
+      end
     end
 
-    it "returns a copy so mutations don't affect the store" do
-      e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "x")
-      store.push_event(e1)
-
-      store.events.clear
-      expect(store.events).to contain_exactly(e1)
+    describe "#clear!" do
+      it "empties all events" do
+        store.push_event(Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "x"))
+        store.clear!
+        expect(store.events).to be_empty
+      end
     end
-  end
 
-  describe "#clear!" do
-    it "empties all events" do
-      store.push_event(Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "x"))
-      store.clear!
-      expect(store.events).to be_empty
-    end
-  end
+    describe "#drain!" do
+      let(:handler_class) do
+        klass = Class.new(Pgbus::EventBus::Handler) do
+          class << self
+            attr_accessor :handled_events
+          end
+          self.handled_events = []
 
-  describe "#drain!" do
-    let(:handler_class) do
-      Class.new(Pgbus::EventBus::Handler) do
-        class << self
-          attr_accessor :handled_events
+          def handle(event)
+            self.class.handled_events << event
+          end
         end
-        self.handled_events = []
+        stub_const("TestDrainHandler", klass)
+        klass
+      end
 
-        def handle(event)
-          self.class.handled_events << event
-        end
-      end.tap { |klass| stub_const("TestDrainHandler", klass) }
-    end
+      before do
+        Pgbus::EventBus::Registry.instance.clear!
+      end
 
-    before do
-      Pgbus::EventBus::Registry.instance.clear!
-    end
+      after do
+        Pgbus::EventBus::Registry.instance.clear!
+      end
 
-    after do
-      Pgbus::EventBus::Registry.instance.clear!
-    end
+      it "dispatches stored events to matching handlers and clears the store" do
+        Pgbus::EventBus::Registry.instance.subscribe("orders.created", handler_class)
 
-    it "dispatches stored events to matching handlers and clears the store" do
-      Pgbus::EventBus::Registry.instance.subscribe("orders.created", handler_class)
+        event = Pgbus::Event.new(event_id: "e1", payload: { "id" => 1 }, routing_key: "orders.created")
+        store.push_event(event)
+        store.drain!
 
-      event = Pgbus::Event.new(event_id: "e1", payload: { "id" => 1 }, routing_key: "orders.created")
-      store.push_event(event)
-      store.drain!
+        expect(handler_class.handled_events.size).to eq(1)
+        expect(handler_class.handled_events.first.event_id).to eq("e1")
+        expect(store.events).to be_empty
+      end
 
-      expect(handler_class.handled_events.size).to eq(1)
-      expect(handler_class.handled_events.first.event_id).to eq("e1")
-      expect(store.events).to be_empty
-    end
+      it "skips events with no matching handlers" do
+        event = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "no.match")
+        store.push_event(event)
 
-    it "skips events with no matching handlers" do
-      event = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "no.match")
-      store.push_event(event)
-
-      expect { store.drain! }.not_to raise_error
-      expect(store.events).to be_empty
+        expect { store.drain! }.not_to raise_error
+        expect(store.events).to be_empty
+      end
     end
   end
 end

--- a/spec/pgbus/testing_spec.rb
+++ b/spec/pgbus/testing_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pgbus/testing"
+
+RSpec.describe Pgbus::Testing do
+  after do
+    described_class.disabled!
+    described_class.store.clear!
+  end
+
+  describe ".mode!" do
+    it "sets global mode" do
+      described_class.mode!(:fake)
+      expect(described_class.mode).to eq(:fake)
+    end
+
+    it "rejects unknown modes" do
+      expect { described_class.mode!(:bogus) }.to raise_error(ArgumentError, /Unknown mode/)
+    end
+
+    it "scopes mode to block and restores afterward" do
+      described_class.mode!(:disabled)
+
+      described_class.mode!(:fake) do
+        expect(described_class.mode).to eq(:fake)
+      end
+
+      expect(described_class.mode).to eq(:disabled)
+    end
+
+    it "restores mode even when block raises" do
+      described_class.mode!(:disabled)
+
+      begin
+        described_class.mode!(:inline) { raise "boom" }
+      rescue RuntimeError
+        nil
+      end
+
+      expect(described_class.mode).to eq(:disabled)
+    end
+  end
+
+  describe ".fake!" do
+    it "sets mode to fake" do
+      described_class.fake!
+      expect(described_class).to be_fake
+    end
+
+    it "accepts a block" do
+      described_class.fake! do
+        expect(described_class).to be_fake
+      end
+      expect(described_class).not_to be_fake
+    end
+  end
+
+  describe ".inline!" do
+    it "sets mode to inline" do
+      described_class.inline!
+      expect(described_class).to be_inline
+    end
+
+    it "accepts a block" do
+      described_class.inline! do
+        expect(described_class).to be_inline
+      end
+      expect(described_class).not_to be_inline
+    end
+  end
+
+  describe ".disabled!" do
+    it "sets mode to disabled" do
+      described_class.fake!
+      described_class.disabled!
+      expect(described_class).to be_disabled
+    end
+  end
+
+  describe ".store" do
+    it "returns a EventStore instance" do
+      expect(described_class.store).to be_a(Pgbus::Testing::EventStore)
+    end
+
+    it "returns the same store across calls" do
+      expect(described_class.store).to equal(described_class.store)
+    end
+  end
+end
+
+RSpec.describe Pgbus::Testing::EventStore do
+  subject(:store) { described_class.new }
+
+  describe "#push_event" do
+    it "stores an event" do
+      event = Pgbus::Event.new(event_id: "e1", payload: { "a" => 1 }, routing_key: "orders.created")
+      store.push_event(event)
+
+      expect(store.events).to contain_exactly(event)
+    end
+  end
+
+  describe "#events" do
+    it "returns events filtered by routing_key" do
+      e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "orders.created")
+      e2 = Pgbus::Event.new(event_id: "e2", payload: {}, routing_key: "orders.shipped")
+      store.push_event(e1)
+      store.push_event(e2)
+
+      expect(store.events(routing_key: "orders.created")).to contain_exactly(e1)
+    end
+
+    it "returns all events when no filter" do
+      e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "orders.created")
+      e2 = Pgbus::Event.new(event_id: "e2", payload: {}, routing_key: "orders.shipped")
+      store.push_event(e1)
+      store.push_event(e2)
+
+      expect(store.events).to contain_exactly(e1, e2)
+    end
+
+    it "returns a copy so mutations don't affect the store" do
+      e1 = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "x")
+      store.push_event(e1)
+
+      store.events.clear
+      expect(store.events).to contain_exactly(e1)
+    end
+  end
+
+  describe "#clear!" do
+    it "empties all events" do
+      store.push_event(Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "x"))
+      store.clear!
+      expect(store.events).to be_empty
+    end
+  end
+
+  describe "#drain!" do
+    let(:handler_class) do
+      Class.new(Pgbus::EventBus::Handler) do
+        class << self
+          attr_accessor :handled_events
+        end
+        self.handled_events = []
+
+        def handle(event)
+          self.class.handled_events << event
+        end
+      end.tap { |klass| stub_const("TestDrainHandler", klass) }
+    end
+
+    before do
+      Pgbus::EventBus::Registry.instance.clear!
+    end
+
+    after do
+      Pgbus::EventBus::Registry.instance.clear!
+    end
+
+    it "dispatches stored events to matching handlers and clears the store" do
+      Pgbus::EventBus::Registry.instance.subscribe("orders.created", handler_class)
+
+      event = Pgbus::Event.new(event_id: "e1", payload: { "id" => 1 }, routing_key: "orders.created")
+      store.push_event(event)
+      store.drain!
+
+      expect(handler_class.handled_events.size).to eq(1)
+      expect(handler_class.handled_events.first.event_id).to eq("e1")
+      expect(store.events).to be_empty
+    end
+
+    it "skips events with no matching handlers" do
+      event = Pgbus::Event.new(event_id: "e1", payload: {}, routing_key: "no.match")
+      store.push_event(event)
+
+      expect { store.drain! }.not_to raise_error
+      expect(store.events).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds first-class test primitives for `Pgbus::EventBus`, solving the double-fire and monkey-patching problems described in #131.

- **`Pgbus::Testing`** — Core module with three modes (`fake`, `inline`, `disabled`) following Sidekiq's proven pattern. Thread-safe via `Thread.current` for block scope, `Thread.main` for global scope.
- **`Pgbus::Testing::EventStore`** — Thread-safe in-memory store for captured events with `push_event`, `events(routing_key:)`, `clear!`, and `drain!`.
- **`Pgbus::Testing::Assertions`** — Framework-agnostic helpers: `assert_pgbus_published`, `assert_no_pgbus_published`, `perform_published_events`, `pgbus_published_events`.
- **`Pgbus::Testing::RSpec`** — `have_published_event` matcher with `.with_payload`, `.with_headers`, `.exactly` chains. Auto-includes assertions.
- **`Pgbus::Testing::MinitestHelpers`** — Drop-in module with `before_setup` hook for automatic fake mode + store clearing.
- **Publisher hook** — `Publisher.publish` checks `defined?(Pgbus::Testing)` (zero cost in production) and intercepts in fake/inline mode.
- **Zeitwerk ignore** — `lib/pgbus/testing/` is ignored by the gem loader so test code never leaks into production.

### Usage

```ruby
# RSpec (spec_helper.rb or rails_helper.rb)
require "pgbus/testing/rspec"

RSpec.configure do |config|
  config.before { Pgbus::Testing.fake!; Pgbus::Testing.store.clear! }
end

# In specs:
expect { Order.create!(...) }
  .to have_published_event("orders.created")
  .with_payload(hash_including("order_id" => 1))

# Minitest (test_helper.rb)
require "pgbus/testing/minitest"

class ActiveSupport::TestCase
  include Pgbus::Testing::MinitestHelpers
end

# In tests:
assert_pgbus_published(count: 1, routing_key: "orders.created") do
  Order.create!(...)
end
```

Closes #131

## Test plan

- [x] 42 new specs covering all modules (core, event store, assertions, RSpec matchers, Minitest structure, publisher hook)
- [x] All 3 modes tested: fake captures without PGMQ, inline dispatches to handlers, disabled passes through
- [x] Block-scoped mode tested for thread safety and restore-on-exception
- [x] Full unit test suite passes (1666 examples, 0 new failures)
- [x] RuboCop clean on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add testing infrastructure to capture and inspect published events without broker interaction.
  * Introduce testing modes: fake (capture), inline (capture + run handlers synchronously), and disabled (normal publishing).
  * Add assertion helpers, Minitest integration, and an RSpec matcher for asserting published events.

* **Chore**
  * Configure loader to ignore test helper paths so test helpers aren’t autoloaded in production.

* **Tests**
  * Add comprehensive specs covering modes, store behavior, assertions, matcher, and publisher hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->