### PR TITLE
feat(events): pending event management — discard, edit, reroute, mark handled

### DIFF
--- a/app/controllers/pgbus/events_controller.rb
+++ b/app/controllers/pgbus/events_controller.rb
@@ -72,15 +72,24 @@ module Pgbus
     end
 
     def discard_selected
-      selections = Array(params[:messages]).reject { |s| s[:queue_name].blank? || s[:msg_id].blank? }
+      # Guard against non-hash entries in params[:messages] — a crafted POST
+      # can otherwise raise NoMethodError on [:queue_name]. Mirrors the
+      # hardening already used in jobs_controller#discard_selected_enqueued.
+      selections = Array(params[:messages]).filter_map do |s|
+        next unless s.respond_to?(:[])
+
+        queue_name = s[:queue_name]
+        msg_id = s[:msg_id]
+        next if queue_name.blank? || msg_id.blank?
+
+        { queue_name: queue_name.to_s, msg_id: msg_id }
+      end
       if selections.empty?
         redirect_to events_path, alert: t("pgbus.events.flash.none_selected")
         return
       end
 
-      count = data_source.discard_selected_events(
-        selections.map { |s| { queue_name: s[:queue_name].to_s, msg_id: s[:msg_id] } }
-      )
+      count = data_source.discard_selected_events(selections)
       redirect_to events_path, notice: t("pgbus.events.flash.discarded_selected", count: count)
     end
   end

--- a/app/controllers/pgbus/events_controller.rb
+++ b/app/controllers/pgbus/events_controller.rb
@@ -23,6 +23,8 @@ module Pgbus
 
     def discard
       queue_name = params[:queue_name].to_s
+      return reject_unknown_queue(:discard_failed) unless registered_queue?(queue_name)
+
       if data_source.discard_event(queue_name, params[:id])
         redirect_to events_path, notice: t("pgbus.events.flash.discarded")
       else
@@ -32,6 +34,8 @@ module Pgbus
 
     def mark_handled
       queue_name = params[:queue_name].to_s
+      return reject_unknown_queue(:mark_handled_failed) unless registered_queue?(queue_name)
+
       # Resolve the handler class server-side from the subscriber registry
       # instead of trusting params[:handler_class] — otherwise a crafted POST
       # could create ProcessedEvent markers for arbitrary class names and
@@ -46,6 +50,8 @@ module Pgbus
 
     def edit_payload
       queue_name = params[:queue_name].to_s
+      return reject_unknown_queue(:payload_update_failed) unless registered_queue?(queue_name)
+
       new_payload = params[:payload].to_s
       if data_source.edit_event_payload(queue_name, params[:id], new_payload)
         redirect_to events_path, notice: t("pgbus.events.flash.payload_updated")
@@ -57,12 +63,11 @@ module Pgbus
     def reroute
       source_queue = params[:queue_name].to_s
       target_queue = params[:target_queue].to_s
-      # Reject rerouting to any queue that isn't a registered handler —
+      # Reject rerouting to/from any queue that isn't a registered handler —
       # the UI dropdown is not a real server-side constraint, so a crafted
-      # POST could otherwise move messages into arbitrary queues.
-      unless data_source.handler_queue_physical_names.include?(target_queue)
-        return redirect_to events_path, alert: t("pgbus.events.flash.reroute_failed")
-      end
+      # POST could otherwise touch arbitrary queues.
+      allowed = registered_queue?(source_queue) && registered_queue?(target_queue)
+      return reject_unknown_queue(:reroute_failed) unless allowed
 
       if data_source.reroute_event(source_queue, params[:id], target_queue)
         redirect_to events_path, notice: t("pgbus.events.flash.rerouted")
@@ -75,12 +80,16 @@ module Pgbus
       # Guard against non-hash entries in params[:messages] — a crafted POST
       # can otherwise raise NoMethodError on [:queue_name]. Mirrors the
       # hardening already used in jobs_controller#discard_selected_enqueued.
+      # Also whitelist queue_name per selection so operators can't archive
+      # arbitrary non-handler queues through this endpoint.
+      allowed = registered_queues
       selections = Array(params[:messages]).filter_map do |s|
         next unless s.respond_to?(:[])
 
         queue_name = s[:queue_name]
         msg_id = s[:msg_id]
         next if queue_name.blank? || msg_id.blank?
+        next unless allowed.include?(queue_name.to_s)
 
         { queue_name: queue_name.to_s, msg_id: msg_id }
       end
@@ -91,6 +100,20 @@ module Pgbus
 
       count = data_source.discard_selected_events(selections)
       redirect_to events_path, notice: t("pgbus.events.flash.discarded_selected", count: count)
+    end
+
+    private
+
+    def registered_queues
+      @registered_queues ||= data_source.handler_queue_physical_names
+    end
+
+    def registered_queue?(name)
+      registered_queues.include?(name)
+    end
+
+    def reject_unknown_queue(flash_key)
+      redirect_to events_path, alert: t("pgbus.events.flash.#{flash_key}")
     end
   end
 end

--- a/app/controllers/pgbus/events_controller.rb
+++ b/app/controllers/pgbus/events_controller.rb
@@ -32,8 +32,12 @@ module Pgbus
 
     def mark_handled
       queue_name = params[:queue_name].to_s
-      handler_class = params[:handler_class].to_s
-      if data_source.mark_event_handled(queue_name, params[:id], handler_class)
+      # Resolve the handler class server-side from the subscriber registry
+      # instead of trusting params[:handler_class] — otherwise a crafted POST
+      # could create ProcessedEvent markers for arbitrary class names and
+      # corrupt replay/idempotency state.
+      handler_class = data_source.handler_class_for_queue(queue_name)
+      if handler_class && data_source.mark_event_handled(queue_name, params[:id], handler_class)
         redirect_to events_path, notice: t("pgbus.events.flash.marked_handled")
       else
         redirect_to events_path, alert: t("pgbus.events.flash.mark_handled_failed")
@@ -53,6 +57,13 @@ module Pgbus
     def reroute
       source_queue = params[:queue_name].to_s
       target_queue = params[:target_queue].to_s
+      # Reject rerouting to any queue that isn't a registered handler —
+      # the UI dropdown is not a real server-side constraint, so a crafted
+      # POST could otherwise move messages into arbitrary queues.
+      unless data_source.handler_queue_physical_names.include?(target_queue)
+        return redirect_to events_path, alert: t("pgbus.events.flash.reroute_failed")
+      end
+
       if data_source.reroute_event(source_queue, params[:id], target_queue)
         redirect_to events_path, notice: t("pgbus.events.flash.rerouted")
       else

--- a/app/controllers/pgbus/events_controller.rb
+++ b/app/controllers/pgbus/events_controller.rb
@@ -5,6 +5,7 @@ module Pgbus
     def index
       @events = data_source.processed_events(page: page_param, per_page: per_page)
       @subscribers = data_source.registered_subscribers
+      @pending = data_source.pending_events(page: page_param, per_page: per_page)
     end
 
     def show
@@ -14,10 +15,62 @@ module Pgbus
     def replay
       event = data_source.processed_event(params[:id])
       if event && data_source.replay_event(event)
-        redirect_to events_path, notice: "Event replayed."
+        redirect_to events_path, notice: t("pgbus.events.flash.replayed")
       else
-        redirect_to events_path, alert: "Event not found or could not be replayed."
+        redirect_to events_path, alert: t("pgbus.events.flash.replay_failed")
       end
+    end
+
+    def discard
+      queue_name = params[:queue_name].to_s
+      if data_source.discard_event(queue_name, params[:id])
+        redirect_to events_path, notice: t("pgbus.events.flash.discarded")
+      else
+        redirect_to events_path, alert: t("pgbus.events.flash.discard_failed")
+      end
+    end
+
+    def mark_handled
+      queue_name = params[:queue_name].to_s
+      handler_class = params[:handler_class].to_s
+      if data_source.mark_event_handled(queue_name, params[:id], handler_class)
+        redirect_to events_path, notice: t("pgbus.events.flash.marked_handled")
+      else
+        redirect_to events_path, alert: t("pgbus.events.flash.mark_handled_failed")
+      end
+    end
+
+    def edit_payload
+      queue_name = params[:queue_name].to_s
+      new_payload = params[:payload].to_s
+      if data_source.edit_event_payload(queue_name, params[:id], new_payload)
+        redirect_to events_path, notice: t("pgbus.events.flash.payload_updated")
+      else
+        redirect_to events_path, alert: t("pgbus.events.flash.payload_update_failed")
+      end
+    end
+
+    def reroute
+      source_queue = params[:queue_name].to_s
+      target_queue = params[:target_queue].to_s
+      if data_source.reroute_event(source_queue, params[:id], target_queue)
+        redirect_to events_path, notice: t("pgbus.events.flash.rerouted")
+      else
+        redirect_to events_path, alert: t("pgbus.events.flash.reroute_failed")
+      end
+    end
+
+    def discard_selected
+      selections = Array(params[:messages]).reject { |s| s[:queue_name].blank? || s[:msg_id].blank? }
+      if selections.empty?
+        redirect_to events_path, alert: t("pgbus.events.flash.none_selected")
+        return
+      end
+
+      count = data_source.discard_selected_events(
+        selections.map { |s| { queue_name: s[:queue_name].to_s, msg_id: s[:msg_id] } }
+      )
+      redirect_to events_path, notice: t("pgbus.events.flash.discarded_selected", count: count)
     end
   end
 end

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -96,13 +96,6 @@ module Pgbus
       {}
     end
 
-    def handler_for_queue(queue_name)
-      return "" unless defined?(@subscribers) && @subscribers
-
-      sub = @subscribers.find { |s| s[:queue_name] == queue_name }
-      sub ? sub[:handler_class] : ""
-    end
-
     def pgbus_json_preview(json_string, max_length: 120)
       return "—" unless json_string
 

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -96,6 +96,13 @@ module Pgbus
       {}
     end
 
+    def handler_for_queue(queue_name)
+      return "" unless defined?(@subscribers) && @subscribers
+
+      sub = @subscribers.find { |s| s[:queue_name] == queue_name }
+      sub ? sub[:handler_class] : ""
+    end
+
     def pgbus_json_preview(json_string, max_length: 120)
       return "—" unless json_string
 

--- a/app/views/pgbus/events/_pending_table.html.erb
+++ b/app/views/pgbus/events/_pending_table.html.erb
@@ -46,9 +46,10 @@
                   <div class="flex items-center justify-between mt-3 mb-3">
                     <span class="text-xs font-mono text-gray-400"><%= t("pgbus.events.pending_table.event_id") %> <%= payload["event_id"] %></span>
                     <div class="flex space-x-2">
-                      <%# Mark Handled %>
+                      <%# Mark Handled — handler_class is resolved server-side
+                          from the subscriber registry, so we only send queue_name. %>
                       <%= button_to t("pgbus.events.pending_table.mark_handled"),
-                            pgbus.mark_handled_event_path(m[:msg_id], queue_name: m[:queue_name], handler_class: handler_for_queue(m[:queue_name])),
+                            pgbus.mark_handled_event_path(m[:msg_id], queue_name: m[:queue_name]),
                             method: :post,
                             class: "rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-500",
                             data: { turbo_confirm: t("pgbus.events.pending_table.mark_handled_confirm"), turbo_frame: "_top" } %>
@@ -60,9 +61,9 @@
                         <div class="absolute right-0 z-10 mt-1 w-64 rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700 p-2">
                           <p class="text-xs text-gray-500 mb-2"><%= t("pgbus.events.pending_table.reroute_label") %></p>
                           <% @subscribers.each do |s| %>
-                            <% next if s[:queue_name] == m[:queue_name] %>
+                            <% next if s[:physical_queue_name] == m[:queue_name] %>
                             <%= button_to s[:handler_class],
-                                  pgbus.reroute_event_path(m[:msg_id], queue_name: m[:queue_name], target_queue: s[:queue_name]),
+                                  pgbus.reroute_event_path(m[:msg_id], queue_name: m[:queue_name], target_queue: s[:physical_queue_name]),
                                   method: :post,
                                   class: "block w-full text-left rounded px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700",
                                   data: { turbo_confirm: t("pgbus.events.pending_table.reroute_confirm"), turbo_frame: "_top" } %>
@@ -128,7 +129,9 @@
           </tr>
         <% end %>
         <% if @pending.empty? %>
-          <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.events.index.pending_empty") %></td></tr>
+          <%# Header only renders the bulk-select column when rows are present,
+              so the empty-state colspan must match (5 without, 6 with). %>
+          <tr><td colspan="5" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.events.index.pending_empty") %></td></tr>
         <% end %>
       </tbody>
     </table>

--- a/app/views/pgbus/events/_pending_table.html.erb
+++ b/app/views/pgbus/events/_pending_table.html.erb
@@ -23,7 +23,12 @@
       </thead>
       <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
         <% @pending.each do |m| %>
+          <%# Preserve the raw message so corrupt payloads stay visible in the
+              edit textarea and full-JSON panel. pgbus_parse_message swallows
+              JSON::ParserError and returns {}, which would otherwise hide
+              exactly the data the operator is trying to inspect/repair. %>
           <% payload = pgbus_parse_message(m[:message]) %>
+          <% parse_ok = m[:message].blank? || payload != {} || m[:message].to_s.strip == "{}" %>
           <tr>
             <td class="w-10 px-4 py-3 align-top">
               <input type="checkbox" data-bulk-item data-pgbus-action="bulk-row-toggle"
@@ -82,7 +87,7 @@
                   <div class="grid grid-cols-2 gap-4 mb-3">
                     <div>
                       <span class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.arguments") %></span>
-                      <pre class="text-xs text-gray-700 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-40"><%= JSON.pretty_generate(payload["payload"] || payload) rescue "—" %></pre>
+                      <pre class="text-xs text-gray-700 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-40"><%= parse_ok ? (JSON.pretty_generate(payload["payload"] || payload) rescue "—") : m[:message] %></pre>
                     </div>
                     <div>
                       <span class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.metadata") %></span>
@@ -101,7 +106,7 @@
                         <%= hidden_field_tag :queue_name, m[:queue_name] %>
                         <label class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.edit_payload_label") %></label>
                         <textarea name="payload" rows="6"
-                                  class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white text-xs font-mono shadow-sm focus:border-indigo-500 focus:ring-indigo-500"><%= JSON.pretty_generate(payload) rescue m[:message] %></textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white text-xs font-mono shadow-sm focus:border-indigo-500 focus:ring-indigo-500"><%= parse_ok ? (JSON.pretty_generate(payload) rescue m[:message]) : m[:message] %></textarea>
                         <div class="mt-2 flex justify-end">
                           <button type="submit"
                                   class="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500"
@@ -115,7 +120,7 @@
                   <%# Full JSON %>
                   <details class="mt-2">
                     <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700"><%= t("pgbus.events.pending_table.full_json_payload") %></summary>
-                    <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-96"><%= JSON.pretty_generate(payload) rescue m[:message] %></pre>
+                    <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-96"><%= parse_ok ? (JSON.pretty_generate(payload) rescue m[:message]) : m[:message] %></pre>
                   </details>
                   <% if m[:headers] %>
                     <details class="mt-2">

--- a/app/views/pgbus/events/_pending_table.html.erb
+++ b/app/views/pgbus/events/_pending_table.html.erb
@@ -1,0 +1,136 @@
+<turbo-frame id="pending-events">
+  <%# Bulk form outside table to avoid nested form issues %>
+  <form id="bulk-discard-events-form" action="<%= pgbus.discard_selected_events_path %>" method="post" data-turbo-frame="_top" class="hidden">
+    <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+  </form>
+  <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700" data-bulk-scope="events">
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <thead class="bg-gray-50 dark:bg-gray-900">
+        <tr>
+          <% if @pending.any? %>
+            <th class="w-10 px-4 py-3">
+              <input type="checkbox" data-bulk-select-all
+                     aria-label="<%= t("pgbus.helpers.bulk_select_all") %>"
+                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
+            </th>
+          <% end %>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.events.index.pending_headers.id") %></th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.events.index.pending_headers.routing_key") %></th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.events.index.pending_headers.handler_queue") %></th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.events.index.pending_headers.enqueued") %></th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500"><%= t("pgbus.events.index.pending_headers.reads") %></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+        <% @pending.each do |m| %>
+          <% payload = pgbus_parse_message(m[:message]) %>
+          <tr>
+            <td class="w-10 px-4 py-3 align-top">
+              <input type="checkbox" data-bulk-item data-pgbus-action="bulk-row-toggle"
+                     aria-label="<%= t("pgbus.helpers.bulk_select_row", id: m[:msg_id]) %>"
+                     data-queue-name="<%= m[:queue_name] %>" data-msg-id="<%= m[:msg_id] %>"
+                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 mt-1">
+              <input type="hidden" name="messages[][queue_name]" value="<%= m[:queue_name] %>" form="bulk-discard-events-form" disabled>
+              <input type="hidden" name="messages[][msg_id]" value="<%= m[:msg_id] %>" form="bulk-discard-events-form" disabled>
+            </td>
+            <td colspan="5" class="p-0">
+              <details class="group">
+                <summary class="flex cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-900 list-none">
+                  <span class="w-16 shrink-0 px-4 py-3 text-sm font-mono text-gray-900 dark:text-white"><%= m[:msg_id] %></span>
+                  <span class="flex-1 px-4 py-3 text-sm font-mono text-indigo-600 truncate"><%= payload["routing_key"] || payload["event_id"] || "—" %></span>
+                  <span class="w-40 shrink-0 px-4 py-3 text-sm text-gray-700"><%= m[:queue_name] %></span>
+                  <span class="w-28 shrink-0 px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(m[:enqueued_at]) %></span>
+                  <span class="w-16 shrink-0 px-4 py-3 text-sm text-gray-500"><%= m[:read_ct] %></span>
+                </summary>
+                <div class="px-4 pb-4 bg-gray-50 dark:bg-gray-900 border-t border-gray-100">
+                  <div class="flex items-center justify-between mt-3 mb-3">
+                    <span class="text-xs font-mono text-gray-400"><%= t("pgbus.events.pending_table.event_id") %> <%= payload["event_id"] %></span>
+                    <div class="flex space-x-2">
+                      <%# Mark Handled %>
+                      <%= button_to t("pgbus.events.pending_table.mark_handled"),
+                            pgbus.mark_handled_event_path(m[:msg_id], queue_name: m[:queue_name], handler_class: handler_for_queue(m[:queue_name])),
+                            method: :post,
+                            class: "rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-500",
+                            data: { turbo_confirm: t("pgbus.events.pending_table.mark_handled_confirm"), turbo_frame: "_top" } %>
+                      <%# Reroute — dropdown with available handlers %>
+                      <details class="relative inline-block">
+                        <summary class="rounded-md bg-yellow-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-yellow-500 cursor-pointer list-none">
+                          <%= t("pgbus.events.pending_table.reroute") %>
+                        </summary>
+                        <div class="absolute right-0 z-10 mt-1 w-64 rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700 p-2">
+                          <p class="text-xs text-gray-500 mb-2"><%= t("pgbus.events.pending_table.reroute_label") %></p>
+                          <% @subscribers.each do |s| %>
+                            <% next if s[:queue_name] == m[:queue_name] %>
+                            <%= button_to s[:handler_class],
+                                  pgbus.reroute_event_path(m[:msg_id], queue_name: m[:queue_name], target_queue: s[:queue_name]),
+                                  method: :post,
+                                  class: "block w-full text-left rounded px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700",
+                                  data: { turbo_confirm: t("pgbus.events.pending_table.reroute_confirm"), turbo_frame: "_top" } %>
+                          <% end %>
+                        </div>
+                      </details>
+                      <%# Discard %>
+                      <%= button_to t("pgbus.events.pending_table.discard"),
+                            pgbus.discard_event_path(m[:msg_id], queue_name: m[:queue_name]),
+                            method: :post,
+                            class: "rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-500",
+                            data: { turbo_confirm: t("pgbus.events.pending_table.discard_confirm"), turbo_frame: "_top" } %>
+                    </div>
+                  </div>
+                  <%# Payload display %>
+                  <div class="grid grid-cols-2 gap-4 mb-3">
+                    <div>
+                      <span class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.arguments") %></span>
+                      <pre class="text-xs text-gray-700 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-40"><%= JSON.pretty_generate(payload["payload"] || payload) rescue "—" %></pre>
+                    </div>
+                    <div>
+                      <span class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.metadata") %></span>
+                      <div class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 space-y-1">
+                        <% if m[:read_ct] %><p><strong><%= t("pgbus.events.pending_table.metadata_labels.read_count") %></strong> <%= m[:read_ct] %></p><% end %>
+                        <% if m[:vt] %><p><strong><%= t("pgbus.events.pending_table.metadata_labels.visible_at") %></strong> <%= m[:vt] %></p><% end %>
+                        <% if m[:last_read_at] %><p><strong><%= t("pgbus.events.pending_table.metadata_labels.last_read") %></strong> <%= m[:last_read_at] %></p><% end %>
+                      </div>
+                    </div>
+                  </div>
+                  <%# Edit Payload form %>
+                  <details class="mt-2">
+                    <summary class="text-xs font-medium text-indigo-600 cursor-pointer hover:text-indigo-500"><%= t("pgbus.events.pending_table.edit_payload") %></summary>
+                    <div class="mt-2 p-3 bg-white dark:bg-gray-800 rounded ring-1 ring-gray-200 dark:ring-gray-700">
+                      <%= form_with url: pgbus.edit_payload_event_path(m[:msg_id]), method: :post, local: true, data: { turbo_frame: "_top" } do |f| %>
+                        <%= hidden_field_tag :queue_name, m[:queue_name] %>
+                        <label class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.edit_payload_label") %></label>
+                        <textarea name="payload" rows="6"
+                                  class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white text-xs font-mono shadow-sm focus:border-indigo-500 focus:ring-indigo-500"><%= JSON.pretty_generate(payload) rescue m[:message] %></textarea>
+                        <div class="mt-2 flex justify-end">
+                          <button type="submit"
+                                  class="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500"
+                                  data-turbo-confirm="<%= t("pgbus.events.pending_table.edit_payload_confirm") %>">
+                            <%= t("pgbus.events.pending_table.edit_payload") %>
+                          </button>
+                        </div>
+                      <% end %>
+                    </div>
+                  </details>
+                  <%# Full JSON %>
+                  <details class="mt-2">
+                    <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700"><%= t("pgbus.events.pending_table.full_json_payload") %></summary>
+                    <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-96"><%= JSON.pretty_generate(payload) rescue m[:message] %></pre>
+                  </details>
+                  <% if m[:headers] %>
+                    <details class="mt-2">
+                      <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700"><%= t("pgbus.events.pending_table.headers_section") %></summary>
+                      <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto"><%= JSON.pretty_generate(JSON.parse(m[:headers])) rescue m[:headers] %></pre>
+                    </details>
+                  <% end %>
+                </div>
+              </details>
+            </td>
+          </tr>
+        <% end %>
+        <% if @pending.empty? %>
+          <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400"><%= t("pgbus.events.index.pending_empty") %></td></tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</turbo-frame>

