### PR TITLE
fix(client): retry enqueue once when pooled pgmq connection was killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Queue names must be alphanumeric and underscores only.** Queue names containing dashes (e.g., `my-app-queue`) will now raise `ArgumentError`. Rename to underscored form (e.g., `my_app_queue`) before upgrading. This restriction prevents SQL injection via PGMQ queue identifiers, which are interpolated into table names and cannot be parameterized.
+
+### Security
+
+- Add `bundler-audit` to CI for dependency vulnerability scanning
+- Add `QueueNameValidator` to enforce strict queue name validation (alphanumeric + underscores, 61 char max)
+- Add `config.allowed_global_id_models` to restrict which models can be deserialized from event payloads
+- Add security headers to dashboard (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)
+- Warn when dashboard `web_auth` is unconfigured
+- Add `globalid` as an explicit runtime dependency (was used but only transitively available via activejob)
+
 ### Fixed
 
 - **Defensive retry on stale pooled pgmq connections in the enqueue path.** `Pgbus::Client#send_message`, `#send_batch`, and `#publish_to_topic` now retry once when `@pgmq.produce*` raises `PGMQ::Errors::ConnectionError` with a message indicating the pooled `PG::Connection` was killed beneath pgmq-ruby — typically by PgBouncer hitting `server_idle_timeout` / `client_idle_timeout`, an admin disconnect, or a TCP RST. Observed in production as `PQsocket() can't get socket descriptor` on the first produce following an idle window. pgmq-ruby's `auto_reconnect` recovers on the *next* pool checkout, so a single retry is sufficient; non-stale errors (pool timeout, misconfiguration, unreachable database) still propagate unchanged. Upstream pgmq-ruby fix for the underlying misclassification is in-flight at mensfeld/pgmq-ruby#94.
@@ -18,21 +31,6 @@
   - Net result: `"*: 3; *: 3; *: 3"` produces 3 anonymous capsules (3 forks), `"critical: 5; default: 10"` produces 2 named capsules (CLI `--capsule critical` still works), and named-vs-named overlap is still rejected as before.
 
   No changes required to user configuration — legacy YAML patterns and the modern DSL both work as documented.
-
-## [Unreleased]
-
-### Breaking Changes
-
-- **Queue names must be alphanumeric and underscores only.** Queue names containing dashes (e.g., `my-app-queue`) will now raise `ArgumentError`. Rename to underscored form (e.g., `my_app_queue`) before upgrading. This restriction prevents SQL injection via PGMQ queue identifiers, which are interpolated into table names and cannot be parameterized.
-
-### Security
-
-- Add `bundler-audit` to CI for dependency vulnerability scanning
-- Add `QueueNameValidator` to enforce strict queue name validation (alphanumeric + underscores, 61 char max)
-- Add `config.allowed_global_id_models` to restrict which models can be deserialized from event payloads
-- Add security headers to dashboard (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)
-- Warn when dashboard `web_auth` is unconfigured
-- Add `globalid` as an explicit runtime dependency (was used but only transitively available via activejob)
 
 ## [0.1.0] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- **Defensive retry on stale pooled pgmq connections in the enqueue path.** `Pgbus::Client#send_message`, `#send_batch`, and `#publish_to_topic` now retry once when `@pgmq.produce*` raises `PGMQ::Errors::ConnectionError` with a message indicating the pooled `PG::Connection` was killed beneath pgmq-ruby — typically by PgBouncer hitting `server_idle_timeout` / `client_idle_timeout`, an admin disconnect, or a TCP RST. Observed in production as `PQsocket() can't get socket descriptor` on the first produce following an idle window. pgmq-ruby's `auto_reconnect` recovers on the *next* pool checkout, so a single retry is sufficient; non-stale errors (pool timeout, misconfiguration, unreachable database) still propagate unchanged. Upstream pgmq-ruby fix for the underlying misclassification is in-flight at mensfeld/pgmq-ruby#94.
+
 ## [0.5.1] - 2026-04-08
 
 ### Fixed

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -524,23 +524,23 @@ module Pgbus
       end
     end
 
