### PR TITLE
fix(streams): add streams_test_mode to prevent hijack DB connection leak in tests

### DIFF
--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -103,7 +103,7 @@ module Pgbus
                   :streams_default_retention, :streams_retention, :streams_heartbeat_interval,
                   :streams_max_connections, :streams_idle_timeout, :streams_listen_health_check_ms,
                   :streams_write_deadline_ms, :streams_falcon_streaming_body,
-                  :streams_stats_enabled
+                  :streams_stats_enabled, :streams_test_mode
 
     def initialize
       @database_url = nil
@@ -209,6 +209,7 @@ module Pgbus
       # gates pgbus_job_stats recording) on purpose — operators
       # usually want job stats on and stream stats off, or vice versa.
       @streams_stats_enabled = false
+      @streams_test_mode = false
     end
 
     def queue_name(name)

--- a/lib/pgbus/testing.rb
+++ b/lib/pgbus/testing.rb
@@ -80,7 +80,10 @@ module Pgbus
         Thread.current[MODE_KEY] = mode
         yield
       ensure
-        Thread.current[MODE_KEY] = old if block
+        if block
+          Thread.current[MODE_KEY] = old
+          sync_streams_test_mode!(old || :disabled)
+        end
       end
 
       def mode

--- a/lib/pgbus/testing.rb
+++ b/lib/pgbus/testing.rb
@@ -69,6 +69,8 @@ module Pgbus
       def mode!(mode, &block)
         raise ArgumentError, "Unknown mode: #{mode}. Valid modes: #{MODES.join(", ")}" unless MODES.include?(mode)
 
+        sync_streams_test_mode!(mode)
+
         unless block
           Thread.main[MODE_KEY] = mode
           return
@@ -94,6 +96,23 @@ module Pgbus
       def disabled? = mode == :disabled
 
       attr_reader :store
+
+      private
+
+      # When entering fake/inline mode, enable streams_test_mode to prevent
+      # rack.hijack from spawning background threads that acquire DB
+      # connections outside the test transaction (see issue #133). When
+      # returning to :disabled mode, restore the previous setting.
+      def sync_streams_test_mode!(mode)
+        return unless defined?(Pgbus.configuration)
+
+        if mode == :disabled
+          Pgbus.configuration.streams_test_mode = false
+          Pgbus::Web::Streamer.reset! if defined?(Pgbus::Web::Streamer)
+        else
+          Pgbus.configuration.streams_test_mode = true
+        end
+      end
     end
   end
 end

--- a/lib/pgbus/web/stream_app.rb
+++ b/lib/pgbus/web/stream_app.rb
@@ -62,6 +62,8 @@ module Pgbus
         cursor = parse_cursor(env, request)
         return bad_request("invalid cursor: #{cursor}") if cursor.is_a?(String)
 
+        return test_mode_stub if config.streams_test_mode
+
         return over_capacity if streamer.registry.size >= config.streams_max_connections
 
         if config.streams_falcon_streaming_body
@@ -209,6 +211,11 @@ module Pgbus
 
       def server_error
         [500, { "content-type" => "text/plain" }, ["pgbus: internal error"]]
+      end
+
+      def test_mode_stub
+        body = ": pgbus test mode — connection accepted, no polling\n\n"
+        [200, sse_headers, [body]]
       end
     end
   end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -1042,6 +1042,10 @@ RSpec.describe Pgbus::Configuration do
     it "does not opt into the Falcon streaming body code path by default" do
       expect(config.streams_falcon_streaming_body).to be false
     end
+
+    it "has streams_test_mode disabled by default" do
+      expect(config.streams_test_mode).to be false
+    end
   end
 
   describe "#validate! with streams settings" do

--- a/spec/pgbus/testing_spec.rb
+++ b/spec/pgbus/testing_spec.rb
@@ -97,10 +97,11 @@ RSpec.describe Pgbus::Testing do
       expect(Pgbus.configuration.streams_test_mode).to be false
     end
 
-    it "enables streams_test_mode inside a scoped block" do
+    it "enables streams_test_mode inside a scoped block and restores afterward" do
       described_class.fake! do
         expect(Pgbus.configuration.streams_test_mode).to be true
       end
+      expect(Pgbus.configuration.streams_test_mode).to be false
     end
   end
 

--- a/spec/pgbus/testing_spec.rb
+++ b/spec/pgbus/testing_spec.rb
@@ -78,6 +78,32 @@ RSpec.describe Pgbus::Testing do
     end
   end
 
+  describe "streams_test_mode sync" do
+    after { Pgbus.configuration.streams_test_mode = false }
+
+    it "enables streams_test_mode when entering fake mode" do
+      described_class.fake!
+      expect(Pgbus.configuration.streams_test_mode).to be true
+    end
+
+    it "enables streams_test_mode when entering inline mode" do
+      described_class.inline!
+      expect(Pgbus.configuration.streams_test_mode).to be true
+    end
+
+    it "disables streams_test_mode when entering disabled mode" do
+      Pgbus.configuration.streams_test_mode = true
+      described_class.disabled!
+      expect(Pgbus.configuration.streams_test_mode).to be false
+    end
+
+    it "enables streams_test_mode inside a scoped block" do
+      described_class.fake! do
+        expect(Pgbus.configuration.streams_test_mode).to be true
+      end
+    end
+  end
+
   describe ".store" do
     it "returns a EventStore instance" do
       expect(described_class.store).to be_a(Pgbus::Testing::EventStore)

--- a/spec/pgbus/web/stream_app_spec.rb
+++ b/spec/pgbus/web/stream_app_spec.rb
@@ -210,6 +210,80 @@ RSpec.describe Pgbus::Web::StreamApp do
     end
   end
 