--- a/app/views/pgbus/events/_pending_table.html.erb
+++ b/app/views/pgbus/events/_pending_table.html.erb
@@ -26,9 +26,13 @@
           <%# Preserve the raw message so corrupt payloads stay visible in the
               edit textarea and full-JSON panel. pgbus_parse_message swallows
               JSON::ParserError and returns {}, which would otherwise hide
-              exactly the data the operator is trying to inspect/repair. %>
-          <% payload = pgbus_parse_message(m[:message]) %>
-          <% parse_ok = m[:message].blank? || payload != {} || m[:message].to_s.strip == "{}" %>
+              exactly the data the operator is trying to inspect/repair.
+              Also coerce scalar JSON values (numbers, booleans, nil, arrays)
+              to {} for hash-style access below — otherwise payload["foo"]
+              raises NoMethodError. %>
+          <% payload_raw = pgbus_parse_message(m[:message]) %>
+          <% payload = payload_raw.is_a?(Hash) ? payload_raw : {} %>
+          <% parse_ok = m[:message].blank? || payload_raw != {} || m[:message].to_s.strip == "{}" %>
           <tr>
             <td class="w-10 px-4 py-3 align-top">
               <input type="checkbox" data-bulk-item data-pgbus-action="bulk-row-toggle"
@@ -87,7 +91,7 @@
                   <div class="grid grid-cols-2 gap-4 mb-3">
                     <div>
                       <span class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.arguments") %></span>
-                      <pre class="text-xs text-gray-700 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-40"><%= parse_ok ? (JSON.pretty_generate(payload["payload"] || payload) rescue "—") : m[:message] %></pre>
+                      <pre class="text-xs text-gray-700 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-40"><%= parse_ok ? (JSON.pretty_generate(payload["payload"] || payload_raw) rescue "—") : m[:message] %></pre>
                     </div>
                     <div>
                       <span class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.metadata") %></span>
@@ -106,7 +110,7 @@
                         <%= hidden_field_tag :queue_name, m[:queue_name] %>
                         <label class="text-xs font-medium text-gray-500"><%= t("pgbus.events.pending_table.edit_payload_label") %></label>
                         <textarea name="payload" rows="6"
-                                  class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white text-xs font-mono shadow-sm focus:border-indigo-500 focus:ring-indigo-500"><%= parse_ok ? (JSON.pretty_generate(payload) rescue m[:message]) : m[:message] %></textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white text-xs font-mono shadow-sm focus:border-indigo-500 focus:ring-indigo-500"><%= parse_ok ? (JSON.pretty_generate(payload_raw) rescue m[:message]) : m[:message] %></textarea>
                         <div class="mt-2 flex justify-end">
                           <button type="submit"
                                   class="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500"
@@ -120,7 +124,7 @@
                   <%# Full JSON %>
                   <details class="mt-2">
                     <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700"><%= t("pgbus.events.pending_table.full_json_payload") %></summary>
-                    <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-96"><%= parse_ok ? (JSON.pretty_generate(payload) rescue m[:message]) : m[:message] %></pre>
+                    <pre class="text-xs text-gray-600 bg-white dark:bg-gray-800 rounded p-2 mt-1 overflow-x-auto max-h-96"><%= parse_ok ? (JSON.pretty_generate(payload_raw) rescue m[:message]) : m[:message] %></pre>
                   </details>
                   <% if m[:headers] %>
                     <details class="mt-2">

--- a/app/views/pgbus/events/index.html.erb
+++ b/app/views/pgbus/events/index.html.erb
@@ -1,4 +1,18 @@
-<h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6"><%= t("pgbus.events.index.title") %></h1>
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold text-gray-900 dark:text-white"><%= t("pgbus.events.index.title") %></h1>
+  <% if @pending.any? %>
+    <div class="flex items-center space-x-2">
+      <div data-bulk-actions class="hidden flex items-center space-x-2">
+        <span class="text-sm text-gray-500 dark:text-gray-400"><span data-bulk-count>0</span> <%= t("pgbus.helpers.bulk_selected") %></span>
+        <button type="submit" form="bulk-discard-events-form"
+                class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-500"
+                data-turbo-confirm="<%= t("pgbus.events.index.discard_selected_confirm") %>">
+          <%= t("pgbus.events.index.discard_selected") %>
+        </button>
+      </div>
+    </div>
+  <% end %>
+</div>
 
 <!-- Registered Subscribers -->
 <div class="mb-8">
@@ -26,6 +40,12 @@
       </tbody>
     </table>
   </div>
+</div>
+
+<!-- Pending Events (Unprocessed messages in handler queues) -->
+<div class="mb-8">
+  <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("pgbus.events.index.pending_title") %></h2>
+  <%= render "pgbus/events/pending_table" %>
 </div>
 
 <!-- Processed Events (Audit Trail) -->

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -66,6 +66,12 @@ da:
       index:
         discard_all: Kassér alle
         discard_all_confirm: Slet permanent alle DLQ-beskeder?
+        discard_selected: Forkast valgte
+        discard_selected_confirm: Forkast valgte DLQ-beskeder?
+        discarded_selected:
+          one: 1 DLQ-besked forkastet.
+          other: "%{count} DLQ-beskeder forkastet."
+        none_selected: Ingen beskeder valgt.
         retry_all: Prøv igen alle
         retry_all_confirm: Prøv igen alle DLQ-beskeder?
         title: Dead Letter Queue
@@ -113,7 +119,34 @@ da:
       delete_title: Slet
       ok: OK
     events:
+      flash:
+        discard_failed: Kunne ikke forkaste begivenhed.
+        discarded: Begivenhed forkastet.
+        discarded_selected:
+          one: 1 begivenhed forkastet.
+          other: "%{count} begivenheder forkastet."
+        mark_handled_failed: Kunne ikke markere begivenhed som håndteret.
+        marked_handled: Begivenhed markeret som håndteret.
+        none_selected: Ingen begivenheder valgt.
+        payload_update_failed: Kunne ikke opdatere payload. Tjek at JSON er gyldig.
+        payload_updated: Payload opdateret og begivenhed genindkøet.
+        replay_failed: Begivenhed ikke fundet eller kunne ikke afspilles.
+        replayed: Begivenhed afspillet.
+        reroute_failed: Kunne ikke omdirigere begivenhed.
+        rerouted: Begivenhed omdirigeret til målhandler.
       index:
+        discard_all: Forkast alle
+        discard_all_confirm: Forkast alle ventende begivenheder? Dette kan ikke fortrydes.
+        discard_selected: Forkast valgte
+        discard_selected_confirm: Forkast valgte begivenheder?
+        pending_empty: Ingen ventende begivenheder
+        pending_headers:
+          enqueued: Indkøet
+          handler_queue: Handler-kø
+          id: ID
+          reads: Læsninger
+          routing_key: Routing-nøgle
+        pending_title: Ventende begivenheder
         processed_empty: Ingen begivenheder behandlet endnu
         processed_headers:
           event_id: Begivenheds-ID
@@ -127,6 +160,26 @@ da:
           queue: Kø
         subscribers_title: Registrerede abonnenter
         title: Begivenheder
+      pending_table:
+        arguments: Payload
+        discard: Forkast
+        discard_confirm: Forkast denne begivenhed? Den vil blive arkiveret.
+        edit_payload: Rediger & prøv igen
+        edit_payload_confirm: Opdater payload og genindkø denne begivenhed?
+        edit_payload_label: 'JSON Payload:'
+        event_id: 'Begivenheds-ID:'
+        full_json_payload: Fuld JSON Payload
+        headers_section: Headers
+        mark_handled: Marker som håndteret
+        mark_handled_confirm: Marker denne begivenhed som håndteret? Den vil blive arkiveret og sprunget over ved afspilning.
+        metadata: Metadata
+        metadata_labels:
+          last_read: Sidst læst
+          read_count: Antal læsninger
+          visible_at: Synlig fra
+        reroute: Omdiriger
+        reroute_confirm: Omdiriger denne begivenhed til en anden handler?
+        reroute_label: 'Målhandler:'
       show:
         back: Tilbage til begivenheder
         labels:
@@ -136,6 +189,9 @@ da:
         not_found: Begivenhed ikke fundet
         title: Begivenhed %{event_id}
     helpers:
+      bulk_select_all: Vælg alle
+      bulk_select_row: Vælg %{id}
+      bulk_selected: valgt
       paused_badge: Pause
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ da:
       show:
         charts:
           failed_to_load: Kunne ikke indlæse diagramdata
+          latency: Køforsinkelse (ms)
+          latency_avg: Gns.
+          latency_p95: P95
           no_data: Ingen data endnu
           series_name: Job/min
           status_distribution: Statusfordeling
           throughput: Gennemstrømning (job/min)
         description_html: Jobpræstationsmålinger for de sidste %{range}
+        latency_by_queue:
+          empty: Ingen forsinkelsesdata endnu
+          headers:
+            avg: Gns. (ms)
+            count: Antal
+            p95: P95 (ms)
+            queue: Kø
+          title: Forsinkelse efter kø
         slowest:
           empty: Ingen jobstatistikker endnu
           headers:
@@ -163,11 +230,32 @@ da:
             job_class: Jobklasse
             max: Max
           title: Langsommeste jobklasser (gennemsnitlig varighed)
+        streams:
+          summary:
+            active: Aktiv
+            avg_fanout: Gns. udbredelse
+            broadcasts: Udsendelser
+            connects: Forbindelser
+            disconnects: Afbrydelser
+          title: Strømme i realtid
+          top:
+            empty: Ingen strømaktivitet registreret i det valgte vindue
+            headers:
+              avg_fanout: Gns. udbredelse
+              avg_ms: Gns. afsendelse
+              broadcasts: Udsendelser
+              stream: Strøm
+            title: Topstrømme efter udsendelsesvolumen
         summary:
           avg_duration: Gennemsnitlig varighed
+          avg_latency: Gns. forsinkelse
+          avg_retries: Gns. genforsøg
           dead_lettered: Døde breve
           failed: Mislykkedes
           max_duration: Maksimal varighed
+          p50_latency: P50 forsinkelse
+          p95_latency: P95 forsinkelse
+          p99_latency: P99 forsinkelse
           succeeded: Succesfuld
           total_jobs: Totale job
         time_ranges:
@@ -222,6 +310,12 @@ da:
         discard_all: Kassér alle
         discard_all_confirm: Kassér alle mislykkede job?
         discard_all_enqueued_notice: Kasserede %{count} ventende jobs og frigav deres låse.
+        discard_selected: Kassér valgte
+        discard_selected_confirm: Kassér valgte elementer?
+        discarded_selected:
+          one: Kasserede 1 valgt element.
+          other: Kasserede %{count} valgte elementer.
+        none_selected: Ingen elementer valgt.
         retry_all: Forsøg alle igen
         retry_all_confirm: Forsøg alle mislykkede job igen?
         title: Job
@@ -259,13 +353,28 @@ da:
       toggle_menu: Skift menu
     locks:
       index:
+        all_locks_discarded:
+          one: Kasserede 1 lås.
+          other: Kasserede %{count} låse.
         description: Aktive unikke låse forhindrer duplikeret jobudførelse
+        discard: Kassér
+        discard_all: Kassér alle
+        discard_all_confirm: Vil du permanent kassere alle låse? Dette kan tillade dublet jobudførelse.
+        discard_confirm: Vil du kassere denne lås? Det tilknyttede job kan blive sat i kø igen.
+        discard_selected: Kassér valgte
+        discard_selected_confirm: Vil du kassere valgte låse?
         empty: Ingen aktive låse
         headers:
           age: Alder
           lock_key: Låsenøgle
           msg_id: Besked-ID
           queue_name: Kø
+        lock_discard_failed: Kunne ikke kassere lås.
+        lock_discarded: Lås kasseret.
+        locks_discarded:
+          one: Kasserede 1 lås.
+          other: Kasserede %{count} låse.
+        none_selected: Ingen låse valgt.
         title: Unikhedsnøgler
     outbox:
       index:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -174,9 +174,9 @@ da:
         mark_handled_confirm: Marker denne begivenhed som håndteret? Den vil blive arkiveret og sprunget over ved afspilning.
         metadata: Metadata
         metadata_labels:
-          last_read: Sidst læst
-          read_count: Antal læsninger
-          visible_at: Synlig fra
+          last_read: 'Sist læst:'
+          read_count: 'Læseantal:'
+          visible_at: 'Synlig fra:'
         reroute: Omdiriger
         reroute_confirm: Omdiriger denne begivenhed til en anden handler?
         reroute_label: 'Målhandler:'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -66,6 +66,12 @@ de:
       index:
         discard_all: Alle verwerfen
         discard_all_confirm: Alle DLQ-Nachrichten dauerhaft verwerfen?
+        discard_selected: Ausgewählte verwerfen
+        discard_selected_confirm: Ausgewählte DLQ-Nachrichten verwerfen?
+        discarded_selected:
+          one: 1 DLQ-Nachricht verworfen.
+          other: "%{count} DLQ-Nachrichten verworfen."
+        none_selected: Keine Nachrichten ausgewählt.
         retry_all: Alle erneut versuchen
         retry_all_confirm: Alle DLQ-Nachrichten erneut versuchen?
         title: Dead Letter Queue
@@ -113,7 +119,34 @@ de:
       delete_title: Löschen
       ok: OK
     events:
+      flash:
+        discard_failed: Ereignis konnte nicht verworfen werden.
+        discarded: Ereignis verworfen.
+        discarded_selected:
+          one: 1 Ereignis verworfen.
+          other: "%{count} Ereignisse verworfen."
+        mark_handled_failed: Ereignis konnte nicht als bearbeitet markiert werden.
+        marked_handled: Ereignis als bearbeitet markiert.
+        none_selected: Keine Ereignisse ausgewählt.
+        payload_update_failed: Nutzlast konnte nicht aktualisiert werden. Überprüfen Sie, ob das JSON gültig ist.
+        payload_updated: Nutzlast aktualisiert und Ereignis erneut in die Warteschlange gestellt.
+        replay_failed: Ereignis nicht gefunden oder konnte nicht erneut abgespielt werden.
+        replayed: Ereignis erneut abgespielt.
+        reroute_failed: Ereignis konnte nicht umgeleitet werden.
+        rerouted: Ereignis an Ziel-Handler umgeleitet.
       index:
+        discard_all: Alle verwerfen
+        discard_all_confirm: Alle ausstehenden Ereignisse verwerfen? Dies kann nicht rückgängig gemacht werden.
+        discard_selected: Ausgewählte verwerfen
+        discard_selected_confirm: Ausgewählte Ereignisse verwerfen?
+        pending_empty: Keine ausstehenden Ereignisse
+        pending_headers:
+          enqueued: In die Warteschlange gestellt
+          handler_queue: Handler-Warteschlange
+          id: ID
+          reads: Lesevorgänge
+          routing_key: Routing-Schlüssel
+        pending_title: Ausstehende Ereignisse
         processed_empty: Noch keine Ereignisse verarbeitet
         processed_headers:
           event_id: Ereignis-ID
@@ -127,6 +160,26 @@ de:
           queue: Warteschlange
         subscribers_title: Registrierte Abonnenten
         title: Ereignisse
+      pending_table:
+        arguments: Nutzlast
+        discard: Verwerfen
+        discard_confirm: Dieses Ereignis verwerfen? Es wird archiviert.
+        edit_payload: Bearbeiten & erneut versuchen
+        edit_payload_confirm: Nutzlast aktualisieren und dieses Ereignis erneut in die Warteschlange stellen?
+        edit_payload_label: 'JSON-Nutzlast:'
+        event_id: 'Ereignis-ID:'
+        full_json_payload: Vollständige JSON-Nutzlast
+        headers_section: Header
+        mark_handled: Als bearbeitet markieren
+        mark_handled_confirm: Dieses Ereignis als bearbeitet markieren? Es wird archiviert und bei der Wiedergabe übersprungen.
+        metadata: Metadaten
+        metadata_labels:
+          last_read: Zuletzt gelesen
+          read_count: Leseanzahl
+          visible_at: Sichtbar ab
+        reroute: Umleiten
+        reroute_confirm: Dieses Ereignis an einen anderen Handler umleiten?
+        reroute_label: 'Ziel-Handler:'
       show:
         back: Zurück zu Ereignissen
         labels:
@@ -136,6 +189,9 @@ de:
         not_found: Ereignis nicht gefunden
         title: Ereignis %{event_id}
     helpers:
+      bulk_select_all: Alle auswählen
+      bulk_select_row: "%{id} auswählen"
+      bulk_selected: ausgewählt
       paused_badge: Pausiert
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ de:
       show:
         charts:
           failed_to_load: Fehler beim Laden der Diagrammdaten
+          latency: Warteschlangenlatenz (ms)
+          latency_avg: Durchschnitt
+          latency_p95: P95
           no_data: Noch keine Daten
           series_name: Aufträge/Min
           status_distribution: Statusverteilung
           throughput: Durchsatz (Aufträge/Min)
         description_html: Leistungskennzahlen für die letzten %{range}
+        latency_by_queue:
+          empty: Noch keine Latenzdaten vorhanden
+          headers:
+            avg: Durchschnitt (ms)
+            count: Anzahl
+            p95: P95 (ms)
+            queue: Warteschlange
+          title: Latenz nach Warteschlange
         slowest:
           empty: Noch keine Auftragsstatistiken
           headers:
@@ -163,11 +230,32 @@ de:
             job_class: Job-Klasse
             max: Max
           title: Langsamste Job-Klassen (durchschnittliche Dauer)
