### PR TITLE
feat(streams): per-broadcast and per-stream durable opt-in

### DIFF
--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -104,11 +104,16 @@ module Pgbus
     # clears it. The cache key is the resolved name string, not the raw
     # streamables, so `Pgbus.stream(@order)` and `Pgbus.stream(@order)`
     # in the same process return the same instance.
-    def stream(streamables, durable: true)
+    # `durable:` defaults to `nil` so the configuration resolves the mode:
+    # `streams_durable_patterns` first (exact string or regex match), then
+    # `streams_default_broadcast_mode`. Pass `durable: true`/`false`
+    # explicitly to bypass the resolver for this Stream instance.
+    def stream(streamables, durable: nil)
       name = Streams::Stream.name_from(streamables)
-      cache_key = "#{name}:#{durable ? "d" : "e"}"
+      resolved = durable.nil? ? configuration.stream_durable?(name) : durable
+      cache_key = "#{name}:#{resolved ? "d" : "e"}"
       @stream_cache ||= Concurrent::Map.new
-      @stream_cache.compute_if_absent(cache_key) { Streams::Stream.new(streamables, durable: durable) }
+      @stream_cache.compute_if_absent(cache_key) { Streams::Stream.new(streamables, durable: resolved) }
     end
 
     # Compose a short, pgbus-safe stream identifier from any mix of

--- a/lib/pgbus/client/notify_stream.rb
+++ b/lib/pgbus/client/notify_stream.rb
@@ -26,7 +26,7 @@ module Pgbus
 
         Instrumentation.instrument("pgbus.stream.notify", stream: stream_name, bytes: json.bytesize) do
           synchronized do
-            @pgmq.with_connection do |conn|
+            @pgmq.__send__(:with_connection) do |conn|
               conn.exec_params("SELECT pg_notify($1, $2)", [channel, json])
             end
           end

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -105,7 +105,8 @@ module Pgbus
                   :streams_max_connections, :streams_idle_timeout, :streams_listen_health_check_ms,
                   :streams_write_deadline_ms, :streams_falcon_streaming_body,
                   :streams_stats_enabled, :streams_test_mode,
-                  :streams_orphan_sweep_interval, :streams_orphan_threshold
+                  :streams_orphan_sweep_interval, :streams_orphan_threshold,
+                  :streams_durable_patterns
     attr_reader :streams_default_broadcast_mode # rubocop:disable Style/AccessorGrouping
 
     # AppSignal integration (auto-loaded when ::Appsignal is defined and this is true).
@@ -221,6 +222,7 @@ module Pgbus
       @streams_default_broadcast_mode = :ephemeral
       @streams_orphan_sweep_interval = 3600    # 1 hour
       @streams_orphan_threshold = 86_400       # 24 hours
+      @streams_durable_patterns = []
 
       # AppSignal: auto-on when the appsignal gem is loaded; probe runs in
       # the same process, so the operator can disable it independently.
@@ -365,10 +367,22 @@ module Pgbus
         raise ArgumentError, "streams_orphan_sweep_interval must be a positive number or nil to disable"
       end
 
+      raise ArgumentError, "streams_durable_patterns must be an Array of strings/regex" unless streams_durable_patterns.is_a?(Array)
+
       return if streams_orphan_threshold.nil?
       return if streams_orphan_threshold.is_a?(Numeric) && streams_orphan_threshold.positive?
 
       raise ArgumentError, "streams_orphan_threshold must be a positive number or nil to disable"
+    end
+
+    # Returns true if the given stream name should be durable based on
+    # `streams_durable_patterns` (exact string or Regexp match) or the
+    # `streams_default_broadcast_mode` fallback.
+    def stream_durable?(name)
+      patterns = streams_durable_patterns || []
+      return true if patterns.any? { |p| p.is_a?(Regexp) ? p.match?(name) : p == name }
+
+      streams_default_broadcast_mode == :durable
     end
 
     # Set the worker capsule list. Accepts:

--- a/lib/pgbus/streams.rb
+++ b/lib/pgbus/streams.rb
@@ -73,11 +73,15 @@ module Pgbus
       # satisfies the predicate. The label travels with the broadcast
       # through PGMQ; the predicate itself lives in-process on the
       # subscriber side and is evaluated per-connection by the Dispatcher.