-    # Substrings that indicate the pooled PG::Connection was closed beneath
-    # pgmq-ruby — typically by a connection pooler such as PgBouncer hitting
-    # server_idle_timeout / client_idle_timeout, an admin disconnect, or a
-    # TCP RST. pgmq-ruby 0.6.0 does not retry on all of these (notably the
-    # pg-gem "PQsocket() can't get socket descriptor" message), so first
-    # enqueue after the reset surfaces the failure to callers unless we
-    # rescue + retry one level up. See mensfeld/pgmq-ruby#94.
+    # Substrings that indicate the pooled PG::Connection was already dead
+    # *before* pgmq-ruby tried to use it — typically killed by a connection
+    # pooler (PgBouncer server_idle_timeout / client_idle_timeout), an admin
+    # disconnect, or a TCP RST while the slot was idle.
+    #
+    # Only pre-checkout / pre-flight errors belong here. Mid-flight errors
+    # like "server closed the connection" or "connection to server was lost"
+    # are excluded because PG may have already committed the INSERT before
+    # the socket died, and retrying would duplicate the message.
+    #
+    # See mensfeld/pgmq-ruby#94.
     STALE_CONNECTION_PATTERNS = [
       "pqsocket() can't get socket descriptor",
       "connection is closed",
       "connection has been closed",
-      "server closed the connection",
       "connection not open",
-      "no connection to the server",
-      "terminating connection",
-      "connection to server was lost",
-      "could not receive data from server"
+      "no connection to the server"
     ].freeze
     private_constant :STALE_CONNECTION_PATTERNS
 

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -87,7 +87,9 @@ module Pgbus
       target = @queue_strategy.target_queue(queue_name, priority)
       ensure_queue(queue_name)
       Instrumentation.instrument("pgbus.client.send_message", queue: target) do
-        synchronized { @pgmq.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay) }
+        with_stale_connection_retry do
+          synchronized { @pgmq.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay) }
+        end
       end
     end
 
@@ -96,7 +98,9 @@ module Pgbus
       ensure_queue(queue_name)
       serialized, serialized_headers = serialize_batch(payloads, headers)
       Instrumentation.instrument("pgbus.client.send_batch", queue: full_name, size: payloads.size) do
-        synchronized { @pgmq.produce_batch(full_name, serialized, headers: serialized_headers, delay: delay) }
+        with_stale_connection_retry do
+          synchronized { @pgmq.produce_batch(full_name, serialized, headers: serialized_headers, delay: delay) }
+        end
       end
     end
 
@@ -318,13 +322,15 @@ module Pgbus
     end
 
     def publish_to_topic(routing_key, payload, headers: nil, delay: 0)
-      synchronized do
-        @pgmq.produce_topic(
-          routing_key,
-          serialize(payload),
-          headers: headers && serialize(headers),
-          delay: delay
-        )
+      with_stale_connection_retry do
+        synchronized do
+          @pgmq.produce_topic(
+            routing_key,
+            serialize(payload),
+            headers: headers && serialize(headers),
+            delay: delay
+          )
+        end
       end
     end
 
@@ -516,6 +522,51 @@ module Pgbus
       else
         yield
       end
