### PR TITLE
feat(streams): in-memory counters and auto-enabled stats for ephemeral broadcasts

### DIFF
--- a/.claude/commands/github-review-pr.md
+++ b/.claude/commands/github-review-pr.md
@@ -1,0 +1,112 @@
+---
+description: "Use when a PR needs full review — fixes CI failures first, then addresses unresolved review comments. Run failures first because comment fixes trigger new CI runs that obscure the original failures."
+model: claude-opus-4-7
+argument-hint: "PR number (e.g., 156 or #156)"
+allowed-tools: Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(gh run view:*), Bash(git log:*), Bash(git blame:*), Bash(git diff:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent
+---
+
+# Review GitHub PR (full pass): $ARGUMENTS
+
+You are running a full review pass on a pull request. The pass has two phases that MUST run in this order:
+
+1. **Phase A: CI failures** — fix anything red before touching review comments.
+2. **Phase B: review comments** — only after Phase A leaves CI green (or pending green after a push).
+
+## Why this order matters
+
+If you fix review comments first, every commit pushes a new CI run. By the time the review-comment fixes finish, the original failure logs are buried under new pipeline runs. Symptoms:
+
+- The "specs (8, 4) failed" log you needed to read is now from a stale run; the latest run is still in progress on top of your unrelated comment fixes.
+- A review-comment fix accidentally repairs the CI failure as a side effect, and you lose the chance to verify the failure was real.
+- A review-comment fix accidentally INTRODUCES a CI failure, and you can't tell whether the new failure was pre-existing or your fault.
+
+Failures-first eliminates this confusion. CI is either green or red on a known commit; the review-comment fixes layer cleanly on top.
+
+## Phase 0: Determine the PR Number
+
+The user may provide a PR number as `$ARGUMENTS`. Parse it flexibly:
+
+- `PR156`, `PR 156`, `pr156` → PR 156
+- `156` → PR 156
+- `#156` → PR 156
+- Empty/blank → auto-detect from current branch
+
+**If no PR number is provided**, detect it automatically:
+
+```bash
+gh pr list --author=@me --head="$(git branch --show-current)" --state=open --json number,title
+```
+
+If exactly one open PR exists for the current branch, use it. If none or multiple, ask the user.
+
+Once you have the PR number, confirm it:
+
+```bash
+gh pr view <PR_NUMBER> --json title,state,url
+```
+
+---
+
+## Phase A: Run `/github-review-failures`
+
+Invoke the existing `/github-review-failures` slash command with the same `$ARGUMENTS` value. Its purpose: fix every failing CI check, push, leave the branch in a state where CI is either green or running-pending-toward-green.
+
+Follow that command's full process — phases 1–6 of the failures runbook. The slash command is at `.claude/commands/github-review-failures.md`. Its workflow:
+
+1. Identify failing checks via `gh pr checks <PR>`.
+2. Fetch failure logs.
+3. Diagnose root cause for each.
+4. Fix locally — lint first (fast, deterministic), then specs, then build issues.
+5. Verify locally before commit (`bundle exec rspec <files>`, `bundle exec rubocop`).
+6. Commit + push + report which checks are now running.
+
+### Phase A exit criteria
+
+Before moving to Phase B, one of these must be true:
+
+- All CI checks are green on the latest pushed commit. OR
+- All CI checks are pending (running) on the latest pushed commit, AND no checks failed in the most recent completed run on this commit. OR
+- A persistent CI failure exists that is **not caused by changes on this branch** (e.g., a flaky test on `main`, a secret-scanning job that fails for environmental reasons). Report this explicitly and proceed to Phase B with the caveat noted.
+
+If failures persist on this branch's changes, **do NOT proceed to Phase B**. Report what's still failing, what's been tried, and ask the user how to proceed.
+
+---
+
+## Phase B: Run `/github-review-comments`
+
+Once Phase A's exit criteria are met, invoke `/github-review-comments` with the same `$ARGUMENTS`. Its purpose: address every unresolved review thread on the PR, push fixes, reply with commit SHAs, and resolve the threads.
+
+The slash command is at `.claude/commands/github-review-comments.md`. Its workflow:
+
+1. Fetch all unresolved review threads via the GitHub GraphQL API.
+2. Read and categorise each comment (valid fix / invalid suggestion / unclear).
+3. Implement accepted fixes; verify locally (specs, validators, rubocop).
+4. Commit all fixes together with a clear message; push.
+5. Reply to every thread with the commit SHA (for accepted fixes) or technical reasoning (for rejections).
+6. Resolve each thread via the GraphQL `resolveReviewThread` mutation.
+7. Verify no unresolved threads remain.
+
+### Phase B exit criteria
+
+- All unresolved review threads have been replied to and resolved (or the user has explicitly approved leaving a specific thread open).
+- The branch has been pushed with all accepted fixes.
+
+---
+
+## Phase C: Final report
+
+After both phases complete, report:
+
+1. **Phase A summary**: which CI failures were diagnosed and fixed. Note the commit SHAs for the fixes.
+2. **Phase B summary**: which review comments were accepted (with commit SHAs), which were pushed back on (with reasoning), and the final unresolved-thread count (should be 0).
+3. **Outstanding work**: anything that still needs attention — e.g., CI was pending at the end of Phase B and the user should verify the latest run after the comment fixes.
+
+---
+
+## Important Notes
+
+- **Do not interleave the phases.** Don't fix a CI failure, then a review comment, then another CI failure. The whole point of this command is the strict ordering.
+- **A new CI failure emerging during Phase B** (e.g., a comment fix breaks a spec) means looping back to Phase A — fix the new failure before continuing comment work. This is the only allowed reverse direction.
+- **If the PR has no failures AND no unresolved comments**, report "PR is clean" and stop.
+- **If `$ARGUMENTS` is the same as the current open PR**, the two child slash commands will see the same PR. They share state through the git branch and the GitHub API, not through any in-process variable.
+- **Don't re-implement the child slash commands' logic**. Invoke them and let them do their work. This command is the orchestrator.

--- a/app/controllers/pgbus/api/insights_controller.rb
+++ b/app/controllers/pgbus/api/insights_controller.rb
@@ -15,6 +15,7 @@ module Pgbus
           payload[:latency_trend] = data_source.latency_trend(minutes: minutes)
           payload[:latency_by_queue] = data_source.latency_by_queue(minutes: minutes)
         end
+        payload[:live_streams] = data_source.live_stream_metrics
         render json: payload
       end
     end

--- a/app/controllers/pgbus/insights_controller.rb
+++ b/app/controllers/pgbus/insights_controller.rb
@@ -9,6 +9,8 @@ module Pgbus
       @latency_by_queue = data_source.latency_by_queue(minutes: @minutes)
       @latency_available = Pgbus::JobStat.latency_columns?
 
+      @live_stream_metrics = data_source.live_stream_metrics
+
       @stream_stats_available = data_source.stream_stats_available?
       return unless @stream_stats_available
 

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -159,6 +159,61 @@
   </table>
 </div>
 
+<% if @live_stream_metrics[:totals][:streams] > 0 %>
+<!-- Live stream counters (in-memory, always-on) -->
+<div class="mt-8">
+  <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("pgbus.insights.show.live_streams.title") %></h2>
+
+  <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 mb-6">
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.live_streams.broadcasts") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@live_stream_metrics[:totals][:broadcasts]) %></dd>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.live_streams.active_connections") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-green-600 dark:text-green-400"><%= pgbus_number(@live_stream_metrics[:totals][:active_connections]) %></dd>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.live_streams.total_connections") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@live_stream_metrics[:totals][:total_connections]) %></dd>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Streams</dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@live_stream_metrics[:totals][:streams]) %></dd>
+    </div>
+  </div>
+
+  <div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+      <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">Per-Stream Counters</h3>
+    </div>
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <thead class="bg-gray-50 dark:bg-gray-900">
+        <tr>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.live_streams.stream") %></th>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.live_streams.broadcasts") %></th>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.live_streams.active_connections") %></th>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.live_streams.total_connections") %></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+        <% @live_stream_metrics[:streams].sort_by { |_name, data| -data[:broadcasts] }.each do |name, data| %>
+          <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+            <td data-label="Stream" class="px-4 py-3 text-sm font-medium text-gray-700 dark:text-gray-300"><%= name %></td>
+            <td data-label="Broadcasts" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_number(data[:broadcasts]) %></td>
+            <td data-label="Active" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_number(data[:active_connections]) %></td>
+            <td data-label="Total" class="px-4 py-3 text-sm text-right font-mono text-gray-700 dark:text-gray-300"><%= pgbus_number(data[:total_connections]) %></td>
+          </tr>
+        <% end %>
+        <% if @live_stream_metrics[:streams].empty? %>
+          <tr><td colspan="4" class="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500"><%= t("pgbus.insights.show.live_streams.empty") %></td></tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<% end %>
+
 <% if @stream_stats_available %>
 <!-- Stream stats -->
 <div class="mt-8">

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -178,14 +178,14 @@
       <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@live_stream_metrics[:totals][:total_connections]) %></dd>
     </div>
     <div class="rounded-lg bg-white dark:bg-gray-800 p-4 shadow ring-1 ring-gray-200 dark:ring-gray-700">