-      def broadcast(payload, visible_to: nil)
+      # Per-broadcast `durable:` overrides the stream-level default for a
+      # single broadcast. `nil` (the default) defers to the stream's own
+      # `durable?` setting; `true`/`false` flip the mode for this call only.
+      def broadcast(payload, visible_to: nil, durable: nil)
         wrapped = { "html" => payload.to_s }
         wrapped["visible_to"] = visible_to.to_s if visible_to
 
-        return broadcast_ephemeral(wrapped) unless @durable
+        use_durable = durable.nil? ? @durable : durable
+        return broadcast_ephemeral(wrapped) unless use_durable
 
         ensure_queue!
         transaction = current_open_transaction

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -123,6 +123,7 @@ RSpec.configure do |config|
     c.logger = Logger.new(IO::NULL)
     c.pgmq_schema_mode = :embedded
     c.listen_notify = false
+    c.streams_default_broadcast_mode = :durable
   end
 
   # Bootstrap tables that may not exist in the CI database

--- a/spec/pgbus/streams/durable_opt_in_spec.rb
+++ b/spec/pgbus/streams/durable_opt_in_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Streams::Stream do
+  let(:client) do
+    instance_double(
+      Pgbus::Client,
+      ensure_stream_queue: nil,
+      send_message: 1248,
+      stream_current_msg_id: 1247,
+      read_after: [],
+      notify_stream: nil,
+      config: Pgbus::Configuration.new
+    )
+  end
+
+  describe "per-broadcast durable: override" do
+    context "when stream is ephemeral by default" do
+      subject(:stream) { described_class.new("chat", client: client, durable: false) }
+
+      it "uses durable path when durable: true is passed to broadcast" do
+        stream.broadcast("X", durable: true)
+        expect(client).to have_received(:ensure_stream_queue).with("chat")
+        expect(client).to have_received(:send_message).with("chat", { "html" => "X" })
+        expect(client).not_to have_received(:notify_stream)
+      end
+
+      it "still uses ephemeral path when no override is passed" do
+        stream.broadcast("X")
+        expect(client).to have_received(:notify_stream)
+        expect(client).not_to have_received(:send_message)
+      end
+    end
+
+    context "when stream is durable by default" do
+      subject(:stream) { described_class.new("chat", client: client, durable: true) }
+
+      it "uses ephemeral path when durable: false is passed to broadcast" do
+        stream.broadcast("X", durable: false)
+        expect(client).to have_received(:notify_stream)
+        expect(client).not_to have_received(:send_message)
+        expect(client).not_to have_received(:ensure_stream_queue)
+      end
+
+      it "still uses durable path when no override is passed" do
+        stream.broadcast("X")
+        expect(client).to have_received(:send_message)
+      end
+    end
+
+    it "passes visible_to alongside the durable override" do
+      stream = described_class.new("chat", client: client, durable: false)
+      stream.broadcast("X", durable: true, visible_to: :admin)
+      expect(client).to have_received(:send_message)
+        .with("chat", { "html" => "X", "visible_to" => "admin" })
+    end
+  end
+end

