### PR TITLE
fix(client): wrap all @pgmq.* calls in stale-connection retry (SSL EOF + ensure_queue scope)

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -107,14 +107,18 @@ module Pgbus
     def read_message(queue_name, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_message", queue: full_name) do
-        synchronized { @pgmq.read(full_name, vt: vt || config.visibility_timeout) }
+        with_stale_connection_retry do
+          synchronized { @pgmq.read(full_name, vt: vt || config.visibility_timeout) }
+        end
       end
     end
 
     def read_batch(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_batch", queue: full_name, qty: qty) do
-        synchronized { @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+        with_stale_connection_retry do
+          synchronized { @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+        end
       end
     end
 
@@ -134,7 +138,9 @@ module Pgbus
         break if remaining <= 0
 
         msgs = Instrumentation.instrument("pgbus.client.read_batch", queue: pq_name, qty: remaining) do
-          synchronized { @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining) }
+          with_stale_connection_retry do
+            synchronized { @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining) }
+          end
         end || []
 
         msgs.each { |m| results << [pq_name, m] }
@@ -146,14 +152,16 @@ module Pgbus
 
     def read_with_poll(queue_name, qty:, vt: nil, max_poll_seconds: 5, poll_interval_ms: 100)
       full_name = config.queue_name(queue_name)
-      synchronized do
-        @pgmq.read_with_poll(
-          full_name,
-          vt: vt || config.visibility_timeout,
-          qty: qty,
-          max_poll_seconds: max_poll_seconds,
-          poll_interval_ms: poll_interval_ms
-        )
+      with_stale_connection_retry do
+        synchronized do
+          @pgmq.read_with_poll(
+            full_name,
+            vt: vt || config.visibility_timeout,
+            qty: qty,
+            max_poll_seconds: max_poll_seconds,
+            poll_interval_ms: poll_interval_ms
+          )
+        end
       end
     end
 
@@ -168,8 +176,10 @@ module Pgbus
     def read_multi(queue_names, qty:, vt: nil, limit: nil)
       full_names = queue_names.map { |q| config.queue_name(q) }
       Instrumentation.instrument("pgbus.client.read_multi", queues: full_names, qty: qty, limit: limit) do
-        synchronized do
-          @pgmq.read_multi(full_names, vt: vt || config.visibility_timeout, qty: qty, limit: limit)
+        with_stale_connection_retry do
+          synchronized do
+            @pgmq.read_multi(full_names, vt: vt || config.visibility_timeout, qty: qty, limit: limit)
+          end
         end
       end
     end
@@ -178,37 +188,52 @@ module Pgbus
     # the full PGMQ queue name (e.g. from priority sub-queues or dashboard).
     def delete_message(queue_name, msg_id, prefixed: true)
       name = prefixed ? config.queue_name(queue_name) : queue_name
-      synchronized { @pgmq.delete(name, msg_id) }
+      with_stale_connection_retry do
+        synchronized { @pgmq.delete(name, msg_id) }
+      end
     end
 
     # Archive a message. Pass prefixed: false when queue_name is already
     # the full PGMQ queue name.
     def archive_message(queue_name, msg_id, prefixed: true)
       name = prefixed ? config.queue_name(queue_name) : queue_name
-      synchronized { @pgmq.archive(name, msg_id) }
+      with_stale_connection_retry do
+        synchronized { @pgmq.archive(name, msg_id) }
+      end
     end
 
     # Batch archive — moves multiple messages to the archive table in one call.
     def archive_batch(queue_name, msg_ids, prefixed: true)
       name = prefixed ? config.queue_name(queue_name) : queue_name
-      synchronized { @pgmq.archive_batch(name, msg_ids) }
+      with_stale_connection_retry do
+        synchronized { @pgmq.archive_batch(name, msg_ids) }
+      end
     end
 
     # Batch delete — permanently removes multiple messages in one call.
     def delete_batch(queue_name, msg_ids, prefixed: true)
       name = prefixed ? config.queue_name(queue_name) : queue_name
-      synchronized { @pgmq.delete_batch(name, msg_ids) }
+      with_stale_connection_retry do
+        synchronized { @pgmq.delete_batch(name, msg_ids) }
+      end
     end
 
     # Set visibility timeout. Pass prefixed: false when queue_name is already
     # the full PGMQ queue name.
     def set_visibility_timeout(queue_name, msg_id, vt:, prefixed: true)
       name = prefixed ? config.queue_name(queue_name) : queue_name
-      synchronized { @pgmq.set_vt(name, msg_id, vt: vt) }
+      with_stale_connection_retry do
+        synchronized { @pgmq.set_vt(name, msg_id, vt: vt) }
+      end
     end
 
+    # Open a PGMQ transaction. The caller block may run twice if the first
+    # attempt hits a pre-flight stale-connection error — safe because no SQL
+    # was sent on the first attempt (the connection was dead before the BEGIN).
     def transaction(&block)
-      synchronized { @pgmq.transaction(&block) }
+      with_stale_connection_retry do
+        synchronized { @pgmq.transaction(&block) }
+      end
     end
 
     def move_to_dead_letter(queue_name, message)
@@ -227,27 +252,35 @@ module Pgbus
     end
 
     def metrics(queue_name = nil)
-      synchronized do
-        if queue_name
-          @pgmq.metrics(config.queue_name(queue_name))
-        else
-          @pgmq.metrics_all
+      with_stale_connection_retry do
+        synchronized do
+          if queue_name
+            @pgmq.metrics(config.queue_name(queue_name))
+          else
+            @pgmq.metrics_all
+          end
         end
       end
     end
 
     def list_queues
-      synchronized { @pgmq.list_queues }
+      with_stale_connection_retry do
+        synchronized { @pgmq.list_queues }
+      end
     end
 
     def purge_queue(queue_name, prefixed: true)
       name = prefixed ? config.queue_name(queue_name) : queue_name
-      synchronized { @pgmq.purge_queue(name) }
+      with_stale_connection_retry do
+        synchronized { @pgmq.purge_queue(name) }
+      end
     end
 
     def drop_queue(queue_name, prefixed: true)
       name = prefixed ? config.queue_name(queue_name) : queue_name
-      result = synchronized { @pgmq.drop_queue(name) }
+      result = with_stale_connection_retry do
+        synchronized { @pgmq.drop_queue(name) }
+      end
       @queues_created.delete(name)
       result
     end
@@ -551,11 +584,18 @@ module Pgbus
     ].freeze
     private_constant :STALE_CONNECTION_PATTERNS
 
-    # Enqueue path guard: rescue PGMQ::Errors::ConnectionError once if its
-    # message matches a known stale-socket pattern. pgmq-ruby's
-    # auto_reconnect + verify_connection! already recovers on the *next*
-    # checkout, so a single retry is sufficient. Other connection errors
-    # (pool timeout, misconfiguration, truly unreachable DB) propagate.
+    # Rescue PGMQ::Errors::ConnectionError once if its message matches a
+    # known stale-socket pattern. pgmq-ruby's auto_reconnect + verify_connection!
+    # already recovers on the *next* checkout, so a single retry is sufficient.
+    # Other connection errors (pool timeout, misconfiguration, truly unreachable
+    # DB) propagate.
+    #
+    # Wraps every @pgmq.* call site. Pattern matching is intentionally narrow
+    # (pre-flight / idle-socket signals only), so retry is safe even for
+    # non-idempotent ops like delete/archive — a matched error means the
+    # connection was dead *before* pgmq-ruby tried to use it, so no SQL was
+    # ever sent. Mid-flight errors like "server closed the connection" are
+    # excluded from the pattern list for this reason.
     def with_stale_connection_retry
       attempts = 0
       begin
@@ -565,7 +605,7 @@ module Pgbus
         raise unless attempts == 1 && stale_connection_error?(e)
 
         Pgbus.logger.warn do
-          "[Pgbus::Client] Retrying produce after stale pgmq connection: #{e.message}"
+          "[Pgbus::Client] Retrying after stale pgmq connection: #{e.message}"
         end
         retry
       end

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -85,9 +85,9 @@ module Pgbus
 
     def send_message(queue_name, payload, headers: nil, delay: 0, priority: nil)
       target = @queue_strategy.target_queue(queue_name, priority)
-      ensure_queue(queue_name)
       Instrumentation.instrument("pgbus.client.send_message", queue: target) do
         with_stale_connection_retry do
+          ensure_queue(queue_name)
           synchronized { @pgmq.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay) }
         end
       end