+        streams:
+          summary:
+            active: Aktiv
+            avg_fanout: Durchschnittliche Verteilung
+            broadcasts: Übertragungen
+            connects: Verbindungen
+            disconnects: Trennungen
+          title: Echtzeit-Streams
+          top:
+            empty: Keine Stream-Aktivität im ausgewählten Zeitraum aufgezeichnet
+            headers:
+              avg_fanout: Durchschnittliche Verteilung
+              avg_ms: Durchschnittliche Zustellung
+              broadcasts: Übertragungen
+              stream: Stream
+            title: Top-Streams nach Übertragungsvolumen
         summary:
           avg_duration: Durchschnittliche Dauer
+          avg_latency: Durchschnittliche Latenz
+          avg_retries: Durchschnittliche Wiederholungen
           dead_lettered: In Dead Letter verschoben
           failed: Fehlgeschlagen
           max_duration: Maximale Dauer
+          p50_latency: P50 Latenz
+          p95_latency: P95 Latenz
+          p99_latency: P99 Latenz
           succeeded: Erfolgreich
           total_jobs: Gesamtanzahl der Jobs
         time_ranges:
@@ -222,6 +310,12 @@ de:
         discard_all: Alle verwerfen
         discard_all_confirm: Alle fehlgeschlagenen Jobs verwerfen?
         discard_all_enqueued_notice: "%{count} eingereihte Jobs verworfen und Sperren freigegeben."
+        discard_selected: Ausgewählte verwerfen
+        discard_selected_confirm: Ausgewählte Elemente verwerfen?
+        discarded_selected:
+          one: 1 ausgewähltes Element verworfen.
+          other: "%{count} ausgewählte Elemente verworfen."
+        none_selected: Keine Elemente ausgewählt.
         retry_all: Alle wiederholen
         retry_all_confirm: Alle fehlgeschlagenen Jobs wiederholen?
         title: Jobs
@@ -259,13 +353,28 @@ de:
       toggle_menu: Menü umschalten
     locks:
       index:
+        all_locks_discarded:
+          one: 1 Sperre verworfen.
+          other: "%{count} Sperren verworfen."
         description: Aktive Einzigartigkeitssperren verhindern doppelte Auftragserstellung
+        discard: Verwerfen
+        discard_all: Alle verwerfen
+        discard_all_confirm: Alle Sperren dauerhaft verwerfen? Dies kann eine doppelte Ausführung von Jobs ermöglichen.
+        discard_confirm: Diese Sperre verwerfen? Der zugehörige Job kann erneut in die Warteschlange gestellt werden.
+        discard_selected: Ausgewählte verwerfen
+        discard_selected_confirm: Ausgewählte Sperren verwerfen?
         empty: Keine aktiven Sperren
         headers:
           age: Alter
           lock_key: Sperrschlüssel
           msg_id: Nachrichten-ID
           queue_name: Warteschlange
+        lock_discard_failed: Sperre konnte nicht verworfen werden.
+        lock_discarded: Sperre verworfen.
+        locks_discarded:
+          one: 1 Sperre verworfen.
+          other: "%{count} Sperren verworfen."
+        none_selected: Keine Sperren ausgewählt.
         title: Eindeutigkeitsschlüssel
     outbox:
       index:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -174,9 +174,9 @@ de:
         mark_handled_confirm: Dieses Ereignis als bearbeitet markieren? Es wird archiviert und bei der Wiedergabe übersprungen.
         metadata: Metadaten
         metadata_labels:
-          last_read: Zuletzt gelesen
-          read_count: Leseanzahl
-          visible_at: Sichtbar ab
+          last_read: 'Zuletzt gelesen:'
+          read_count: 'Leseanzahl:'
+          visible_at: 'Sichtbar ab:'
         reroute: Umleiten
         reroute_confirm: Dieses Ereignis an einen anderen Handler umleiten?
         reroute_label: 'Ziel-Handler:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,9 +174,9 @@ en:
         mark_handled_confirm: Mark this event as handled? It will be archived and skipped on replay.
         metadata: Metadata
         metadata_labels:
-          last_read: Last Read
-          read_count: Read Count
-          visible_at: Visible At
+          last_read: 'Last read:'
+          read_count: 'Read count:'
+          visible_at: 'Visible at:'
         reroute: Reroute
         reroute_confirm: Reroute this event to a different handler?
         reroute_label: 'Target handler:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,7 +119,34 @@ en:
       delete_title: Delete
       ok: OK
     events:
+      flash:
+        discard_failed: Could not discard event.
+        discarded: Event discarded.
+        discarded_selected:
+          one: Discarded 1 event.
+          other: Discarded %{count} events.
+        mark_handled_failed: Could not mark event as handled.
+        marked_handled: Event marked as handled.
+        none_selected: No events selected.
+        payload_update_failed: Could not update payload. Check that the JSON is valid.
+        payload_updated: Payload updated and event re-enqueued.
+        replay_failed: Event not found or could not be replayed.
+        replayed: Event replayed.
+        reroute_failed: Could not reroute event.
+        rerouted: Event rerouted to target handler.
       index:
+        discard_all: Discard All
+        discard_all_confirm: Discard all pending events? This cannot be undone.
+        discard_selected: Discard Selected
+        discard_selected_confirm: Discard selected events?
+        pending_empty: No pending events
+        pending_headers:
+          enqueued: Enqueued
+          handler_queue: Handler Queue
+          id: ID
+          reads: Reads
+          routing_key: Routing Key
+        pending_title: Pending Events
         processed_empty: No events processed yet
         processed_headers:
           event_id: Event ID
@@ -133,6 +160,26 @@ en:
           queue: Queue
         subscribers_title: Registered Subscribers
         title: Events
+      pending_table:
+        arguments: Payload
+        discard: Discard
+        discard_confirm: Discard this event? It will be archived.
+        edit_payload: Edit & Retry
+        edit_payload_confirm: Update payload and re-enqueue this event?
+        edit_payload_label: 'JSON Payload:'
+        event_id: 'Event ID:'
+        full_json_payload: Full JSON Payload
+        headers_section: Headers
+        mark_handled: Mark Handled
+        mark_handled_confirm: Mark this event as handled? It will be archived and skipped on replay.
+        metadata: Metadata
+        metadata_labels:
+          last_read: Last Read
+          read_count: Read Count
+          visible_at: Visible At
+        reroute: Reroute
+        reroute_confirm: Reroute this event to a different handler?
+        reroute_label: 'Target handler:'
       show:
         back: Back to Events
         labels:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -174,9 +174,9 @@ es:
         mark_handled_confirm: "¿Marcar este evento como manejado? Será archivado y omitido en la reproducción."
         metadata: Metadatos
         metadata_labels:
-          last_read: Última lectura
-          read_count: Cantidad de lecturas
-          visible_at: Visible en
+          last_read: 'Última lectura:'
+          read_count: 'Cantidad de lecturas:'
+          visible_at: 'Visible en:'
         reroute: Redirigir
         reroute_confirm: "¿Redirigir este evento a un manejador diferente?"
         reroute_label: 'Manejador objetivo:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -66,6 +66,12 @@ es:
       index:
         discard_all: Descartar todo
         discard_all_confirm: "¿Descartar permanentemente todos los mensajes DLQ?"
+        discard_selected: Descartar seleccionados
+        discard_selected_confirm: "¿Descartar mensajes DLQ seleccionados?"
+        discarded_selected:
+          one: 1 mensaje DLQ descartado.
+          other: "%{count} mensajes DLQ descartados."
+        none_selected: No hay mensajes seleccionados.
         retry_all: Reintentar todo
         retry_all_confirm: "¿Reintentar todos los mensajes DLQ?"
         title: Cola de mensajes muertos
@@ -113,7 +119,34 @@ es:
       delete_title: Eliminar
       ok: Aceptar
     events:
+      flash:
+        discard_failed: No se pudo descartar el evento.
+        discarded: Evento descartado.
+        discarded_selected:
+          one: 1 evento descartado.
+          other: "%{count} eventos descartados."
+        mark_handled_failed: No se pudo marcar el evento como manejado.
+        marked_handled: Evento marcado como manejado.
+        none_selected: No hay eventos seleccionados.
+        payload_update_failed: No se pudo actualizar la carga útil. Verifique que el JSON sea válido.
+        payload_updated: Carga útil actualizada y evento reenviado a la cola.
+        replay_failed: Evento no encontrado o no se pudo reproducir.
+        replayed: Evento reproducido.
+        reroute_failed: No se pudo redirigir el evento.
+        rerouted: Evento redirigido al manejador objetivo.
       index:
+        discard_all: Descartar todo
+        discard_all_confirm: "¿Descartar todos los eventos pendientes? Esto no se puede deshacer."
+        discard_selected: Descartar seleccionados
+        discard_selected_confirm: "¿Descartar eventos seleccionados?"
+        pending_empty: No hay eventos pendientes
+        pending_headers:
+          enqueued: En cola
+          handler_queue: Cola del manejador
+          id: ID
+          reads: Lecturas
+          routing_key: Clave de enrutamiento
+        pending_title: Eventos pendientes
         processed_empty: No se han procesado eventos aún
         processed_headers:
           event_id: ID del evento
@@ -127,6 +160,26 @@ es:
           queue: Cola
         subscribers_title: Suscriptores registrados
         title: Eventos
+      pending_table:
+        arguments: Carga útil
+        discard: Descartar
+        discard_confirm: "¿Descartar este evento? Será archivado."
+        edit_payload: Editar y reintentar
+        edit_payload_confirm: "¿Actualizar la carga útil y reenviar este evento a la cola?"
+        edit_payload_label: 'Carga útil JSON:'
+        event_id: 'ID del evento:'
+        full_json_payload: Carga útil JSON completa
+        headers_section: Encabezados
+        mark_handled: Marcar como manejado
+        mark_handled_confirm: "¿Marcar este evento como manejado? Será archivado y omitido en la reproducción."
+        metadata: Metadatos
+        metadata_labels:
+          last_read: Última lectura
+          read_count: Cantidad de lecturas
+          visible_at: Visible en
+        reroute: Redirigir
+        reroute_confirm: "¿Redirigir este evento a un manejador diferente?"
+        reroute_label: 'Manejador objetivo:'
       show:
         back: Volver a eventos
         labels:
@@ -136,6 +189,9 @@ es:
         not_found: Evento no encontrado
         title: Evento %{event_id}
     helpers:
+      bulk_select_all: Seleccionar todo
+      bulk_select_row: Seleccionar %{id}
+      bulk_selected: seleccionado
       paused_badge: Pausado
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ es:
       show:
         charts:
           failed_to_load: Error al cargar datos del gráfico
+          latency: Latencia de Cola (ms)
+          latency_avg: Promedio
+          latency_p95: P95
           no_data: Aún no hay datos
           series_name: Trabajos/min
           status_distribution: Distribución de estado
           throughput: Rendimiento (trabajos/min)
         description_html: Métricas de desempeño laboral para los últimos %{range}
+        latency_by_queue:
+          empty: Aún no hay datos de latencia
+          headers:
+            avg: Promedio (ms)
+            count: Cantidad
+            p95: P95 (ms)
+            queue: Cola
+          title: Latencia por Cola
         slowest:
           empty: Aún no hay estadísticas de trabajos
           headers:
@@ -163,11 +230,32 @@ es:
             job_class: Clase de trabajo
             max: Máximo
           title: Clases de Trabajo Más Lentas (duración promedio)
+        streams:
+          summary:
+            active: Activo
+            avg_fanout: Promedio de Difusión
+            broadcasts: Transmisiones
+            connects: Conexiones
+            disconnects: Desconexiones
+          title: Transmisiones en Tiempo Real
+          top:
+            empty: No se registró actividad de transmisión en la ventana seleccionada
+            headers:
+              avg_fanout: Promedio de Difusión
+              avg_ms: Promedio de Despacho
+              broadcasts: Transmisiones
+              stream: Transmisión
+            title: Principales Transmisiones por Volumen de Transmisión
         summary:
           avg_duration: Duración Promedio
+          avg_latency: Latencia Promedio
+          avg_retries: Reintentos Promedio
           dead_lettered: Enviado a Dead Letter
           failed: Fallado
           max_duration: Duración Máxima
+          p50_latency: Latencia P50
+          p95_latency: Latencia P95
+          p99_latency: Latencia P99
           succeeded: Exitoso
           total_jobs: Total de Trabajos
         time_ranges:
@@ -222,6 +310,12 @@ es:
         discard_all: Descartar Todo
         discard_all_confirm: "¿Descartar todos los trabajos fallidos?"
         discard_all_enqueued_notice: Se descartaron %{count} trabajos en cola y se liberaron sus bloqueos.
+        discard_selected: Descartar Seleccionados
+        discard_selected_confirm: "¿Descartar los elementos seleccionados?"
+        discarded_selected:
+          one: Se descartó 1 elemento seleccionado.
+          other: Se descartaron %{count} elementos seleccionados.
+        none_selected: No hay elementos seleccionados.
         retry_all: Reintentar Todo
         retry_all_confirm: "¿Reintentar todos los trabajos fallidos?"
         title: Trabajos
@@ -259,13 +353,28 @@ es:
       toggle_menu: Alternar menú
     locks:
       index:
+        all_locks_discarded:
+          one: Se descartó 1 bloqueo.
+          other: Se descartaron %{count} bloqueos.
         description: Bloqueos de unicidad activos que impiden la ejecución duplicada del trabajo
+        discard: Descartar
+        discard_all: Descartar Todo
+        discard_all_confirm: "¿Descartar permanentemente todos los bloqueos? Esto puede permitir la ejecución duplicada de trabajos."
+        discard_confirm: "¿Descartar este bloqueo? El trabajo asociado puede ser encolado nuevamente."
+        discard_selected: Descartar Seleccionados
+        discard_selected_confirm: "¿Descartar los bloqueos seleccionados?"
         empty: No hay bloqueos activos
         headers:
           age: Antigüedad
           lock_key: Clave de bloqueo
           msg_id: ID de mensaje
           queue_name: Cola
+        lock_discard_failed: No se pudo descartar el bloqueo.
+        lock_discarded: Bloqueo descartado.
+        locks_discarded:
+          one: Se descartó 1 bloqueo.
+          other: Se descartaron %{count} bloqueos.
+        none_selected: No hay bloqueos seleccionados.
         title: Claves de unicidad
     outbox:
       index:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -174,9 +174,9 @@ fi:
         mark_handled_confirm: Merkitäänkö tämä tapahtuma käsitellyksi? Se arkistoidaan ja ohitetaan toistossa.
         metadata: Metatiedot
         metadata_labels:
-          last_read: Viimeksi luettu
-          read_count: Lukukerrat
-          visible_at: Näkyvissä
+          last_read: 'Viimeksi luettu:'
+          read_count: 'Lukukerrat:'
+          visible_at: 'Näkyvissä:'
         reroute: Uudelleenreititys
         reroute_confirm: Uudelleenreititetäänkö tämä tapahtuma toiselle käsittelijälle?
         reroute_label: 'Kohdekäsittelijä:'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -66,6 +66,12 @@ fi:
       index:
         discard_all: Hylkää kaikki
         discard_all_confirm: Hylätäänkö kaikki DLQ-viestit pysyvästi?
+        discard_selected: Hylkää valitut
+        discard_selected_confirm: Hylätäänkö valitut DLQ-viestit?
+        discarded_selected:
+          one: 1 DLQ-viesti hylätty.
+          other: "%{count} DLQ-viestiä hylätty."
+        none_selected: Ei viestejä valittuna.
         retry_all: Yritä uudelleen kaikki
         retry_all_confirm: Yritetäänkö uudelleen kaikkia DLQ-viestejä?
         title: Dead Letter -jono
@@ -113,7 +119,34 @@ fi:
       delete_title: Poista
       ok: OK
     events:
+      flash:
+        discard_failed: Tapahtumaa ei voitu hylätä.
+        discarded: Tapahtuma hylätty.
+        discarded_selected:
+          one: 1 tapahtuma hylätty.
+          other: "%{count} tapahtumaa hylätty."
+        mark_handled_failed: Tapahtumaa ei voitu merkitä käsitellyksi.
+        marked_handled: Tapahtuma merkitty käsitellyksi.
+        none_selected: Ei tapahtumia valittuna.
+        payload_update_failed: Kuormaa ei voitu päivittää. Tarkista, että JSON on kelvollinen.
+        payload_updated: Kuorma päivitetty ja tapahtuma uudelleen jonotettu.
+        replay_failed: Tapahtumaa ei löytynyt tai sitä ei voitu toistaa.
+        replayed: Tapahtuma toistettu.
+        reroute_failed: Tapahtumaa ei voitu uudelleenreitittää.
+        rerouted: Tapahtuma uudelleenreititetty kohdekäsittelijälle.
       index:
+        discard_all: Hylkää kaikki
+        discard_all_confirm: Hylätäänkö kaikki odottavat tapahtumat? Tätä ei voi peruuttaa.
+        discard_selected: Hylkää valitut
+        discard_selected_confirm: Hylätäänkö valitut tapahtumat?
+        pending_empty: Ei odottavia tapahtumia
+        pending_headers:
+          enqueued: Jonotettu
+          handler_queue: Käsittelijäjono
+          id: ID
+          reads: Lukukerrat
+          routing_key: Reitityksen avain
+        pending_title: Odotettavat tapahtumat
         processed_empty: Ei vielä käsiteltyjä tapahtumia
         processed_headers:
           event_id: Tapahtuman tunnus
@@ -127,6 +160,26 @@ fi:
           queue: Jono
         subscribers_title: Rekisteröidyt tilaajat
         title: Tapahtumat
+      pending_table:
+        arguments: Kuorma
+        discard: Hylkää
+        discard_confirm: Hylätäänkö tämä tapahtuma? Se arkistoidaan.
+        edit_payload: Muokkaa ja yritä uudelleen
+        edit_payload_confirm: Päivitetäänkö kuorma ja uudelleen jonotetaanko tämä tapahtuma?
+        edit_payload_label: 'JSON-kuorma:'
+        event_id: 'Tapahtuman ID:'
+        full_json_payload: Täysi JSON-kuorma
+        headers_section: Otsikot
+        mark_handled: Merkitse käsitellyksi
+        mark_handled_confirm: Merkitäänkö tämä tapahtuma käsitellyksi? Se arkistoidaan ja ohitetaan toistossa.
+        metadata: Metatiedot
+        metadata_labels:
+          last_read: Viimeksi luettu
+          read_count: Lukukerrat
+          visible_at: Näkyvissä
+        reroute: Uudelleenreititys
+        reroute_confirm: Uudelleenreititetäänkö tämä tapahtuma toiselle käsittelijälle?
+        reroute_label: 'Kohdekäsittelijä:'
       show:
         back: Takaisin tapahtumiin
         labels:
@@ -136,6 +189,9 @@ fi:
         not_found: Tapahtumaa ei löytynyt
         title: Tapahtuma %{event_id}
     helpers:
+      bulk_select_all: Valitse kaikki
+      bulk_select_row: Valitse %{id}
+      bulk_selected: valittu
       paused_badge: Tauolla
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ fi:
       show:
         charts:
           failed_to_load: Latauksen kaavioaineisto epäonnistui
+          latency: Jon viive (ms)
+          latency_avg: Keskim.
+          latency_p95: P95
           no_data: Ei vielä tietoja
           series_name: Tehtäviä/min
           status_distribution: Tilajakauma
           throughput: Kapasiteetti (tehtäviä/min)
         description_html: Työsuorituksen mittarit viimeiseltä %{range}
+        latency_by_queue:
+          empty: Ei viivetietoja vielä
+          headers:
+            avg: Keskim. (ms)
+            count: Määrä
+            p95: P95 (ms)
+            queue: Jono
+          title: Viive jonon mukaan
         slowest:
           empty: Ei vielä tehtävätilastoja
           headers:
@@ -163,11 +230,32 @@ fi:
             job_class: Tehtäväluokka
             max: Maksimi
           title: Hitaimmat työn luokat (keskimääräinen kesto)