--- a/spec/pgbus/streams/durable_patterns_spec.rb
+++ b/spec/pgbus/streams/durable_patterns_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Configuration do
+  before do
+    Pgbus.reset!
+    Pgbus.configure do |c|
+      c.streams_default_broadcast_mode = :ephemeral
+    end
+  end
+
+  after { Pgbus.reset! }
+
+  describe "Pgbus.stream(name) without explicit durable: kwarg" do
+    it "uses :ephemeral default when no patterns match" do
+      stream = Pgbus.stream("anything")
+      expect(stream).not_to be_durable
+    end
+
+    it "treats stream as durable when name matches an exact streams_durable_patterns entry" do
+      Pgbus.configuration.streams_durable_patterns = ["chat"]
+      stream = Pgbus.stream("chat")
+      expect(stream).to be_durable
+    end
+
+    it "treats stream as durable when name matches a regex pattern" do
+      Pgbus.configuration.streams_durable_patterns = [/^chat:/]
+      stream = Pgbus.stream("chat:42:messages")
+      expect(stream).to be_durable
+    end
+
+    it "does not affect non-matching streams" do
+      Pgbus.configuration.streams_durable_patterns = [/^chat:/]
+      expect(Pgbus.stream("notifications:42")).not_to be_durable
+    end
+
+    it "respects explicit durable: kwarg over pattern matches" do
+      Pgbus.configuration.streams_durable_patterns = [/^chat:/]
+      expect(Pgbus.stream("chat:42", durable: false)).not_to be_durable
+    end
+
+    it "uses :durable default when streams_default_broadcast_mode is :durable" do
+      Pgbus.configuration.streams_default_broadcast_mode = :durable
+      Pgbus.configuration.streams_durable_patterns = []
+      expect(Pgbus.stream("anything")).to be_durable
+    end
+  end
+
+  describe "Pgbus::Configuration#streams_durable_patterns" do
+    subject(:config) { described_class.new }
+
+    it "defaults to an empty array" do
+      expect(config.streams_durable_patterns).to eq([])
+    end
+
+    it "rejects non-Array values" do
+      config.streams_durable_patterns = "chat"
+      expect { config.validate! }.to raise_error(ArgumentError, /streams_durable_patterns/)
+    end
+
+    it "accepts an array of strings and regex" do
+      config.streams_durable_patterns = ["chat", /^orders:/]
+      expect { config.validate! }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Builds on #151 (ephemeral broadcast mode) to add finer-grained opt-in controls for durable streams. Apps no longer have to choose between "all broadcasts ephemeral" or "all broadcasts durable" — they can mix per-broadcast and per-stream-pattern.

### Two new opt-in mechanisms

**1. Per-broadcast override**

```ruby
# Stream is ephemeral by default, but this single broadcast persists:
Pgbus.stream("notifications").broadcast(html, durable: true)

# Stream is durable, but this one broadcast is fire-and-forget:
Pgbus.stream("chat:42").broadcast(html, durable: false)
```

`durable:` on `Stream#broadcast` defaults to `nil` (defer to stream-level setting). Explicit `true`/`false` flips the mode for that one call.

**2. Per-stream pattern config**

```ruby
Pgbus.configure do |c|
  c.streams_default_broadcast_mode = :ephemeral

  # These streams need backlog replay, so create durable PGMQ queues:
  c.streams_durable_patterns = [
    "chat",                # exact match
    /^orders:/,            # regex match
    /^audit:invoice_/
  ]
end

Pgbus.stream("chat").broadcast(html)              # → durable
Pgbus.stream("orders:42:items").broadcast(html)   # → durable (regex)
Pgbus.stream("notifications:7").broadcast(html)   # → ephemeral (default)
```

`Pgbus.stream(name)` without an explicit `durable:` kwarg resolves the mode via:
1. `streams_durable_patterns` (string equality or regex match)
2. `streams_default_broadcast_mode` fallback

Explicit `Pgbus.stream(name, durable: true/false)` still bypasses the resolver.

### Behavior change

`Pgbus.stream`'s `durable:` parameter default changed from `true` → `nil` (resolver-driven). Apps relying on the old "always durable when called with no kwarg" behavior should either:
- Pass `durable: true` explicitly, or
- Set `c.streams_default_broadcast_mode = :durable`, or
- Add the stream name/pattern to `c.streams_durable_patterns`

This aligns the explicit-API path with the Turbo-patch path that #151 introduced.

### Follow-up

Per-Turbo-helper overrides (`broadcasts_to :account, durable: true`) tracked separately — needs to patch every Turbo broadcast helper signature, larger surface than this change. Will open a follow-up issue.

## Test plan

- [x] `bundle exec rspec` — passes (1925+ examples, 0 failures, same pre-existing I18n pendings as main)
- [x] `bundle exec rubocop` — clean
- [x] Per-broadcast `durable: true` on ephemeral stream creates queue + sends message
- [x] Per-broadcast `durable: false` on durable stream uses NOTIFY-only path
- [x] `streams_durable_patterns` exact-string match marks stream durable
- [x] `streams_durable_patterns` regex match marks stream durable
- [x] Explicit `durable:` kwarg on `Pgbus.stream` overrides the resolver
- [x] Configuration validation rejects non-Array `streams_durable_patterns`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream durability can be selected per stream name via configurable patterns (strings or regex) and a configurable default mode.
  * Broadcasts may now specify durability per call, overriding the stream’s default.

* **Behavior**
  * Omitting a per-call durability causes the system to resolve durability from patterns/defaults.

* **Tests**
  * Added tests covering pattern matching, per-broadcast overrides, validation, and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->