@@ -95,10 +95,10 @@ module Pgbus
 
     def send_batch(queue_name, payloads, headers: nil, delay: 0)
       full_name = config.queue_name(queue_name)
-      ensure_queue(queue_name)
       serialized, serialized_headers = serialize_batch(payloads, headers)
       Instrumentation.instrument("pgbus.client.send_batch", queue: full_name, size: payloads.size) do
         with_stale_connection_retry do
+          ensure_queue(queue_name)
           synchronized { @pgmq.produce_batch(full_name, serialized, headers: serialized_headers, delay: delay) }
         end
       end
@@ -212,14 +212,16 @@ module Pgbus
     end
 
     def move_to_dead_letter(queue_name, message)
-      ensure_dead_letter_queue(queue_name)
       dlq_name = config.dead_letter_queue_name(queue_name)
       full_queue = config.queue_name(queue_name)
 
-      synchronized do
-        @pgmq.transaction do |txn|
-          txn.produce(dlq_name, message.message, headers: message.headers)
-          txn.delete(full_queue, message.msg_id.to_i)
+      with_stale_connection_retry do
+        ensure_dead_letter_queue(queue_name)
+        synchronized do
+          @pgmq.transaction do |txn|
+            txn.produce(dlq_name, message.message, headers: message.headers)
+            txn.delete(full_queue, message.msg_id.to_i)
+          end
         end
       end
     end