-      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Streams</dt>
+      <dt class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.live_streams.streams") %></dt>
       <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white"><%= pgbus_number(@live_stream_metrics[:totals][:streams]) %></dd>
     </div>
   </div>
 
   <div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
     <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
-      <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">Per-Stream Counters</h3>
+      <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300"><%= t("pgbus.insights.show.live_streams.per_stream_title") %></h3>
     </div>
     <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
       <thead class="bg-gray-50 dark:bg-gray-900">

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -222,6 +222,13 @@ da:
             p95: P95 (ms)
             queue: Kø
           title: Forsinkelse efter kø
+        live_streams:
+          active_connections: Aktive forbindelser
+          broadcasts: Samlede udsendelser
+          empty: Ingen aktive streams i denne proces
+          stream: Stream
+          title: Live stream-tællere
+          total_connections: Samlede forbindelser
         slowest:
           empty: Ingen jobstatistikker endnu
           headers:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -226,7 +226,9 @@ da:
           active_connections: Aktive forbindelser
           broadcasts: Samlede udsendelser
           empty: Ingen aktive streams i denne proces
+          per_stream_title: Per-stream tællere
           stream: Stream
+          streams: Streams
           title: Live stream-tællere
           total_connections: Samlede forbindelser
         slowest:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -226,7 +226,9 @@ de:
           active_connections: Aktive Verbindungen
           broadcasts: Gesamt-Broadcasts
           empty: Keine aktiven Streams in diesem Prozess