+        streams:
+          summary:
+            active: Aktiivinen
+            avg_fanout: Keskim. haarautuminen
+            broadcasts: Lähetykset
+            connects: Yhdistämiset
+            disconnects: Katkaisut
+          title: Reaaliaikaiset striimit
+          top:
+            empty: Valitulla aikavälillä ei striimitoimintaa
+            headers:
+              avg_fanout: Keskim. haarautuminen
+              avg_ms: Keskim. lähetys
+              broadcasts: Lähetykset
+              stream: Striimi
+            title: Suosituimmat striimit lähetysmäärän mukaan
         summary:
           avg_duration: Keskimääräinen kesto
+          avg_latency: Keskim. viive
+          avg_retries: Keskim. uudelleenyritykset
           dead_lettered: Kuolleet kirjeet
           failed: Epäonnistuneet
           max_duration: Maksimikesto
+          p50_latency: P50-viive
+          p95_latency: P95-viive
+          p99_latency: P99-viive
           succeeded: Onnistuneet
           total_jobs: Yhteensä töitä
         time_ranges:
@@ -222,6 +310,12 @@ fi:
         discard_all: Hylkää kaikki
         discard_all_confirm: Hylätäänkö kaikki epäonnistuneet työt?
         discard_all_enqueued_notice: Hylättiin %{count} jonossa olevaa tehtävää ja vapautettiin lukot.
+        discard_selected: Hylkää valitut
+        discard_selected_confirm: Hylätäänkö valitut kohteet?
+        discarded_selected:
+          one: Hylättiin 1 valittu kohde.
+          other: Hylättiin %{count} valittua kohdetta.
+        none_selected: Ei valittuja kohteita.
         retry_all: Yritä uudelleen kaikki
         retry_all_confirm: Yritetäänkö uudelleen kaikki epäonnistuneet työt?
         title: Työt
@@ -259,13 +353,28 @@ fi:
       toggle_menu: Vaihda valikko
     locks:
       index:
+        all_locks_discarded:
+          one: Hylättiin 1 lukko.
+          other: Hylättiin %{count} lukkoa.
         description: Aktiiviset ainutlaatuisuuden lukot estävät päällekkäisen työn suorittamisen
+        discard: Hylkää
+        discard_all: Hylkää kaikki
+        discard_all_confirm: Hylätäänkö kaikki lukot pysyvästi? Tämä saattaa sallia tehtävien toistuvan suorituksen.
+        discard_confirm: Hylätäänkö tämä lukko? Liittyvä tehtävä voidaan laittaa jonoon uudelleen.
+        discard_selected: Hylkää valitut
+        discard_selected_confirm: Hylätäänkö valitut lukot?
         empty: Ei aktiivisia lukkoja
         headers:
           age: Ikä
           lock_key: Lukon avain
           msg_id: Viestin tunnus
           queue_name: Jono
+        lock_discard_failed: Lukkoa ei voitu hylätä.
+        lock_discarded: Lukko hylätty.
+        locks_discarded:
+          one: Hylättiin 1 lukko.
+          other: Hylättiin %{count} lukkoa.
+        none_selected: Ei valittuja lukkoja.
         title: Yksikäsitteisyysavaimet
     outbox:
       index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -66,6 +66,12 @@ fr:
       index:
         discard_all: Tout rejeter
         discard_all_confirm: Rejeter définitivement tous les messages DLQ ?
+        discard_selected: Jeter la sélection
+        discard_selected_confirm: Jeter les messages DLQ sélectionnés ?
+        discarded_selected:
+          one: 1 message DLQ jeté.
+          other: "%{count} messages DLQ jetés."
+        none_selected: Aucun message sélectionné.
         retry_all: Tout réessayer
         retry_all_confirm: Réessayer tous les messages DLQ ?
         title: File d'attente des messages morts
@@ -113,7 +119,34 @@ fr:
       delete_title: Supprimer
       ok: OK
     events:
+      flash:
+        discard_failed: Impossible de jeter l'événement.
+        discarded: Événement jeté.
+        discarded_selected:
+          one: 1 événement jeté.
+          other: "%{count} événements jetés."
+        mark_handled_failed: Impossible de marquer l'événement comme traité.
+        marked_handled: Événement marqué comme traité.
+        none_selected: Aucun événement sélectionné.
+        payload_update_failed: Impossible de mettre à jour la charge utile. Vérifiez que le JSON est valide.
+        payload_updated: Charge utile mise à jour et événement réenregistré.
+        replay_failed: Événement non trouvé ou impossible à rejouer.
+        replayed: Événement rejoué.
+        reroute_failed: Impossible de rediriger l'événement.
+        rerouted: Événement redirigé vers le gestionnaire cible.
       index:
+        discard_all: Tout jeter
+        discard_all_confirm: Jeter tous les événements en attente ? Cette action est irréversible.
+        discard_selected: Jeter la sélection
+        discard_selected_confirm: Jeter les événements sélectionnés ?
+        pending_empty: Aucun événement en attente
+        pending_headers:
+          enqueued: Enregistré
+          handler_queue: File du gestionnaire
+          id: ID
+          reads: Lectures
+          routing_key: Clé de routage
+        pending_title: Événements en attente
         processed_empty: Aucun événement traité pour le moment
         processed_headers:
           event_id: ID de l'événement
@@ -127,6 +160,26 @@ fr:
           queue: File d'attente
         subscribers_title: Abonnés enregistrés
         title: Événements
+      pending_table:
+        arguments: Charge utile
+        discard: Jeter
+        discard_confirm: Jeter cet événement ? Il sera archivé.
+        edit_payload: Modifier & Réessayer
+        edit_payload_confirm: Mettre à jour la charge utile et réenregistrer cet événement ?
+        edit_payload_label: 'Charge utile JSON :'
+        event_id: 'ID de l''événement :'
+        full_json_payload: Charge utile JSON complète
+        headers_section: En-têtes
+        mark_handled: Marquer comme traité
+        mark_handled_confirm: Marquer cet événement comme traité ? Il sera archivé et ignoré lors du relecture.
+        metadata: Métadonnées
+        metadata_labels:
+          last_read: Dernière lecture
+          read_count: Nombre de lectures
+          visible_at: Visible à
+        reroute: Rediriger
+        reroute_confirm: Rediriger cet événement vers un autre gestionnaire ?
+        reroute_label: 'Gestionnaire cible :'
       show:
         back: Retour aux événements
         labels:
@@ -136,6 +189,9 @@ fr:
         not_found: Événement non trouvé
         title: Événement %{event_id}
     helpers:
+      bulk_select_all: Tout sélectionner
+      bulk_select_row: Sélectionner %{id}
+      bulk_selected: sélectionné
       paused_badge: En pause
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ fr:
       show:
         charts:
           failed_to_load: Échec du chargement des données du graphique
+          latency: Latence de la file d'attente (ms)
+          latency_avg: Moyenne
+          latency_p95: P95
           no_data: Pas encore de données
           series_name: Tâches/min
           status_distribution: Répartition du statut
           throughput: Débit (tâches/min)
         description_html: Indicateurs de performance professionnelle pour les derniers %{range}
+        latency_by_queue:
+          empty: Pas encore de données de latence
+          headers:
+            avg: Moyenne (ms)
+            count: Nombre
+            p95: P95 (ms)
+            queue: File d'attente
+          title: Latence par file d'attente
         slowest:
           empty: Pas encore de statistiques de tâches
           headers:
@@ -163,11 +230,32 @@ fr:
             job_class: Classe de tâche
             max: Max
           title: Classes de travail les plus lentes (durée moyenne)
+        streams:
+          summary:
+            active: Actif
+            avg_fanout: Moyenne de diffusion
+            broadcasts: Diffusions
+            connects: Connexions
+            disconnects: Déconnexions
+          title: Flux en temps réel
+          top:
+            empty: Aucune activité de flux enregistrée dans la fenêtre sélectionnée
+            headers:
+              avg_fanout: Moyenne de diffusion
+              avg_ms: Moyenne d'envoi
+              broadcasts: Diffusions
+              stream: Flux
+            title: Principaux flux par volume de diffusion
         summary:
           avg_duration: Durée moyenne
+          avg_latency: Latence moyenne
+          avg_retries: Nombre moyen de tentatives
           dead_lettered: Lettré mort
           failed: Échoué
           max_duration: Durée maximale
+          p50_latency: Latence P50
+          p95_latency: Latence P95
+          p99_latency: Latence P99
           succeeded: Réussi
           total_jobs: Total des travaux
         time_ranges:
@@ -222,6 +310,12 @@ fr:
         discard_all: Tout ignorer
         discard_all_confirm: Ignorer tous les travaux échoués ?
         discard_all_enqueued_notice: "%{count} travaux en file d'attente supprimés et verrous libérés."
+        discard_selected: Supprimer la sélection
+        discard_selected_confirm: Supprimer les éléments sélectionnés ?
+        discarded_selected:
+          one: 1 élément sélectionné supprimé.
+          other: "%{count} éléments sélectionnés supprimés."
+        none_selected: Aucun élément sélectionné.
         retry_all: Tout réessayer
         retry_all_confirm: Réessayer tous les travaux échoués ?
         title: Travaux
@@ -259,13 +353,28 @@ fr:
       toggle_menu: Basculer le menu
     locks:
       index:
+        all_locks_discarded:
+          one: 1 verrou supprimé.
+          other: "%{count} verrous supprimés."
         description: Verrous d'unicité actifs empêchant l'exécution de travaux en double
+        discard: Supprimer
+        discard_all: Tout supprimer
+        discard_all_confirm: Supprimer définitivement tous les verrous ? Cela peut permettre l'exécution en double des tâches.
+        discard_confirm: Supprimer ce verrou ? La tâche associée peut être remise en file d'attente.
+        discard_selected: Supprimer la sélection
+        discard_selected_confirm: Supprimer les verrous sélectionnés ?
         empty: Aucun verrou actif
         headers:
           age: Âge
           lock_key: Clé de verrou
           msg_id: ID du message
           queue_name: File
+        lock_discard_failed: Impossible de supprimer le verrou.
+        lock_discarded: Verrou supprimé.
+        locks_discarded:
+          one: 1 verrou supprimé.
+          other: "%{count} verrous supprimés."
+        none_selected: Aucun verrou sélectionné.
         title: Clés d'unicité
     outbox:
       index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -174,9 +174,9 @@ fr:
         mark_handled_confirm: Marquer cet événement comme traité ? Il sera archivé et ignoré lors du relecture.
         metadata: Métadonnées
         metadata_labels:
-          last_read: Dernière lecture
-          read_count: Nombre de lectures
-          visible_at: Visible à
+          last_read: 'Dernière lecture :'
+          read_count: 'Nombre de lectures :'
+          visible_at: 'Visible à :'
         reroute: Rediriger
         reroute_confirm: Rediriger cet événement vers un autre gestionnaire ?
         reroute_label: 'Gestionnaire cible :'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -66,6 +66,12 @@ it:
       index:
         discard_all: Scarta tutto
         discard_all_confirm: Scartare definitivamente tutti i messaggi DLQ?
+        discard_selected: Scarta selezionati
+        discard_selected_confirm: Scartare i messaggi DLQ selezionati?
+        discarded_selected:
+          one: 1 messaggio DLQ scartato.
+          other: "%{count} messaggi DLQ scartati."
+        none_selected: Nessun messaggio selezionato.
         retry_all: Riprova tutto
         retry_all_confirm: Riprova tutti i messaggi DLQ?
         title: Coda di lettere morte
@@ -113,7 +119,34 @@ it:
       delete_title: Elimina
       ok: OK
     events:
+      flash:
+        discard_failed: Impossibile scartare l'evento.
+        discarded: Evento scartato.
+        discarded_selected:
+          one: 1 evento scartato.
+          other: "%{count} eventi scartati."
+        mark_handled_failed: Impossibile contrassegnare l'evento come gestito.
+        marked_handled: Evento contrassegnato come gestito.
+        none_selected: Nessun evento selezionato.
+        payload_update_failed: Impossibile aggiornare il payload. Verifica che il JSON sia valido.
+        payload_updated: Payload aggiornato ed evento reinserito in coda.
+        replay_failed: Evento non trovato o non riproducibile.
+        replayed: Evento riprodotto.
+        reroute_failed: Impossibile reindirizzare l'evento.
+        rerouted: Evento reindirizzato al gestore di destinazione.
       index:
+        discard_all: Scarta tutto
+        discard_all_confirm: Scartare tutti gli eventi in sospeso? Questa operazione non può essere annullata.
+        discard_selected: Scarta selezionati
+        discard_selected_confirm: Scartare gli eventi selezionati?
+        pending_empty: Nessun evento in sospeso
+        pending_headers:
+          enqueued: In coda
+          handler_queue: Coda del gestore
+          id: ID
+          reads: Letture
+          routing_key: Chiave di routing
+        pending_title: Eventi in sospeso
         processed_empty: Nessun evento elaborato ancora
         processed_headers:
           event_id: ID evento
@@ -127,6 +160,26 @@ it:
           queue: Coda
         subscribers_title: Iscritti registrati
         title: Eventi
+      pending_table:
+        arguments: Payload
+        discard: Scarta
+        discard_confirm: Scartare questo evento? Verrà archiviato.
+        edit_payload: Modifica e riprova
+        edit_payload_confirm: Aggiornare il payload e reinserire questo evento in coda?
+        edit_payload_label: 'Payload JSON:'
+        event_id: 'ID evento:'
+        full_json_payload: Payload JSON completo
+        headers_section: Intestazioni
+        mark_handled: Contrassegna come gestito
+        mark_handled_confirm: Contrassegnare questo evento come gestito? Verrà archiviato e saltato durante la riproduzione.
+        metadata: Metadati
+        metadata_labels:
+          last_read: Ultima lettura
+          read_count: Conteggio letture
+          visible_at: Visibile il
+        reroute: Reindirizza
+        reroute_confirm: Reindirizzare questo evento a un gestore diverso?
+        reroute_label: 'Gestore di destinazione:'
       show:
         back: Torna agli eventi
         labels:
@@ -136,6 +189,9 @@ it:
         not_found: Evento non trovato
         title: Evento %{event_id}
     helpers:
+      bulk_select_all: Seleziona tutto
+      bulk_select_row: Seleziona %{id}
+      bulk_selected: selezionato
       paused_badge: In pausa
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ it:
       show:
         charts:
           failed_to_load: Impossibile caricare i dati del grafico
+          latency: Latenza in coda (ms)
+          latency_avg: Media
+          latency_p95: P95
           no_data: Nessun dato ancora
           series_name: Lavori/min
           status_distribution: Distribuzione stato
           throughput: Throughput (lavori/min)
         description_html: Metriche di rendimento lavorativo per gli ultimi %{range}
+        latency_by_queue:
+          empty: Nessun dato di latenza disponibile
+          headers:
+            avg: Media (ms)
+            count: Conteggio
+            p95: P95 (ms)
+            queue: Coda
+          title: Latenza per coda
         slowest:
           empty: Nessuna statistica lavori ancora
           headers:
@@ -163,11 +230,32 @@ it:
             job_class: Classe lavoro
             max: Massimo
           title: Classi di Lavoro Più Lente (durata media)
+        streams:
+          summary:
+            active: Attivo
+            avg_fanout: Media Fanout
+            broadcasts: Trasmissioni
+            connects: Connessioni
+            disconnects: Disconnessioni
+          title: Stream in tempo reale
+          top:
+            empty: Nessuna attività di stream registrata nella finestra selezionata
+            headers:
+              avg_fanout: Media Fanout
+              avg_ms: Media Invii
+              broadcasts: Trasmissioni
+              stream: Stream
+            title: Stream principali per volume di trasmissione
         summary:
           avg_duration: Durata Media
+          avg_latency: Latenza media
+          avg_retries: Media tentativi
           dead_lettered: Messaggi in Dead Letter
           failed: Falliti
           max_duration: Durata Massima
+          p50_latency: Latenza P50
+          p95_latency: Latenza P95
+          p99_latency: Latenza P99
           succeeded: Riusciti
           total_jobs: Totale Lavori
         time_ranges:
@@ -222,6 +310,12 @@ it:
         discard_all: Scarta Tutto
         discard_all_confirm: Scartare tutti i lavori falliti?
         discard_all_enqueued_notice: Scartati %{count} lavori in coda e rilasciati i relativi blocchi.
+        discard_selected: Scarta selezionati
+        discard_selected_confirm: Scartare gli elementi selezionati?
+        discarded_selected:
+          one: 1 elemento selezionato scartato.
+          other: "%{count} elementi selezionati scartati."
+        none_selected: Nessun elemento selezionato.
         retry_all: Riprova Tutto
         retry_all_confirm: Riprova tutti i lavori falliti?
         title: Lavori
@@ -259,13 +353,28 @@ it:
       toggle_menu: Attiva/disattiva menu
     locks:
       index:
+        all_locks_discarded:
+          one: 1 blocco scartato.
+          other: "%{count} blocchi scartati."
         description: Blocchi di unicità attivi che impediscono l'esecuzione duplicata del lavoro
+        discard: Scarta
+        discard_all: Scarta tutto
+        discard_all_confirm: Scartare definitivamente tutti i blocchi? Questo potrebbe consentire l'esecuzione duplicata dei lavori.
+        discard_confirm: Scartare questo blocco? Il lavoro associato potrebbe essere nuovamente messo in coda.
+        discard_selected: Scarta selezionati
+        discard_selected_confirm: Scartare i blocchi selezionati?
         empty: Nessun blocco attivo
         headers:
           age: Età
           lock_key: Chiave di blocco
           msg_id: ID messaggio
           queue_name: Coda
+        lock_discard_failed: Impossibile scartare il blocco.
+        lock_discarded: Blocco scartato.
+        locks_discarded:
+          one: 1 blocco scartato.
+          other: "%{count} blocchi scartati."
+        none_selected: Nessun blocco selezionato.
         title: Chiavi di unicità
     outbox:
       index:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -174,9 +174,9 @@ it:
         mark_handled_confirm: Contrassegnare questo evento come gestito? Verrà archiviato e saltato durante la riproduzione.
         metadata: Metadati
         metadata_labels:
-          last_read: Ultima lettura
-          read_count: Conteggio letture
-          visible_at: Visibile il
+          last_read: 'Ultima lettura:'
+          read_count: 'Conteggio letture:'
+          visible_at: 'Visibile il:'
         reroute: Reindirizza
         reroute_confirm: Reindirizzare questo evento a un gestore diverso?
         reroute_label: 'Gestore di destinazione:'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -70,7 +70,7 @@ ja:
         discard_selected_confirm: 選択したDLQメッセージを破棄しますか？
         discarded_selected:
           one: 1件のDLQメッセージを破棄しました。
-          other: "%{%{count}}件のDLQメッセージを破棄しました。"
+          other: "%{count}件のDLQメッセージを破棄しました。"
         none_selected: メッセージが選択されていません。
         retry_all: すべて再試行
         retry_all_confirm: すべてのDLQメッセージを再試行しますか？
@@ -124,7 +124,7 @@ ja:
         discarded: イベントが破棄されました。
         discarded_selected:
           one: 1件のイベントを破棄しました。
-          other: "%{%{count}}件のイベントを破棄しました。"
+          other: "%{count}件のイベントを破棄しました。"
         mark_handled_failed: イベントを処理済みとしてマークできませんでした。
         marked_handled: イベントが処理済みとしてマークされました。
         none_selected: イベントが選択されていません。
@@ -174,9 +174,9 @@ ja:
         mark_handled_confirm: このイベントを処理済みとしてマークしますか？アーカイブされ、再生時にスキップされます。
         metadata: メタデータ
         metadata_labels:
-          last_read: 最終読み取り
-          read_count: 読み取り回数
-          visible_at: 表示日時
+          last_read: 最終読み取り：
+          read_count: 読み取り回数：
+          visible_at: 表示日時：
         reroute: ルーティング変更
         reroute_confirm: このイベントを別のハンドラーにルーティングしますか？
         reroute_label: 'ターゲットハンドラー:'
@@ -190,7 +190,7 @@ ja:
         title: イベント %{event_id}
     helpers:
       bulk_select_all: すべて選択
-      bulk_select_row: "%{%{id}}を選択"
+      bulk_select_row: "%{id}を選択"
       bulk_selected: 選択済み
       paused_badge: 一時停止中
       queue_badge:
@@ -314,7 +314,7 @@ ja:
         discard_selected_confirm: 選択した項目を破棄しますか？
         discarded_selected:
           one: 1件の選択項目を破棄しました。