@@ -317,8 +319,10 @@ module Pgbus
     # Topic routing
     def bind_topic(pattern, queue_name)
       full_name = config.queue_name(queue_name)
-      ensure_queue(queue_name)
-      synchronized { @pgmq.bind_topic(pattern, full_name) }
+      with_stale_connection_retry do
+        ensure_queue(queue_name)
+        synchronized { @pgmq.bind_topic(pattern, full_name) }
+      end
     end
 
     def publish_to_topic(routing_key, payload, headers: nil, delay: 0)
@@ -541,7 +545,9 @@ module Pgbus
       "connection is closed",
       "connection has been closed",
       "connection not open",
-      "no connection to the server"
+      "no connection to the server",
+      "ssl error: unexpected eof",
+      "ssl syscall error"
     ].freeze
     private_constant :STALE_CONNECTION_PATTERNS
 

--- a/lib/pgbus/client/ensure_stream_queue.rb
+++ b/lib/pgbus/client/ensure_stream_queue.rb
@@ -19,17 +19,20 @@ module Pgbus
     # stream and from the streamer on first subscription per stream.
     module EnsureStreamQueue
       def ensure_stream_queue(stream_name)
-        ensure_queue(stream_name)
         full_name = config.queue_name(stream_name)
 
-        # PGMQ's default NOTIFY throttle is 250ms — meant to coalesce
-        # high-frequency worker queue inserts. Streams are latency-
-        # sensitive and need every broadcast to fire a NOTIFY, even
-        # when several are batched within a single millisecond.
-        # Override the throttle to 0 specifically for stream queues.
-        # Use the idempotent path to avoid deadlocks when multiple
-        # processes race to set up the same stream queue.
-        synchronized { enable_notify_if_needed(full_name, 0) }
+        with_stale_connection_retry do
+          ensure_queue(stream_name)
+
+          # PGMQ's default NOTIFY throttle is 250ms — meant to coalesce
+          # high-frequency worker queue inserts. Streams are latency-
+          # sensitive and need every broadcast to fire a NOTIFY, even
+          # when several are batched within a single millisecond.
+          # Override the throttle to 0 specifically for stream queues.
+          # Use the idempotent path to avoid deadlocks when multiple
+          # processes race to set up the same stream queue.
+          synchronized { enable_notify_if_needed(full_name, 0) }
+        end
 
         # CREATE INDEX IF NOT EXISTS is idempotent in Postgres but still
         # requires a roundtrip and a brief ACCESS SHARE lock on the archive

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -836,6 +836,119 @@ RSpec.describe Pgbus::Client do
         expect(call_count).to eq(1)
       end
     end