+    end
+
+    # Substrings that indicate the pooled PG::Connection was closed beneath
+    # pgmq-ruby — typically by a connection pooler such as PgBouncer hitting
+    # server_idle_timeout / client_idle_timeout, an admin disconnect, or a
+    # TCP RST. pgmq-ruby 0.6.0 does not retry on all of these (notably the
+    # pg-gem "PQsocket() can't get socket descriptor" message), so first
+    # enqueue after the reset surfaces the failure to callers unless we
+    # rescue + retry one level up. See mensfeld/pgmq-ruby#94.
+    STALE_CONNECTION_PATTERNS = [
+      "pqsocket() can't get socket descriptor",
+      "connection is closed",
+      "connection has been closed",
+      "server closed the connection",
+      "connection not open",
+      "no connection to the server",
+      "terminating connection",
+      "connection to server was lost",
+      "could not receive data from server"
+    ].freeze
+    private_constant :STALE_CONNECTION_PATTERNS
+
+    # Enqueue path guard: rescue PGMQ::Errors::ConnectionError once if its
+    # message matches a known stale-socket pattern. pgmq-ruby's
+    # auto_reconnect + verify_connection! already recovers on the *next*
+    # checkout, so a single retry is sufficient. Other connection errors
+    # (pool timeout, misconfiguration, truly unreachable DB) propagate.
+    def with_stale_connection_retry
+      attempts = 0
+      begin
+        yield
+      rescue PGMQ::Errors::ConnectionError => e
+        attempts += 1
+        raise unless attempts == 1 && stale_connection_error?(e)
+
+        Pgbus.logger.warn do
+          "[Pgbus::Client] Retrying produce after stale pgmq connection: #{e.message}"
+        end
+        retry
+      end
+    end
+
+    def stale_connection_error?(error)
+      message = error.message.to_s.downcase
+      STALE_CONNECTION_PATTERNS.any? { |pattern| message.include?(pattern) }
     end
 
     def serialize(data)

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -754,18 +754,11 @@ RSpec.describe Pgbus::Client do
         expect(call_count).to eq(2)
       end
 
-      it "retries once on the pre-existing server-close message" do
-        call_count = 0
-        allow(mock_pgmq).to receive(:produce) do
-          call_count += 1
-          raise(PGMQ::Errors::ConnectionError, "Database connection error: server closed the connection unexpectedly") if call_count == 1
+      it "does not retry on mid-flight server-close errors (potential duplicate risk)" do
+        allow(mock_pgmq).to receive(:produce)
+          .and_raise(PGMQ::Errors::ConnectionError, "Database connection error: server closed the connection unexpectedly")
 
-          1
-        end
-
-        client.send_message("default", { "k" => "v" })
-
-        expect(call_count).to eq(2)
+        expect { client.send_message("default", { "k" => "v" }) }.to raise_error(PGMQ::Errors::ConnectionError, /server closed/)
       end
 
       it "does not retry on non-stale ConnectionError (e.g. pool timeout)" do

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -735,6 +735,116 @@ RSpec.describe Pgbus::Client do
     end
   end
 
+  describe "stale pgmq connection recovery" do
+    before do
+      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+    end
+
+    describe "#send_message" do
+      it "retries once when the pooled pgmq connection was killed (PQsocket)" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Database connection error: PQsocket() can't get socket descriptor") if call_count == 1
+
+          1
+        end
+
+        expect(client.send_message("default", { "k" => "v" })).to eq(1)
+        expect(call_count).to eq(2)
+      end
+
+      it "retries once on the pre-existing server-close message" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Database connection error: server closed the connection unexpectedly") if call_count == 1
+
+          1
+        end
+
+        client.send_message("default", { "k" => "v" })
+
+        expect(call_count).to eq(2)
+      end
+
+      it "does not retry on non-stale ConnectionError (e.g. pool timeout)" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Connection pool timeout: waited 5.00s")
+        end
+
+        expect { client.send_message("default", { "k" => "v" }) }.to raise_error(PGMQ::Errors::ConnectionError, /pool timeout/)
+        expect(call_count).to eq(1)
+      end
+
+      it "gives up after one retry and re-raises" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Database connection error: PQsocket() can't get socket descriptor")
+        end
+
+        expect { client.send_message("default", { "k" => "v" }) }.to raise_error(PGMQ::Errors::ConnectionError)
+        expect(call_count).to eq(2)
+      end
+    end
+
+    describe "#send_batch" do
+      it "retries once when the pooled pgmq connection was killed" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce_batch) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Database connection error: PQsocket() can't get socket descriptor") if call_count == 1
+
+          [1]
+        end
+
+        expect(client.send_batch("default", [{ "k" => "v" }])).to eq([1])
+        expect(call_count).to eq(2)
+      end
+
+      it "does not retry on non-stale ConnectionError" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce_batch) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Connection pool timeout: waited 5.00s")
+        end
+
+        expect { client.send_batch("default", [{ "k" => "v" }]) }.to raise_error(PGMQ::Errors::ConnectionError, /pool timeout/)
+        expect(call_count).to eq(1)
+      end
+    end
+
+    describe "#publish_to_topic" do
+      it "retries once when the pooled pgmq connection was killed" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce_topic) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Database connection error: PQsocket() can't get socket descriptor") if call_count == 1
+
+          nil
+        end
+
+        client.publish_to_topic("orders.created", { "id" => 1 })
+
+        expect(call_count).to eq(2)
+      end
+
+      it "does not retry on non-stale ConnectionError" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce_topic) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Connection pool timeout: waited 5.00s")
+        end
+
+        expect { client.publish_to_topic("orders.created", { "id" => 1 }) }.to raise_error(PGMQ::Errors::ConnectionError, /pool timeout/)
+        expect(call_count).to eq(1)
+      end
+    end
+  end
+
   describe "#ensure_all_queues" do
     it "creates the default queue" do
       client.ensure_all_queues