+          per_stream_title: Pro-Stream-Zähler
           stream: Stream
+          streams: Streams
           title: Live-Stream-Zähler
           total_connections: Gesamtverbindungen
         slowest:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -222,6 +222,13 @@ de:
             p95: P95 (ms)
             queue: Warteschlange
           title: Latenz nach Warteschlange
+        live_streams:
+          active_connections: Aktive Verbindungen
+          broadcasts: Gesamt-Broadcasts
+          empty: Keine aktiven Streams in diesem Prozess
+          stream: Stream
+          title: Live-Stream-Zähler
+          total_connections: Gesamtverbindungen
         slowest:
           empty: Noch keine Auftragsstatistiken
           headers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,7 +226,9 @@ en:
           active_connections: Active Connections
           broadcasts: Total Broadcasts
           empty: No streams active in this process
+          per_stream_title: Per-Stream Counters
           stream: Stream
+          streams: Streams
           title: Live Stream Counters
           total_connections: Total Connections
         slowest:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,6 +222,13 @@ en:
             p95: P95 (ms)
             queue: Queue
           title: Latency by Queue
+        live_streams:
+          active_connections: Active Connections
+          broadcasts: Total Broadcasts
+          empty: No streams active in this process
+          stream: Stream
+          title: Live Stream Counters
+          total_connections: Total Connections
         slowest:
           empty: No job stats yet
           headers:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -226,7 +226,9 @@ es:
           active_connections: Conexiones activas
           broadcasts: Emisiones totales
           empty: No hay streams activos en este proceso
+          per_stream_title: Contadores por stream
           stream: Stream
+          streams: Streams
           title: Contadores de streams en vivo
           total_connections: Conexiones totales
         slowest:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -222,6 +222,13 @@ es:
             p95: P95 (ms)
             queue: Cola
           title: Latencia por Cola
+        live_streams:
+          active_connections: Conexiones activas
+          broadcasts: Emisiones totales
+          empty: No hay streams activos en este proceso
+          stream: Stream
+          title: Contadores de streams en vivo
+          total_connections: Conexiones totales
         slowest:
           empty: Aún no hay estadísticas de trabajos
           headers:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -226,7 +226,9 @@ fi:
           active_connections: Aktiiviset yhteydet
           broadcasts: Lähetykset yhteensä
           empty: Ei aktiivisia striimejä tässä prosessissa
+          per_stream_title: Striimikohtaiset laskurit
           stream: Striimi
+          streams: Striimit
           title: Reaaliaikaiset striimilaskurit
           total_connections: Yhteydet yhteensä
         slowest:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -222,6 +222,13 @@ fi:
             p95: P95 (ms)
             queue: Jono
           title: Viive jonon mukaan
+        live_streams:
+          active_connections: Aktiiviset yhteydet
+          broadcasts: Lähetykset yhteensä
+          empty: Ei aktiivisia striimejä tässä prosessissa
+          stream: Striimi
+          title: Reaaliaikaiset striimilaskurit
+          total_connections: Yhteydet yhteensä
         slowest:
           empty: Ei vielä tehtävätilastoja
           headers:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -222,6 +222,13 @@ fr:
             p95: P95 (ms)
             queue: File d'attente
           title: Latence par file d'attente
+        live_streams:
+          active_connections: Connexions actives
+          broadcasts: Diffusions totales
+          empty: Aucun flux actif dans ce processus
+          stream: Flux
+          title: Compteurs de flux en direct
+          total_connections: Connexions totales
         slowest:
           empty: Pas encore de statistiques de tâches
           headers:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -226,7 +226,9 @@ fr:
           active_connections: Connexions actives
           broadcasts: Diffusions totales
           empty: Aucun flux actif dans ce processus
+          per_stream_title: Compteurs par flux
           stream: Flux
+          streams: Flux
           title: Compteurs de flux en direct
           total_connections: Connexions totales
         slowest:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -222,6 +222,13 @@ it:
             p95: P95 (ms)
             queue: Coda
           title: Latenza per coda