+
+    describe "SSL connection patterns" do
+      let(:ssl_eof_msg) { "Database connection error: PQconsumeInput() SSL error: unexpected eof while reading" }
+      let(:ssl_syscall_msg) { "Database connection error: SSL SYSCALL error: Connection reset by peer" }
+
+      it "retries on SSL EOF error" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, ssl_eof_msg) if call_count == 1
+
+          1
+        end
+
+        expect(client.send_message("default", { "k" => "v" })).to eq(1)
+        expect(call_count).to eq(2)
+      end
+
+      it "retries on SSL SYSCALL error" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:produce) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, ssl_syscall_msg) if call_count == 1
+
+          1
+        end
+
+        expect(client.send_message("default", { "k" => "v" })).to eq(1)
+        expect(call_count).to eq(2)
+      end
+    end
+
+    describe "ensure_queue inside retry scope" do
+      it "retries send_message when ensure_queue raises stale connection error" do
+        create_count = 0
+        allow(mock_pgmq).to receive(:create) do
+          create_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Database connection error: PQsocket() can't get socket descriptor") if create_count == 1
+
+          nil
+        end
+        # Reset the queues_created memo so ensure_queue actually calls @pgmq.create
+        client.instance_variable_get(:@queues_created).clear
+
+        expect(client.send_message("default", { "k" => "v" })).to eq(1)
+        expect(create_count).to eq(2)
+      end
+
+      it "retries send_batch when ensure_queue raises stale connection error" do
+        create_count = 0
+        allow(mock_pgmq).to receive(:create) do
+          create_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Database connection error: connection is closed") if create_count == 1
+
+          nil
+        end
+        client.instance_variable_get(:@queues_created).clear
+
+        expect(client.send_batch("default", [{ "k" => "v" }])).to eq([1, 2])
+        expect(create_count).to eq(2)
+      end
+
+      it "retries send_message when ensure_queue raises SSL EOF error" do
+        ssl_eof = "Database connection error: PQconsumeInput() SSL error: unexpected eof while reading"
+        create_count = 0
+        allow(mock_pgmq).to receive(:create) do
+          create_count += 1
+          raise(PGMQ::Errors::ConnectionError, ssl_eof) if create_count == 1
+
+          nil
+        end
+        client.instance_variable_get(:@queues_created).clear
+
+        expect(client.send_message("default", { "k" => "v" })).to eq(1)
+        expect(create_count).to eq(2)
+      end
+    end
+
+    describe "ensure_dead_letter_queue inside retry scope" do
+      it "retries move_to_dead_letter when ensure_dead_letter_queue raises stale connection error" do
+        create_count = 0
+        allow(mock_pgmq).to receive(:create) do |name|
+          if name.end_with?("_dlq")
+            create_count += 1
+            raise(PGMQ::Errors::ConnectionError, "Database connection error: connection is closed") if create_count == 1
+          end
+          nil
+        end
+
+        message = build_message_double(msg_id: 42, message: '{"job":"test"}', read_ct: 5)
+        client.move_to_dead_letter("default", message)
+
+        expect(create_count).to eq(2)
+      end
+    end
+
+    describe "bind_topic inside retry scope" do
+      it "retries bind_topic when ensure_queue raises stale connection error" do
+        create_count = 0
+        allow(mock_pgmq).to receive(:create) do
+          create_count += 1
+          raise(PGMQ::Errors::ConnectionError, "Database connection error: connection not open") if create_count == 1
+
+          nil
+        end
+        client.instance_variable_get(:@queues_created).clear
+
+        client.bind_topic("orders.*", "default")
+
+        expect(create_count).to eq(2)
+        expect(mock_pgmq).to have_received(:bind_topic)
+      end
+    end
   end
 
   describe "#ensure_all_queues" do

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -949,6 +949,223 @@ RSpec.describe Pgbus::Client do
         expect(mock_pgmq).to have_received(:bind_topic)
       end
     end