-          other: "%{%{count}}件の選択項目を破棄しました。"
+          other: "%{count}件の選択項目を破棄しました。"
         none_selected: 項目が選択されていません。
         retry_all: すべてリトライ
         retry_all_confirm: すべての失敗したジョブをリトライしますか？
@@ -355,7 +355,7 @@ ja:
       index:
         all_locks_discarded:
           one: 1件のロックを破棄しました。
-          other: "%{%{count}}件のロックを破棄しました。"
+          other: "%{count}件のロックを破棄しました。"
         description: 重複ジョブ実行を防ぐアクティブなユニークロック
         discard: 破棄
         discard_all: すべて破棄
@@ -373,7 +373,7 @@ ja:
         lock_discarded: ロックを破棄しました。
         locks_discarded:
           one: 1件のロックを破棄しました。
-          other: "%{%{count}}件のロックを破棄しました。"
+          other: "%{count}件のロックを破棄しました。"
         none_selected: ロックが選択されていません。
         title: 一意性キー
     outbox:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -66,6 +66,12 @@ ja:
       index:
         discard_all: すべて破棄
         discard_all_confirm: すべてのDLQメッセージを完全に破棄しますか？
+        discard_selected: 選択を破棄
+        discard_selected_confirm: 選択したDLQメッセージを破棄しますか？
+        discarded_selected:
+          one: 1件のDLQメッセージを破棄しました。
+          other: "%{%{count}}件のDLQメッセージを破棄しました。"
+        none_selected: メッセージが選択されていません。
         retry_all: すべて再試行
         retry_all_confirm: すべてのDLQメッセージを再試行しますか？
         title: デッドレターキュー
@@ -113,7 +119,34 @@ ja:
       delete_title: 削除
       ok: OK
     events:
+      flash:
+        discard_failed: イベントを破棄できませんでした。
+        discarded: イベントが破棄されました。
+        discarded_selected:
+          one: 1件のイベントを破棄しました。
+          other: "%{%{count}}件のイベントを破棄しました。"
+        mark_handled_failed: イベントを処理済みとしてマークできませんでした。
+        marked_handled: イベントが処理済みとしてマークされました。
+        none_selected: イベントが選択されていません。
+        payload_update_failed: ペイロードを更新できませんでした。JSONが有効であることを確認してください。
+        payload_updated: ペイロードが更新され、イベントが再キューに登録されました。
+        replay_failed: イベントが見つからないか再生できませんでした。
+        replayed: イベントが再生されました。
+        reroute_failed: イベントをルーティングできませんでした。
+        rerouted: イベントがターゲットハンドラーにルーティングされました。
       index:
+        discard_all: すべて破棄
+        discard_all_confirm: 保留中のすべてのイベントを破棄しますか？これは元に戻せません。
+        discard_selected: 選択を破棄
+        discard_selected_confirm: 選択したイベントを破棄しますか？
+        pending_empty: 保留中のイベントはありません
+        pending_headers:
+          enqueued: キューに登録済み
+          handler_queue: ハンドラーキュー
+          id: ID
+          reads: 読み取り数
+          routing_key: ルーティングキー
+        pending_title: 保留中のイベント
         processed_empty: まだ処理されたイベントはありません
         processed_headers:
           event_id: イベントID
@@ -127,6 +160,26 @@ ja:
           queue: キュー
         subscribers_title: 登録された購読者
         title: イベント
+      pending_table:
+        arguments: ペイロード
+        discard: 破棄
+        discard_confirm: このイベントを破棄しますか？アーカイブされます。
+        edit_payload: 編集して再試行
+        edit_payload_confirm: ペイロードを更新してこのイベントを再キューに登録しますか？
+        edit_payload_label: 'JSONペイロード:'
+        event_id: 'イベントID:'
+        full_json_payload: 完全なJSONペイロード
+        headers_section: ヘッダー
+        mark_handled: 処理済みとしてマーク
+        mark_handled_confirm: このイベントを処理済みとしてマークしますか？アーカイブされ、再生時にスキップされます。
+        metadata: メタデータ
+        metadata_labels:
+          last_read: 最終読み取り
+          read_count: 読み取り回数
+          visible_at: 表示日時
+        reroute: ルーティング変更
+        reroute_confirm: このイベントを別のハンドラーにルーティングしますか？
+        reroute_label: 'ターゲットハンドラー:'
       show:
         back: イベントに戻る
         labels:
@@ -136,6 +189,9 @@ ja:
         not_found: イベントが見つかりません
         title: イベント %{event_id}
     helpers:
+      bulk_select_all: すべて選択
+      bulk_select_row: "%{%{id}}を選択"
+      bulk_selected: 選択済み
       paused_badge: 一時停止中
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ ja:
       show:
         charts:
           failed_to_load: チャートデータの読み込みに失敗しました
+          latency: キュー遅延 (ms)
+          latency_avg: 平均
+          latency_p95: P95
           no_data: まだデータがありません
           series_name: ジョブ/分
           status_distribution: ステータス分布
           throughput: スループット（ジョブ/分）
         description_html: 過去%{range}の仕事のパフォーマンス指標
+        latency_by_queue:
+          empty: まだ遅延データがありません
+          headers:
+            avg: 平均 (ms)
+            count: 件数
+            p95: P95 (ms)
+            queue: キュー
+          title: キュー別遅延
         slowest:
           empty: まだジョブ統計がありません
           headers:
@@ -163,11 +230,32 @@ ja:
             job_class: ジョブクラス
             max: 最大
           title: 最も遅いジョブクラス（平均実行時間）
+        streams:
+          summary:
+            active: アクティブ
+            avg_fanout: 平均ファンアウト
+            broadcasts: ブロードキャスト
+            connects: 接続数
+            disconnects: 切断数
+          title: リアルタイムストリーム
+          top:
+            empty: 選択した期間にストリームのアクティビティが記録されていません
+            headers:
+              avg_fanout: 平均ファンアウト
+              avg_ms: 平均ディスパッチ
+              broadcasts: ブロードキャスト
+              stream: ストリーム
+            title: ブロードキャスト量によるトップストリーム
         summary:
           avg_duration: 平均実行時間
+          avg_latency: 平均遅延
+          avg_retries: 平均リトライ回数
           dead_lettered: デッドレター化された
           failed: 失敗した
           max_duration: 最大実行時間
+          p50_latency: P50遅延
+          p95_latency: P95遅延
+          p99_latency: P99遅延
           succeeded: 成功した
           total_jobs: 合計ジョブ数
         time_ranges:
@@ -222,6 +310,12 @@ ja:
         discard_all: すべて破棄
         discard_all_confirm: すべての失敗したジョブを破棄しますか？
         discard_all_enqueued_notice: "%{count}件のキュー内ジョブを破棄し、ロックを解放しました。"
+        discard_selected: 選択を破棄
+        discard_selected_confirm: 選択した項目を破棄しますか？
+        discarded_selected:
+          one: 1件の選択項目を破棄しました。
+          other: "%{%{count}}件の選択項目を破棄しました。"
+        none_selected: 項目が選択されていません。
         retry_all: すべてリトライ
         retry_all_confirm: すべての失敗したジョブをリトライしますか？
         title: ジョブ
@@ -259,13 +353,28 @@ ja:
       toggle_menu: メニュー切替
     locks:
       index:
+        all_locks_discarded:
+          one: 1件のロックを破棄しました。
+          other: "%{%{count}}件のロックを破棄しました。"
         description: 重複ジョブ実行を防ぐアクティブなユニークロック
+        discard: 破棄
+        discard_all: すべて破棄
+        discard_all_confirm: すべてのロックを完全に破棄しますか？これによりジョブの重複実行が発生する可能性があります。
+        discard_confirm: このロックを破棄しますか？関連するジョブが再度キューに入る可能性があります。
+        discard_selected: 選択を破棄
+        discard_selected_confirm: 選択したロックを破棄しますか？
         empty: アクティブなロックはありません
         headers:
           age: 経過時間
           lock_key: ロックキー
           msg_id: メッセージID
           queue_name: キュー
+        lock_discard_failed: ロックを破棄できませんでした。
+        lock_discarded: ロックを破棄しました。
+        locks_discarded:
+          one: 1件のロックを破棄しました。
+          other: "%{%{count}}件のロックを破棄しました。"
+        none_selected: ロックが選択されていません。
         title: 一意性キー
     outbox:
       index:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -174,9 +174,9 @@ nb:
         mark_handled_confirm: Merk denne hendelsen som håndtert? Den vil bli arkivert og hoppes over ved avspilling.
         metadata: Metadata
         metadata_labels:
-          last_read: Sist lest
-          read_count: Antall lesninger
-          visible_at: Synlig fra
+          last_read: 'Sist lest:'
+          read_count: 'Antall lesninger:'
+          visible_at: 'Synlig fra:'
         reroute: Omdiriger
         reroute_confirm: Omdiriger denne hendelsen til en annen behandler?
         reroute_label: 'Målbehandler:'

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -66,6 +66,12 @@ nb:
       index:
         discard_all: Forkast alle
         discard_all_confirm: Slett alle DLQ-meldinger permanent?
+        discard_selected: Forkast valgte
+        discard_selected_confirm: Forkast valgte DLQ-meldinger?
+        discarded_selected:
+          one: 1 DLQ-melding forkastet.
+          other: "%{count} DLQ-meldinger forkastet."
+        none_selected: Ingen meldinger valgt.
         retry_all: Prøv alle på nytt
         retry_all_confirm: Prøv alle DLQ-meldinger på nytt?
         title: Dead Letter Queue
@@ -113,7 +119,34 @@ nb:
       delete_title: Slett
       ok: OK
     events:
+      flash:
+        discard_failed: Kunne ikke forkaste hendelse.
+        discarded: Hendelse forkastet.
+        discarded_selected:
+          one: 1 hendelse forkastet.
+          other: "%{count} hendelser forkastet."
+        mark_handled_failed: Kunne ikke merke hendelse som håndtert.
+        marked_handled: Hendelse merket som håndtert.
+        none_selected: Ingen hendelser valgt.
+        payload_update_failed: Kunne ikke oppdatere nyttelast. Sjekk at JSON er gyldig.
+        payload_updated: Nyttelast oppdatert og hendelse lagt i kø på nytt.
+        replay_failed: Hendelse ikke funnet eller kunne ikke spilles av på nytt.
+        replayed: Hendelse spilt av på nytt.
+        reroute_failed: Kunne ikke omdirigere hendelse.
+        rerouted: Hendelse omdirigert til målbehandler.
       index:
+        discard_all: Forkast alle
+        discard_all_confirm: Forkast alle ventende hendelser? Dette kan ikke angres.
+        discard_selected: Forkast valgte
+        discard_selected_confirm: Forkast valgte hendelser?
+        pending_empty: Ingen ventende hendelser
+        pending_headers:
+          enqueued: I kø
+          handler_queue: Behandlerkø
+          id: ID
+          reads: Lesninger
+          routing_key: Rutingsnøkkel
+        pending_title: Ventende hendelser
         processed_empty: Ingen hendelser behandlet ennå
         processed_headers:
           event_id: Hendelses-ID
@@ -127,6 +160,26 @@ nb:
           queue: Kø
         subscribers_title: Registrerte abonnenter
         title: Hendelser
+      pending_table:
+        arguments: Nyttelast
+        discard: Forkast
+        discard_confirm: Forkast denne hendelsen? Den vil bli arkivert.
+        edit_payload: Rediger & prøv på nytt
+        edit_payload_confirm: Oppdater nyttelast og legg denne hendelsen i kø på nytt?
+        edit_payload_label: 'JSON-nyttelast:'
+        event_id: 'Hendelses-ID:'
+        full_json_payload: Full JSON-nyttelast
+        headers_section: Overskrifter
+        mark_handled: Merk som håndtert
+        mark_handled_confirm: Merk denne hendelsen som håndtert? Den vil bli arkivert og hoppes over ved avspilling.
+        metadata: Metadata
+        metadata_labels:
+          last_read: Sist lest
+          read_count: Antall lesninger
+          visible_at: Synlig fra
+        reroute: Omdiriger
+        reroute_confirm: Omdiriger denne hendelsen til en annen behandler?
+        reroute_label: 'Målbehandler:'
       show:
         back: Tilbake til hendelser
         labels:
@@ -136,6 +189,9 @@ nb:
         not_found: Hendelse ikke funnet
         title: Hendelse %{event_id}
     helpers:
+      bulk_select_all: Velg alle
+      bulk_select_row: Velg %{id}
+      bulk_selected: valgt
       paused_badge: Pause
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ nb:
       show:
         charts:
           failed_to_load: Kunne ikke laste diagramdata
+          latency: Køforsinkelse (ms)
+          latency_avg: Gj.snitt
+          latency_p95: P95
           no_data: Ingen data ennå
           series_name: Jobber/min
           status_distribution: Statusfordeling
           throughput: Gjennomstrømning (jobber/min)
         description_html: Jobbprestasjonsmålinger for de siste %{range}
+        latency_by_queue:
+          empty: Ingen forsinkelsesdata ennå
+          headers:
+            avg: Gj.snitt (ms)
+            count: Antall
+            p95: P95 (ms)
+            queue: Kø
+          title: Forsinkelse per kø
         slowest:
           empty: Ingen jobbstatistikk ennå
           headers:
@@ -163,11 +230,32 @@ nb:
             job_class: Jobbklasse
             max: Maks
           title: Sakte jobber (gj.snitt varighet)
+        streams:
+          summary:
+            active: Aktiv
+            avg_fanout: Gj.snitt Fanout
+            broadcasts: Sendinger
+            connects: Tilkoblinger
+            disconnects: Frakoblinger
+          title: Sanntidsstrømmer
+          top:
+            empty: Ingen strømaktivitet registrert i det valgte tidsvinduet
+            headers:
+              avg_fanout: Gj.snitt Fanout
+              avg_ms: Gj.snitt Distribusjon
+              broadcasts: Sendinger
+              stream: Strøm
+            title: Toppstrømmer etter sendingsvolum
         summary:
           avg_duration: Gj.snitt varighet
+          avg_latency: Gj.snitt Forsinkelse
+          avg_retries: Gj.snitt Forsøk på nytt
           dead_lettered: Døde brev
           failed: Mislyktes
           max_duration: Maks varighet
+          p50_latency: P50 Forsinkelse
+          p95_latency: P95 Forsinkelse
+          p99_latency: P99 Forsinkelse
           succeeded: Lyktes
           total_jobs: Totalt antall jobber
         time_ranges:
@@ -222,6 +310,12 @@ nb:
         discard_all: Forkast alle
         discard_all_confirm: Forkast alle mislykkede jobber?
         discard_all_enqueued_notice: Forkastet %{count} køede jobber og frigitt låsene.
+        discard_selected: Forkast valgte
+        discard_selected_confirm: Forkast valgte elementer?
+        discarded_selected:
+          one: Forkastet 1 valgt element.
+          other: Forkastet %{count} valgte elementer.
+        none_selected: Ingen elementer valgt.
         retry_all: Prøv alle på nytt
         retry_all_confirm: Prøv alle mislykkede jobber på nytt?
         title: Jobber
@@ -259,13 +353,28 @@ nb:
       toggle_menu: Veksle meny
     locks:
       index:
+        all_locks_discarded:
+          one: Forkastet 1 lås.
+          other: Forkastet %{count} låser.
         description: Aktive unike låser som forhindrer duplisert jobbkjøring
+        discard: Forkast
+        discard_all: Forkast alle
+        discard_all_confirm: Vil du permanent forkaste alle låser? Dette kan tillate duplisert jobbutførelse.
+        discard_confirm: Vil du forkaste denne låsen? Den tilknyttede jobben kan bli satt i kø igjen.
+        discard_selected: Forkast valgte
+        discard_selected_confirm: Vil du forkaste valgte låser?
         empty: Ingen aktive låser
         headers:
           age: Alder
           lock_key: Låsenøkkel
           msg_id: Meldings-ID
           queue_name: Kø
+        lock_discard_failed: Kunne ikke forkaste lås.
+        lock_discarded: Lås forkastet.
+        locks_discarded:
+          one: Forkastet 1 lås.
+          other: Forkastet %{count} låser.
+        none_selected: Ingen låser valgt.
         title: Unikhetsnøkler
     outbox:
       index:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -66,6 +66,12 @@ nl:
       index:
         discard_all: Alles weggooien
         discard_all_confirm: Alle DLQ-berichten permanent verwijderen?
+        discard_selected: Verwijder Geselecteerde
+        discard_selected_confirm: Geselecteerde DLQ-berichten verwijderen?
+        discarded_selected:
+          one: 1 DLQ-bericht verwijderd.
+          other: "%{count} DLQ-berichten verwijderd."
+        none_selected: Geen berichten geselecteerd.
         retry_all: Alles opnieuw proberen
         retry_all_confirm: Alle DLQ-berichten opnieuw proberen?
         title: Dead Letter Queue
@@ -113,7 +119,34 @@ nl:
       delete_title: Verwijderen
       ok: OK
     events:
+      flash:
+        discard_failed: Kon gebeurtenis niet verwijderen.
+        discarded: Gebeurtenis verwijderd.
+        discarded_selected:
+          one: 1 gebeurtenis verwijderd.
+          other: "%{count} gebeurtenissen verwijderd."
+        mark_handled_failed: Kon gebeurtenis niet als afgehandeld markeren.
+        marked_handled: Gebeurtenis als afgehandeld gemarkeerd.
+        none_selected: Geen gebeurtenissen geselecteerd.
+        payload_update_failed: Kon payload niet bijwerken. Controleer of de JSON geldig is.
+        payload_updated: Payload bijgewerkt en gebeurtenis opnieuw in de wachtrij geplaatst.
+        replay_failed: Gebeurtenis niet gevonden of kon niet worden afgespeeld.
+        replayed: Gebeurtenis afgespeeld.
+        reroute_failed: Kon gebeurtenis niet omleiden.
+        rerouted: Gebeurtenis omgeleid naar doelhandler.
       index:
+        discard_all: Alles Verwijderen
+        discard_all_confirm: Alle openstaande gebeurtenissen verwijderen? Dit kan niet ongedaan worden gemaakt.
+        discard_selected: Geselecteerde Verwijderen
+        discard_selected_confirm: Geselecteerde gebeurtenissen verwijderen?
+        pending_empty: Geen openstaande gebeurtenissen
+        pending_headers:
+          enqueued: In de wachtrij geplaatst
+          handler_queue: Handler Wachtrij
+          id: ID
+          reads: Lezingen
+          routing_key: Routing Key
+        pending_title: Openstaande Gebeurtenissen
         processed_empty: Nog geen gebeurtenissen verwerkt
         processed_headers:
           event_id: Gebeurtenis ID
@@ -127,6 +160,26 @@ nl:
           queue: Wachtrij
         subscribers_title: Geregistreerde abonnees
         title: Gebeurtenissen
+      pending_table:
+        arguments: Payload
+        discard: Verwijderen
+        discard_confirm: Deze gebeurtenis verwijderen? Deze wordt gearchiveerd.
+        edit_payload: Bewerken & Opnieuw Proberen
+        edit_payload_confirm: Payload bijwerken en deze gebeurtenis opnieuw in de wachtrij plaatsen?
+        edit_payload_label: 'JSON Payload:'
+        event_id: 'Gebeurtenis ID:'
+        full_json_payload: Volledige JSON Payload
+        headers_section: Headers
+        mark_handled: Markeren als Afgehandeld
+        mark_handled_confirm: Deze gebeurtenis als afgehandeld markeren? Deze wordt gearchiveerd en overgeslagen bij het afspelen.
+        metadata: Metadata
+        metadata_labels:
+          last_read: Laatst Gelezen
+          read_count: Aantal Lezingen
+          visible_at: Zichtbaar Op
+        reroute: Omleiden
+        reroute_confirm: Deze gebeurtenis omleiden naar een andere handler?
+        reroute_label: 'Doelhandler:'
       show:
         back: Terug naar gebeurtenissen
         labels:
@@ -136,6 +189,9 @@ nl:
         not_found: Gebeurtenis niet gevonden
         title: Gebeurtenis %{event_id}
     helpers:
+      bulk_select_all: Alles selecteren
+      bulk_select_row: Selecteer %{id}
+      bulk_selected: geselecteerd
       paused_badge: Gepauzeerd
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ nl:
       show:
         charts:
           failed_to_load: Fout bij laden grafiekgegevens
+          latency: Wachtrijvertraging (ms)
+          latency_avg: Gemiddeld
+          latency_p95: P95
           no_data: Nog geen gegevens
           series_name: Taken/min
           status_distribution: Statusverdeling
           throughput: Doorvoer (taken/min)
         description_html: Prestatie-indicatoren voor de laatste %{range}
+        latency_by_queue:
+          empty: Nog geen vertraginggegevens
+          headers:
+            avg: Gemiddeld (ms)
+            count: Aantal
+            p95: P95 (ms)
+            queue: Wachtrij
+          title: Vertraging per wachtrij
         slowest:
           empty: Nog geen taakstatistieken
           headers:
@@ -163,11 +230,32 @@ nl:
             job_class: Taakklasse
             max: Maximaal
           title: Langzaamste Taakklassen (gem. duur)
+        streams:
+          summary:
+            active: Actief
+            avg_fanout: Gemiddelde verspreiding
+            broadcasts: Uitzendingen
+            connects: Verbindingen
+            disconnects: Verbrekingen
+          title: Realtime streams
+          top:
+            empty: Geen streamactiviteit geregistreerd in het geselecteerde venster
+            headers:
+              avg_fanout: Gemiddelde verspreiding
+              avg_ms: Gemiddelde verzending
+              broadcasts: Uitzendingen
+              stream: Stream
+            title: Topstreams op basis van uitzendsvolume
         summary:
           avg_duration: Gem. Duur
+          avg_latency: Gemiddelde vertraging
+          avg_retries: Gemiddeld aantal pogingen
           dead_lettered: Dead Lettered
           failed: Mislukt
           max_duration: Maximale Duur
+          p50_latency: P50 vertraging
+          p95_latency: P95 vertraging
+          p99_latency: P99 vertraging
           succeeded: Geslaagd
           total_jobs: Totaal Taken
         time_ranges:
@@ -222,6 +310,12 @@ nl:
         discard_all: Alles Verwijderen
         discard_all_confirm: Alle mislukte taken verwijderen?
         discard_all_enqueued_notice: "%{count} taken in de wachtrij verwijderd en vergrendelingen vrijgegeven."
+        discard_selected: Geselecteerd verwijderen
+        discard_selected_confirm: Geselecteerde items verwijderen?
+        discarded_selected:
+          one: 1 geselecteerd item verwijderd.
+          other: "%{count} geselecteerde items verwijderd."
+        none_selected: Geen items geselecteerd.
         retry_all: Alles Opnieuw Proberen
         retry_all_confirm: Alle mislukte taken opnieuw proberen?
         title: Taken
@@ -259,13 +353,28 @@ nl:
       toggle_menu: Menu wisselen
     locks:
       index:
+        all_locks_discarded:
+          one: 1 slot verwijderd.
+          other: "%{count} sloten verwijderd."
         description: Actieve uniekheidsvergrendelingen voorkomen dubbele taakuitvoering
+        discard: Verwijderen
+        discard_all: Alles verwijderen
+        discard_all_confirm: Alle sloten permanent verwijderen? Dit kan dubbele taakuitvoering toestaan.
+        discard_confirm: Dit slot verwijderen? De bijbehorende taak kan opnieuw in de wachtrij worden geplaatst.
+        discard_selected: Geselecteerd verwijderen
+        discard_selected_confirm: Geselecteerde sloten verwijderen?
         empty: Geen actieve vergrendelingen
         headers:
           age: Leeftijd
           lock_key: Vergrendelingssleutel
           msg_id: Bericht-ID
           queue_name: Wachtrij
+        lock_discard_failed: Kon slot niet verwijderen.
+        lock_discarded: Slot verwijderd.
+        locks_discarded:
+          one: 1 slot verwijderd.
+          other: "%{count} sloten verwijderd."
+        none_selected: Geen sloten geselecteerd.
         title: Uniciteitsleutels
     outbox:
       index:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -174,9 +174,9 @@ nl:
         mark_handled_confirm: Deze gebeurtenis als afgehandeld markeren? Deze wordt gearchiveerd en overgeslagen bij het afspelen.
         metadata: Metadata
         metadata_labels:
-          last_read: Laatst Gelezen
-          read_count: Aantal Lezingen
-          visible_at: Zichtbaar Op
+          last_read: 'Laatst gelezen:'
+          read_count: 'Aantal lezingen:'
+          visible_at: 'Zichtbaar op:'
         reroute: Omleiden
         reroute_confirm: Deze gebeurtenis omleiden naar een andere handler?
         reroute_label: 'Doelhandler:'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -66,6 +66,12 @@ pt:
       index:
         discard_all: Descartar Tudo
         discard_all_confirm: Descartar permanentemente todas as mensagens DLQ?
+        discard_selected: Descartar Selecionados
+        discard_selected_confirm: Descartar mensagens DLQ selecionadas?
+        discarded_selected:
+          one: 1 mensagem DLQ descartada.
+          other: "%{count} mensagens DLQ descartadas."
+        none_selected: Nenhuma mensagem selecionada.
         retry_all: Tentar Novamente Tudo
         retry_all_confirm: Tentar novamente todas as mensagens DLQ?
         title: Fila de Mensagens Mortas
@@ -113,7 +119,34 @@ pt:
       delete_title: Excluir
       ok: OK
     events:
+      flash:
+        discard_failed: Não foi possível descartar o evento.
+        discarded: Evento descartado.
+        discarded_selected:
+          one: 1 evento descartado.
+          other: "%{count} eventos descartados."
+        mark_handled_failed: Não foi possível marcar o evento como tratado.
+        marked_handled: Evento marcado como tratado.
+        none_selected: Nenhum evento selecionado.
+        payload_update_failed: Não foi possível atualizar o payload. Verifique se o JSON é válido.
+        payload_updated: Payload atualizado e evento reenfileirado.
+        replay_failed: Evento não encontrado ou não pôde ser reproduzido.
+        replayed: Evento reproduzido.
+        reroute_failed: Não foi possível redirecionar o evento.
+        rerouted: Evento redirecionado para o manipulador alvo.
       index:
+        discard_all: Descartar Todos
+        discard_all_confirm: Descartar todos os eventos pendentes? Esta ação não pode ser desfeita.
+        discard_selected: Descartar Selecionados
+        discard_selected_confirm: Descartar eventos selecionados?
+        pending_empty: Nenhum evento pendente
+        pending_headers:
+          enqueued: Enfileirado
+          handler_queue: Fila do Manipulador
+          id: ID
+          reads: Leituras
+          routing_key: Chave de Roteamento
+        pending_title: Eventos Pendentes
         processed_empty: Nenhum evento processado ainda
         processed_headers:
           event_id: ID do evento
@@ -127,6 +160,26 @@ pt:
           queue: Fila
         subscribers_title: Assinantes registrados
         title: Eventos
+      pending_table:
+        arguments: Payload
+        discard: Descartar
+        discard_confirm: Descartar este evento? Ele será arquivado.
+        edit_payload: Editar e Tentar Novamente
+        edit_payload_confirm: Atualizar payload e reenfileirar este evento?
+        edit_payload_label: 'Payload JSON:'
+        event_id: 'ID do Evento:'
+        full_json_payload: Payload JSON Completo
+        headers_section: Cabeçalhos
+        mark_handled: Marcar como Tratado
+        mark_handled_confirm: Marcar este evento como tratado? Ele será arquivado e ignorado na reprodução.
+        metadata: Metadados
+        metadata_labels:
+          last_read: Última Leitura
+          read_count: Contagem de Leituras
+          visible_at: Visível em
+        reroute: Redirecionar
+        reroute_confirm: Redirecionar este evento para um manipulador diferente?
+        reroute_label: 'Manipulador alvo:'
       show:
         back: Voltar para eventos
         labels:
@@ -136,6 +189,9 @@ pt:
         not_found: Evento não encontrado
         title: Evento %{event_id}
     helpers:
+      bulk_select_all: Selecionar todos
+      bulk_select_row: Selecionar %{id}
+      bulk_selected: selecionado
       paused_badge: Pausado
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ pt:
       show:
         charts:
           failed_to_load: Falha ao carregar dados do gráfico
+          latency: Latência da Fila (ms)
+          latency_avg: Média
+          latency_p95: P95
           no_data: Sem dados ainda
           series_name: Tarefas/min
           status_distribution: Distribuição de status
           throughput: Taxa de transferência (tarefas/min)
         description_html: Métricas de desempenho de trabalho para os últimos %{range}
+        latency_by_queue:
+          empty: Ainda não há dados de latência
+          headers:
+            avg: Média (ms)
+            count: Contagem
+            p95: P95 (ms)
+            queue: Fila
+          title: Latência por Fila
         slowest:
           empty: Nenhuma estatística de tarefa ainda
           headers:
@@ -163,11 +230,32 @@ pt:
             job_class: Classe da tarefa
             max: Máximo
           title: Classes de Trabalho Mais Lentas (duração média)
+        streams:
+          summary:
+            active: Ativo
+            avg_fanout: Média de Ramificações
+            broadcasts: Transmissões
+            connects: Conexões
+            disconnects: Desconexões
+          title: Streams em Tempo Real
+          top:
+            empty: Nenhuma atividade de stream registrada na janela selecionada
+            headers:
+              avg_fanout: Média de Ramificações
+              avg_ms: Média de Despacho
+              broadcasts: Transmissões
+              stream: Stream
+            title: Principais Streams por Volume de Transmissão
         summary:
           avg_duration: Duração Média
+          avg_latency: Latência Média
+          avg_retries: Média de Tentativas
           dead_lettered: Cartas Mortas
           failed: Falhou
           max_duration: Duração Máxima
+          p50_latency: Latência P50
+          p95_latency: Latência P95
+          p99_latency: Latência P99
           succeeded: Bem-sucedido
           total_jobs: Total de Trabalhos
         time_ranges:
@@ -222,6 +310,12 @@ pt:
         discard_all: Descartar Todos
         discard_all_confirm: Descartar todos os trabalhos falhados?
         discard_all_enqueued_notice: Descartados %{count} trabalhos na fila e bloqueios liberados.
+        discard_selected: Descartar Selecionados
+        discard_selected_confirm: Descartar itens selecionados?
+        discarded_selected:
+          one: 1 item selecionado descartado.
+          other: "%{%{count}} itens selecionados descartados."
+        none_selected: Nenhum item selecionado.
         retry_all: Tentar Novamente Todos
         retry_all_confirm: Tentar novamente todos os trabalhos falhados?
         title: Trabalhos
@@ -259,13 +353,28 @@ pt:
       toggle_menu: Alternar menu
     locks:
       index:
+        all_locks_discarded:
+          one: 1 bloqueio descartado.
+          other: "%{%{count}} bloqueios descartados."
         description: Bloqueios de exclusividade ativos impedindo a execução duplicada do trabalho
+        discard: Descartar
+        discard_all: Descartar Todos
+        discard_all_confirm: Descartar permanentemente todos os bloqueios? Isso pode permitir a execução duplicada de trabalhos.
+        discard_confirm: Descartar este bloqueio? O trabalho associado pode ser enfileirado novamente.
+        discard_selected: Descartar Selecionados
+        discard_selected_confirm: Descartar bloqueios selecionados?
         empty: Nenhum bloqueio ativo
         headers:
           age: Idade
           lock_key: Chave de Bloqueio
           msg_id: ID da mensagem
           queue_name: Fila
+        lock_discard_failed: Não foi possível descartar o bloqueio.
+        lock_discarded: Bloqueio descartado.
+        locks_discarded:
+          one: 1 bloqueio descartado.
+          other: "%{%{count}} bloqueios descartados."
+        none_selected: Nenhum bloqueio selecionado.
         title: Chaves de unicidade
     outbox:
       index:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -174,9 +174,9 @@ pt:
         mark_handled_confirm: Marcar este evento como tratado? Ele será arquivado e ignorado na reprodução.
         metadata: Metadados
         metadata_labels:
-          last_read: Última Leitura
-          read_count: Contagem de Leituras
-          visible_at: Visível em
+          last_read: 'Última leitura:'
+          read_count: 'Contagem de leituras:'
+          visible_at: 'Visível em:'
         reroute: Redirecionar
         reroute_confirm: Redirecionar este evento para um manipulador diferente?
         reroute_label: 'Manipulador alvo:'
@@ -314,7 +314,7 @@ pt:
         discard_selected_confirm: Descartar itens selecionados?
         discarded_selected:
           one: 1 item selecionado descartado.
-          other: "%{%{count}} itens selecionados descartados."
+          other: "%{count} itens selecionados descartados."
         none_selected: Nenhum item selecionado.
         retry_all: Tentar Novamente Todos
         retry_all_confirm: Tentar novamente todos os trabalhos falhados?
@@ -355,7 +355,7 @@ pt:
       index:
         all_locks_discarded:
           one: 1 bloqueio descartado.
-          other: "%{%{count}} bloqueios descartados."
+          other: "%{count} bloqueios descartados."
         description: Bloqueios de exclusividade ativos impedindo a execução duplicada do trabalho
         discard: Descartar
         discard_all: Descartar Todos
@@ -373,7 +373,7 @@ pt:
         lock_discarded: Bloqueio descartado.
         locks_discarded:
           one: 1 bloqueio descartado.
-          other: "%{%{count}} bloqueios descartados."
+          other: "%{count} bloqueios descartados."
         none_selected: Nenhum bloqueio selecionado.
         title: Chaves de unicidade
     outbox:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -66,6 +66,12 @@ sv:
       index:
         discard_all: Kassera alla
         discard_all_confirm: Kassera permanent alla DLQ-meddelanden?
+        discard_selected: Kassera valda
+        discard_selected_confirm: Kassera valda DLQ-meddelanden?
+        discarded_selected:
+          one: Kasserade 1 DLQ-meddelande.
+          other: Kasserade %{count} DLQ-meddelanden.
+        none_selected: Inga meddelanden valda.
         retry_all: Försök igen alla
         retry_all_confirm: Försök igen alla DLQ-meddelanden?
         title: Dead Letter-kö
@@ -113,7 +119,34 @@ sv:
       delete_title: Ta bort
       ok: OK
     events:
+      flash:
+        discard_failed: Kunde inte kassera händelsen.
+        discarded: Händelse kasserad.
+        discarded_selected:
+          one: Kasserade 1 händelse.
+          other: Kasserade %{count} händelser.
+        mark_handled_failed: Kunde inte markera händelsen som hanterad.
+        marked_handled: Händelse markerad som hanterad.
+        none_selected: Inga händelser valda.
+        payload_update_failed: Kunde inte uppdatera payload. Kontrollera att JSON är giltig.
+        payload_updated: Payload uppdaterad och händelsen återköad.
+        replay_failed: Händelsen hittades inte eller kunde inte spelas upp.
+        replayed: Händelsen spelades upp.
+        reroute_failed: Kunde inte omdirigera händelsen.
+        rerouted: Händelsen omdirigerades till målhanteraren.
       index:
+        discard_all: Kassera alla
+        discard_all_confirm: Kassera alla väntande händelser? Detta kan inte ångras.
+        discard_selected: Kassera valda
+        discard_selected_confirm: Kassera valda händelser?
+        pending_empty: Inga väntande händelser
+        pending_headers:
+          enqueued: Köad
+          handler_queue: Handler-kö
+          id: ID
+          reads: Läsningar
+          routing_key: Routing-nyckel
+        pending_title: Väntande händelser
         processed_empty: Inga händelser behandlade än
         processed_headers:
           event_id: Händelse-ID
@@ -127,6 +160,26 @@ sv:
           queue: Kö
         subscribers_title: Registrerade prenumeranter
         title: Händelser
+      pending_table:
+        arguments: Payload
+        discard: Kassera
+        discard_confirm: Kassera denna händelse? Den kommer att arkiveras.
+        edit_payload: Redigera & Försök igen
+        edit_payload_confirm: Uppdatera payload och återköa denna händelse?
+        edit_payload_label: 'JSON Payload:'
+        event_id: 'Händelse-ID:'
+        full_json_payload: Fullständig JSON Payload
+        headers_section: Headers
+        mark_handled: Markera som hanterad
+        mark_handled_confirm: Markera denna händelse som hanterad? Den kommer att arkiveras och hoppas över vid uppspelning.
+        metadata: Metadata
+        metadata_labels:
+          last_read: Senast läst
+          read_count: Läsantal
+          visible_at: Synlig vid
+        reroute: Omdirigera
+        reroute_confirm: Omdirigera denna händelse till en annan hanterare?
+        reroute_label: 'Målhanterare:'
       show:
         back: Tillbaka till händelser
         labels:
@@ -136,6 +189,9 @@ sv:
         not_found: Händelse hittades inte
         title: Händelse %{event_id}
     helpers:
+      bulk_select_all: Markera alla
+      bulk_select_row: Markera %{id}
+      bulk_selected: valda
       paused_badge: Pausad
       queue_badge:
         dlq: DLQ
@@ -150,11 +206,22 @@ sv:
       show:
         charts:
           failed_to_load: Misslyckades att ladda diagramdata
+          latency: Köfördröjning (ms)
+          latency_avg: Genomsnitt
+          latency_p95: P95
           no_data: Inga data än
           series_name: Jobb/min
           status_distribution: Statusfördelning
           throughput: Genomströmning (jobb/min)
         description_html: Jobbprestandamått för de senaste %{range}
+        latency_by_queue:
+          empty: Ingen fördröjningsdata än
+          headers:
+            avg: Genomsnitt (ms)
+            count: Antal
+            p95: P95 (ms)
+            queue: Kö
+          title: Fördröjning per kö
         slowest:
           empty: Inga jobbstatistik än
           headers:
@@ -163,11 +230,32 @@ sv:
             job_class: Jobbklass
             max: Max
           title: Långsammaste jobbklasser (genomsnittlig varaktighet)
+        streams:
+          summary:
+            active: Aktiv
+            avg_fanout: Genomsnittlig spridning
+            broadcasts: Sändningar
+            connects: Anslutningar
+            disconnects: Frånkopplingar
+          title: Strömmar i realtid
+          top:
+            empty: Ingen strömaktivitet registrerad i det valda fönstret
+            headers:
+              avg_fanout: Genomsnittlig spridning
+              avg_ms: Genomsnittlig utsändning
+              broadcasts: Sändningar
+              stream: Ström
+            title: Toppströmmar efter sändningsvolym
         summary:
           avg_duration: Genomsnittlig varaktighet
+          avg_latency: Genomsnittlig fördröjning
+          avg_retries: Genomsnittliga omförsök
           dead_lettered: Dead Lettered
           failed: Misslyckades
           max_duration: Maximal varaktighet
+          p50_latency: P50-fördröjning
+          p95_latency: P95-fördröjning
+          p99_latency: P99-fördröjning
           succeeded: Lyckades
           total_jobs: Totalt antal jobb
         time_ranges:
@@ -222,6 +310,12 @@ sv:
         discard_all: Kassera alla
         discard_all_confirm: Kassera alla misslyckade jobb?
         discard_all_enqueued_notice: Kasserade %{count} köade jobb och frigjorde deras lås.
+        discard_selected: Kassera valda
+        discard_selected_confirm: Kassera valda objekt?
+        discarded_selected:
+          one: Kasserade 1 valt objekt.
+          other: Kasserade %{count} valda objekt.
+        none_selected: Inga objekt valda.
         retry_all: Försök igen alla
         retry_all_confirm: Försök igen alla misslyckade jobb?
         title: Jobb
@@ -259,13 +353,28 @@ sv:
       toggle_menu: Växla meny
     locks:
       index:
+        all_locks_discarded:
+          one: Kasserade 1 lås.
+          other: Kasserade %{count} lås.
         description: Aktiva unika lås som förhindrar duplicerad jobbexekvering
+        discard: Kassera
+        discard_all: Kassera alla
+        discard_all_confirm: Kassera alla lås permanent? Detta kan tillåta duplicerad jobbexekvering.
+        discard_confirm: Kassera detta lås? Det associerade jobbet kan köas igen.
+        discard_selected: Kassera valda
+        discard_selected_confirm: Kassera valda lås?
         empty: Inga aktiva lås
         headers:
           age: Ålder
           lock_key: Låsningsnyckel
           msg_id: Meddelande-ID
           queue_name: Kö