+        live_streams:
+          active_connections: Connessioni attive
+          broadcasts: Trasmissioni totali
+          empty: Nessuno stream attivo in questo processo
+          stream: Stream
+          title: Contatori stream in tempo reale
+          total_connections: Connessioni totali
         slowest:
           empty: Nessuna statistica lavori ancora
           headers:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -226,7 +226,9 @@ it:
           active_connections: Connessioni attive
           broadcasts: Trasmissioni totali
           empty: Nessuno stream attivo in questo processo
+          per_stream_title: Contatori per stream
           stream: Stream
+          streams: Stream
           title: Contatori stream in tempo reale
           total_connections: Connessioni totali
         slowest:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -226,7 +226,9 @@ ja:
           active_connections: アクティブ接続
           broadcasts: 総ブロードキャスト
           empty: このプロセスにアクティブなストリームはありません
+          per_stream_title: ストリーム別カウンター
           stream: ストリーム
+          streams: ストリーム
           title: ライブストリームカウンター
           total_connections: 総接続数
         slowest:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -222,6 +222,13 @@ ja:
             p95: P95 (ms)
             queue: キュー
           title: キュー別遅延
+        live_streams:
+          active_connections: アクティブ接続
+          broadcasts: 総ブロードキャスト
+          empty: このプロセスにアクティブなストリームはありません
+          stream: ストリーム
+          title: ライブストリームカウンター
+          total_connections: 総接続数
         slowest:
           empty: まだジョブ統計がありません
           headers:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -226,7 +226,9 @@ nb:
           active_connections: Aktive tilkoblinger
           broadcasts: Totale kringkastinger
           empty: Ingen aktive strømmer i denne prosessen
+          per_stream_title: Per-strøm tellere
           stream: Strøm
+          streams: Strømmer
           title: Sanntids strømtellere
           total_connections: Totale tilkoblinger
         slowest:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -222,6 +222,13 @@ nb:
             p95: P95 (ms)
             queue: Kø
           title: Forsinkelse per kø
+        live_streams:
+          active_connections: Aktive tilkoblinger
+          broadcasts: Totale kringkastinger
+          empty: Ingen aktive strømmer i denne prosessen
+          stream: Strøm
+          title: Sanntids strømtellere
+          total_connections: Totale tilkoblinger
         slowest:
           empty: Ingen jobbstatistikk ennå
           headers:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -222,6 +222,13 @@ nl:
             p95: P95 (ms)
             queue: Wachtrij
           title: Vertraging per wachtrij
+        live_streams:
+          active_connections: Actieve verbindingen
+          broadcasts: Totaal uitzendingen
+          empty: Geen actieve streams in dit proces
+          stream: Stream
+          title: Live stream-tellers
+          total_connections: Totale verbindingen
         slowest:
           empty: Nog geen taakstatistieken
           headers:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -226,7 +226,9 @@ nl:
           active_connections: Actieve verbindingen
           broadcasts: Totaal uitzendingen
           empty: Geen actieve streams in dit proces
+          per_stream_title: Per-stream tellers
           stream: Stream
+          streams: Streams
           title: Live stream-tellers
           total_connections: Totale verbindingen
         slowest:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -222,6 +222,13 @@ pt:
             p95: P95 (ms)
             queue: Fila
           title: Latência por Fila
+        live_streams:
+          active_connections: Conexões ativas
+          broadcasts: Transmissões totais
+          empty: Nenhum stream ativo neste processo
+          stream: Stream
+          title: Contadores de stream ao vivo
+          total_connections: Conexões totais
         slowest:
           empty: Nenhuma estatística de tarefa ainda
           headers:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -226,7 +226,9 @@ pt:
           active_connections: Conexões ativas
           broadcasts: Transmissões totais
           empty: Nenhum stream ativo neste processo
+          per_stream_title: Contadores por stream
           stream: Stream
+          streams: Streams
           title: Contadores de stream ao vivo
           total_connections: Conexões totais
         slowest:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -222,6 +222,13 @@ sv:
             p95: P95 (ms)
             queue: Kö
           title: Fördröjning per kö
+        live_streams:
+          active_connections: Aktiva anslutningar
+          broadcasts: Totala sändningar
+          empty: Inga aktiva strömmar i denna process
+          stream: Ström
+          title: Realtids strömmätare
+          total_connections: Totala anslutningar
         slowest:
           empty: Inga jobbstatistik än
           headers:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -226,7 +226,9 @@ sv:
           active_connections: Aktiva anslutningar
           broadcasts: Totala sändningar
           empty: Inga aktiva strömmar i denna process
+          per_stream_title: Per-ström mätare
           stream: Ström
+          streams: Strömmar
           title: Realtids strömmätare
           total_connections: Totala anslutningar
         slowest:

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -681,6 +681,19 @@ module Pgbus
       # true AND the migration has been run. Controllers should gate
       # rendering on `stream_stats_available?` to avoid showing empty
       # sections.
