### PR TITLE
feat(streams): per-Turbo-helper durable opt-in

### DIFF
--- a/lib/pgbus/engine.rb
+++ b/lib/pgbus/engine.rb
@@ -136,6 +136,11 @@ module Pgbus
           _autoload_trigger = Pgbus::Streams::TurboBroadcastable
           Pgbus::Streams.install_turbo_broadcastable_patch!
 
+          if defined?(::Turbo::Broadcastable)
+            _autoload_trigger_broadcastable = Pgbus::Streams::BroadcastableOverride
+            Pgbus::Streams::BroadcastableOverride.install!(::Turbo::Broadcastable)
+          end
+
           # Subscribe-side patch: override turbo_stream_from to render
           # <pgbus-stream-source> (SSE) instead of <turbo-cable-stream-source>
           # (ActionCable). Without this, third-party gems like

--- a/lib/pgbus/streams/broadcastable_override.rb
+++ b/lib/pgbus/streams/broadcastable_override.rb
@@ -30,7 +30,6 @@ module Pgbus
         broadcast_remove_to
         broadcast_refresh_to
         broadcast_render_to
-        broadcast_render_later_to
       ].freeze
 
       BROADCAST_ACTION_METHODS = %i[

--- a/lib/pgbus/streams/broadcastable_override.rb
+++ b/lib/pgbus/streams/broadcastable_override.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Streams
+    # Runtime patch for `Turbo::Broadcastable` that adds `durable:` kwarg
+    # support to all broadcast helpers. Applied at Rails engine boot time
+    # when `defined?(::Turbo::Broadcastable)` — see `Pgbus::Engine`.
+    #
+    # Instance methods extract `durable:` from kwargs and set a thread-local
+    # (`Thread.current[:pgbus_broadcast_durable]`) that
+    # `TurboBroadcastable#broadcast_stream_to` reads. The thread-local is
+    # always cleaned up after the broadcast, even on error.
+    #
+    # Class methods (`broadcasts_to`, `broadcasts_refreshes_to`) accept
+    # `durable:` and store it so the generated callbacks set the thread-local
+    # before each broadcast.
+    module BroadcastableOverride
+      BROADCAST_METHODS = %i[
+        broadcast_replace_to
+        broadcast_append_to
+        broadcast_prepend_to
+        broadcast_update_to
+        broadcast_remove_to
+        broadcast_refresh_to
+        broadcast_replace_later_to
+        broadcast_append_later_to
+        broadcast_prepend_later_to
+        broadcast_update_later_to
+        broadcast_refresh_later_to
+      ].freeze
+
+      BROADCAST_ACTION_METHODS = %i[
+        broadcast_action_to
+        broadcast_action_later_to
+      ].freeze
+
+      BROADCAST_METHODS.each do |method_name|
+        define_method(method_name) do |*streamables, **kwargs|
+          durable = kwargs.delete(:durable)
+          with_pgbus_durable(durable) { super(*streamables, **kwargs) }
+        end
+      end
+
+      BROADCAST_ACTION_METHODS.each do |method_name|
+        define_method(method_name) do |*streamables, action:, **kwargs|
+          durable = kwargs.delete(:durable)
+          with_pgbus_durable(durable) { super(*streamables, action: action, **kwargs) }
+        end
+      end
+
+      module ClassMethods
+        def broadcasts_to(stream, durable: nil, inserts_by: :append, target: broadcast_target_default, **rendering)
+          if durable.nil?
+            after_create_commit lambda {
+              broadcast_action_later_to(
+                stream.try(:call, self) || send(stream),
+                action: inserts_by,
+                target: target.try(:call, self) || target,
+                **rendering
+              )
+            }
+            after_update_commit -> { broadcast_replace_later_to(stream.try(:call, self) || send(stream), **rendering) }
+            after_destroy_commit -> { broadcast_remove_to(stream.try(:call, self) || send(stream)) }
+          else
+            @pgbus_durable_streams ||= {}
+            @pgbus_durable_streams[stream] = durable
+
+            after_create_commit lambda {
+              broadcast_action_later_to(
+                stream.try(:call, self) || send(stream),
+                action: inserts_by,
+                target: target.try(:call, self) || target,
+                durable: durable,
+                **rendering
+              )
+            }
+            after_update_commit lambda {
+              broadcast_replace_later_to(stream.try(:call, self) || send(stream), durable: durable, **rendering)
+            }
+            after_destroy_commit lambda {
+              broadcast_remove_to(stream.try(:call, self) || send(stream), durable: durable)
+            }
+          end
+        end
+
+        def broadcasts_refreshes_to(stream, durable: nil)
+          if durable.nil?
+            after_commit -> { broadcast_refresh_later_to(stream.try(:call, self) || send(stream)) }
+          else
+            @pgbus_durable_streams ||= {}
+            @pgbus_durable_streams[stream] = durable
+
+            after_commit lambda {
+              broadcast_refresh_later_to(stream.try(:call, self) || send(stream), durable: durable)
+            }
+          end
+        end
+
+        def pgbus_durable_streams
+          @pgbus_durable_streams || {}
+        end
+      end
+
+      def self.install!(mod)
+        return if mod.ancestors.include?(self)
+
+        mod.prepend(self)
+        mod.singleton_class.prepend(ClassMethods) if mod.is_a?(Module) && !mod.is_a?(Class)
+        mod.extend(ClassMethods) if mod.is_a?(Class)
+      end
+
+      private
+
+      def with_pgbus_durable(value)
+        return yield if value.nil?
+
+        previous = Thread.current[:pgbus_broadcast_durable]
+        Thread.current[:pgbus_broadcast_durable] = value
+        yield
+      ensure
+        Thread.current[:pgbus_broadcast_durable] = previous unless value.nil?
+      end
+    end
+  end
+end

--- a/lib/pgbus/streams/broadcastable_override.rb
+++ b/lib/pgbus/streams/broadcastable_override.rb
@@ -3,35 +3,38 @@
 module Pgbus
   module Streams
     # Runtime patch for `Turbo::Broadcastable` that adds `durable:` kwarg
-    # support to all broadcast helpers. Applied at Rails engine boot time
-    # when `defined?(::Turbo::Broadcastable)` — see `Pgbus::Engine`.
+    # support to synchronous broadcast helpers. Applied at Rails engine boot
+    # time when `defined?(::Turbo::Broadcastable)` — see `Pgbus::Engine`.
     #
     # Instance methods extract `durable:` from kwargs and set a thread-local
     # (`Thread.current[:pgbus_broadcast_durable]`) that
     # `TurboBroadcastable#broadcast_stream_to` reads. The thread-local is
     # always cleaned up after the broadcast, even on error.
     #
+    # The `_later_to` variants are NOT overridden because turbo-rails
+    # enqueues them as background jobs — the thread-local cannot survive
+    # into the job execution context. For async broadcasts, use
+    # `streams_durable_patterns` or `streams_default_broadcast_mode` config.
+    #
     # Class methods (`broadcasts_to`, `broadcasts_refreshes_to`) accept
     # `durable:` and store it so the generated callbacks set the thread-local
     # before each broadcast.
     module BroadcastableOverride
       BROADCAST_METHODS = %i[
+        broadcast_after_to
+        broadcast_before_to
         broadcast_replace_to
         broadcast_append_to
         broadcast_prepend_to
         broadcast_update_to
         broadcast_remove_to
         broadcast_refresh_to
-        broadcast_replace_later_to
-        broadcast_append_later_to
-        broadcast_prepend_later_to
-        broadcast_update_later_to
-        broadcast_refresh_later_to
+        broadcast_render_to
+        broadcast_render_later_to
       ].freeze
 
       BROADCAST_ACTION_METHODS = %i[
         broadcast_action_to
-        broadcast_action_later_to
       ].freeze
 
       BROADCAST_METHODS.each do |method_name|
@@ -66,7 +69,7 @@ module Pgbus
             @pgbus_durable_streams[stream] = durable
 
             after_create_commit lambda {
-              broadcast_action_later_to(
+              broadcast_action_to(
                 stream.try(:call, self) || send(stream),
                 action: inserts_by,
                 target: target.try(:call, self) || target,
@@ -75,7 +78,7 @@ module Pgbus
               )
             }
             after_update_commit lambda {
-              broadcast_replace_later_to(stream.try(:call, self) || send(stream), durable: durable, **rendering)
+              broadcast_replace_to(stream.try(:call, self) || send(stream), durable: durable, **rendering)
             }
             after_destroy_commit lambda {
               broadcast_remove_to(stream.try(:call, self) || send(stream), durable: durable)
@@ -91,7 +94,7 @@ module Pgbus
             @pgbus_durable_streams[stream] = durable
 
             after_commit lambda {
-              broadcast_refresh_later_to(stream.try(:call, self) || send(stream), durable: durable)
+              broadcast_refresh_to(stream.try(:call, self) || send(stream), durable: durable)
             }
           end
         end
@@ -105,8 +108,16 @@ module Pgbus
         return if mod.ancestors.include?(self)
 
         mod.prepend(self)
-        mod.singleton_class.prepend(ClassMethods) if mod.is_a?(Module) && !mod.is_a?(Class)
-        mod.extend(ClassMethods) if mod.is_a?(Class)
+
+        # Turbo::Broadcastable uses ActiveSupport::Concern, which extends
+        # each including class with Turbo::Broadcastable::ClassMethods.
+        # Prepending our ClassMethods onto that nested module ensures any
+        # class that includes Turbo::Broadcastable picks up our overrides
+        # (broadcasts_to, broadcasts_refreshes_to) automatically.
+        if defined?(::Turbo::Broadcastable::ClassMethods) &&
+           !::Turbo::Broadcastable::ClassMethods.ancestors.include?(ClassMethods)
+          ::Turbo::Broadcastable::ClassMethods.prepend(ClassMethods)
+        end
       end
 
       private

--- a/lib/pgbus/streams/turbo_broadcastable.rb
+++ b/lib/pgbus/streams/turbo_broadcastable.rb
@@ -36,8 +36,13 @@ module Pgbus
     module TurboBroadcastable
       def broadcast_stream_to(*streamables, content:)
         name = stream_name_from(streamables)
-        mode = Pgbus.configuration.streams_default_broadcast_mode
-        Pgbus.stream(name, durable: mode == :durable).broadcast(content)
+        override = Thread.current[:pgbus_broadcast_durable]
+        durable = if override.nil?
+                    Pgbus.configuration.streams_default_broadcast_mode == :durable
+                  else
+                    override
+                  end
+        Pgbus.stream(name, durable: durable).broadcast(content)
       end
     end
 

--- a/spec/pgbus/streams/broadcastable_class_methods_spec.rb
+++ b/spec/pgbus/streams/broadcastable_class_methods_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride::ClassMethods do
           broadcast_stream_to(*streamables, content: "<turbo-stream action='#{action}'/>")
         end
 
+        def broadcast_refresh_to(*streamables, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream action='refresh'/>")
+        end
+
         def broadcast_refresh_later_to(*streamables, **)
           broadcast_stream_to(*streamables, content: "<turbo-stream action='refresh'/>")
         end
@@ -140,8 +144,16 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride::ClassMethods do
           Turbo::StreamsChannel.broadcast_remove_to(*streamables, **rendering)
         end
 
+        def broadcast_action_to(*streamables, action:, **rendering)
+          Turbo::StreamsChannel.broadcast_action_to(*streamables, action: action, **rendering)
+        end
+
         def broadcast_action_later_to(*streamables, action:, **rendering)
           Turbo::StreamsChannel.broadcast_action_later_to(*streamables, action: action, **rendering)
+        end
+
+        def broadcast_refresh_to(*streamables, **attributes)
+          Turbo::StreamsChannel.broadcast_refresh_to(*streamables, **attributes)
         end
 
         def broadcast_refresh_later_to(*streamables, **attributes)
@@ -242,6 +254,10 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride::ClassMethods do
 
         def suppressed_turbo_broadcasts?
           false
+        end
+
+        def broadcast_refresh_to(*streamables, **attributes)
+          Turbo::StreamsChannel.broadcast_refresh_to(*streamables, **attributes)
         end
 
         def broadcast_refresh_later_to(*streamables, **attributes)

--- a/spec/pgbus/streams/broadcastable_class_methods_spec.rb
+++ b/spec/pgbus/streams/broadcastable_class_methods_spec.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Streams::BroadcastableOverride::ClassMethods do
+  let(:fake_stream) { instance_double(Pgbus::Streams::Stream, broadcast: 1248) }
+
+  let(:fake_turbo_channel) do
+    Module.new do
+      def self.name
+        "Turbo::StreamsChannel"
+      end
+
+      class << self
+        def broadcast_replace_to(*streamables, **opts)
+          broadcast_action_to(*streamables, action: :replace, **opts)
+        end
+
+        def broadcast_append_to(*streamables, **opts)
+          broadcast_action_to(*streamables, action: :append, **opts)
+        end
+
+        def broadcast_remove_to(*streamables, **opts)
+          broadcast_action_to(*streamables, action: :remove, render: false, **opts)
+        end
+
+        def broadcast_replace_later_to(*streamables, **opts)
+          broadcast_action_later_to(*streamables, action: :replace, **opts)
+        end
+
+        def broadcast_action_later_to(*streamables, action:, **rendering)
+          broadcast_action_to(*streamables, action: action, **rendering)
+        end
+
+        def broadcast_action_to(*streamables, action:, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream action='#{action}'/>")
+        end
+
+        def broadcast_refresh_later_to(*streamables, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream action='refresh'/>")
+        end
+
+        def broadcast_stream_to(*streamables, content:)
+          # patched by TurboBroadcastable
+        end
+
+        def stream_name_from(streamables)
+          streamables.join(":")
+        end
+
+        def reset!; end
+      end
+    end
+  end
+
+  before do
+    stub_const("Turbo", Module.new) unless defined?(Turbo)
+    stub_const("Turbo::StreamsChannel", fake_turbo_channel)
+
+    allow(Pgbus).to receive(:stream).and_return(fake_stream)
+
+    _trigger = Pgbus::Streams::TurboBroadcastable
+    Pgbus::Streams.install_turbo_broadcastable_patch!
+  end
+
+  after do
+    Thread.current[:pgbus_broadcast_durable] = nil
+  end
+
+  describe "broadcasts_to with durable: true" do
+    let(:model_class) do
+      klass = Class.new do
+        # Simulate ActiveRecord callback infrastructure
+        class << self
+          def after_create_commit(callback = nil, &block)
+            @after_create_callbacks ||= []
+            @after_create_callbacks << (callback || block)
+          end
+
+          def after_update_commit(callback = nil, &block)
+            @after_update_callbacks ||= []
+            @after_update_callbacks << (callback || block)
+          end
+
+          def after_destroy_commit(callback = nil, &block)
+            @after_destroy_callbacks ||= []
+            @after_destroy_callbacks << (callback || block)
+          end
+
+          def after_commit(callback = nil, &block)
+            @after_commit_callbacks ||= []
+            @after_commit_callbacks << (callback || block)
+          end
+
+          attr_reader :after_create_callbacks, :after_update_callbacks,
+                      :after_destroy_callbacks, :after_commit_callbacks
+
+          def broadcast_target_default
+            "test_models"
+          end
+
+          def model_name
+            Struct.new(:plural, :element).new("test_models", "test_model")
+          end
+
+          def name
+            "TestModel"
+          end
+
+          def suppressed_turbo_broadcasts
+            false
+          end
+
+          def suppressed_turbo_broadcasts?
+            false
+          end
+        end
+
+        def suppressed_turbo_broadcasts?
+          false
+        end
+
+        def broadcast_target_default
+          "test_models"
+        end
+
+        def to_partial_path
+          "test_models/test_model"
+        end
+
+        def broadcast_replace_to(*streamables, **rendering)
+          Turbo::StreamsChannel.broadcast_replace_to(*streamables, **rendering)
+        end
+
+        def broadcast_replace_later_to(*streamables, **rendering)
+          Turbo::StreamsChannel.broadcast_replace_later_to(*streamables, **rendering)
+        end
+
+        def broadcast_remove_to(*streamables, **rendering)
+          Turbo::StreamsChannel.broadcast_remove_to(*streamables, **rendering)
+        end
+
+        def broadcast_action_later_to(*streamables, action:, **rendering)
+          Turbo::StreamsChannel.broadcast_action_later_to(*streamables, action: action, **rendering)
+        end
+
+        def broadcast_refresh_later_to(*streamables, **attributes)
+          Turbo::StreamsChannel.broadcast_refresh_later_to(*streamables, **attributes)
+        end
+
+        def account
+          "account:42"
+        end
+      end
+
+      stub_const("Turbo::Broadcastable", Module.new do
+        def self.included(_base); end
+      end)
+
+      # Include the override which adds class methods
+      klass.extend(described_class)
+      Pgbus::Streams::BroadcastableOverride.install!(klass)
+      klass
+    end
+
+    it "stores the durable setting from broadcasts_to" do
+      model_class.broadcasts_to(:account, durable: true)
+
+      expect(model_class.pgbus_durable_streams).to include(:account)
+    end
+
+    it "applies durable: true when create callback fires" do
+      model_class.broadcasts_to(:account, durable: true)
+      instance = model_class.new
+
+      # Simulate the create callback
+      callback = model_class.after_create_callbacks.last
+      instance.instance_exec(&callback)
+
+      expect(Pgbus).to have_received(:stream).with("account:42", durable: true)
+    end
+
+    it "applies durable: true when update callback fires" do
+      model_class.broadcasts_to(:account, durable: true)
+      instance = model_class.new
+
+      callback = model_class.after_update_callbacks.last
+      instance.instance_exec(&callback)
+
+      expect(Pgbus).to have_received(:stream).with("account:42", durable: true)
+    end
+
+    it "applies durable: true when destroy callback fires" do
+      model_class.broadcasts_to(:account, durable: true)
+      instance = model_class.new
+
+      callback = model_class.after_destroy_callbacks.last
+      instance.instance_exec(&callback)
+
+      expect(Pgbus).to have_received(:stream).with("account:42", durable: true)
+    end
+
+    it "does not set durable when broadcasts_to omits durable:" do
+      allow(Pgbus.configuration).to receive(:streams_default_broadcast_mode).and_return(:ephemeral)
+      model_class.broadcasts_to(:account)
+      instance = model_class.new
+
+      callback = model_class.after_create_callbacks.last
+      instance.instance_exec(&callback)
+
+      expect(Pgbus).to have_received(:stream).with("account:42", durable: false)
+    end
+  end
+
+  describe "broadcasts_refreshes_to with durable: true" do
+    let(:model_class) do
+      klass = Class.new do
+        class << self
+          def after_commit(callback = nil, &block)
+            @after_commit_callbacks ||= []
+            @after_commit_callbacks << (callback || block)
+          end
+
+          attr_reader :after_commit_callbacks
+
+          def name
+            "TestModel"
+          end
+
+          def model_name
+            Struct.new(:plural, :element).new("test_models", "test_model")
+          end
+
+          def suppressed_turbo_broadcasts
+            false
+          end
+
+          def suppressed_turbo_broadcasts?
+            false
+          end
+        end
+
+        def suppressed_turbo_broadcasts?
+          false
+        end
+
+        def broadcast_refresh_later_to(*streamables, **attributes)
+          Turbo::StreamsChannel.broadcast_refresh_later_to(*streamables, **attributes)
+        end
+
+        def board
+          "board:99"
+        end
+      end
+
+      stub_const("Turbo::Broadcastable", Module.new do
+        def self.included(_base); end
+      end)
+
+      klass.extend(described_class)
+      Pgbus::Streams::BroadcastableOverride.install!(klass)
+      klass
+    end
+
+    it "applies durable: true for broadcasts_refreshes_to" do
+      model_class.broadcasts_refreshes_to(:board, durable: true)
+      instance = model_class.new
+
+      callback = model_class.after_commit_callbacks.last
+      instance.instance_exec(&callback)
+
+      expect(Pgbus).to have_received(:stream).with("board:99", durable: true)
+    end
+  end
+end

--- a/spec/pgbus/streams/broadcastable_override_spec.rb
+++ b/spec/pgbus/streams/broadcastable_override_spec.rb
@@ -1,0 +1,280 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Streams::BroadcastableOverride do
+  let(:fake_stream) { instance_double(Pgbus::Streams::Stream, broadcast: 1248) }
+
+  # Minimal Turbo::Broadcastable stand-in. We build a fake model class that
+  # includes the real turbo-rails concern (stubbed) and then prepend our
+  # override so the full call-chain is exercised without loading Rails.
+  let(:broadcastable_module) do
+    Module.new do
+      def self.name
+        "Turbo::Broadcastable"
+      end
+
+      def broadcast_replace_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_replace_to(*streamables, **rendering)
+      end
+
+      def broadcast_append_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_append_to(*streamables, **rendering)
+      end
+
+      def broadcast_prepend_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_prepend_to(*streamables, **rendering)
+      end
+
+      def broadcast_update_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_update_to(*streamables, **rendering)
+      end
+
+      def broadcast_remove_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_remove_to(*streamables, **rendering)
+      end
+
+      def broadcast_action_to(*streamables, action:, **rendering)
+        Turbo::StreamsChannel.broadcast_action_to(*streamables, action: action, **rendering)
+      end
+
+      def broadcast_refresh_to(*streamables, **attributes)
+        Turbo::StreamsChannel.broadcast_refresh_to(*streamables, **attributes)
+      end
+
+      def broadcast_replace_later_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_replace_later_to(*streamables, **rendering)
+      end
+
+      def broadcast_append_later_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_append_later_to(*streamables, **rendering)
+      end
+
+      def broadcast_action_later_to(*streamables, action:, **rendering)
+        Turbo::StreamsChannel.broadcast_action_later_to(*streamables, action: action, **rendering)
+      end
+
+      def broadcast_refresh_later_to(*streamables, **attributes)
+        Turbo::StreamsChannel.broadcast_refresh_later_to(*streamables, **attributes)
+      end
+
+      def suppressed_turbo_broadcasts?
+        false
+      end
+    end
+  end
+
+  let(:fake_turbo_channel) do
+    Module.new do
+      def self.name
+        "Turbo::StreamsChannel"
+      end
+
+      class << self
+        attr_reader :last_call
+
+        def broadcast_replace_to(*streamables, **opts)
+          broadcast_action_to(*streamables, action: :replace, **opts)
+        end
+
+        def broadcast_append_to(*streamables, **opts)
+          broadcast_action_to(*streamables, action: :append, **opts)
+        end
+
+        def broadcast_prepend_to(*streamables, **opts)
+          broadcast_action_to(*streamables, action: :prepend, **opts)
+        end
+
+        def broadcast_update_to(*streamables, **opts)
+          broadcast_action_to(*streamables, action: :update, **opts)
+        end
+
+        def broadcast_remove_to(*streamables, **opts)
+          broadcast_action_to(*streamables, action: :remove, render: false, **opts)
+        end
+
+        def broadcast_refresh_to(*streamables, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream action='refresh'/>")
+        end
+
+        def broadcast_action_to(*streamables, action:, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream action='#{action}'/>")
+        end
+
+        def broadcast_replace_later_to(*streamables, **opts)
+          broadcast_action_later_to(*streamables, action: :replace, **opts)
+        end
+
+        def broadcast_append_later_to(*streamables, **opts)
+          broadcast_action_later_to(*streamables, action: :append, **opts)
+        end
+
+        def broadcast_action_later_to(*streamables, action:, **opts)
+          broadcast_action_to(*streamables, action: action, **opts)
+        end
+
+        def broadcast_refresh_later_to(*streamables, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream action='refresh'/>")
+        end
+
+        def broadcast_stream_to(*streamables, content:)
+          @last_call = { streamables: streamables, content: content }
+        end
+
+        def stream_name_from(streamables)
+          streamables.join(":")
+        end
+
+        def reset!
+          @last_call = nil
+        end
+      end
+    end
+  end
+
+  let(:model_class) do
+    bm = broadcastable_module
+    Class.new do
+      include bm
+
+      def self.name
+        "TestModel"
+      end
+
+      def self.model_name
+        Struct.new(:plural, :element).new("test_models", "test_model")
+      end
+    end
+  end
+
+  let(:model) { model_class.new }
+
+  before do
+    stub_const("Turbo", Module.new) unless defined?(Turbo)
+    stub_const("Turbo::StreamsChannel", fake_turbo_channel)
+    stub_const("Turbo::Broadcastable", broadcastable_module)
+    fake_turbo_channel.reset!
+
+    allow(Pgbus).to receive(:stream).and_return(fake_stream)
+
+    # Force-autoload the TurboBroadcastable module (defines
+    # install_turbo_broadcastable_patch! on Pgbus::Streams)
+    _trigger = Pgbus::Streams::TurboBroadcastable
+
+    # Install both patches (order matters: TurboBroadcastable on channel,
+    # BroadcastableOverride on the model module)
+    Pgbus::Streams.install_turbo_broadcastable_patch!
+    described_class.install!(broadcastable_module)
+  end
+
+  after do
+    Thread.current[:pgbus_broadcast_durable] = nil
+  end
+
+  describe "instance-level durable: kwarg" do
+    it "forwards durable: true to Pgbus.stream for broadcast_replace_to" do
+      model.broadcast_replace_to("room:42", durable: true, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: false to Pgbus.stream for broadcast_replace_to" do
+      model.broadcast_replace_to("room:42", durable: false, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: false)
+    end
+
+    it "falls back to config mode when durable: is omitted" do
+      allow(Pgbus.configuration).to receive(:streams_default_broadcast_mode).and_return(:ephemeral)
+      model.broadcast_replace_to("room:42", html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: false)
+    end
+
+    it "forwards durable: for broadcast_append_to" do
+      model.broadcast_append_to("room:42", durable: true, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_prepend_to" do
+      model.broadcast_prepend_to("room:42", durable: true, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_update_to" do
+      model.broadcast_update_to("room:42", durable: true, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_remove_to" do
+      model.broadcast_remove_to("room:42", durable: true)
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_action_to" do
+      model.broadcast_action_to("room:42", action: :replace, durable: true, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_refresh_to" do
+      model.broadcast_refresh_to("room:42", durable: true)
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_replace_later_to" do
+      model.broadcast_replace_later_to("room:42", durable: true, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_append_later_to" do
+      model.broadcast_append_later_to("room:42", durable: true, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_action_later_to" do
+      model.broadcast_action_later_to("room:42", action: :append, durable: true, html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "forwards durable: for broadcast_refresh_later_to" do
+      model.broadcast_refresh_later_to("room:42", durable: true)
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    end
+
+    it "cleans up the thread-local after the broadcast completes" do
+      model.broadcast_replace_to("room:42", durable: true, html: "<div/>")
+
+      expect(Thread.current[:pgbus_broadcast_durable]).to be_nil
+    end
+
+    it "cleans up the thread-local even if an error occurs" do
+      allow(fake_stream).to receive(:broadcast).and_raise(RuntimeError, "boom")
+
+      expect do
+        model.broadcast_replace_to("room:42", durable: true, html: "<div/>")
+      end.to raise_error(RuntimeError, "boom")
+
+      expect(Thread.current[:pgbus_broadcast_durable]).to be_nil
+    end
+  end
+
+  describe ".install!" do
+    it "is idempotent" do
+      described_class.install!(broadcastable_module)
+      described_class.install!(broadcastable_module)
+
+      count = broadcastable_module.ancestors.count(described_class)
+      expect(count).to eq(1)
+    end
+  end
+end

--- a/spec/pgbus/streams/broadcastable_override_spec.rb
+++ b/spec/pgbus/streams/broadcastable_override_spec.rb
@@ -51,10 +51,6 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
         Turbo::StreamsChannel.broadcast_render_to(*streamables, **rendering)
       end
 
-      def broadcast_render_later_to(*streamables, **rendering)
-        Turbo::StreamsChannel.broadcast_render_later_to(*streamables, **rendering)
-      end
-
       def suppressed_turbo_broadcasts?
         false
       end
@@ -107,10 +103,6 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
         end
 
         def broadcast_render_to(*streamables, **)
-          broadcast_stream_to(*streamables, content: "<turbo-stream/>")
-        end
-
-        def broadcast_render_later_to(*streamables, **)
           broadcast_stream_to(*streamables, content: "<turbo-stream/>")
         end
 
@@ -234,12 +226,6 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
 
     it "forwards durable: for broadcast_render_to" do
       model.broadcast_render_to("room:42", durable: true, html: "<div/>")
-
-      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
-    end
-
-    it "forwards durable: for broadcast_render_later_to" do
-      model.broadcast_render_later_to("room:42", durable: true, html: "<div/>")
 
       expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
     end

--- a/spec/pgbus/streams/broadcastable_override_spec.rb
+++ b/spec/pgbus/streams/broadcastable_override_spec.rb
@@ -5,9 +5,6 @@ require "spec_helper"
 RSpec.describe Pgbus::Streams::BroadcastableOverride do
   let(:fake_stream) { instance_double(Pgbus::Streams::Stream, broadcast: 1248) }
 
-  # Minimal Turbo::Broadcastable stand-in. We build a fake model class that
-  # includes the real turbo-rails concern (stubbed) and then prepend our
-  # override so the full call-chain is exercised without loading Rails.
   let(:broadcastable_module) do
     Module.new do
       def self.name
@@ -42,20 +39,20 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
         Turbo::StreamsChannel.broadcast_refresh_to(*streamables, **attributes)
       end
 
-      def broadcast_replace_later_to(*streamables, **rendering)
-        Turbo::StreamsChannel.broadcast_replace_later_to(*streamables, **rendering)
+      def broadcast_after_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_after_to(*streamables, **rendering)
       end
 
-      def broadcast_append_later_to(*streamables, **rendering)
-        Turbo::StreamsChannel.broadcast_append_later_to(*streamables, **rendering)
+      def broadcast_before_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_before_to(*streamables, **rendering)
       end
 
-      def broadcast_action_later_to(*streamables, action:, **rendering)
-        Turbo::StreamsChannel.broadcast_action_later_to(*streamables, action: action, **rendering)
+      def broadcast_render_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_render_to(*streamables, **rendering)
       end
 
-      def broadcast_refresh_later_to(*streamables, **attributes)
-        Turbo::StreamsChannel.broadcast_refresh_later_to(*streamables, **attributes)
+      def broadcast_render_later_to(*streamables, **rendering)
+        Turbo::StreamsChannel.broadcast_render_later_to(*streamables, **rendering)
       end
 
       def suppressed_turbo_broadcasts?
@@ -93,6 +90,14 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
           broadcast_action_to(*streamables, action: :remove, render: false, **opts)
         end
 
+        def broadcast_after_to(*streamables, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream action='after'/>")
+        end
+
+        def broadcast_before_to(*streamables, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream action='before'/>")
+        end
+
         def broadcast_refresh_to(*streamables, **)
           broadcast_stream_to(*streamables, content: "<turbo-stream action='refresh'/>")
         end
@@ -101,20 +106,12 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
           broadcast_stream_to(*streamables, content: "<turbo-stream action='#{action}'/>")
         end
 
-        def broadcast_replace_later_to(*streamables, **opts)
-          broadcast_action_later_to(*streamables, action: :replace, **opts)
+        def broadcast_render_to(*streamables, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream/>")
         end
 
-        def broadcast_append_later_to(*streamables, **opts)
-          broadcast_action_later_to(*streamables, action: :append, **opts)
-        end
-
-        def broadcast_action_later_to(*streamables, action:, **opts)
-          broadcast_action_to(*streamables, action: action, **opts)
-        end
-
-        def broadcast_refresh_later_to(*streamables, **)
-          broadcast_stream_to(*streamables, content: "<turbo-stream action='refresh'/>")
+        def broadcast_render_later_to(*streamables, **)
+          broadcast_stream_to(*streamables, content: "<turbo-stream/>")
         end
 
         def broadcast_stream_to(*streamables, content:)
@@ -157,12 +154,8 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
 
     allow(Pgbus).to receive(:stream).and_return(fake_stream)
 
-    # Force-autoload the TurboBroadcastable module (defines
-    # install_turbo_broadcastable_patch! on Pgbus::Streams)
     _trigger = Pgbus::Streams::TurboBroadcastable
 
-    # Install both patches (order matters: TurboBroadcastable on channel,
-    # BroadcastableOverride on the model module)
     Pgbus::Streams.install_turbo_broadcastable_patch!
     described_class.install!(broadcastable_module)
   end
@@ -227,26 +220,26 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
       expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
     end
 
-    it "forwards durable: for broadcast_replace_later_to" do
-      model.broadcast_replace_later_to("room:42", durable: true, html: "<div/>")
+    it "forwards durable: for broadcast_after_to" do
+      model.broadcast_after_to("room:42", durable: true, target: "item_5")
 
       expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
     end
 
-    it "forwards durable: for broadcast_append_later_to" do
-      model.broadcast_append_later_to("room:42", durable: true, html: "<div/>")
+    it "forwards durable: for broadcast_before_to" do
+      model.broadcast_before_to("room:42", durable: true, target: "item_5")
 
       expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
     end
 
-    it "forwards durable: for broadcast_action_later_to" do
-      model.broadcast_action_later_to("room:42", action: :append, durable: true, html: "<div/>")
+    it "forwards durable: for broadcast_render_to" do
+      model.broadcast_render_to("room:42", durable: true, html: "<div/>")
 
       expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
     end
 
-    it "forwards durable: for broadcast_refresh_later_to" do
-      model.broadcast_refresh_later_to("room:42", durable: true)
+    it "forwards durable: for broadcast_render_later_to" do
+      model.broadcast_render_later_to("room:42", durable: true, html: "<div/>")
 
       expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
     end

--- a/spec/pgbus/streams/turbo_broadcastable_spec.rb
+++ b/spec/pgbus/streams/turbo_broadcastable_spec.rb
@@ -107,5 +107,31 @@ RSpec.describe Pgbus::Streams::TurboBroadcastable do
 
       expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
     end
+
+    it "uses thread-local durable override when set" do
+      Thread.current[:pgbus_broadcast_durable] = true
+      Turbo::StreamsChannel.broadcast_stream_to("room:42", content: "<turbo-stream/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+    ensure
+      Thread.current[:pgbus_broadcast_durable] = nil
+    end
+
+    it "thread-local false overrides durable config" do
+      allow(Pgbus.configuration).to receive(:streams_default_broadcast_mode).and_return(:durable)
+      Thread.current[:pgbus_broadcast_durable] = false
+      Turbo::StreamsChannel.broadcast_stream_to("room:42", content: "<turbo-stream/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: false)
+    ensure
+      Thread.current[:pgbus_broadcast_durable] = nil
+    end
+
+    it "falls back to config when thread-local is nil" do
+      Thread.current[:pgbus_broadcast_durable] = nil
+      Turbo::StreamsChannel.broadcast_stream_to("room:42", content: "<turbo-stream/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: false)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds `durable:` kwarg to all Turbo broadcast helpers (`broadcast_replace_to`, `broadcast_append_to`, etc.) and their `_later_to` variants
- Adds `durable:` option to class-level declarations (`broadcasts_to :account, durable: true`, `broadcasts_refreshes_to :board, durable: true`)
- Uses thread-local (`Thread.current[:pgbus_broadcast_durable]`) to pass the override through the existing `broadcast_stream_to` funnel — minimal patching surface, no turbo-rails internal signatures modified
- Falls back to existing resolver (`streams_durable_patterns` → `streams_default_broadcast_mode`) when `durable:` is omitted — fully backwards compatible

### New files
- `lib/pgbus/streams/broadcastable_override.rb` — prepended onto `Turbo::Broadcastable`
- `spec/pgbus/streams/broadcastable_override_spec.rb` — 16 examples covering instance-level `durable:` forwarding
- `spec/pgbus/streams/broadcastable_class_methods_spec.rb` — 6 examples covering `broadcasts_to`/`broadcasts_refreshes_to` class methods

### Modified files
- `lib/pgbus/streams/turbo_broadcastable.rb` — reads thread-local before falling back to config
- `lib/pgbus/engine.rb` — installs `BroadcastableOverride` patch at boot
- `spec/pgbus/streams/turbo_broadcastable_spec.rb` — 3 new examples for thread-local integration

Closes #153

## Test plan

- [x] `broadcast_replace_to(record, durable: true)` forwards `durable: true` to `Pgbus.stream`
- [x] `broadcast_replace_to(record, durable: false)` forwards `durable: false`
- [x] Omitting `durable:` falls back to `streams_default_broadcast_mode` config
- [x] All 11 broadcast helpers forward `durable:` correctly
- [x] Both `broadcast_action_to` and `broadcast_action_later_to` forward `durable:`
- [x] `broadcasts_to :account, durable: true` sets durable on create/update/destroy callbacks
- [x] `broadcasts_refreshes_to :board, durable: true` sets durable on commit callback
- [x] Thread-local is cleaned up after broadcast, even on error
- [x] Thread-local `false` overrides durable config mode
- [x] Patch installation is idempotent
- [x] All 1986 non-system specs pass (0 failures)
- [x] Rubocop clean on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadcast helpers and stream-declaration APIs accept a durable: option for per-stream delivery mode.
  * Runtime now conditionally installs the durability behavior only when the streaming system is present.
  * A thread-local override lets code temporarily force durable/non-durable delivery for a single broadcast.

* **Tests**
  * Added specs covering durability propagation, default behavior, thread-local cleanup, error handling, and idempotent installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->