+
+    describe "read operations" do
+      # Every read call site goes through with_stale_connection_retry.
+      # Using a stale-socket message ensures pgmq-ruby's pre-flight error
+      # is recoverable via one retry.
+      let(:stale_msg) { "Database connection error: PQsocket() can't get socket descriptor" }
+
+      it "retries read_message" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:read) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          nil
+        end
+
+        client.read_message("default")
+        expect(call_count).to eq(2)
+      end
+
+      it "retries read_batch" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:read_batch) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          []
+        end
+
+        client.read_batch("default", qty: 5)
+        expect(call_count).to eq(2)
+      end
+
+      it "retries read_with_poll" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:read_with_poll) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          []
+        end
+
+        client.read_with_poll("default", qty: 5)
+        expect(call_count).to eq(2)
+      end
+
+      it "retries read_multi" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:read_multi) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          []
+        end
+
+        client.read_multi(["default"], qty: 5)
+        expect(call_count).to eq(2)
+      end
+    end
+
+    describe "modification operations" do
+      let(:stale_msg) { "Database connection error: PQsocket() can't get socket descriptor" }
+
+      it "retries delete_message" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:delete) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          true
+        end
+
+        client.delete_message("default", 1)
+        expect(call_count).to eq(2)
+      end
+
+      it "retries archive_message" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:archive) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          true
+        end
+
+        client.archive_message("default", 1)
+        expect(call_count).to eq(2)
+      end
+
+      it "retries delete_batch" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:delete_batch) do |_q, ids|
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          ids.map(&:to_s)
+        end
+
+        client.delete_batch("default", [1, 2])
+        expect(call_count).to eq(2)
+      end
+
+      it "retries archive_batch" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:archive_batch) do |_q, ids|
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          ids.map(&:to_s)
+        end
+
+        client.archive_batch("default", [1, 2])
+        expect(call_count).to eq(2)
+      end
+
+      it "retries set_visibility_timeout" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:set_vt) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          nil
+        end
+
+        client.set_visibility_timeout("default", 1, vt: 30)
+        expect(call_count).to eq(2)
+      end
+
+      it "retries transaction (caller block re-runs on pre-flight error)" do
+        call_count = 0
+        block_count = 0
+        # @pgmq.transaction raises before yielding on first attempt,
+        # then yields on second — matches pre-flight semantics.
+        allow(mock_pgmq).to receive(:transaction) do |&blk|
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          blk.call(mock_pgmq)
+        end
+
+        client.transaction { |_txn| block_count += 1 }
+
+        expect(call_count).to eq(2)
+        expect(block_count).to eq(1)
+      end
+    end
+
+    describe "admin operations" do
+      let(:stale_msg) { "Database connection error: PQsocket() can't get socket descriptor" }
+
+      it "retries metrics for single queue" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:metrics) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          nil
+        end
+
+        client.metrics("default")
+        expect(call_count).to eq(2)
+      end
+
+      it "retries metrics_all when no queue given" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:metrics_all) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          []
+        end
+
+        client.metrics
+        expect(call_count).to eq(2)
+      end
+
+      it "retries list_queues" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:list_queues) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          []
+        end
+
+        client.list_queues
+        expect(call_count).to eq(2)
+      end
+
+      it "retries purge_queue" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:purge_queue) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          nil
+        end
+
+        client.purge_queue("default")
+        expect(call_count).to eq(2)
+      end
+
+      it "retries drop_queue and clears the memo after success" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:drop_queue) do
+          call_count += 1
+          raise(PGMQ::Errors::ConnectionError, stale_msg) if call_count == 1
+
+          true
+        end
+        client.instance_variable_get(:@queues_created)["pgbus_test_default"] = true
+
+        expect(client.drop_queue("default")).to be(true)
+        expect(call_count).to eq(2)
+        expect(client.instance_variable_get(:@queues_created)["pgbus_test_default"]).to be_nil
+      end
+    end
   end
 
   describe "#ensure_all_queues" do


### PR DESCRIPTION
## Summary

Fixes issue #143 **and** the broader audit called out at the bottom of it.