+      def live_stream_metrics
+        counter = Pgbus::Web::Streamer.stream_counter
+        unless counter
+          empty_totals = { broadcasts: 0, active_connections: 0, total_connections: 0, streams: 0 }
+          return { streams: {}, totals: empty_totals }
+        end
+
+        { streams: counter.snapshot, totals: counter.totals }
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching live stream metrics: #{e.message}" }
+        { streams: {}, totals: { broadcasts: 0, active_connections: 0, total_connections: 0, streams: 0 } }
+      end
+
       def stream_stats_available?
         Pgbus.configuration.streams_stats_enabled && StreamStat.table_exists?
       rescue StandardError => e

--- a/lib/pgbus/web/streamer.rb
+++ b/lib/pgbus/web/streamer.rb
@@ -37,8 +37,10 @@ module Pgbus
           @current_mutex.synchronize { @current = instance }
         end
 
-        # Tear down the current instance and clear the slot. Called by the
-        # Puma shutdown hook (Phase 4.4) and by tests between examples.
+        def stream_counter
+          @current_mutex.synchronize { @current&.stream_counter }
+        end
+
         def reset!
           instance = nil
           @current_mutex.synchronize do

--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -20,7 +20,7 @@ module Pgbus
       # production the module-level Streamer.current(...) builds all of the
       # defaults from the configuration.
       class Instance