+        lock_discard_failed: Kunde inte kassera lås.
+        lock_discarded: Lås kasserat.
+        locks_discarded:
+          one: Kasserade 1 lås.
+          other: Kasserade %{count} lås.
+        none_selected: Inga lås valda.
         title: Unikhetsnycklar
     outbox:
       index:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -174,9 +174,9 @@ sv:
         mark_handled_confirm: Markera denna händelse som hanterad? Den kommer att arkiveras och hoppas över vid uppspelning.
         metadata: Metadata
         metadata_labels:
-          last_read: Senast läst
-          read_count: Läsantal
-          visible_at: Synlig vid
+          last_read: 'Senast läst:'
+          read_count: 'Läsantal:'
+          visible_at: 'Synlig vid:'
         reroute: Omdirigera
         reroute_confirm: Omdirigera denna händelse till en annan hanterare?
         reroute_label: 'Målhanterare:'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,13 @@ Pgbus::Engine.routes.draw do
   resources :events, only: %i[index show] do
     member do
       post :replay
+      post :discard
+      post :mark_handled
+      post :edit_payload
+      post :reroute
+    end
+    collection do
+      post :discard_selected
     end
   end
 

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -707,6 +707,110 @@ module Pgbus
         []
       end
 
+      # Pending events — messages sitting in handler queues that haven't been processed.
+      # Identifies handler queues via the subscriber registry and queries them
+      # for unprocessed messages.
+      def pending_events(page: 1, per_page: 25)
+        handler_queues = registered_subscribers.map { |s| s[:queue_name] }.uniq
+        return [] if handler_queues.empty?
+
+        existing = connection.select_values(
+          "SELECT queue_name FROM pgmq.meta ORDER BY queue_name", "Pgbus Queue Names"
+        )
+        target_queues = handler_queues & existing
+        return [] if target_queues.empty?
+
+        offset = (page - 1) * per_page
+        paginated_queue_messages(target_queues, per_page, offset)
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching pending events: #{e.message}" }
+        []
+      end
+
+      # Discard (archive) an event message from a handler queue.
+      def discard_event(queue_name, msg_id)
+        release_lock_for_message(queue_name, msg_id)
+        @client.archive_message(queue_name, msg_id.to_i, prefixed: false)
+        true
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error discarding event #{msg_id}: #{e.message}" }
+        false
+      end
+
+      # Mark an event as handled: archive the queue message and insert a
+      # ProcessedEvent record so it won't be reprocessed on replay.
+      def mark_event_handled(queue_name, msg_id, handler_class)
+        detail = job_detail(queue_name, msg_id)
+        return false unless detail
+
+        raw = JSON.parse(detail[:message])
+        event_id = raw["event_id"]
+        return false unless event_id
+
+        @client.archive_message(queue_name, msg_id.to_i, prefixed: false)
+        ProcessedEvent.insert(
+          { event_id: event_id, handler_class: handler_class, processed_at: Time.now.utc },
+          unique_by: %i[event_id handler_class]
+        )
+        true
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error marking event #{msg_id} handled: #{e.message}" }
+        false
+      end
+
+      # Edit the payload of a stuck event: delete old message and re-enqueue
+      # with the corrected payload in the same queue.
+      def edit_event_payload(queue_name, msg_id, new_payload_json)
+        begin
+          parsed = JSON.parse(new_payload_json)
+        rescue JSON::ParserError
+          return false
+        end
+
+        detail = job_detail(queue_name, msg_id)
+        return false unless detail
+
+        @client.delete_message(queue_name, msg_id.to_i, prefixed: false)
+        connection.execute(
+          "SELECT pgmq.send('#{sanitize_name(queue_name)}', '#{connection.quote_string(parsed.to_json)}'::jsonb)"
+        )
+        true
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error editing event #{msg_id}: #{e.message}" }
+        false
+      end
+
+      # Reroute an event from one handler queue to another.
+      def reroute_event(source_queue, msg_id, target_queue)
+        detail = job_detail(source_queue, msg_id)
+        return false unless detail
+
+        payload = detail[:message]
+
+        @client.delete_message(source_queue, msg_id.to_i, prefixed: false)
+        connection.execute(
+          "SELECT pgmq.send('#{sanitize_name(target_queue)}', '#{connection.quote_string(payload)}'::jsonb)"
+        )
+        true
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error rerouting event #{msg_id}: #{e.message}" }
+        false
+      end
+
+      # Bulk discard selected events from handler queues.
+      def discard_selected_events(selections)
+        return 0 if selections.empty?
+
+        count = 0
+        selections.each do |sel|
+          discard_event(sel[:queue_name], sel[:msg_id]) && count += 1
+        rescue StandardError => e
+          Pgbus.logger.debug { "[Pgbus::Web] Error in bulk discard for #{sel[:msg_id]}: #{e.message}" }
+          next
+        end
+        count
+      end
+
       # Subscriber registry
       def registered_subscribers
         EventBus::Registry.instance.subscribers.map do |s|

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -709,9 +709,12 @@ module Pgbus
 
       # Pending events — messages sitting in handler queues that haven't been processed.
       # Identifies handler queues via the subscriber registry and queries them
-      # for unprocessed messages.
+      # for unprocessed messages. Subscriber queue names are logical
+      # (e.g. "task_completion_handler"), while `pgmq.meta.queue_name` stores
+      # physical names (e.g. "pgbus_task_completion_handler"), so we normalize
+      # through `config.queue_name` before intersecting.
       def pending_events(page: 1, per_page: 25)
-        handler_queues = registered_subscribers.map { |s| s[:queue_name] }.uniq
+        handler_queues = handler_queue_physical_names
         return [] if handler_queues.empty?
 
         existing = connection.select_values(
@@ -727,6 +730,21 @@ module Pgbus
         []
       end
 
+      # Physical queue names for all registered subscribers. Used for both
+      # pending_events lookup and server-side validation of target queues
+      # in reroute_event.
+      def handler_queue_physical_names
+        registered_subscribers.map { |s| s[:physical_queue_name] }.uniq
+      end
+
+      # Find the handler class registered for a given physical queue name.
+      # Returns nil if no subscriber matches — used to reject forged handler
+      # values in mark_event_handled / reroute_event.
+      def handler_class_for_queue(physical_queue_name)
+        sub = registered_subscribers.find { |s| s[:physical_queue_name] == physical_queue_name }
+        sub && sub[:handler_class]
+      end
+
       # Discard (archive) an event message from a handler queue.
       def discard_event(queue_name, msg_id)
         release_lock_for_message(queue_name, msg_id)
@@ -739,6 +757,13 @@ module Pgbus
 
       # Mark an event as handled: archive the queue message and insert a
       # ProcessedEvent record so it won't be reprocessed on replay.
+      #
+      # The insert is performed BEFORE archive. If the archive step fails
+      # afterwards the operator can retry — replay protection is already in
+      # place and the idempotency dedup will cause the handler to skip the
+      # event even if it is eventually re-read from the queue. Doing it the
+      # other way around would risk losing the message without recording the
+      # marker.
       def mark_event_handled(queue_name, msg_id, handler_class)
         detail = job_detail(queue_name, msg_id)
         return false unless detail
@@ -747,11 +772,11 @@ module Pgbus
         event_id = raw["event_id"]
         return false unless event_id
 
-        @client.archive_message(queue_name, msg_id.to_i, prefixed: false)
         ProcessedEvent.insert(
           { event_id: event_id, handler_class: handler_class, processed_at: Time.now.utc },
           unique_by: %i[event_id handler_class]
         )
+        @client.archive_message(queue_name, msg_id.to_i, prefixed: false)
         true
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error marking event #{msg_id} handled: #{e.message}" }
@@ -759,7 +784,9 @@ module Pgbus
       end
 
       # Edit the payload of a stuck event: delete old message and re-enqueue
-      # with the corrected payload in the same queue.
+      # with the corrected payload in the same queue. The produce + delete
+      # are wrapped in a PGMQ transaction so the message can't be lost if
+      # either half fails (same pattern as retry_dlq_message).
       def edit_event_payload(queue_name, msg_id, new_payload_json)
         begin
           parsed = JSON.parse(new_payload_json)
@@ -770,27 +797,27 @@ module Pgbus
         detail = job_detail(queue_name, msg_id)
         return false unless detail
 
-        @client.delete_message(queue_name, msg_id.to_i, prefixed: false)
-        connection.execute(
-          "SELECT pgmq.send('#{sanitize_name(queue_name)}', '#{connection.quote_string(parsed.to_json)}'::jsonb)"
-        )
+        @client.transaction do |txn|
+          txn.produce(queue_name, parsed.to_json, headers: detail[:headers])
+          txn.delete(queue_name, msg_id.to_i)
+        end
         true
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error editing event #{msg_id}: #{e.message}" }
         false
       end
 
-      # Reroute an event from one handler queue to another.
+      # Reroute an event from one handler queue to another. Wrapped in a
+      # PGMQ transaction so produce on the target and delete on the source
+      # are atomic.
       def reroute_event(source_queue, msg_id, target_queue)
         detail = job_detail(source_queue, msg_id)
         return false unless detail
 
-        payload = detail[:message]
-
-        @client.delete_message(source_queue, msg_id.to_i, prefixed: false)
-        connection.execute(
-          "SELECT pgmq.send('#{sanitize_name(target_queue)}', '#{connection.quote_string(payload)}'::jsonb)"
-        )
+        @client.transaction do |txn|
+          txn.produce(target_queue, detail[:message], headers: detail[:headers])
+          txn.delete(source_queue, msg_id.to_i)
+        end
         true
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error rerouting event #{msg_id}: #{e.message}" }
@@ -811,10 +838,19 @@ module Pgbus
         count
       end
 
-      # Subscriber registry
+      # Subscriber registry. `queue_name` is the logical name the subscriber
+      # registered with; `physical_queue_name` is what the queue is actually
+      # called in `pgmq.meta` (e.g. logical "task_completion_handler" ->
+      # physical "pgbus_task_completion_handler"). The dashboard needs the
+      # physical name to match against pending messages / target queues.
       def registered_subscribers
         EventBus::Registry.instance.subscribers.map do |s|
-          { pattern: s.pattern, handler_class: s.handler_class.name, queue_name: s.queue_name }
+          {
+            pattern: s.pattern,
+            handler_class: s.handler_class.name,
+            queue_name: s.queue_name,
+            physical_queue_name: @client.config.queue_name(s.queue_name)
+          }
         end
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus::Web] Error fetching subscribers: #{e.message}" }

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -776,6 +776,11 @@ module Pgbus
           { event_id: event_id, handler_class: handler_class, processed_at: Time.now.utc },
           unique_by: %i[event_id handler_class]
         )
+        # Release the uniqueness lock while we still hold the payload in
+        # memory — otherwise the message is archived but the lock row stays
+        # behind, blocking later publishes with the same key. Mirrors
+        # discard_event.
+        release_lock_for_payload(detail[:message])
         @client.archive_message(queue_name, msg_id.to_i, prefixed: false)
         true
       rescue StandardError => e

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -125,6 +125,8 @@ RSpec.describe Pgbus::Web::DataSource do
       allow(mock_client).to receive(:config).and_return(mock_config)
     end
 
+    after { Pgbus::EventBus::Registry.instance.clear! }
+
     it "returns subscriber info from registry with physical queue name" do
       handler_class = Class.new(Pgbus::EventBus::Handler)
       stub_const("MyHandler", handler_class)

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -119,7 +119,13 @@ RSpec.describe Pgbus::Web::DataSource do
   end
 
   describe "#registered_subscribers" do
-    it "returns subscriber info from registry" do
+    before do
+      mock_config = double("Pgbus::Configuration")
+      allow(mock_config).to receive(:queue_name) { |n| "pgbus_#{n}" }
+      allow(mock_client).to receive(:config).and_return(mock_config)
+    end
+
+    it "returns subscriber info from registry with physical queue name" do
       handler_class = Class.new(Pgbus::EventBus::Handler)
       stub_const("MyHandler", handler_class)
 
@@ -131,6 +137,8 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(result.size).to eq(1)
       expect(result.first[:pattern]).to eq("orders.#")
       expect(result.first[:handler_class]).to eq("MyHandler")
+      expect(result.first[:queue_name]).to eq("my_handler")
+      expect(result.first[:physical_queue_name]).to eq("pgbus_my_handler")
     end
   end
 
@@ -529,20 +537,23 @@ RSpec.describe Pgbus::Web::DataSource do
 
   describe "#pending_events" do
     let(:handler_class) { Class.new(Pgbus::EventBus::Handler) }
+    let(:mock_config) { double("Pgbus::Configuration") }
 
     before do
       stub_const("TaskCompletionHandler", handler_class)
       registry = Pgbus::EventBus::Registry.instance
       registry.clear!
       registry.subscribe("task.completed", handler_class, queue_name: "task_completion_handler")
+      allow(mock_config).to receive(:queue_name) { |n| "pgbus_#{n}" }
+      allow(mock_client).to receive(:config).and_return(mock_config)
     end
 
     after { Pgbus::EventBus::Registry.instance.clear! }
 
-    it "queries handler queues for pending event messages" do
+    it "normalizes subscriber queue names to physical before intersecting with pgmq.meta" do
       allow(mock_connection).to receive(:select_values)
         .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name", "Pgbus Queue Names")
-        .and_return(["task_completion_handler"])
+        .and_return(["pgbus_task_completion_handler"])
 
       event_msg = '{"event_id":"evt-123","payload":{"foo":"bar"},' \
                   '"published_at":"2026-04-09T00:00:00Z"}'
@@ -554,7 +565,7 @@ RSpec.describe Pgbus::Web::DataSource do
                                                                     "vt" => "2026-04-09T00:02:00Z",
                                                                     "message" => event_msg,
                                                                     "headers" => nil,
-                                                                    "queue_name" => "task_completion_handler"
+                                                                    "queue_name" => "pgbus_task_completion_handler"
                                                                   }
                                                                 ])
 
@@ -562,7 +573,16 @@ RSpec.describe Pgbus::Web::DataSource do
 
       expect(result.size).to eq(1)
       expect(result.first[:msg_id]).to eq(1)
-      expect(result.first[:queue_name]).to eq("task_completion_handler")
+      expect(result.first[:queue_name]).to eq("pgbus_task_completion_handler")
+    end
+
+    it "returns empty when subscriber queues have not been created in pgmq.meta" do
+      # Logical name "task_completion_handler" becomes physical
+      # "pgbus_task_completion_handler"; but pgmq.meta returns an unrelated queue
+      # so the intersection is empty.
+      allow(mock_connection).to receive(:select_values).and_return(["pgbus_other"])
+
+      expect(data_source.pending_events).to eq([])
     end
 
     it "returns empty array when no handler queues exist" do
@@ -575,6 +595,51 @@ RSpec.describe Pgbus::Web::DataSource do
       allow(mock_connection).to receive(:select_values).and_raise(StandardError, "boom")
 
       expect(data_source.pending_events).to eq([])
+    end
+  end
+
+  describe "#handler_queue_physical_names" do
+    let(:handler_class) { Class.new(Pgbus::EventBus::Handler) }
+    let(:mock_config) { double("Pgbus::Configuration") }
+
+    before do
+      stub_const("TaskCompletionHandler", handler_class)
+      registry = Pgbus::EventBus::Registry.instance
+      registry.clear!
+      registry.subscribe("task.completed", handler_class, queue_name: "task_completion_handler")
+      allow(mock_config).to receive(:queue_name) { |n| "pgbus_#{n}" }
+      allow(mock_client).to receive(:config).and_return(mock_config)
+    end
+
+    after { Pgbus::EventBus::Registry.instance.clear! }
+
+    it "returns subscriber queue names prefixed with config.queue_prefix" do
+      expect(data_source.handler_queue_physical_names).to eq(["pgbus_task_completion_handler"])
+    end
+  end
+
+  describe "#handler_class_for_queue" do
+    let(:handler_class) { Class.new(Pgbus::EventBus::Handler) }
+    let(:mock_config) { double("Pgbus::Configuration") }
+
+    before do
+      stub_const("TaskCompletionHandler", handler_class)
+      registry = Pgbus::EventBus::Registry.instance
+      registry.clear!
+      registry.subscribe("task.completed", handler_class, queue_name: "task_completion_handler")
+      allow(mock_config).to receive(:queue_name) { |n| "pgbus_#{n}" }
+      allow(mock_client).to receive(:config).and_return(mock_config)
+    end
+
+    after { Pgbus::EventBus::Registry.instance.clear! }
+
+    it "returns the handler class for a registered physical queue" do
+      expect(data_source.handler_class_for_queue("pgbus_task_completion_handler"))
+        .to eq("TaskCompletionHandler")
+    end
+
+    it "returns nil for an unregistered queue" do
+      expect(data_source.handler_class_for_queue("pgbus_unknown")).to be_nil
     end
   end
 
@@ -607,8 +672,10 @@ RSpec.describe Pgbus::Web::DataSource do
   end
 
   describe "#mark_event_handled" do
-    it "archives the message and creates a ProcessedEvent record" do
-      allow(mock_client).to receive(:archive_message)
+    it "inserts the ProcessedEvent record before archiving the message" do
+      call_order = []
+      allow(Pgbus::ProcessedEvent).to receive(:insert) { call_order << :insert }
+      allow(mock_client).to receive(:archive_message) { call_order << :archive }
       allow(mock_connection).to receive(:select_one)
         .with(anything, "Pgbus Job Detail", [42])
         .and_return({
@@ -617,11 +684,11 @@ RSpec.describe Pgbus::Web::DataSource do
                       "message" => '{"event_id":"evt-123","payload":{"foo":"bar"}}',
                       "headers" => nil, "last_read_at" => nil
                     })
-      allow(Pgbus::ProcessedEvent).to receive(:insert)
 
       result = data_source.mark_event_handled("task_completion_handler", 42, "TaskCompletionHandler")
 
       expect(result).to be true
