### PR TITLE
fix(streams): release AR connections after each dispatcher iteration

### DIFF
--- a/lib/pgbus/web/streamer/stream_event_dispatcher.rb
+++ b/lib/pgbus/web/streamer/stream_event_dispatcher.rb
@@ -131,21 +131,16 @@ module Pgbus
             msg = @queue.pop
             break if msg == :__stop__
 
-            # Wake coalescing: if a WakeMessage arrives, opportunistically
-            # drain consecutive same-stream wakes from the queue. Without
-            # this, N broadcasts in rapid succession produce N
-            # WakeMessages, each running its own read_after roundtrip
-            # even though one read_after with the lowest cursor would
-            # have pulled all N messages. The drain is bounded by the
-            # queue's current contents — once we hit a non-Wake or a
-            # different stream, we stop and let the regular path handle
-            # the rest.
-            if msg.is_a?(WakeMessage) && msg.payload.nil?
-              wakes, trailing = drain_wakes_for(msg)
-              wakes.each { |w| handle(w) }
-              handle(trailing) if trailing
-            else
-              handle(msg)
+            begin
+              if msg.is_a?(WakeMessage) && msg.payload.nil?
+                wakes, trailing = drain_wakes_for(msg)
+                wakes.each { |w| handle(w) }
+                handle(trailing) if trailing
+              else
+                handle(msg)
+              end
+            ensure
+              release_ar_connections
             end
           end
         rescue StandardError => e
@@ -483,6 +478,19 @@ module Pgbus
         # if operators actually look at it. All failures are
         # swallowed by StreamStat.record! itself so a stats-table
         # outage cannot block the dispatcher.
+        # Release any AR connections the dispatcher fiber acquired during
+        # this iteration (typically from StreamStat.record! via BusRecord).
+        # Without this, the connection stays leased while the fiber parks
+        # on @queue.pop, blocking clear_reloadable_connections! on the
+        # next Rails code reload (10s wedge under rack-timeout).
+        def release_ar_connections
+          return unless defined?(::ActiveRecord::Base)
+
+          Pgbus::BusRecord.connection_handler.clear_active_connections!
+        rescue StandardError => e
+          @logger.debug { "[Pgbus::Streamer::StreamEventDispatcher] AR connection release failed: #{e.class}: #{e.message}" }
+        end
+
         def record_stat(stream_name:, event_type:, started_at:, fanout: nil, ephemeral: false)
           return unless ephemeral || @config.streams_stats_enabled
 

--- a/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
+++ b/spec/pgbus/web/streamer/stream_event_dispatcher_spec.rb
@@ -590,6 +590,47 @@ RSpec.describe Pgbus::Web::Streamer::StreamEventDispatcher do
     end
   end
 
+  describe "AR connection release after each run_loop iteration" do
+    it "releases ActiveRecord connections after processing a message" do
+      c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+      registry.register(c)
+      allow(client).to receive(:read_after).and_return([build_envelope(10)])
+
+      handler = double("ConnectionHandler")
+      allow(Pgbus::BusRecord).to receive(:connection_handler).and_return(handler)
+      allow(handler).to receive(:clear_active_connections!)
+
+      dispatcher.start
+      dispatch_queue << described_class::WakeMessage.new(queue_name: "chat")
+
+      deadline = Time.now + 2
+      sleep 0.01 until c.enqueued.any? || Time.now > deadline
+
+      dispatcher.stop
+
+      expect(handler).to have_received(:clear_active_connections!).at_least(:once)
+    end
+
+    it "releases connections even when handle raises" do
+      c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)
+      registry.register(c)
+      allow(client).to receive(:read_after).and_raise(StandardError, "boom")
+
+      handler = double("ConnectionHandler")
+      allow(Pgbus::BusRecord).to receive(:connection_handler).and_return(handler)
+      allow(handler).to receive(:clear_active_connections!)
+
+      dispatcher.start
+      dispatch_queue << described_class::WakeMessage.new(queue_name: "chat")
+
+      sleep 0.05
+
+      dispatcher.stop
+
+      expect(handler).to have_received(:clear_active_connections!).at_least(:once)
+    end
+  end
+
   describe "in-memory stream counters (always-on)" do
     it "increments broadcast counter on durable wake" do
       c = build_conn(id: "a", stream_name: "chat", last_msg_id_sent: 0)


### PR DESCRIPTION
## Summary

Fixes the AR connection leak in `StreamEventDispatcher` that causes 10s request wedges in development on every Rails code reload when the dashboard/SSE is open.

The dispatcher runs in a background fiber (`Thread.new { run_loop }`). When `StreamStat.record!` fires, it leases an AR connection from the `BusRecord` pool. After the INSERT, the fiber parks on `@queue.pop` — but the connection stays leased to the parked fiber.

Under `config.active_support.isolation_level = :fiber` (common in modern Rails apps), AR connection leases are keyed to the owning Fiber. The dispatcher's fiber never dies and never calls `clear_active_connections!`, so the lease persists for the life of the worker.

On the next dev file save, the Rails reloader runs `clear_reloadable_connections!`, which calls `attempt_to_checkout_all_existing_connections` on every pool. The `:pgbus` pool has exactly one connection leased to the parked dispatcher fiber — so it blocks until rack-timeout fires (10s).

**Fix:** call `BusRecord.connection_handler.clear_active_connections!` in an `ensure` block at the end of each `run_loop` iteration. This releases any AR connections the dispatcher acquired during message handling before parking on the queue.

```ruby
begin
  # handle message(s)
ensure
  release_ar_connections
end
```

The `ensure` guarantees cleanup even when `handle()` raises. The method is guarded by `defined?(::ActiveRecord::Base)` so non-Rails contexts aren't affected, and errors in the release itself are swallowed at debug level.

**Impact in prod:** beyond fixing the dev wedge, this also reclaims the wasted connection-per-puma-worker that was permanently leased in production. One fewer idle connection per worker on the `:pgbus` pool.

## Test plan

- [x] `bundle exec rspec spec/pgbus/web/streamer/` — 160 examples, 0 failures
- [x] New specs:
  - "releases ActiveRecord connections after processing a message" — verifies `clear_active_connections!` is called after a normal message
  - "releases connections even when handle raises" — verifies the `ensure` path
- [x] `bundle exec rubocop` — clean
- [x] Full unit suite: 2017 examples, 0 failures
- [ ] Manual: `bin/dev` in a Zazu-like app → open dashboard (subscribes to SSE) → save files rapidly → no 10s wedge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced event streaming reliability by improving database connection management. The system now consistently releases connections after processing each message, preventing potential resource exhaustion and improving overall system stability.

* **Tests**
  * Added test coverage for database connection release behavior, including error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mhenrixon/pgbus/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->