-        attr_reader :registry, :listener, :dispatcher, :heartbeat, :dispatch_queue
+        attr_reader :registry, :listener, :dispatcher, :heartbeat, :dispatch_queue, :stream_counter
 
         def initialize(
           client: Pgbus.client,
@@ -36,6 +36,7 @@ module Pgbus
           @registry = registry || Registry.new
           @dispatch_queue = dispatch_queue || Queue.new
 
+          @stream_counter = StreamCounter.new
           @pg_connection = pg_connection || build_pg_connection
           @listener = Listener.new(
             pg_connection: @pg_connection,
@@ -49,7 +50,8 @@ module Pgbus
             listener: @listener,
             dispatch_queue: @dispatch_queue,
             logger: @logger,
-            config: @config
+            config: @config,
+            stream_counter: @stream_counter
           )
           @heartbeat = Heartbeat.new(
             registry: @registry,

--- a/lib/pgbus/web/streamer/stream_counter.rb
+++ b/lib/pgbus/web/streamer/stream_counter.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Pgbus
+  module Web
+    module Streamer
+      class StreamCounter
+        def initialize
+          @streams = Concurrent::Map.new
+        end
+
+        def increment_broadcasts(stream_name)
+          counters_for(stream_name)[:broadcasts].increment
+        end
+
+        def increment_connections(stream_name)
+          counters_for(stream_name)[:active_connections].increment
+        end
+
+        def decrement_connections(stream_name)
+          counters_for(stream_name)[:active_connections].decrement
+        end
+
+        def increment_total_connections(stream_name)
+          counters_for(stream_name)[:total_connections].increment
+        end
+
+        def broadcasts(stream_name)
+          entry = @streams[stream_name]
+          entry ? entry[:broadcasts].value : 0
+        end
+
+        def active_connections(stream_name)
+          entry = @streams[stream_name]
+          return 0 unless entry
+
+          [entry[:active_connections].value, 0].max
+        end
+
+        def total_connections(stream_name)
+          entry = @streams[stream_name]
+          entry ? entry[:total_connections].value : 0
+        end
+
+        def snapshot
+          result = {}
+          @streams.each_pair do |name, counters|
+            result[name] = {
+              broadcasts: counters[:broadcasts].value,
+              active_connections: [counters[:active_connections].value, 0].max,
+              total_connections: counters[:total_connections].value
+            }
+          end
+          result
+        end
+
+        def totals
+          total_broadcasts = 0
+          total_active = 0
+          total_conns = 0
+          stream_count = 0
+
+          @streams.each_pair do |_name, counters|
+            total_broadcasts += counters[:broadcasts].value
+            total_active += [counters[:active_connections].value, 0].max
+            total_conns += counters[:total_connections].value
+            stream_count += 1
+          end
+
+          {
+            broadcasts: total_broadcasts,
+            active_connections: total_active,
+            total_connections: total_conns,
+            streams: stream_count
+          }
+        end
+
+        private
+
+        def counters_for(stream_name)
+          @streams.compute_if_absent(stream_name) do
+            {
+              broadcasts: Concurrent::AtomicFixnum.new(0),
+              active_connections: Concurrent::AtomicFixnum.new(0),
+              total_connections: Concurrent::AtomicFixnum.new(0)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/web/streamer/stream_event_dispatcher.rb
+++ b/lib/pgbus/web/streamer/stream_event_dispatcher.rb
@@ -47,9 +47,11 @@ module Pgbus
 
         DEFAULT_READ_LIMIT = 500
 
+        attr_reader :stream_counter
+
         def initialize(client:, registry:, listener:, dispatch_queue:,
                        logger: Pgbus.logger, read_limit: DEFAULT_READ_LIMIT,
-                       filters: nil, config: nil)
+                       filters: nil, config: nil, stream_counter: nil)
           @client = client
           @registry = registry
           @listener = listener
@@ -67,6 +69,7 @@ module Pgbus
           # process-wide setting. Falls back to the global config
           # for production call sites that don't specify one.
           @config = config || Pgbus.configuration
+          @stream_counter = stream_counter || StreamCounter.new
           # stream_name → Array<[connection, Array<Envelope>]>
           @in_flight = Hash.new { |h, k| h[k] = [] }
           # PGMQ full table name (pgbus_<prefix>_<name>) → logical stream
@@ -224,6 +227,7 @@ module Pgbus
           end
 
           prune_dead(registered)
+          @stream_counter.increment_broadcasts(stream)
 
           record_stat(
             stream_name: stream,
@@ -258,12 +262,14 @@ module Pgbus
           end
 
           prune_dead(registered)
+          @stream_counter.increment_broadcasts(stream)
 
           record_stat(
             stream_name: stream,
             event_type: "broadcast",
             started_at: started_at,
-            fanout: registered.size + in_flight_pairs.size
+            fanout: registered.size + in_flight_pairs.size,
+            ephemeral: true
           )
         end
 
@@ -312,18 +318,15 @@ module Pgbus
           # here. Otherwise this stream's state is pinned for the
           # life of the worker.
           remove_in_flight(stream, connection)
+          @stream_counter.increment_total_connections(stream)
           if connection.dead?
             @scanned_cursor.delete(connection)
             cleanup_stream_if_unused(stream)
           else
+            @stream_counter.increment_connections(stream)
             @registry.register(connection)
           end
 
-          # Record the connect regardless of whether the connection
-          # survived the replay — a dead-before-register is still an
-          # operator-visible "connection attempt" and disconnects
-          # won't be recorded for it, so dropping it here would
-          # under-count.
           record_stat(
             stream_name: stream,
             event_type: "connect",
@@ -347,6 +350,7 @@ module Pgbus
           stream = connection.stream_name
           @registry.unregister(connection)
           @scanned_cursor.delete(connection)
+          @stream_counter.decrement_connections(stream)
           cleanup_stream_if_unused(stream)
 
           record_stat(
@@ -479,8 +483,8 @@ module Pgbus
         # if operators actually look at it. All failures are
         # swallowed by StreamStat.record! itself so a stats-table
         # outage cannot block the dispatcher.
-        def record_stat(stream_name:, event_type:, started_at:, fanout: nil)
-          return unless @config.streams_stats_enabled
+        def record_stat(stream_name:, event_type:, started_at:, fanout: nil, ephemeral: false)
+          return unless ephemeral || @config.streams_stats_enabled
 
           Pgbus::StreamStat.record!(
             stream_name: stream_name,

--- a/spec/dummy/lib/stub_data_source.rb
+++ b/spec/dummy/lib/stub_data_source.rb
@@ -182,6 +182,17 @@ module DummyApp
       { "success" => 335, "failed" => 5, "dead_lettered" => 2 }
     end
 
+    def live_stream_metrics
+      {
+        streams: {
+          "chat:lobby" => { broadcasts: 420, active_connections: 12, total_connections: 92 },
+          "orders:dashboard" => { broadcasts: 312, active_connections: 3, total_connections: 45 },
+          "notifications:admin" => { broadcasts: 214, active_connections: 1, total_connections: 18 }
+        },
+        totals: { broadcasts: 946, active_connections: 16, total_connections: 155, streams: 3 }
+      }
+    end
+
     # Stream stats — opt-in in production, always "available" in the
     # dummy app so the Insights QA surface demos the section.
     def stream_stats_available?

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -916,4 +916,41 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(result.first[:queue_name]).to eq("pgbus_default_dlq")
     end
   end
+
+  describe "#live_stream_metrics" do
+    let(:counter) { Pgbus::Web::Streamer::StreamCounter.new }
+
+    before do
+      allow(Pgbus::Web::Streamer).to receive(:stream_counter).and_return(counter)
+    end
+
+    it "returns per-stream metrics from the in-memory counter" do
+      counter.increment_broadcasts("chat")
+      counter.increment_broadcasts("chat")
+      counter.increment_connections("chat")
+      counter.increment_total_connections("chat")
+      counter.increment_broadcasts("alerts")
+
+      result = data_source.live_stream_metrics
+
+      expect(result[:streams]).to include(
+        "chat" => hash_including(broadcasts: 2, active_connections: 1, total_connections: 1),
+        "alerts" => hash_including(broadcasts: 1, active_connections: 0, total_connections: 0)
+      )
+      expect(result[:totals]).to include(
+        broadcasts: 3,
+        active_connections: 1,
+        streams: 2
+      )
+    end
+
+    it "returns empty metrics when no streamer is running" do
+      allow(Pgbus::Web::Streamer).to receive(:stream_counter).and_return(nil)
+
+      result = data_source.live_stream_metrics
+
+      expect(result[:streams]).to eq({})
+      expect(result[:totals]).to eq(broadcasts: 0, active_connections: 0, total_connections: 0, streams: 0)
+    end
+  end
 end

--- a/spec/pgbus/web/streamer/stream_counter_spec.rb
+++ b/spec/pgbus/web/streamer/stream_counter_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Web::Streamer::StreamCounter do
+  subject(:counter) { described_class.new }
+
+  describe "#increment_broadcasts" do
+    it "tracks broadcasts per stream" do
+      counter.increment_broadcasts("chat")
+      counter.increment_broadcasts("chat")
+      counter.increment_broadcasts("alerts")
+
+      expect(counter.broadcasts("chat")).to eq(2)
+      expect(counter.broadcasts("alerts")).to eq(1)
+    end
+
+    it "returns 0 for unknown streams" do
+      expect(counter.broadcasts("unknown")).to eq(0)
+    end
+  end
+
+  describe "#increment_connections / #decrement_connections" do
+    it "tracks net active connections per stream" do
+      counter.increment_connections("chat")
+      counter.increment_connections("chat")
+      counter.increment_connections("chat")
+      counter.decrement_connections("chat")
+
+      expect(counter.active_connections("chat")).to eq(2)
+    end
+
+    it "floors at zero" do
+      counter.decrement_connections("chat")
+      expect(counter.active_connections("chat")).to eq(0)
+    end
+
+    it "returns 0 for unknown streams" do
+      expect(counter.active_connections("unknown")).to eq(0)
+    end
+  end
+
+  describe "#increment_total_connections" do
+    it "tracks cumulative connection count per stream" do
+      counter.increment_total_connections("chat")
+      counter.increment_total_connections("chat")
+
+      expect(counter.total_connections("chat")).to eq(2)
+    end
+  end
+
+  describe "#snapshot" do
+    it "returns per-stream metrics for all known streams" do
+      counter.increment_broadcasts("chat")
+      counter.increment_broadcasts("chat")
+      counter.increment_connections("chat")
+      counter.increment_total_connections("chat")
+      counter.increment_broadcasts("alerts")
+
+      result = counter.snapshot
+
+      expect(result).to include(
+        "chat" => {
+          broadcasts: 2,
+          active_connections: 1,
+          total_connections: 1
+        }
+      )
+      expect(result).to include(
+        "alerts" => {
+          broadcasts: 1,
+          active_connections: 0,
+          total_connections: 0
+        }
+      )
+    end
+
+    it "returns an empty hash when no streams have been seen" do
+      expect(counter.snapshot).to eq({})
+    end
+  end
+
+  describe "#totals" do
+    it "returns aggregate counts across all streams" do
+      counter.increment_broadcasts("chat")
+      counter.increment_broadcasts("alerts")
+      counter.increment_connections("chat")
+      counter.increment_total_connections("chat")
+
+      result = counter.totals
+
+      expect(result).to eq(
+        broadcasts: 2,
+        active_connections: 1,
+        total_connections: 1,
+        streams: 2
+      )
+    end
+  end
+
+  describe "thread safety" do
+    it "handles concurrent increments without data loss" do
+      threads = 10.times.map do
+        Thread.new do
+          100.times { counter.increment_broadcasts("chat") }
+        end
+      end
+      threads.each(&:join)
+
+      expect(counter.broadcasts("chat")).to eq(1000)
+    end
+  end
+end

--- a/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
+++ b/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
@@ -488,6 +488,19 @@ RSpec.describe Pgbus::Web::Streamer::StreamEventDispatcher do
         expect(Pgbus::StreamStat).not_to have_received(:record!)
       end
 
+      it "records an ephemeral broadcast even when stats are disabled" do
+        c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+        registry.register(c)
+        allow(Pgbus::StreamStat).to receive(:record!)
+        payload = '{"html":"<turbo-stream>hi</turbo-stream>"}'
+
+        dispatcher.send(:handle, described_class::WakeMessage.new(queue_name: "chat", payload: payload))
+
+        expect(Pgbus::StreamStat).to have_received(:record!).with(
+          hash_including(stream_name: "chat", event_type: "broadcast")
+        )
+      end
+
       it "does not record a connect on handle_connect" do
         c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
         allow(client).to receive(:read_after).and_return([])
@@ -574,6 +587,60 @@ RSpec.describe Pgbus::Web::Streamer::StreamEventDispatcher do
           dispatcher.send(:handle, described_class::WakeMessage.new(queue_name: "chat"))
         end.not_to raise_error
       end
+    end
+  end
+
+  describe "in-memory stream counters (always-on)" do
+    it "increments broadcast counter on durable wake" do
+      c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+      registry.register(c)
+      allow(client).to receive(:read_after).and_return([build_envelope(10)])
+
+      dispatcher.send(:handle, described_class::WakeMessage.new(queue_name: "chat"))
+
+      expect(dispatcher.stream_counter.broadcasts("chat")).to eq(1)
+    end
+
+    it "increments broadcast counter on ephemeral wake" do
+      c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+      registry.register(c)
+      payload = '{"html":"<turbo-stream>hi</turbo-stream>"}'
+
+      dispatcher.send(:handle, described_class::WakeMessage.new(queue_name: "chat", payload: payload))
+
+      expect(dispatcher.stream_counter.broadcasts("chat")).to eq(1)
+    end
+
+    it "increments connection counter on connect" do
+      c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+      allow(client).to receive(:read_after).and_return([])
+
+      dispatcher.send(:handle, described_class::ConnectMessage.new(connection: c))
+
+      expect(dispatcher.stream_counter.active_connections("chat")).to eq(1)
+      expect(dispatcher.stream_counter.total_connections("chat")).to eq(1)
+    end
+
+    it "decrements connection counter on disconnect" do
+      c = build_conn(id: "a", stream_name: "chat")
+      registry.register(c)
+      allow(client).to receive(:read_after).and_return([])
+      dispatcher.send(:handle, described_class::ConnectMessage.new(connection: c))
+
+      dispatcher.send(:handle, described_class::DisconnectMessage.new(connection: c))
+
+      expect(dispatcher.stream_counter.active_connections("chat")).to eq(0)
+    end
+
+    it "does not increment connection counter when connect dies before registry" do
+      c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+      c.mark_dead!
+      allow(client).to receive(:read_after).and_return([])
+
+      dispatcher.send(:handle, described_class::ConnectMessage.new(connection: c))
+
+      expect(dispatcher.stream_counter.active_connections("chat")).to eq(0)
+      expect(dispatcher.stream_counter.total_connections("chat")).to eq(1)
     end
   end
 

--- a/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
+++ b/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
@@ -632,7 +632,7 @@ RSpec.describe Pgbus::Web::Streamer::StreamEventDispatcher do
       expect(dispatcher.stream_counter.active_connections("chat")).to eq(0)
     end
 
-    it "does not increment connection counter when connect dies before registry" do
+    it "increments total_connections but not active_connections when connect dies before registry" do
       c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
       c.mark_dead!
       allow(client).to receive(:read_after).and_return([])

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -118,6 +118,11 @@ module Pgbus
       def job_throughput(minutes: 60) = @insights_throughput
       def job_status_counts(minutes: 60) = @insights_status_counts
 
+      # Live stream metrics (always-on in-memory counters)
+      def live_stream_metrics
+        { streams: {}, totals: { broadcasts: 0, active_connections: 0, total_connections: 0, streams: 0 } }
+      end
+
       # Insights (stream stats — opt-in, default unavailable)
       def stream_stats_available? = @stream_stats_available
       def stream_stats_summary(minutes: 60) = @stream_summary


### PR DESCRIPTION
## Summary

- **StreamCounter**: Always-on, zero-cost in-memory counters per stream (broadcasts, active connections, total connections) using `Concurrent::AtomicFixnum`. Exposed via `DataSource#live_stream_metrics` and rendered in the Insights dashboard as "Live Stream Counters".
- **Auto-enabled StreamStat for ephemeral broadcasts**: Ephemeral broadcasts now always write to `pgbus_stream_stats` regardless of `streams_stats_enabled`. Durable broadcasts remain gated by the flag since they already have PGMQ queue-level metrics. This provides historical analytics (top streams, throughput, fanout) for the default ephemeral mode without configuration.
- **Dashboard integration**: New "Live Stream Counters" section in Insights view shows per-stream broadcast count, active connections, and total connections — visible even when `streams_stats_enabled` is false.

### Architecture

```
StreamEventDispatcher
  ├── StreamCounter (always-on, in-memory)
  │   ├── increment_broadcasts() on every wake (durable + ephemeral)
  │   ├── increment_connections() on successful connect
  │   └── decrement_connections() on disconnect
  └── record_stat() (StreamStat DB writes)
      ├── ephemeral broadcasts → always records
      └── durable broadcasts → gated by streams_stats_enabled
```

### Files changed

| Area | Files |
|------|-------|
| Core | `lib/pgbus/web/streamer/stream_counter.rb` (new), `stream_event_dispatcher.rb`, `instance.rb`, `streamer.rb` |
| Dashboard | `data_source.rb`, `insights_controller.rb`, `api/insights_controller.rb`, `show.html.erb` |
| i18n | All 12 locale files |
| Specs | `stream_counter_spec.rb` (new, 10 examples), `stream_event_dispatcher_spec.rb` (+6 examples), `data_source_spec.rb` (+2 examples) |

## Test plan

- [x] `bundle exec rspec` — 2003 examples, 0 failures
- [x] `bundle exec rubocop` — 359 files, no offenses
- [x] i18n files normalized, no inconsistent interpolations
- [ ] Manual: verify Insights page renders Live Stream Counters when ephemeral streams are active
- [ ] Manual: verify ephemeral broadcasts create `pgbus_stream_stats` rows without `streams_stats_enabled`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insights page now shows live stream counters (totals and per-stream breakdown) and includes live stream metrics from the streaming subsystem.

* **Localization**
  * Added localized labels for live stream metrics in 12 languages.

* **Tests**
  * Added test coverage for live stream metrics, stream counter behavior, and concurrent counter safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mhenrixon/pgbus/pull/156)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->