The original issue reported two gaps on the enqueue path. After discussion we expanded the fix to cover **every** `@pgmq.*` call site, because the same gaps affect reads (crash a worker loop), acks (`delete`/`archive`/`set_vt`), and admin operations (crash the dashboard).

### Root gaps

- **Pattern gap** — `STALE_CONNECTION_PATTERNS` didn't include SSL-layer EOF variants (`"ssl error: unexpected eof"`, `"ssl syscall error"`), so `with_stale_connection_retry` re-raised on the first attempt.
- **Scope gap** — `ensure_queue` (and `ensure_dead_letter_queue`) were called **outside** the retry block in `send_message`, `send_batch`, `move_to_dead_letter`, and `bind_topic`, so a stale-connection error during queue creation was never retried.
- **Coverage gap** — Only 3 of 25 `@pgmq.*` call sites were wrapped. Reads crashed worker loops; deletes/archives/transactions crashed the ack path; metrics/list/purge/drop crashed the dashboard.

### Why broader retry is safe

`STALE_CONNECTION_PATTERNS` is deliberately narrow — it only matches **pre-flight / idle-socket signals**. A matched error means the connection was dead *before* pgmq-ruby tried to use it, so no SQL was ever sent. That makes retry safe even for non-idempotent operations like `delete`, `archive`, and `transaction` (the caller block re-runs from scratch). Mid-flight errors like `"server closed the connection"` stay excluded from the pattern list for exactly this reason.

### Wrapped call sites (`lib/pgbus/client.rb` + `lib/pgbus/client/ensure_stream_queue.rb`)

| Category | Methods |
|----------|---------|
| Enqueue (pre-existing) | `send_message`, `send_batch`, `publish_to_topic` |
| **Enqueue w/ ensure_queue scope fix** | `send_message`, `send_batch`, `move_to_dead_letter`, `bind_topic` |
| **Reads (NEW)** | `read_message`, `read_batch`, `read_batch_prioritized`, `read_with_poll`, `read_multi` |
| **Mutations (NEW)** | `delete_message`, `archive_message`, `delete_batch`, `archive_batch`, `set_visibility_timeout`, `transaction` |
| **Admin (NEW)** | `metrics`, `metrics_all`, `list_queues`, `purge_queue`, `drop_queue` |
| **Stream setup (NEW)** | `ensure_stream_queue` (wraps `enable_notify_if_needed` override) |

### Other changes

- Added `"ssl error: unexpected eof"` and `"ssl syscall error"` to `STALE_CONNECTION_PATTERNS`
- Renamed log line from `"Retrying produce after stale pgmq connection"` to `"Retrying after stale pgmq connection"` since the wrapper is no longer enqueue-specific
- Updated `with_stale_connection_retry` comment to document that pattern narrowness makes retry safe for non-idempotent ops

Closes #143

## Test plan

- [x] 2 tests: SSL EOF and SSL SYSCALL patterns trigger retry and succeed
- [x] 3 tests: `send_message`, `send_batch`, `send_message` (SSL EOF) retry when `ensure_queue` raises stale connection error
- [x] 1 test: `move_to_dead_letter` retries when `ensure_dead_letter_queue` raises stale connection error
- [x] 1 test: `bind_topic` retries when `ensure_queue` raises stale connection error
- [x] 4 tests: every read method retries on stale connection
- [x] 6 tests: every mutation method retries on stale connection (including `transaction` with block re-run semantics)
- [x] 5 tests: every admin method retries on stale connection (including `drop_queue` memo cleanup)
- [x] All 116 client_spec tests pass
- [x] All 1870 non-system tests pass (0 failures)
- [x] RuboCop clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended retry handling for transient/stale DB connection and SSL/TLS errors across more queue, message, transaction, and admin operations to improve reliability.
  * Ensured queue, dead-letter, and topic provisioning steps are now protected by the same retry logic.

* **Tests**
  * Added comprehensive tests covering retry behavior and pre-flight/transaction retry semantics.

* **Documentation**
  * Clarified retry scope, safe-to-retry pre-flight errors, and transaction/idempotency expectations.

* **Notes**
  * No public API signature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->