### PR TITLE
fix(streams): add CSP nonce to inline script tag

### DIFF
--- a/app/helpers/pgbus/streams_helper.rb
+++ b/app/helpers/pgbus/streams_helper.rb
@@ -131,7 +131,9 @@ module Pgbus
       return nil if cache[:script_emitted]
 
       cache[:script_emitted] = true
-      script = '<script type="module">import "pgbus/stream_source_element"</script>'
+      nonce = content_security_policy_nonce if respond_to?(:content_security_policy_nonce)
+      nonce_attr = nonce ? %( nonce="#{CGI.escape_html(nonce)}") : ""
+      script = %(<script type="module"#{nonce_attr}>import "pgbus/stream_source_element"</script>)
       script.respond_to?(:html_safe) ? script.html_safe : script
     end
 

--- a/spec/pgbus/streams_helper_spec.rb
+++ b/spec/pgbus/streams_helper_spec.rb
@@ -151,6 +151,20 @@ RSpec.describe Pgbus::StreamsHelper do
   end
 
   describe "#pgbus_stream_from CSP nonce" do
+    it "omits nonce when content_security_policy_nonce returns nil" do
+      nil_nonce_view_class = Class.new do
+        include Pgbus::StreamsHelper
+
+        def content_security_policy_nonce
+          nil
+        end
+      end
+      html = nil_nonce_view_class.new.pgbus_stream_from("chat")
+
+      expect(html).to include('<script type="module">')
+      expect(html).not_to include("nonce=")
+    end
+
     it "adds nonce to the inline script tag when content_security_policy_nonce is available" do
       nonce_view_class = Class.new do
         include Pgbus::StreamsHelper

--- a/spec/pgbus/streams_helper_spec.rb
+++ b/spec/pgbus/streams_helper_spec.rb
@@ -150,6 +150,45 @@ RSpec.describe Pgbus::StreamsHelper do
     end
   end
 
+  describe "#pgbus_stream_from CSP nonce" do
+    it "adds nonce to the inline script tag when content_security_policy_nonce is available" do
+      nonce_view_class = Class.new do
+        include Pgbus::StreamsHelper
+
+        def content_security_policy_nonce
+          "test-nonce-abc123"
+        end
+      end
+      nonce_view = nonce_view_class.new
+
+      html = nonce_view.pgbus_stream_from("chat")
+
+      expect(html).to include('<script type="module" nonce="test-nonce-abc123">')
+    end
+
+    it "omits nonce when content_security_policy_nonce is not available" do
+      html = view.pgbus_stream_from("chat")
+
+      expect(html).to include('<script type="module">')
+      expect(html).not_to include("nonce=")
+    end
+
+    it "does not add nonce to the pgbus-stream-source element" do
+      nonce_view_class = Class.new do
+        include Pgbus::StreamsHelper
+
+        def content_security_policy_nonce
+          "test-nonce-abc123"
+        end
+      end
+      nonce_view = nonce_view_class.new
+
+      html = nonce_view.pgbus_stream_from("chat")
+
+      expect(html).not_to match(/<pgbus-stream-source[^>]*nonce=/)
+    end
+  end
+
   describe "#pgbus_stream_from with replay: option" do
     it "sets since-id=0 when replay: :all so the client receives the full retained backlog" do
       html = view.pgbus_stream_from("chat", replay: :all)


### PR DESCRIPTION
## Summary

- `StreamsHelper#pgbus_stream_source_script_tag` emitted a `<script type="module">` tag without a `nonce` attribute
- Apps with `Content-Security-Policy: script-src 'nonce-...'` blocked the script, preventing the `<pgbus-stream-source>` custom element from registering — SSE connection never opened, real-time updates silently broke
- Now calls `content_security_policy_nonce` (Rails view helper) when available and includes `nonce="..."` on the script tag; graceful no-op when CSP is not configured

## Test plan
- [x] New spec: nonce included when `content_security_policy_nonce` is defined
- [x] New spec: nonce omitted when method is unavailable (backwards compat)
- [x] New spec: nonce not leaked to `<pgbus-stream-source>` element
- [x] All existing StreamsHelper specs pass (23 examples, 0 failures)
- [x] `bundle exec rubocop` clean
- [ ] Deploy to staging and verify `<pgbus-stream-source>` gets `connected` attribute
- [ ] Verify no CSP violation in browser devtools


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stream source functionality now conditionally embeds Content Security Policy (CSP) nonces into script tags when provided, with proper HTML escaping for security.

* **Tests**
  * Added comprehensive test coverage for CSP nonce behavior, ensuring proper handling when nonces are present or absent and validating correct escaping practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->