+      expect(call_order).to eq(%i[insert archive])
       expect(mock_client).to have_received(:archive_message).with("task_completion_handler", 42, prefixed: false)
       expect(Pgbus::ProcessedEvent).to have_received(:insert).with(
         hash_including(event_id: "evt-123", handler_class: "TaskCompletionHandler"),
@@ -639,7 +706,9 @@ RSpec.describe Pgbus::Web::DataSource do
   end
 
   describe "#edit_event_payload" do
-    it "deletes old message and sends new one with updated payload" do
+    let(:txn) { double("txn") }
+
+    it "uses a PGMQ transaction to produce new message and delete the old atomically" do
       allow(mock_connection).to receive(:select_one)
         .with(anything, "Pgbus Job Detail", [42])
         .and_return({
@@ -649,16 +718,17 @@ RSpec.describe Pgbus::Web::DataSource do
                       "headers" => '{"x-routing":"task.completed"}',
                       "last_read_at" => nil
                     })
-
-      allow(mock_client).to receive(:delete_message)
-      allow(mock_connection).to receive(:execute)
-      allow(mock_connection).to receive(:quote_string) { |s| s }
+      allow(txn).to receive(:produce)
+      allow(txn).to receive(:delete)
+      allow(mock_client).to receive(:transaction).and_yield(txn)
 
       new_payload = '{"event_id":"evt-1","payload":{"corrected":"data"}}'
       result = data_source.edit_event_payload("task_completion_handler", 42, new_payload)
 
       expect(result).to be true
-      expect(mock_client).to have_received(:delete_message).with("task_completion_handler", 42, prefixed: false)
+      expect(txn).to have_received(:produce)
+        .with("task_completion_handler", new_payload, headers: '{"x-routing":"task.completed"}')
+      expect(txn).to have_received(:delete).with("task_completion_handler", 42)
     end
 
     it "returns false when message not found" do
@@ -677,7 +747,9 @@ RSpec.describe Pgbus::Web::DataSource do
   end
 
   describe "#reroute_event" do
-    it "moves message from source to target queue" do
+    let(:txn) { double("txn") }
+
+    it "uses a PGMQ transaction to produce on target and delete on source atomically" do
       allow(mock_connection).to receive(:select_one)
         .with(anything, "Pgbus Job Detail", [42])
         .and_return({
@@ -687,15 +759,17 @@ RSpec.describe Pgbus::Web::DataSource do
                       "headers" => '{"x-routing":"task.completed"}',
                       "last_read_at" => nil
                     })
-
-      allow(mock_client).to receive(:delete_message)
-      allow(mock_connection).to receive(:execute)
-      allow(mock_connection).to receive(:quote_string) { |s| s }
+      allow(txn).to receive(:produce)
+      allow(txn).to receive(:delete)
+      allow(mock_client).to receive(:transaction).and_yield(txn)
 
       result = data_source.reroute_event("task_completion_handler", 42, "webhook_handler")
 
       expect(result).to be true
-      expect(mock_client).to have_received(:delete_message).with("task_completion_handler", 42, prefixed: false)
+      expect(txn).to have_received(:produce)
+        .with("webhook_handler", '{"event_id":"evt-1","payload":{"foo":"bar"}}',
+              headers: '{"x-routing":"task.completed"}')
+      expect(txn).to have_received(:delete).with("task_completion_handler", 42)
     end
 
     it "returns false when message not found" do

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -672,24 +672,38 @@ RSpec.describe Pgbus::Web::DataSource do
   end
 
   describe "#mark_event_handled" do
-    it "inserts the ProcessedEvent record before archiving the message" do
+    let(:event_detail) do
+      {
+        "msg_id" => 42, "read_ct" => 3,
+        "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
+        "message" => '{"event_id":"evt-123","pgbus_uniqueness_key":"uk-42","payload":{"foo":"bar"}}',
+        "headers" => nil, "last_read_at" => nil
+      }
+    end
+
+    it "performs insert -> release -> archive in strict order" do
       call_order = []
       allow(Pgbus::ProcessedEvent).to receive(:insert) { call_order << :insert }
+      allow(Pgbus::UniquenessKey).to receive(:release!) { call_order << :release }
       allow(mock_client).to receive(:archive_message) { call_order << :archive }
       allow(mock_connection).to receive(:select_one)
-        .with(anything, "Pgbus Job Detail", [42])
-        .and_return({
-                      "msg_id" => 42, "read_ct" => 3,
-                      "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
-                      "message" => '{"event_id":"evt-123","payload":{"foo":"bar"}}',
-                      "headers" => nil, "last_read_at" => nil
-                    })
+        .with(anything, "Pgbus Job Detail", [42]).and_return(event_detail)
+
+      data_source.mark_event_handled("task_completion_handler", 42, "TaskCompletionHandler")
+
+      expect(call_order).to eq(%i[insert release archive])
+    end
+
+    it "inserts the ProcessedEvent row for the event" do
+      allow(Pgbus::ProcessedEvent).to receive(:insert)
+      allow(Pgbus::UniquenessKey).to receive(:release!)
+      allow(mock_client).to receive(:archive_message)
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Job Detail", [42]).and_return(event_detail)
 
       result = data_source.mark_event_handled("task_completion_handler", 42, "TaskCompletionHandler")
 
       expect(result).to be true
-      expect(call_order).to eq(%i[insert archive])
-      expect(mock_client).to have_received(:archive_message).with("task_completion_handler", 42, prefixed: false)
       expect(Pgbus::ProcessedEvent).to have_received(:insert).with(
         hash_including(event_id: "evt-123", handler_class: "TaskCompletionHandler"),
         unique_by: %i[event_id handler_class]

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -527,6 +527,208 @@ RSpec.describe Pgbus::Web::DataSource do
     end
   end
 
+  describe "#pending_events" do
+    let(:handler_class) { Class.new(Pgbus::EventBus::Handler) }
+
+    before do
+      stub_const("TaskCompletionHandler", handler_class)
+      registry = Pgbus::EventBus::Registry.instance
+      registry.clear!
+      registry.subscribe("task.completed", handler_class, queue_name: "task_completion_handler")
+    end
+
+    after { Pgbus::EventBus::Registry.instance.clear! }
+
+    it "queries handler queues for pending event messages" do
+      allow(mock_connection).to receive(:select_values)
+        .with("SELECT queue_name FROM pgmq.meta ORDER BY queue_name", "Pgbus Queue Names")
+        .and_return(["task_completion_handler"])
+
+      event_msg = '{"event_id":"evt-123","payload":{"foo":"bar"},' \
+                  '"published_at":"2026-04-09T00:00:00Z"}'
+      allow(mock_connection).to receive(:select_all).and_return([
+                                                                  {
+                                                                    "msg_id" => 1, "read_ct" => 3,
+                                                                    "enqueued_at" => "2026-04-09T00:00:00Z",
+                                                                    "last_read_at" => "2026-04-09T00:01:00Z",
+                                                                    "vt" => "2026-04-09T00:02:00Z",
+                                                                    "message" => event_msg,
+                                                                    "headers" => nil,
+                                                                    "queue_name" => "task_completion_handler"
+                                                                  }
+                                                                ])
+
+      result = data_source.pending_events(page: 1, per_page: 25)
+
+      expect(result.size).to eq(1)
+      expect(result.first[:msg_id]).to eq(1)
+      expect(result.first[:queue_name]).to eq("task_completion_handler")
+    end
+
+    it "returns empty array when no handler queues exist" do
+      allow(mock_connection).to receive(:select_values).and_return([])
+
+      expect(data_source.pending_events).to eq([])
+    end
+
+    it "returns empty array on error" do
+      allow(mock_connection).to receive(:select_values).and_raise(StandardError, "boom")
+
+      expect(data_source.pending_events).to eq([])
+    end
+  end
+
+  describe "#discard_event" do
+    it "archives the message from the handler queue" do
+      allow(mock_client).to receive(:archive_message)
+      allow(mock_connection).to receive(:select_one).and_return(nil)
+
+      data_source.discard_event("task_completion_handler", 42)
+
+      expect(mock_client).to have_received(:archive_message).with("task_completion_handler", 42, prefixed: false)
+    end
+
+    it "releases uniqueness lock when present" do
+      allow(mock_client).to receive(:archive_message)
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Job Detail", [42])
+        .and_return({
+                      "msg_id" => 42, "read_ct" => 0,
+                      "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
+                      "message" => '{"event_id":"evt-1","pgbus_uniqueness_key":"uk-42"}',
+                      "headers" => nil, "last_read_at" => nil
+                    })
+      allow(Pgbus::UniquenessKey).to receive(:release!).and_return(1)
+
+      data_source.discard_event("task_completion_handler", 42)
+
+      expect(Pgbus::UniquenessKey).to have_received(:release!).with("uk-42")
+    end
+  end
+
+  describe "#mark_event_handled" do
+    it "archives the message and creates a ProcessedEvent record" do
+      allow(mock_client).to receive(:archive_message)
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Job Detail", [42])
+        .and_return({
+                      "msg_id" => 42, "read_ct" => 3,
+                      "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
+                      "message" => '{"event_id":"evt-123","payload":{"foo":"bar"}}',
+                      "headers" => nil, "last_read_at" => nil
+                    })
+      allow(Pgbus::ProcessedEvent).to receive(:insert)
+
+      result = data_source.mark_event_handled("task_completion_handler", 42, "TaskCompletionHandler")
+
+      expect(result).to be true
+      expect(mock_client).to have_received(:archive_message).with("task_completion_handler", 42, prefixed: false)
+      expect(Pgbus::ProcessedEvent).to have_received(:insert).with(
+        hash_including(event_id: "evt-123", handler_class: "TaskCompletionHandler"),
+        unique_by: %i[event_id handler_class]
+      )
+    end
+
+    it "returns false when message not found" do
+      allow(mock_connection).to receive(:select_one).and_return(nil)
+
+      result = data_source.mark_event_handled("task_completion_handler", 99, "TaskCompletionHandler")
+
+      expect(result).to be false
+    end
+  end
+
+  describe "#edit_event_payload" do
+    it "deletes old message and sends new one with updated payload" do
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Job Detail", [42])
+        .and_return({
+                      "msg_id" => 42, "read_ct" => 0,
+                      "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
+                      "message" => '{"event_id":"evt-1","payload":{"old":"data"}}',
+                      "headers" => '{"x-routing":"task.completed"}',
+                      "last_read_at" => nil
+                    })
+
+      allow(mock_client).to receive(:delete_message)
+      allow(mock_connection).to receive(:execute)
+      allow(mock_connection).to receive(:quote_string) { |s| s }
+
+      new_payload = '{"event_id":"evt-1","payload":{"corrected":"data"}}'
+      result = data_source.edit_event_payload("task_completion_handler", 42, new_payload)
+
+      expect(result).to be true
+      expect(mock_client).to have_received(:delete_message).with("task_completion_handler", 42, prefixed: false)
+    end
+
+    it "returns false when message not found" do
+      allow(mock_connection).to receive(:select_one).and_return(nil)
+
+      result = data_source.edit_event_payload("task_completion_handler", 99, "{}")
+
+      expect(result).to be false
+    end
+
+    it "returns false for invalid JSON payload" do
+      result = data_source.edit_event_payload("task_completion_handler", 42, "not json")
+
+      expect(result).to be false
+    end
+  end
+
+  describe "#reroute_event" do
+    it "moves message from source to target queue" do
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Job Detail", [42])
+        .and_return({
+                      "msg_id" => 42, "read_ct" => 0,
+                      "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
+                      "message" => '{"event_id":"evt-1","payload":{"foo":"bar"}}',
+                      "headers" => '{"x-routing":"task.completed"}',
+                      "last_read_at" => nil
+                    })
+
+      allow(mock_client).to receive(:delete_message)
+      allow(mock_connection).to receive(:execute)
+      allow(mock_connection).to receive(:quote_string) { |s| s }
+
+      result = data_source.reroute_event("task_completion_handler", 42, "webhook_handler")
+
+      expect(result).to be true
+      expect(mock_client).to have_received(:delete_message).with("task_completion_handler", 42, prefixed: false)
+    end
+
+    it "returns false when message not found" do
+      allow(mock_connection).to receive(:select_one).and_return(nil)
+
+      result = data_source.reroute_event("task_completion_handler", 99, "webhook_handler")
+
+      expect(result).to be false
+    end
+  end
+
+  describe "#discard_selected_events" do
+    it "archives multiple messages and returns count" do
+      allow(mock_client).to receive(:archive_message)
+      allow(mock_connection).to receive(:select_one).and_return(nil)
+
+      selections = [
+        { queue_name: "task_completion_handler", msg_id: 1 },
+        { queue_name: "task_completion_handler", msg_id: 2 },
+        { queue_name: "webhook_handler", msg_id: 3 }
+      ]
+
+      result = data_source.discard_selected_events(selections)
+
+      expect(result).to eq(3)
+      expect(mock_client).to have_received(:archive_message).exactly(3).times
+    end
+
+    it "returns 0 for empty selections" do
+      expect(data_source.discard_selected_events([])).to eq(0)
+    end
+  end
+
   describe "#dlq_messages (SQL pagination pushdown)" do
     let(:queue_metrics) do
       [

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -703,6 +703,24 @@ RSpec.describe Pgbus::Web::DataSource do
 
       expect(result).to be false
     end
+
+    it "releases the uniqueness lock for the event payload" do
+      allow(mock_client).to receive(:archive_message)
+      allow(Pgbus::ProcessedEvent).to receive(:insert)
+      allow(mock_connection).to receive(:select_one)
+        .with(anything, "Pgbus Job Detail", [42])
+        .and_return({
+                      "msg_id" => 42, "read_ct" => 0,
+                      "enqueued_at" => Time.now.to_s, "vt" => Time.now.to_s,
+                      "message" => '{"event_id":"evt-1","pgbus_uniqueness_key":"uk-42"}',
+                      "headers" => nil, "last_read_at" => nil
+                    })
+      allow(Pgbus::UniquenessKey).to receive(:release!).and_return(1)
+
+      data_source.mark_event_handled("task_completion_handler", 42, "TaskCompletionHandler")
+
+      expect(Pgbus::UniquenessKey).to have_received(:release!).with("uk-42")
+    end
   end
 
   describe "#edit_event_payload" do

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Events", type: :system do
     expect(page).to have_css("h1", text: "Events")
     expect(page).to have_text("No subscribers registered")
     expect(page).to have_text("No events processed yet")
+    expect(page).to have_text("No pending events")
   end
 
   context "with subscribers" do
@@ -40,6 +41,90 @@ RSpec.describe "Events", type: :system do
 
       expect(page).to have_text("evt-abc-123")
       expect(page).to have_text("OrderHandler")
+    end
+  end
+
+  context "with pending events" do
+    before do
+      @stub_data_source.subscribers_list = [
+        { pattern: "task.completed", handler_class: "TaskCompletionHandler", queue_name: "task_completion_handler" },
+        { pattern: "webhook.*", handler_class: "WebhookHandler", queue_name: "webhook_handler" }
+      ]
+
+      @stub_data_source.pending_events_list = [
+        {
+          msg_id: 42, read_ct: 5,
+          enqueued_at: Time.now.utc.iso8601,
+          last_read_at: Time.now.utc.iso8601,
+          vt: (Time.now + 300).utc.iso8601,
+          message: '{"event_id":"evt-stuck-1","payload":{"order_id":123},"published_at":"2026-04-09T00:00:00Z"}',
+          headers: nil,
+          queue_name: "task_completion_handler"
+        }
+      ]
+    end
+
+    it "displays pending events section" do
+      visit "/pgbus/events"
+
+      expect(page).to have_text("Pending Events")
+      expect(page).to have_text("42")
+      expect(page).to have_text("task_completion_handler")
+    end
+
+    it "shows discard button for pending events" do
+      visit "/pgbus/events"
+
+      # Expand the details row
+      find("details.group summary").click
+
+      expect(page).to have_button("Discard")
+    end
+
+    it "shows mark handled button for pending events" do
+      visit "/pgbus/events"
+
+      find("details.group summary").click
+
+      expect(page).to have_button("Mark Handled")
+    end
+
+    it "shows reroute option for pending events" do
+      visit "/pgbus/events"
+
+      find("details.group summary").click
+
+      expect(page).to have_text("Reroute")
+    end
+
+    it "shows edit payload section for pending events" do
+      visit "/pgbus/events"
+
+      find("details.group summary").click
+
+      expect(page).to have_text("Edit & Retry")
+    end
+
+    it "discards a pending event" do
+      visit "/pgbus/events"
+
+      find("details.group summary").click
+      click_button "Discard"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("discarded")
+      expect(@stub_data_source).to be_called(:discard_event)
+    end
+
+    it "marks a pending event as handled" do
+      visit "/pgbus/events"
+
+      find("details.group summary").click
+      click_button "Mark Handled"
+      accept_confirm_dialog
+
+      expect(page).to have_toast("handled")
+      expect(@stub_data_source).to be_called(:mark_event_handled)
     end
   end
 end

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -92,6 +92,18 @@ module Pgbus
       def edit_event_payload(queue_name, msg_id, payload) = record(:edit_event_payload, queue_name, msg_id, payload)
       def reroute_event(source_queue, msg_id, target_queue) = record(:reroute_event, source_queue, msg_id, target_queue)
       def discard_selected_events(selections) = record(:discard_selected_events, selections) && selections.size
+
+      def handler_queue_physical_names
+        @subscribers_list.map { |s| s[:physical_queue_name] || s[:queue_name] }.uniq
+      end
+
+      def handler_class_for_queue(queue_name)
+        sub = @subscribers_list.find do |s|
+          s[:physical_queue_name] == queue_name || s[:queue_name] == queue_name
+        end
+        sub && sub[:handler_class]
+      end
+
       def discard_lock(key)          = record(:discard_lock, key) && 1
       def discard_locks(keys)        = record(:discard_locks, keys) && keys.size
       def discard_all_locks          = record(:discard_all_locks) && @locks_list.size

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -8,7 +8,8 @@ module Pgbus
                     :paused_queues, :locks_list, :recurring_tasks_list,
                     :insights_summary, :insights_slowest, :insights_latency_by_queue,
                     :insights_latency_trend, :insights_throughput, :insights_status_counts,
-                    :stream_stats_available, :stream_summary, :top_streams_list
+                    :stream_stats_available, :stream_summary, :top_streams_list,
+                    :pending_events_list
       attr_reader :calls
 
       def initialize
@@ -32,6 +33,7 @@ module Pgbus
         @stream_stats_available = false
         @stream_summary = default_stream_summary
         @top_streams_list = []
+        @pending_events_list = []
         @calls = Hash.new { |h, k| h[k] = [] }
       end
 
@@ -83,7 +85,13 @@ module Pgbus
       def discard_dlq_message(queue_name, msg_id) = record(:discard_dlq_message, queue_name, msg_id)
       def retry_all_dlq              = record(:retry_all_dlq) && @dlq_messages_list.size
       def discard_all_dlq            = record(:discard_all_dlq) && @dlq_messages_list.size
-      def replay_event(event)        = record(:replay_event, event)
+      def pending_events(page: 1, per_page: 25) = @pending_events_list
+      def replay_event(event) = record(:replay_event, event)
+      def discard_event(queue_name, msg_id) = record(:discard_event, queue_name, msg_id)
+      def mark_event_handled(queue_name, msg_id, handler_class) = record(:mark_event_handled, queue_name, msg_id, handler_class)
+      def edit_event_payload(queue_name, msg_id, payload) = record(:edit_event_payload, queue_name, msg_id, payload)
+      def reroute_event(source_queue, msg_id, target_queue) = record(:reroute_event, source_queue, msg_id, target_queue)
+      def discard_selected_events(selections) = record(:discard_selected_events, selections) && selections.size
       def discard_lock(key)          = record(:discard_lock, key) && 1
       def discard_locks(keys)        = record(:discard_locks, keys) && keys.size
       def discard_all_locks          = record(:discard_all_locks) && @locks_list.size


### PR DESCRIPTION
## Summary

Adds comprehensive event management capabilities to the Pgbus dashboard Events page. Operators can now manage stuck, misrouted, or data-corrupted events directly from the UI without needing console access.

- **Pending Events section** — shows unprocessed messages sitting in handler queues, identified via the subscriber registry
- **Discard** — archive stuck events with uniqueness lock release
- **Edit & Retry** — modify JSON payload inline and re-enqueue to the same queue for reprocessing
- **Reroute** — move an event from one handler queue to another (e.g., fix a misrouted `incoming.transfer.created` by sending it to `FirstDepositHandler` instead of `WebhookHandler`)
- **Mark Handled** — archive the message AND create a `ProcessedEvent` record so it won't be reprocessed on replay
- **Bulk discard** — select multiple events via checkboxes and discard in batch

### Architecture

All PGMQ operations go through `Pgbus::Client` or raw SQL via `Web::DataSource` (following existing patterns from DLQ/Jobs pages). The pending events query identifies handler queues via `EventBus::Registry` subscribers, then queries those PGMQ queue tables via `paginated_queue_messages`.

### Files changed

| File | Purpose |
|------|---------|
| `lib/pgbus/web/data_source.rb` | 6 new methods: `pending_events`, `discard_event`, `mark_event_handled`, `edit_event_payload`, `reroute_event`, `discard_selected_events` |
| `app/controllers/pgbus/events_controller.rb` | 5 new actions: `discard`, `mark_handled`, `edit_payload`, `reroute`, `discard_selected` |
| `config/routes.rb` | New member + collection routes on events resource |
| `app/views/pgbus/events/_pending_table.html.erb` | New partial with collapsible rows, action buttons, inline edit form |
| `app/views/pgbus/events/index.html.erb` | Added pending events section + bulk action bar |
| `app/helpers/pgbus/application_helper.rb` | `handler_for_queue` helper |
| `config/locales/en.yml` | All new translations |

## Test plan

- [x] 14 unit specs for DataSource methods (pending_events, discard, edit, reroute, mark_handled, bulk discard)
- [x] 10 system specs covering UI rendering and user action flows
- [x] Rubocop clean (336 files, 0 offenses)
- [x] Existing specs unaffected
- [ ] Manual test with real stuck events in a dev environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Pending Events section with per-event details and controls (discard, mark handled, edit & retry, reroute).
  * Bulk selection and bulk-discard UX for removing multiple events at once.
  * Inline payload editing with retry and per-row confirmation flows.

* **Localization**
  * Added translated UI text for new pending-events controls, confirmations, and flash notifications across multiple locales.

* **Tests**
  * System and unit tests updated to cover pending-events UI and control flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->