### PR TITLE
fix(streams): deliver ephemeral broadcasts, idempotent disconnect counter

### DIFF
--- a/lib/pgbus/web/streamer/connection.rb
+++ b/lib/pgbus/web/streamer/connection.rb
@@ -38,7 +38,8 @@ module Pgbus
         def enqueue(envelopes)
           written = []
           envelopes.each do |envelope|
-            next if envelope.msg_id <= @last_msg_id_sent
+            ephemeral = envelope.msg_id.negative?
+            next if !ephemeral && envelope.msg_id <= @last_msg_id_sent
 
             bytes = Pgbus::Streams::Envelope.message(
               id: envelope.msg_id,
@@ -48,7 +49,7 @@ module Pgbus
 
             result = @writer.write(self, bytes, deadline_ms: @write_deadline_ms)
             if result == :ok
-              @last_msg_id_sent = envelope.msg_id
+              @last_msg_id_sent = envelope.msg_id unless ephemeral
               @last_write_at = monotonic
               written << envelope
             else

--- a/lib/pgbus/web/streamer/registry.rb
+++ b/lib/pgbus/web/streamer/registry.rb
@@ -37,16 +37,23 @@ module Pgbus
           end
         end
 
+        # Returns true if a matching connection was removed, false if it
+        # was not registered. Callers (e.g. StreamEventDispatcher) use the
+        # return value to make per-connection bookkeeping idempotent on
+        # duplicate DisconnectMessages — prune_dead can enqueue a
+        # DisconnectMessage on every wake while the first one is still
+        # waiting in the queue.
         def unregister(connection)
           @mutex.synchronize do
             existing = @by_id.delete(connection.id)
-            return unless existing
+            return false unless existing
 
             set = @by_stream[existing.stream_name]
-            next unless set
-
-            set.delete(existing)
-            @by_stream.delete(existing.stream_name) if set.empty?
+            if set
+              set.delete(existing)
+              @by_stream.delete(existing.stream_name) if set.empty?
+            end
+            true
           end
         end
 

--- a/lib/pgbus/web/streamer/stream_event_dispatcher.rb
+++ b/lib/pgbus/web/streamer/stream_event_dispatcher.rb
@@ -348,9 +348,9 @@ module Pgbus
           started_at = monotonic_ms
           connection = msg.connection
           stream = connection.stream_name
-          @registry.unregister(connection)
+          removed = @registry.unregister(connection)
           @scanned_cursor.delete(connection)
-          @stream_counter.decrement_connections(stream)
+          @stream_counter.decrement_connections(stream) if removed
           cleanup_stream_if_unused(stream)
 
           record_stat(

--- a/spec/pgbus/web/streamer/connection_spec.rb
+++ b/spec/pgbus/web/streamer/connection_spec.rb
@@ -98,6 +98,60 @@ RSpec.describe Pgbus::Web::Streamer::Connection do
       expect(conn.last_msg_id_sent).to eq(1249)
     end
 
+    describe "ephemeral envelopes (negative msg_id)" do
+      # Ephemeral broadcasts arrive via PG NOTIFY and bypass PGMQ entirely.
+      # The Dispatcher tags them with -@ephemeral_seq (-1, -2, ...) so they
+      # don't pollute the real PGMQ cursor space. Without special handling,
+      # the cursor check `msg_id <= last_msg_id_sent` would reject every
+      # negative id against any non-negative cursor, silently dropping
+      # every ephemeral broadcast on every fresh connection (since_id: 0).
+      subject(:conn) do
+        described_class.new(
+          id: "c1", stream_name: "chat", io: io, since_id: 0,
+          writer: writer, write_deadline_ms: 5_000
+        )
+      end
+
+      it "delivers ephemeral envelopes through the cursor filter (since_id: 0)" do
+        conn.enqueue([build_envelope(msg_id: -1, payload: "ephemeral-1")])
+
+        expect(writer.writes.length).to eq(1)
+        expect(writer.writes.first[:bytes]).to include("data: ephemeral-1")
+      end
+
+      it "delivers ephemeral envelopes when last_msg_id_sent is positive (post-replay)" do
+        # First a durable broadcast advances the cursor to 1248.
+        conn.enqueue([build_envelope(msg_id: 1248, payload: "durable")])
+        writer.writes.clear
+
+        # Then an ephemeral broadcast with msg_id=-1 must still go through.
+        conn.enqueue([build_envelope(msg_id: -1, payload: "ephemeral")])
+
+        expect(writer.writes.length).to eq(1)
+        expect(writer.writes.first[:bytes]).to include("data: ephemeral")
+      end
+
+      it "does not advance last_msg_id_sent for ephemeral envelopes" do
+        # Cursor must stay at 0 (or wherever it was) so that durable replay
+        # on reconnect still picks up the right starting point.
+        conn.enqueue([build_envelope(msg_id: -1, payload: "x")])
+        expect(conn.last_msg_id_sent).to eq(0)
+      end
+
+      it "delivers a mix of durable and ephemeral envelopes in one call" do
+        envelopes = [
+          build_envelope(msg_id: 1248, payload: "durable-1"),
+          build_envelope(msg_id: -1, payload: "ephemeral"),
+          build_envelope(msg_id: 1249, payload: "durable-2")
+        ]
+
+        conn.enqueue(envelopes)
+
+        expect(writer.writes.length).to eq(3)
+        expect(conn.last_msg_id_sent).to eq(1249)
+      end
+    end
+
     it "passes the configured write deadline through to the writer" do
       conn.enqueue([build_envelope(msg_id: 1248)])
       expect(writer.writes.first[:deadline_ms]).to eq(5_000)

--- a/spec/pgbus/web/streamer/registry_spec.rb
+++ b/spec/pgbus/web/streamer/registry_spec.rb
@@ -90,6 +90,24 @@ RSpec.describe Pgbus::Web::Streamer::Registry do
       registry.unregister(conn)
       expect(registry.streams).to be_empty
     end
+
+    it "returns true when it actually removed a registered connection" do
+      conn = build_conn(id: "c1", stream_name: "chat")
+      registry.register(conn)
+      expect(registry.unregister(conn)).to be true
+    end
+
+    it "returns false when the connection was not registered" do
+      conn = build_conn(id: "ghost", stream_name: "chat")
+      expect(registry.unregister(conn)).to be false
+    end
+
+    it "returns false on a duplicate unregister" do
+      conn = build_conn(id: "c1", stream_name: "chat")
+      registry.register(conn)
+      registry.unregister(conn)
+      expect(registry.unregister(conn)).to be false
+    end
   end
 
   describe "#connections_for" do

--- a/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
+++ b/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
@@ -632,6 +632,28 @@ RSpec.describe Pgbus::Web::Streamer::StreamEventDispatcher do
       expect(dispatcher.stream_counter.active_connections("chat")).to eq(0)
     end
 
+    it "is idempotent on duplicate disconnect (does not over-decrement when prune_dead races)" do
+      # prune_dead enqueues a DisconnectMessage on every wake when the
+      # connection is dead. If two wakes hit before the first
+      # DisconnectMessage drains the queue, two DisconnectMessages exist
+      # for the same connection. The second one used to keep
+      # decrementing, driving the counter negative for the next real
+      # connection.
+      c1 = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+      c2 = build_conn(id: "b", stream_name: "chat", last_msg_id_sent: 0)
+      registry.register(c1)
+      registry.register(c2)
+      dispatcher.stream_counter.increment_connections("chat")
+      dispatcher.stream_counter.increment_connections("chat")
+
+      dispatcher.send(:handle, described_class::DisconnectMessage.new(connection: c1))
+      dispatcher.send(:handle, described_class::DisconnectMessage.new(connection: c1))
+
+      # c2 is still registered, so the active count must reflect that —
+      # not be falsely zero from the duplicate decrement.
+      expect(dispatcher.stream_counter.active_connections("chat")).to eq(1)
+    end
+
     it "increments total_connections but not active_connections when connect dies before registry" do
       c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
       c.mark_dead!


### PR DESCRIPTION
## Summary

Two related streamer bugs surfaced after 0.8.1. Both ship together because they affect the same delivery path and share a fix branch.

### 1. Ephemeral broadcasts never reach browsers (the load-bearing fix)

**Ephemeral broadcasts arrive at the streamer as PG NOTIFY payloads but never reach the browser.

The `StreamEventDispatcher` tags ephemeral envelopes with negative `msg_id`s (`-@ephemeral_seq`) so they don't pollute the PGMQ cursor space:

```ruby
envelope = StreamEnvelope.new(msg_id: -@ephemeral_seq, ..., source: "ephemeral")
```

But `Connection#enqueue` applied the same cursor check used for durable replay:

```ruby
next if envelope.msg_id <= @last_msg_id_sent
```

A fresh connection starts at `since_id = 0`, so `last_msg_id_sent = 0`. Every ephemeral envelope has `msg_id = -1, -2, ...`, and `-1 <= 0` is true — **every ephemeral broadcast got dropped before being written to the SSE socket**.

**Failure scenario** (Juraj's reproduction):
1. Browser connects to SSE stream.
2. Another tab updates a payment link, calling `Pgbus.stream(...).broadcast(html)`.
3. pgbus sends ephemeral PG NOTIFY → streamer receives it → creates envelope with `msg_id = -1`.
4. Connection rejects it because `-1 <= 0`.
5. Browser never sees the Turbo stream.

**Fix:** ephemeral envelopes (negative `msg_id`) bypass the cursor check and do not advance `last_msg_id_sent`. They have no replay semantics, so the cursor must continue tracking only durable PGMQ ids — otherwise a single ephemeral broadcast would set the cursor to a negative value and break subsequent durable replay.

### 2. Duplicate DisconnectMessages over-decremented active_connections (CodeRabbit comment)

`prune_dead` enqueues a `DisconnectMessage` on every wake when a connection is dead. Under burst traffic, two wakes can fire before the first `DisconnectMessage` drains the queue — leaving two `DisconnectMessage`s for the same connection. The second `decrement_connections` call drove the active-connection counter negative, undercounting subsequent legitimate connections.

**Fix:** `Registry#unregister` now returns `true` when it actually removed a connection, `false` when the connection was already gone. `handle_disconnect` only decrements when `unregister` returns true.

## Test plan

- [x] `bundle exec rspec spec/pgbus/web/streamer/` — 158 examples, 0 failures
- [x] New specs prove the cursor bug exists and is fixed:
  - `Connection#enqueue ephemeral envelopes (negative msg_id)` — 4 examples covering since_id=0, post-replay cursor positions, mixed durable+ephemeral, and cursor non-advancement
- [x] New spec proves duplicate-disconnect idempotency:
  - `is idempotent on duplicate disconnect (does not over-decrement when prune_dead races)`
- [x] `bundle exec rubocop` — clean

## Files changed

| File | Why |
|------|-----|
| `lib/pgbus/web/streamer/connection.rb` | Cursor bypass for negative msg_id; do not advance cursor for ephemeral |
| `lib/pgbus/web/streamer/registry.rb` | `unregister` returns true/false |
| `lib/pgbus/web/streamer/stream_event_dispatcher.rb` | Decrement only when registry actually removed |
| `spec/pgbus/web/streamer/connection_spec.rb` | 4 new ephemeral envelope specs |
| `spec/pgbus/web/streamer/registry_spec.rb` | 3 new return-value specs for `unregister` |
| `spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb` | Idempotent disconnect spec |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ephemeral messages that bypass normal message filtering and don't advance the cursor.

* **Bug Fixes**
  * Improved disconnect handling to be idempotent, preventing duplicate disconnects from incorrectly decrementing connection counters.

* **Tests**
  * Added comprehensive test coverage for ephemeral message delivery and idempotent connection cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mhenrixon/pgbus/pull/157)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->