### PR TITLE
fix(event_bus): embed routing_key in Publisher message body

### DIFF
--- a/lib/pgbus/event_bus/publisher.rb
+++ b/lib/pgbus/event_bus/publisher.rb
@@ -8,7 +8,7 @@ module Pgbus
       module_function
 
       def publish(routing_key, payload, headers: nil, delay: 0)
-        event_data = build_event_data(payload)
+        event_data = build_event_data(payload, routing_key: routing_key)
 
         if defined?(Pgbus::Testing) && !Pgbus::Testing.disabled?
           event = Pgbus::Event.new(
@@ -37,7 +37,7 @@ module Pgbus
         publish(routing_key, payload, headers: headers, delay: delay)
       end
 
-      def build_event_data(payload)
+      def build_event_data(payload, routing_key: nil)
         event_id = SecureRandom.uuid
 
         serialized_payload = if payload.respond_to?(:to_global_id)
@@ -48,11 +48,13 @@ module Pgbus
                                { "value" => payload }
                              end
 
-        {
+        data = {
           "event_id" => event_id,
           "payload" => serialized_payload,
           "published_at" => Time.now.utc.iso8601(6)
         }
+        data["routing_key"] = routing_key if routing_key
+        data
       end
     end
   end

--- a/spec/pgbus/event_bus/publisher_spec.rb
+++ b/spec/pgbus/event_bus/publisher_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Pgbus::EventBus::Publisher do
 
       expect(mock_client).to have_received(:publish_to_topic).with(
         "orders.created",
-        hash_including("event_id" => a_kind_of(String), "payload" => { "order_id" => 1 }),
+        hash_including("event_id" => a_kind_of(String), "payload" => { "order_id" => 1 },
+                       "routing_key" => "orders.created"),
         headers: nil,
         delay: 0
       )
@@ -78,6 +79,18 @@ RSpec.describe Pgbus::EventBus::Publisher do
 
       expect(result).to include("event_id" => a_kind_of(String), "published_at" => a_kind_of(String))
       expect(result["payload"]).to eq("foo" => "bar")
+    end
+
+    it "includes routing_key when provided" do
+      result = described_class.build_event_data({ "foo" => "bar" }, routing_key: "orders.created")
+
+      expect(result["routing_key"]).to eq("orders.created")
+    end
+
+    it "omits routing_key when not provided" do
+      result = described_class.build_event_data({ "foo" => "bar" })
+
+      expect(result).not_to have_key("routing_key")
     end
 
     it "wraps GlobalID-capable payloads with _global_id key" do

--- a/spec/pgbus/process/consumer_spec.rb
+++ b/spec/pgbus/process/consumer_spec.rb
@@ -104,6 +104,23 @@ RSpec.describe Pgbus::Process::Consumer do
 
       expect { consumer.send(:handle_message, message, "q_orders") }.not_to raise_error
     end
+
+    context "when routing_key is in the message body (not headers)" do
+      let(:message_body) { JSON.generate("routing_key" => "orders.shipped", "payload" => { "id" => 99 }) }
+      let(:message) { build_message_double(msg_id: 8, message: message_body) }
+
+      before do
+        allow(registry).to receive(:handlers_for).with("orders.shipped").and_return([matching_subscriber])
+      end
+
+      it "extracts routing_key from the top-level body field" do
+        consumer.send(:handle_message, message, "q_orders")
+
+        expect(registry).to have_received(:handlers_for).with("orders.shipped")
+        expect(handler_instance).to have_received(:process).with(message)
+        expect(mock_client).to have_received(:archive_message).with("q_orders", 8)
+      end
+    end
   end
 
   describe "fetch_multi_consumer (private)" do


### PR DESCRIPTION
## Summary

- `Publisher#build_event_data` now accepts an optional `routing_key:` keyword and embeds it in the serialized message body
- `Publisher#publish` passes the `routing_key` through to `build_event_data`
- Consumer already reads `raw["routing_key"]` from the body — no consumer changes needed

Without this fix, the Consumer could never extract the routing key from the message body, so `handlers_for("")` only matched wildcard `#` handlers. Specific-pattern handlers (e.g. `orders.created`) were silently never dispatched.

Closes #136

## Test plan

- [x] `build_event_data` includes `routing_key` when provided
- [x] `build_event_data` omits `routing_key` when not provided (backwards compat)
- [x] `publish` embeds `routing_key` in the event_data sent to `publish_to_topic`
- [x] Consumer extracts `routing_key` from top-level body field
- [x] All existing publisher, consumer, and testing hook specs pass
- [x] RuboCop clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events published through the event bus now include routing context information in their serialized payload data.

* **Tests**
  * Added test coverage for consumers to handle routing information extracted directly from message payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->