+  describe "test mode (streams_test_mode)" do
+    before { Pgbus.configuration.streams_test_mode = true }
+    after { Pgbus.configuration.streams_test_mode = false }
+
+    it "returns 200 with SSE headers" do
+      env = get_env("/pgbus/streams/#{signed("chat")}")
+      status, headers, = app.call(env)
+      expect(status).to eq(200)
+      expect(headers["content-type"]).to eq("text/event-stream")
+      expect(headers["cache-control"]).to eq("no-cache, no-transform")
+      expect(headers["x-accel-buffering"]).to eq("no")
+    end
+
+    it "does not invoke rack.hijack" do
+      hijack_called = false
+      env = get_env(
+        "/pgbus/streams/#{signed("chat")}",
+        "rack.hijack?" => true,
+        "rack.hijack" => lambda {
+          hijack_called = true
+          StringIO.new
+        }
+      )
+      app.call(env)
+      expect(hijack_called).to be false
+    end
+
+    it "does not register any connection with the streamer" do
+      env = get_env("/pgbus/streams/#{signed("chat")}", "rack.hijack?" => true)
+      app.call(env)
+      expect(streamer.registered).to be_empty
+    end
+
+    it "returns a body containing a stub SSE comment" do
+      env = get_env("/pgbus/streams/#{signed("chat")}")
+      _, _, body = app.call(env)
+      joined = body.join
+      expect(joined).to include(": pgbus test mode")
+    end
+
+    it "still validates the signed stream name" do
+      env = get_env("/pgbus/streams/not-a-valid-token")
+      status, = app.call(env)
+      expect(status).to eq(404)
+    end
+
+    it "still runs the authorize hook" do
+      restricted = described_class.new(
+        streamer: streamer,
+        config: Pgbus.configuration,
+        logger: Logger.new(IO::NULL),
+        authorize: ->(_env, _name) { false }
+      )
+      env = get_env("/pgbus/streams/#{signed("chat")}")
+      status, = restricted.call(env)
+      expect(status).to eq(403)
+    end
+
+    it "takes priority over both hijack and Falcon streaming body" do
+      Pgbus.configuration.streams_falcon_streaming_body = true
+      env = get_env(
+        "/pgbus/streams/#{signed("chat")}",
+        "rack.hijack?" => true
+      )
+      status, _, body = app.call(env)
+      expect(status).to eq(200)
+      # Body should be a plain Array, not a Writable
+      expect(body).to be_a(Array)
+      expect(body.first).to include(": pgbus test mode")
+    ensure
+      Pgbus.configuration.streams_falcon_streaming_body = false
+    end
+  end
+
   describe "Falcon streaming body path" do
     before { Pgbus.configuration.streams_falcon_streaming_body = true }
     after { Pgbus.configuration.streams_falcon_streaming_body = false }


### PR DESCRIPTION
## Summary

- Add `streams_test_mode` configuration option (default `false`) that makes `StreamApp` return a stub SSE response without `rack.hijack` or background threads
- Integrate with `Pgbus::Testing` — entering `fake!`/`inline!` mode auto-enables `streams_test_mode`; `disabled!` restores it
- Stub response returns valid SSE headers + comment line + immediate close — enough for `<pgbus-stream-source>` to render without spawning DB connections outside the test transaction

Closes #133

## Root Cause

When `use_transactional_fixtures = true`, `rack.hijack` spawns a background thread per SSE connection that acquires its own DB connection from the pool. This connection is outside the test transaction (transactional isolation), cannot see uncommitted test data, and may not be returned cleanly on disconnect — eventually exhausting the pool and deadlocking CI.

## Design

Option A from the issue: `streams_test_mode` configuration. When enabled, the `StreamApp` short-circuits after auth/validation checks but before any hijack, streaming body, or capacity logic:

```ruby
# StreamApp#call — after verify + authorize + parse cursor
return test_mode_stub if config.streams_test_mode
```

The stub returns `[200, sse_headers, [": pgbus test mode...\n\n"]]` — a plain Rack response. No `Streamer.current` is accessed (no threads, no PG connection, no registry).

### Integration with `Pgbus::Testing` (#132)

`Pgbus::Testing.fake!` and `.inline!` now also set `streams_test_mode = true`. Users who already `require "pgbus/testing"` get SSE test safety for free. Users who don't use EventBus testing can set it directly:

```ruby
Pgbus.configure { |c| c.streams_test_mode = true }
```

## Test plan

- [ ] `streams_test_mode` defaults to `false` (configuration_spec)
- [ ] Test mode returns 200 with SSE headers, no hijack, no streamer registration (stream_app_spec × 7 examples)
- [ ] Test mode still validates signed names and runs authorize hooks
- [ ] Test mode takes priority over both hijack and Falcon streaming body paths
- [ ] `Pgbus::Testing.fake!` enables `streams_test_mode` (testing_spec)
- [ ] `Pgbus::Testing.inline!` enables `streams_test_mode` (testing_spec)
- [ ] `Pgbus::Testing.disabled!` disables `streams_test_mode` (testing_spec)
- [ ] Scoped block mode enables `streams_test_mode` within the block (testing_spec)
- [ ] Full non-system test suite passes (1777 examples, 0 failures)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a configurable stream test mode that returns a minimal test response instead of establishing live streaming
  - Test mode state automatically synchronizes with test-mode toggles
  - Stream endpoints continue to validate requests and enforce authorization while in test mode

* **Tests**
  - Added comprehensive tests covering test-mode responses, synchronization behavior, validation, and authorization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->