### PR DESCRIPTION
## Summary

Adds a defensive retry to `Pgbus::Client#send_message`, `#send_batch`, and `#publish_to_topic` for the case where a pooled `PG::Connection` has been closed beneath pgmq-ruby — typically by a connection pooler such as PgBouncer, an admin disconnect, or a TCP RST. In production this surfaces as:

```
PGMQ::Errors::ConnectionError: Database connection error: PQsocket() can't get socket descriptor
```

…on the first enqueue after any idle window longer than the pooler's `server_idle_timeout` / `client_idle_timeout`.

## Why this belongs in pgbus too

The underlying misclassification lives in pgmq-ruby — see mensfeld/pgmq-ruby#94 — where:

1. `PGMQ::Connection#verify_connection!` only checks `conn.finished?`, missing server-side closes.
2. `PGMQ::Connection#connection_lost_error?` does not include `"PQsocket() can't get socket descriptor"`, so the `auto_reconnect` retry path inside `with_connection` skips this error and re-raises.

Upstream will ship a fix, but pgbus users shouldn't have to wait. And even once pgmq-ruby ships the fix, pgbus' own retry is cheap insurance: pgmq-ruby recovers the bad pool slot on the *next* checkout, so one retry at the pgbus layer is sufficient.

## What changes

- New private helper `Pgbus::Client#with_stale_connection_retry` rescues `PGMQ::Errors::ConnectionError` exactly once when the message matches a known stale-socket pattern (the pg-gem `PQsocket` string plus the pgmq-ruby "server closed"/"connection lost" family). A log line at WARN level records the retry.
- `send_message`, `send_batch`, and `publish_to_topic` wrap their `synchronized { @pgmq.produce* }` calls with this helper.
- Other `ConnectionError` variants — pool timeout, misconfiguration, truly unreachable database — propagate unchanged.

The retry is scoped to the enqueue path on purpose: readers already run under the worker's supervision loop, and admin/management calls (`metrics`, `list_queues`, `drop_queue`) run rarely enough that callers can handle the transient themselves.

## Test plan

Adds 8 unit specs in `spec/pgbus/client_spec.rb` under `stale pgmq connection recovery`:

- `#send_message` retries once on `PQsocket`, retries once on `server closed the connection`, does not retry on `pool timeout`, and raises after one exhausted retry.
- `#send_batch` retries once on `PQsocket`, does not retry on `pool timeout`.
- `#publish_to_topic` retries once on `PQsocket`, does not retry on `pool timeout`.

Full `spec/pgbus/client_spec.rb` passes (94 examples, 0 failures). RuboCop clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enqueue/produce/publish operations now perform a single automatic retry when encountering stale or killed pooled database connections; other connection errors continue to propagate immediately.
* **Tests**
  * Added tests covering the retry behavior and confirming no retry for non-stale connection errors.
* **Documentation**
  * CHANGELOG updated to document the fix and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->