### PR TITLE
fix(client): wrap notify_stream in with_stale_connection_retry

### DIFF
--- a/lib/pgbus/client/notify_stream.rb
+++ b/lib/pgbus/client/notify_stream.rb
@@ -25,9 +25,11 @@ module Pgbus
         json = payload.is_a?(String) ? payload : JSON.generate(payload)
 
         Instrumentation.instrument("pgbus.stream.notify", stream: stream_name, bytes: json.bytesize) do
-          synchronized do
-            @pgmq.__send__(:with_connection) do |conn|
-              conn.exec_params("SELECT pg_notify($1, $2)", [channel, json])
+          with_stale_connection_retry do
+            synchronized do
+              @pgmq.__send__(:with_connection) do |conn|
+                conn.exec_params("SELECT pg_notify($1, $2)", [channel, json])
+              end
             end
           end
         end

--- a/spec/pgbus/client/notify_stream_spec.rb
+++ b/spec/pgbus/client/notify_stream_spec.rb
@@ -66,5 +66,68 @@ RSpec.describe Pgbus::Client::NotifyStream do
         )
       )
     end
+
+    context "with stale pgmq connection recovery" do
+      before do
+        stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      end
+
+      let(:ssl_eof_msg) { "Database connection error: PQconsumeInput() SSL error: unexpected eof while reading" }
+
+      it "retries once on an idle-socket SSL EOF" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:with_connection) do |&block|
+          call_count += 1
+          raise PGMQ::Errors::ConnectionError, ssl_eof_msg if call_count == 1
+
+          block.call(raw_conn)
+        end
+
+        expect do
+          client.notify_stream("chat", { "html" => "<turbo-stream/>" })
+        end.not_to raise_error
+
+        expect(call_count).to eq(2)
+      end
+
+      it "does not retry on a non-matching ConnectionError" do
+        allow(mock_pgmq).to receive(:with_connection)
+          .and_raise(PGMQ::Errors::ConnectionError, "Connection pool timeout: waited 5.00s")
+
+        expect do
+          client.notify_stream("chat", { "html" => "X" })
+        end.to raise_error(PGMQ::Errors::ConnectionError, /pool timeout/)
+      end
+
+      it "gives up after one retry (double failure) and re-raises" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:with_connection) do |&_block|
+          call_count += 1
+          raise PGMQ::Errors::ConnectionError, ssl_eof_msg
+        end
+
+        expect do
+          client.notify_stream("chat", { "html" => "X" })
+        end.to raise_error(PGMQ::Errors::ConnectionError)
+
+        expect(call_count).to eq(2)
+      end
+
+      it "logs a warning on the retry path" do
+        call_count = 0
+        allow(mock_pgmq).to receive(:with_connection) do |&block|
+          call_count += 1
+          raise PGMQ::Errors::ConnectionError, ssl_eof_msg if call_count == 1
+
+          block.call(raw_conn)
+        end
+
+        allow(Pgbus.logger).to receive(:warn)
+
+        client.notify_stream("chat", { "html" => "X" })
+
+        expect(Pgbus.logger).to have_received(:warn)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `notify_stream` was the only `@pgmq.*` call site on `Pgbus::Client` that bypassed `with_stale_connection_retry`, causing transient idle-socket TLS errors (`SSL error: unexpected eof`, `SSL SYSCALL error`) to propagate to callers — typically Rails requests, `after_commit` callbacks, or event handlers using the ephemeral broadcast path
- Wrapped `notify_stream` body in `with_stale_connection_retry` with `synchronized` inside the retry, matching the pattern used by `send_message`, `send_batch`, and every other method on `Pgbus::Client`
- Added 4 specs covering: matched retry succeeds, non-matching error propagates, double-failure re-raises, and warning log emitted on retry

No public API change, no configuration change, no migration.

## Test plan

- [x] `bundle exec rspec spec/pgbus/client/notify_stream_spec.rb` — 8 examples, 0 failures
- [x] `bundle exec rspec spec/pgbus/client_spec.rb` — 116 examples, 0 failures
- [x] `bundle exec rubocop lib/pgbus/client/notify_stream.rb spec/pgbus/client/notify_stream_spec.rb` — clean
- [ ] Verify in staging with ephemeral Turbo broadcasts under idle-pool conditions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification delivery now includes automatic retry logic for stale PostgreSQL connections, improving reliability when transient connection issues occur. The system will attempt to recover from idle-socket SSL EOF conditions automatically.

* **Tests**
  * Added test coverage for stale connection recovery scenarios, validating retry attempts, error propagation for non-recoverable failures, and warning notifications during recovery operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mhenrixon/pgbus/pull/155)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->