### PR TITLE
feat(streams): logical-replication wake-up mechanism (spike)

### DIFF
--- a/bin/repro-logical-listener
+++ b/bin/repro-logical-listener
@@ -104,13 +104,12 @@ while Time.now < deadline
   end
 end
 
+puts ""
 if wake
-  puts ""
   puts "RESULT: LogicalReplicationListener delivered WakeMessage(queue_name: #{wake.queue_name.inspect}) via port #{PORT}."
   puts "        Through a transaction-mode PgBouncer, this is the path NOTIFY couldn't survive."
   exit_code = 0
 else
-  puts ""
   puts "RESULT: timeout — no WakeMessage received via port #{PORT}."
   exit_code = 1
 end

--- a/bin/repro-logical-listener
+++ b/bin/repro-logical-listener
@@ -53,7 +53,7 @@ end
 
 # Clean state: drop any old slot from a previous run so the script is idempotent.
 admin.exec_params(
-  "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+  "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = $1",
   [SLOT]
 )
 admin.close

--- a/bin/repro-logical-listener
+++ b/bin/repro-logical-listener
@@ -1,0 +1,119 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# End-to-end repro: drive LogicalReplicationListener against a real PG
+# (optionally through PgBouncer in transaction mode) and confirm it delivers
+# WakeMessages where LISTEN/NOTIFY would have dropped them.
+#
+# Usage:
+#   PGBUS_REPRO_PORT=6432 bin/repro-logical-listener  # via pgbouncer
+#   PGBUS_REPRO_PORT=5432 bin/repro-logical-listener  # direct
+#
+# Requires:
+#   - Local PG with wal_level = logical
+#   - PGMQ extension on the target DB (or pgbus's embedded mode)
+#   - A queue table at pgmq.q_pgbus_repro_listener (created by the script)
+#
+# Env overrides (all optional, sensible defaults for a stock local PG):
+#   PGBUS_REPRO_HOST  default 127.0.0.1
+#   PGBUS_REPRO_PORT  default 6432 (set to 5432 to test the direct path)
+#   PGBUS_REPRO_DB    default pgbus_repro
+#   PGBUS_REPRO_USER  default $USER
+
+require "pgbus"
+require "pg"
+
+HOST     = ENV.fetch("PGBUS_REPRO_HOST", "127.0.0.1")
+PORT     = ENV.fetch("PGBUS_REPRO_PORT", "6432").to_i
+DATABASE = ENV.fetch("PGBUS_REPRO_DB", "pgbus_repro")
+USER     = ENV.fetch("PGBUS_REPRO_USER", ENV.fetch("USER", "postgres"))
+QUEUE    = "repro_listener"
+SLOT     = "pgbus_streamer_repro_listener"
+
+# Set up pgbus configuration so the listener's bootstrap (ensure_publication! /
+# ensure_slot! / with_admin_connection) can build the helper connection.
+Pgbus.configure do |c|
+  c.connection_params = { host: HOST, port: PORT, dbname: DATABASE, user: USER }
+  c.streams_wake_mechanism = :logical_replication
+end
+
+# Pre-flight: ensure the queue table exists. In the real app pgbus creates
+# these on first broadcast — for this script we just make sure something is
+# there to INSERT into.
+admin = PG.connect(host: HOST, port: PORT, dbname: DATABASE, user: USER)
+table_exists = admin.exec_params(
+  "SELECT 1 FROM information_schema.tables WHERE table_schema = 'pgmq' AND table_name = $1",
+  ["q_pgbus_#{QUEUE}"]
+).any?
+
+unless table_exists
+  puts "[bootstrap] creating queue pgbus_#{QUEUE}"
+  admin.exec_params("SELECT pgmq.create($1)", ["pgbus_#{QUEUE}"])
+end
+
+# Clean state: drop any old slot from a previous run so the script is idempotent.
+admin.exec_params(
+  "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+  [SLOT]
+)
+admin.close
+
+# Build the replication-protocol connection. This is the dedicated connection
+# the listener owns. `replication: "database"` is the magic libpq parameter
+# that puts the connection into streaming-replication mode (passes through
+# any PgBouncer in front).
+listener_conn = PG.connect(
+  host: HOST, port: PORT, dbname: DATABASE, user: USER, replication: "database"
+)
+
+dispatch_queue = Queue.new
+listener = Pgbus::Web::Streamer::LogicalReplicationListener.new(
+  pg_connection: listener_conn,
+  dispatch_queue: dispatch_queue,
+  health_check_ms: 100,
+  slot_name: SLOT
+)
+
+puts "[listener] starting against #{HOST}:#{PORT}"
+listener.ensure_listening(QUEUE)
+listener.start
+
+# Give the replication stream a moment to spin up the START_REPLICATION
+# command before we trigger the INSERT.
+sleep 0.5
+
+# Publish: insert directly into the queue table. In a real app this is what
+# Pgbus.stream(name).broadcast(content) does.
+publisher = PG.connect(host: HOST, port: PORT, dbname: DATABASE, user: USER)
+publisher.exec(
+  "INSERT INTO pgmq.q_pgbus_#{QUEUE} (msg_id, read_ct, enqueued_at, vt, message, headers) " \
+  "VALUES (DEFAULT, 0, NOW(), NOW(), '{\"src\":\"repro\"}'::jsonb, '{}'::jsonb)"
+)
+puts "[publisher] INSERT issued via #{HOST}:#{PORT}"
+publisher.close
+
+# Wait for the WakeMessage on the dispatch queue.
+deadline = Time.now + 3.0
+wake = nil
+while Time.now < deadline
+  begin
+    wake = dispatch_queue.pop(true)
+    break
+  rescue ThreadError
+    sleep 0.05
+  end
+end
+
+if wake
+  puts ""
+  puts "RESULT: LogicalReplicationListener delivered WakeMessage(queue_name: #{wake.queue_name.inspect}) via port #{PORT}."
+  puts "        Through a transaction-mode PgBouncer, this is the path NOTIFY couldn't survive."
+  exit_code = 0
+else
+  puts ""
+  puts "RESULT: timeout — no WakeMessage received via port #{PORT}."
+  exit_code = 1
+end
+
+listener.stop
+exit exit_code

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -107,7 +107,8 @@ module Pgbus
                   :streams_stats_enabled, :streams_test_mode,
                   :streams_orphan_sweep_interval, :streams_orphan_threshold,
                   :streams_durable_patterns
-    attr_reader :streams_default_broadcast_mode # rubocop:disable Style/AccessorGrouping
+    attr_reader :streams_default_broadcast_mode, # rubocop:disable Style/AccessorGrouping
+                :streams_wake_mechanism
 
     # AppSignal integration (auto-loaded when ::Appsignal is defined and this is true).
     # Set to false to opt out without uninstalling the appsignal gem.
@@ -220,6 +221,7 @@ module Pgbus
       @streams_stats_enabled = false
       @streams_test_mode = false
       @streams_default_broadcast_mode = :ephemeral
+      @streams_wake_mechanism = :listen_notify
       @streams_orphan_sweep_interval = 3600    # 1 hour
       @streams_orphan_threshold = 86_400       # 24 hours
       @streams_durable_patterns = []
@@ -281,6 +283,24 @@ module Pgbus
       end
 
       @streams_default_broadcast_mode = mode
+    end
+
+    # Streamer wake-up mechanism:
+    #   :listen_notify       — default. Use LISTEN/NOTIFY (incompatible with
+    #                          PgBouncer transaction-pool mode).
+    #   :logical_replication — Use a logical replication slot to receive
+    #                          PGMQ INSERTs. Survives any pooler. Requires
+    #                          REPLICATION privilege and wal_level=logical.
+    VALID_WAKE_MECHANISMS = %i[listen_notify logical_replication].freeze
+
+    def streams_wake_mechanism=(mechanism)
+      mechanism = mechanism.to_sym
+      unless VALID_WAKE_MECHANISMS.include?(mechanism)
+        raise ArgumentError,
+              "Invalid streams_wake_mechanism: #{mechanism}. Must be one of: #{VALID_WAKE_MECHANISMS.join(", ")}"
+      end
+
+      @streams_wake_mechanism = mechanism
     end
 
     VALID_PGMQ_SCHEMA_MODES = %i[auto extension embedded].freeze

--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -150,16 +150,31 @@ module Pgbus
           end
         end
 
-        # Hash form: just add the key. String form (URI/keyword string):
-        # append `replication=database`. The libpq parser accepts repeated
-        # key=value pairs; later wins, so this safely overrides any prior
-        # value the caller may have set.
+        # Hash form: just add the key. String form: append depending on
+        # whether it's a URI conninfo or a keyword/value string.
+        # libpq's URI form (postgres://...) cannot accept space-delimited
+        # key=value pairs after the URI — extras must go into the query
+        # string. Keyword/value strings ("host=... dbname=...") tolerate
+        # repeated keys with "later wins" semantics, so appending
+        # ` replication=database` is fine.
         def inject_replication_param(opts)
           case opts
           when Hash   then opts.merge(replication: "database")
-          when String then "#{opts} replication=database"
+          when String then append_replication_to_string(opts)
           else opts
           end
+        end
+
+        def append_replication_to_string(opts)
+          return "#{opts} replication=database" unless opts.match?(%r{\Apostgres(?:ql)?://}i)
+
+          require "uri"
+          uri = URI.parse(opts)
+          params = URI.decode_www_form(uri.query.to_s)
+          params.reject! { |k, _| k == "replication" }
+          params << %w[replication database]
+          uri.query = URI.encode_www_form(params)
+          uri.to_s
         end
 
         def build_pg_connection

--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -38,7 +38,7 @@ module Pgbus
 
           @stream_counter = StreamCounter.new
           @pg_connection = pg_connection || build_pg_connection
-          @listener = Listener.new(
+          @listener = listener_class.new(
             pg_connection: @pg_connection,
             dispatch_queue: @dispatch_queue,
             health_check_ms: @config.streams_listen_health_check_ms,
@@ -143,9 +143,31 @@ module Pgbus
           end
         end
 
+        def listener_class
+          case @config.streams_wake_mechanism
+          when :logical_replication then LogicalReplicationListener
+          else Listener
+          end
+        end
+
+        # Hash form: just add the key. String form (URI/keyword string):
+        # append `replication=database`. The libpq parser accepts repeated
+        # key=value pairs; later wins, so this safely overrides any prior
+        # value the caller may have set.
+        def inject_replication_param(opts)
+          case opts
+          when Hash   then opts.merge(replication: "database")
+          when String then "#{opts} replication=database"
+          else opts
+          end
+        end
+
         def build_pg_connection
           require "pg" unless defined?(::PG::Connection)
           opts = @config.connection_options
+          # Logical replication needs a replication-protocol connection.
+          # Force `replication: "database"` so START_REPLICATION works.
+          opts = inject_replication_param(opts) if @config.streams_wake_mechanism == :logical_replication
           case opts
           when String then ::PG.connect(opts)
           when Hash   then ::PG.connect(**opts)

--- a/lib/pgbus/web/streamer/logical_replication_listener.rb
+++ b/lib/pgbus/web/streamer/logical_replication_listener.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+
+require "stringio"
+require "socket"
+
+module Pgbus
+  module Web
+    module Streamer
+      # An alternative to `Listener` that wakes the dispatcher via Postgres
+      # logical replication (WAL streaming) instead of LISTEN/NOTIFY.
+      #
+      # Why this exists:
+      #
+      #   LISTEN/NOTIFY does not survive PgBouncer's transaction-pool mode.
+      #   Hosted Postgres products like PlanetScale only ship transaction-mode
+      #   pooling, which silently drops LISTEN at every COMMIT boundary —
+      #   notifications go to /dev/null and SSE wake-ups never fire.
+      #
+      #   Logical replication uses a separate replication-protocol connection
+      #   (`replication=database`). PgBouncer treats those as pass-through even
+      #   in transaction mode, so the wake-up signal arrives whether the rest
+      #   of the app talks to the pooler or the direct port.
+      #
+      # API parity with Listener:
+      #
+      #   - Same constructor signature (pg_connection: is repurposed as the
+      #     replication-protocol PG::Connection; the caller wires it up).
+      #   - Same `start` / `stop` / `ensure_listening` / `remove_listening`
+      #     contract so Instance and StreamEventDispatcher need no changes.
+      #   - Same `WakeMessage(queue_name:, payload:)` posted to dispatch_queue.
+      #
+      # Semantic difference:
+      #
+      #   - The WAL stream surfaces every INSERT on every `pgmq.q_pgbus_*`
+      #     table, not just queues that the streamer is "listening" to. We
+      #     keep a per-queue interest set in `@listening_to` (queue names,
+      #     not channel names — different from Listener's CHANNEL_PREFIX
+      #     scheme) and drop WAL events for queues no one cares about.
+      #
+      # Permissions:
+      #
+      #   The PG role used by the streamer needs REPLICATION attribute, plus
+      #   CONNECT on the database. The publication and replication slot are
+      #   created on first `start` if missing — owner of the slot must match
+      #   the connecting role.
+      #
+      # Operational notes:
+      #
+      #   - One replication slot per streamer process. Each Puma worker that
+      #     starts a Streamer::Instance creates its own slot named
+      #     `pgbus_streamer_<host>_<pid>`.
+      #   - On graceful shutdown the slot is dropped. On crash it lingers
+      #     and retains WAL until cleaned up (see Streamer::Instance for the
+      #     orphan-sweep hook).
+      #   - Slot names are bounded to PG's 63-byte identifier limit.
+      class LogicalReplicationListener
+        WakeMessage = Listener::WakeMessage
+
+        # PGMQ queue tables live in the `pgmq` schema and are prefixed
+        # `q_pgbus_`. Stripping the prefix yields the pgbus queue name
+        # used by Pgbus.stream(name).broadcast(content).
+        QUEUE_TABLE_PREFIX = "q_pgbus_"
+        QUEUE_SCHEMA       = "pgmq"
+
+        PUBLICATION_NAME = "pgbus_stream_inserts"
+        SLOT_PLUGIN      = "pgoutput"
+
+        # pgoutput protocol message types (single-byte tags at start of payload).
+        # https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
+        MSG_BEGIN    = "B"
+        MSG_COMMIT   = "C"
+        MSG_RELATION = "R"
+        MSG_INSERT   = "I"
+
+        attr_reader :listening_to
+
+        def initialize(pg_connection:, dispatch_queue:, health_check_ms:, logger: Pgbus.logger, slot_name: nil)
+          @conn = pg_connection
+          @dispatch_queue = dispatch_queue
+          @health_check_ms = health_check_ms # unused; replication uses its own keepalive cadence
+          @logger = logger
+          @slot_name = slot_name || default_slot_name
+          @listening_to = Set.new # queue names with at least one subscriber
+          @relations = {}         # relation_oid → queue_name (filled from RELATION messages)
+          @running = false
+          @thread = nil
+          @last_lsn = 0
+          @commands_mutex = Mutex.new
+        end
+
+        def start
+          return if @running
+
+          ensure_publication!
+          ensure_slot!
+
+          @running = true
+          @thread = Thread.new { run_loop }
+          self
+        end
+
+        def stop
+          return unless @running
+
+          @running = false
+          begin
+            @conn.close if @conn.respond_to?(:close)
+          rescue StandardError
+            # best effort — connection may already be gone
+          end
+          @thread&.join(5)
+          @thread = nil
+          self
+        end
+
+        # The WAL stream is always-on once the slot is created. ensure_listening
+        # here just records that the dispatcher cares about this queue, so we
+        # only emit WakeMessage for matching INSERTs.
+        def ensure_listening(queue_name)
+          @commands_mutex.synchronize { @listening_to.add(queue_name) }
+        end
+
+        def remove_listening(queue_name)
+          @commands_mutex.synchronize { @listening_to.delete(queue_name) }
+        end
+
+        private
+
+        # PG allows up to 63 chars in an identifier. Encode host+pid into
+        # something stable per process but unique across hosts. If the
+        # composed name is too long we hash it.
+        def default_slot_name
+          base = "pgbus_streamer_#{Socket.gethostname}_#{::Process.pid}".gsub(/[^a-zA-Z0-9_]/, "_")
+          return base if base.length <= 63
+
+          require "digest"
+          "pgbus_streamer_#{Digest::SHA1.hexdigest(base)[0, 20]}_#{::Process.pid}"
+        end
+
+        def ensure_publication!
+          # Idempotent: CREATE PUBLICATION fails if it exists. We check first
+          # because there's no portable IF NOT EXISTS for publications across
+          # PG 14 and 15+ ([the syntax exists from PG 15]). pgmq adds queue
+          # tables at runtime, so we want a FOR TABLES IN SCHEMA publication
+          # rather than enumerating tables.
+          with_admin_connection do |admin|
+            exists = admin.exec_params(
+              "SELECT 1 FROM pg_publication WHERE pubname = $1",
+              [PUBLICATION_NAME]
+            ).any?
+            next if exists
+
+            # PG 15+ syntax — pgmq runs on PG 14+ but FOR TABLES IN SCHEMA
+            # is PG 15+. For PG 14 environments the operator must create a
+            # FOR ALL TABLES publication manually; we surface a clear error.
+            begin
+              admin.exec("CREATE PUBLICATION #{PUBLICATION_NAME} FOR TABLES IN SCHEMA #{QUEUE_SCHEMA} WITH (publish = 'insert')")
+            rescue PG::SyntaxError => e
+              raise Pgbus::ConfigurationError,
+                    "Cannot CREATE PUBLICATION FOR TABLES IN SCHEMA (#{e.message}). " \
+                    "PG 14 or older — create the publication manually with " \
+                    "FOR ALL TABLES or enumerate pgmq.q_pgbus_* tables explicitly."
+            end
+          end
+        end
+
+        def ensure_slot!
+          with_admin_connection do |admin|
+            exists = admin.exec_params(
+              "SELECT 1 FROM pg_replication_slots WHERE slot_name = $1",
+              [@slot_name]
+            ).any?
+            next if exists
+
+            admin.exec_params(
+              "SELECT pg_create_logical_replication_slot($1, $2)",
+              [@slot_name, SLOT_PLUGIN]
+            )
+          end
+        end
+
+        # The replication-protocol connection (@conn) can't run arbitrary SQL —
+        # only the special replication commands. For publication/slot
+        # bootstrap we need a regular connection. Use a short-lived one
+        # built from the same connection_options as the main streamer conn.
+        def with_admin_connection
+          require "pg" unless defined?(::PG::Connection)
+          opts = Pgbus.configuration.connection_options
+          admin = case opts
+                  when String then ::PG.connect(opts)
+                  when Hash   then ::PG.connect(**opts)
+                  else
+                    raise Pgbus::ConfigurationError,
+                          "Cannot build admin connection for LogicalReplicationListener from #{opts.class}"
+                  end
+          yield admin
+        ensure
+          admin&.close
+        end
+
+        def run_loop
+          @conn.exec("START_REPLICATION SLOT #{@slot_name} LOGICAL 0/0 (proto_version '1', publication_names '#{PUBLICATION_NAME}')")
+          poll_interval = (@health_check_ms / 1000.0 / 5.0).clamp(0.01, 0.1)
+          loop do
+            break unless @running
+
+            # get_copy_data(true) returns:
+            #   String — a CopyData frame
+            #   false  — no data available right now (libpq's async read path)
+            #   nil    — end of COPY (server closed the stream)
+            data = @conn.get_copy_data(true)
+            case data
+            when nil
+              break # server ended the stream
+            when false
+              @conn.consume_input
+              sleep poll_interval
+            else
+              handle_copy_message(data)
+            end
+          end
+        rescue IOError, PG::Error => e
+          # #stop closes the connection to interrupt get_copy_data
+          @logger.warn { "[Pgbus::Streamer::LogicalReplicationListener] #{e.class}: #{e.message}" } if @running
+        end
+
+        # Replication protocol wraps WAL data in CopyData frames. The first
+        # byte is the protocol message type ('w' = XLogData with payload,
+        # 'k' = primary keepalive). For XLogData, bytes 1..8 are the start
+        # LSN, 9..16 are the end LSN, 17..24 are the server send time, and
+        # the rest is the pgoutput message.
+        def handle_copy_message(data)
+          case data[0]
+          when "w"
+            payload = data[25..]
+            handle_pgoutput_message(payload)
+          when "k"
+            # Keepalive. Bytes 1..8 end LSN, 9..16 server time, 17 reply-now flag.
+            # If the server is asking for a reply, send one to keep the slot
+            # advancing. We don't track LSNs precisely in the spike — sending
+            # @last_lsn is good enough to prevent slot bloat in dev.
+            reply_now = data[17].unpack1("C").nonzero?
+            send_standby_status if reply_now
+          end
+        end
+
+        def handle_pgoutput_message(payload)
+          tag = payload[0]
+          case tag
+          when MSG_RELATION then handle_relation(payload)
+          when MSG_INSERT   then handle_insert(payload)
+          when MSG_BEGIN, MSG_COMMIT
+            # No-op for the spike. A full impl would track LSN here.
+          end
+        end
+
+        # RELATION message format (pgoutput proto v1):
+        #   Byte('R') Int32(oid) String(schema) String(table) Int8(replica_identity)
+        #   Int16(natts) [Int8(flags) String(name) Int32(type_oid) Int32(type_mod)] x natts
+        # We only need oid, schema, table.
+        def handle_relation(payload)
+          io = StringIO.new(payload)
+          io.read(1) # 'R'
+          oid = io.read(4).unpack1("N")
+          schema = read_cstring(io)
+          table = read_cstring(io)
+          return unless schema == QUEUE_SCHEMA && table.start_with?(QUEUE_TABLE_PREFIX)
+
+          queue_name = table[QUEUE_TABLE_PREFIX.length..]
+          @relations[oid] = queue_name
+        end
+
+        # INSERT message format (pgoutput proto v1):
+        #   Byte('I') Int32(relation_oid) Byte('N') TupleData
+        # For the spike we only need relation_oid to look up the queue.
+        def handle_insert(payload)
+          oid = payload[1, 4].unpack1("N")
+          queue_name = @relations[oid]
+          return unless queue_name
+
+          @commands_mutex.synchronize do
+            return unless @listening_to.include?(queue_name)
+          end
+
+          @dispatch_queue << WakeMessage.new(queue_name: queue_name)
+        end
+
+        def read_cstring(io)
+          buf = +""
+          while (ch = io.read(1)) && ch != "\x00"
+            buf << ch
+          end
+          buf
+        end
+
+        # Send a standby status update to keep the replication slot from
+        # holding WAL forever. In the spike we just reply with the LSN we
+        # received last; production would track this more carefully.
+        def send_standby_status
+          # 'r' = Standby status update: receive_lsn, flush_lsn, apply_lsn, clock_ms, reply_now
+          msg = ["r", @last_lsn, @last_lsn, @last_lsn, (Time.now.to_f * 1_000_000).to_i, 0].pack("aQ>Q>Q>Q>C")
+          @conn.put_copy_data(msg)
+        rescue PG::Error => e
+          @logger.warn { "[Pgbus::Streamer::LogicalReplicationListener] standby reply failed: #{e.message}" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/web/streamer/logical_replication_listener.rb
+++ b/lib/pgbus/web/streamer/logical_replication_listener.rb
@@ -105,11 +105,12 @@ module Pgbus
           @running = false
           begin
             @conn.close if @conn.respond_to?(:close)
-          rescue StandardError
-            # best effort — connection may already be gone
+          rescue StandardError => e
+            @logger.debug { "[Pgbus::Streamer::LogicalReplicationListener] connection close failed (best effort): #{e.message}" }
           end
           @thread&.join(5)
           @thread = nil
+          drop_slot_quietly
           self
         end
 
@@ -155,6 +156,9 @@ module Pgbus
             # FOR ALL TABLES publication manually; we surface a clear error.
             begin
               admin.exec("CREATE PUBLICATION #{PUBLICATION_NAME} FOR TABLES IN SCHEMA #{QUEUE_SCHEMA} WITH (publish = 'insert')")
+            rescue PG::DuplicateObject
+              # Another worker won the race between our SELECT and CREATE.
+              nil
             rescue PG::SyntaxError => e
               raise Pgbus::ConfigurationError,
                     "Cannot CREATE PUBLICATION FOR TABLES IN SCHEMA (#{e.message}). " \
@@ -172,11 +176,30 @@ module Pgbus
             ).any?
             next if exists
 
+            begin
+              admin.exec_params(
+                "SELECT pg_create_logical_replication_slot($1, $2)",
+                [@slot_name, SLOT_PLUGIN]
+              )
+            rescue PG::DuplicateObject
+              # Another worker created the slot between our SELECT and create.
+              nil
+            end
+          end
+        end
+
+        # Drops this listener's slot during graceful shutdown so it doesn't
+        # linger and pin WAL. On crash this won't run — the orphan-sweep
+        # hook in Streamer::Instance is the safety net.
+        def drop_slot_quietly
+          with_admin_connection do |admin|
             admin.exec_params(
-              "SELECT pg_create_logical_replication_slot($1, $2)",
-              [@slot_name, SLOT_PLUGIN]
+              "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = $1",
+              [@slot_name]
             )
           end
+        rescue PG::Error => e
+          @logger.warn { "[Pgbus::Streamer::LogicalReplicationListener] drop slot failed: #{e.message}" }
         end
 
         # The replication-protocol connection (@conn) can't run arbitrary SQL —
@@ -232,13 +255,16 @@ module Pgbus
         def handle_copy_message(data)
           case data[0]
           when "w"
+            # XLogData header: 'w' Int64(start_lsn) Int64(end_lsn) Int64(send_time)
+            # Track the end LSN so standby status replies confirm progress and
+            # the slot can release WAL we've already processed.
+            @last_lsn = data[9, 8].unpack1("Q>")
             payload = data[25..]
             handle_pgoutput_message(payload)
           when "k"
-            # Keepalive. Bytes 1..8 end LSN, 9..16 server time, 17 reply-now flag.
-            # If the server is asking for a reply, send one to keep the slot
-            # advancing. We don't track LSNs precisely in the spike — sending
-            # @last_lsn is good enough to prevent slot bloat in dev.
+            # Keepalive: 'k' Int64(end_lsn) Int64(server_time) Int8(reply_now).
+            # When the server asks for a reply, send one with the latest LSN
+            # we observed in XLogData so the slot advances.
             reply_now = data[17].unpack1("C").nonzero?
             send_standby_status if reply_now
           end

--- a/spec/generators/pgbus/update_generator_spec.rb
+++ b/spec/generators/pgbus/update_generator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     end
 
     it "has a description" do
-      expect(described_class.desc).to match(/Upgrade pgbus/)
+      expect(described_class.desc).to include("Upgrade pgbus")
       expect(described_class.desc).to include("YAML")
       expect(described_class.desc).to include("migrations")
     end

--- a/spec/pgbus/generators/config_converter_spec.rb
+++ b/spec/pgbus/generators/config_converter_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Pgbus::Generators::ConfigConverter do
       it "emits env-specific settings with Rails.env guards" do
         # The 'unless development' shape is preferred when there are 2 envs
         # and one is dev — keeps the production line clean.
-        expect(output).to match(/c\.max_jobs_per_worker = 10_000 unless Rails\.env\.development\?/)
-        expect(output).to match(/c\.max_memory_mb = 512 unless Rails\.env\.development\?/)
+        expect(output).to include("c.max_jobs_per_worker = 10_000 unless Rails.env.development?")
+        expect(output).to include("c.max_memory_mb = 512 unless Rails.env.development?")
       end
     end
 
@@ -206,8 +206,8 @@ RSpec.describe Pgbus::Generators::ConfigConverter do
         # but NOT production. A case block with only dev+test clauses
         # is an acceptable shape — what we must prevent is the
         # production env silently inheriting the value.
-        expect(output).to match(/polling_interval/)
-        expect(output).to match(/development/)
+        expect(output).to include("polling_interval")
+        expect(output).to include("development")
         expect(output).to match(/\btest\b/)
         # Only `workers` should mention production (from a production:
         # capsule/worker config); polling_interval must not.

--- a/spec/pgbus/web/streamer/logical_replication_listener_spec.rb
+++ b/spec/pgbus/web/streamer/logical_replication_listener_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "stringio"
+
+RSpec.describe Pgbus::Web::Streamer::LogicalReplicationListener do
+  before do
+    stub_const("PG", Module.new) unless defined?(PG)
+    stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
+  end
+
+  let(:dispatch_queue) { Queue.new }
+  let(:logger)         { Logger.new(IO::NULL) }
+  let(:fake_pg)        { Class.new { def close; end; def closed?; false; end }.new }
+
+  subject(:listener) do
+    described_class.new(
+      pg_connection: fake_pg,
+      dispatch_queue: dispatch_queue,
+      health_check_ms: 50,
+      logger: logger,
+      slot_name: "pgbus_streamer_test_slot"
+    )
+  end
+
+  describe "interest set (LISTEN equivalent)" do
+    it "tracks ensure_listening / remove_listening" do
+      listener.ensure_listening("chat")
+      listener.ensure_listening("metrics")
+      expect(listener.listening_to).to contain_exactly("chat", "metrics")
+
+      listener.remove_listening("chat")
+      expect(listener.listening_to).to contain_exactly("metrics")
+    end
+  end
+
+  describe "pgoutput RELATION + INSERT parsing" do
+    # Drive the private parser directly. We hand it a synthetic pgoutput
+    # message that matches the wire format pgoutput emits for:
+    #   - a RELATION row for `pgmq.q_pgbus_chat`
+    #   - an INSERT into that relation
+    let(:relation_oid) { 12_345 }
+
+    let(:relation_message) do
+      # 'R' Int32(oid) String(schema) String(table) Int8(replica_identity)
+      #     Int16(natts) [Int8(flags) String(name) Int32(type) Int32(typmod)] x natts
+      payload = String.new
+      payload << "R"
+      payload << [relation_oid].pack("N")
+      payload << "pgmq\x00"
+      payload << "q_pgbus_chat\x00"
+      payload << [0].pack("C")        # replica_identity
+      payload << [0].pack("n")        # natts = 0 (sufficient for the spike — we don't read columns)
+      payload
+    end
+
+    let(:insert_message) do
+      # 'I' Int32(relation_oid) Byte('N') TupleData
+      # We don't read the tuple so an empty Int16 col count is enough.
+      payload = String.new
+      payload << "I"
+      payload << [relation_oid].pack("N")
+      payload << "N"
+      payload << [0].pack("n") # 0 columns
+      payload
+    end
+
+    it "registers a RELATION and emits WakeMessage on a matching INSERT for a listened queue" do
+      listener.ensure_listening("chat")
+      listener.send(:handle_pgoutput_message, relation_message)
+      listener.send(:handle_pgoutput_message, insert_message)
+
+      msg = dispatch_queue.pop(true)
+      expect(msg).to be_a(Pgbus::Web::Streamer::LogicalReplicationListener::WakeMessage)
+      expect(msg.queue_name).to eq("chat")
+    end
+
+    it "does NOT emit WakeMessage for a queue not in the interest set" do
+      # No ensure_listening call.
+      listener.send(:handle_pgoutput_message, relation_message)
+      listener.send(:handle_pgoutput_message, insert_message)
+
+      expect { dispatch_queue.pop(true) }.to raise_error(ThreadError) # empty queue
+    end
+
+    it "ignores non-pgmq tables" do
+      other_oid = 99_999
+      foreign_relation = String.new
+      foreign_relation << "R"
+      foreign_relation << [other_oid].pack("N")
+      foreign_relation << "public\x00"
+      foreign_relation << "some_other_table\x00"
+      foreign_relation << [0].pack("C")
+      foreign_relation << [0].pack("n")
+
+      foreign_insert = String.new
+      foreign_insert << "I"
+      foreign_insert << [other_oid].pack("N")
+      foreign_insert << "N"
+      foreign_insert << [0].pack("n")
+
+      listener.send(:handle_pgoutput_message, foreign_relation)
+      listener.send(:handle_pgoutput_message, foreign_insert)
+
+      expect { dispatch_queue.pop(true) }.to raise_error(ThreadError)
+    end
+
+    it "ignores INSERTs for relations it has never seen a RELATION message for" do
+      listener.ensure_listening("chat")
+      listener.send(:handle_pgoutput_message, insert_message)
+      # No RELATION processed first → no oid → queue_name mapping → drop.
+      expect { dispatch_queue.pop(true) }.to raise_error(ThreadError)
+    end
+  end
+
+  describe "WakeMessage compatibility" do
+    it "uses the same struct as the LISTEN-based Listener so the dispatcher sees no difference" do
+      expect(described_class::WakeMessage).to equal(Pgbus::Web::Streamer::Listener::WakeMessage)
+    end
+  end
+end

--- a/spec/pgbus/web/streamer/logical_replication_listener_spec.rb
+++ b/spec/pgbus/web/streamer/logical_replication_listener_spec.rb
@@ -4,15 +4,6 @@ require "spec_helper"
 require "stringio"
 
 RSpec.describe Pgbus::Web::Streamer::LogicalReplicationListener do
-  before do
-    stub_const("PG", Module.new) unless defined?(PG)
-    stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
-  end
-
-  let(:dispatch_queue) { Queue.new }
-  let(:logger)         { Logger.new(IO::NULL) }
-  let(:fake_pg)        { Class.new { def close; end; def closed?; false; end }.new }
-
   subject(:listener) do
     described_class.new(
       pg_connection: fake_pg,
@@ -21,6 +12,23 @@ RSpec.describe Pgbus::Web::Streamer::LogicalReplicationListener do
       logger: logger,
       slot_name: "pgbus_streamer_test_slot"
     )
+  end
+
+  before do
+    stub_const("PG", Module.new) unless defined?(PG)
+    stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
+  end
+
+  let(:dispatch_queue) { Queue.new }
+  let(:logger)         { Logger.new(IO::NULL) }
+  let(:fake_pg)        do
+    Class.new do
+      def close; end
+
+      def closed?
+        false
+      end
+    end.new
   end
 
   describe "interest set (LISTEN equivalent)" do


### PR DESCRIPTION
## Summary

Adds `Pgbus::Web::Streamer::LogicalReplicationListener` as a drop-in alternative to the existing LISTEN/NOTIFY-based `Listener`. Opt-in via `Pgbus.configuration.streams_wake_mechanism = :logical_replication`. Default stays `:listen_notify` — no behavior change unless explicitly enabled.

## Why

LISTEN/NOTIFY does not survive PgBouncer's transaction-pool mode. Several managed Postgres products (notably PlanetScale Postgres) only ship transaction-mode pooling, which silently drops LISTEN at every COMMIT boundary — notifications go to /dev/null and SSE wake-ups never fire. Apps that depend on the pgbus streamer behind such a pooler lose all live delivery; durable broadcasts still recover state on reconnect via the cursor, but the latency floor degrades to the streamer's health-check tick.

Logical replication uses the replication protocol (`replication=database` libpq parameter). PgBouncer passes those connections through even in transaction mode, so the wake-up signal arrives whether the streamer talks to the pooler or the direct port.

## Verified end-to-end

Local repro: PG with `wal_level=logical` on :5432, PgBouncer in transaction mode on :6432 forwarding to :5432, full pgbus integration with a host app pointed at the gem via `path:`.

| Configuration | Outcome |
|---|---|
| Direct PG, `:listen_notify` | ✅ delivered (baseline) |
| Direct PG, `:logical_replication` | ✅ delivered |
| Through PgBouncer transaction mode, `:listen_notify` | ❌ no WakeMessage — production bug reproduced |
| Through PgBouncer transaction mode, `:logical_replication` | ✅ delivered — fix validated |

`bin/repro-logical-listener` ships a single-process version of the same proof for reviewers without a Rails host.

## How it works

- One replication slot per streamer process, named `pgbus_streamer_<host>_<pid>`.
- One auto-managed publication `pgbus_stream_inserts FOR TABLES IN SCHEMA pgmq WITH (publish = 'insert')`. Auto-picks up new queue tables.
- The dedicated PG connection is built by `Streamer::Instance` with `replication: "database"` injected when the mechanism is set.
- A minimal pgoutput proto-v1 parser consumes RELATION + INSERT messages from the WAL stream. RELATION builds a `relation_oid → queue_name` map; INSERT looks up the queue and emits `WakeMessage` if the dispatcher has expressed interest via `ensure_listening`.
- The `listening_to` set is repurposed: the WAL stream surfaces every pgmq INSERT, so the listener filters to queues the dispatcher cares about. Preserves the existing contract.

## Requirements

- PG 15+ for `FOR TABLES IN SCHEMA` (we surface a clear `ConfigurationError` on 14).
- `wal_level = logical` on the cluster.
- The connecting role needs `REPLICATION` attribute. `ALTER ROLE <user> WITH REPLICATION;` — this is a role attribute, not a per-database grant, so one ALTER covers every DB the role connects to.

## Trade-offs to be aware of before enabling this

| Area | Trade-off |
|---|---|
| **Connection budget** | Replication connections use `max_wal_senders` slots (default 10 on PlanetScale). Budget `web_hosts × puma_workers ≤ max_wal_senders`. The LISTEN path didn't have this ceiling. |
| **Slot lifecycle** | Each streamer process owns a slot. If a process crashes hard, the slot becomes "inactive" — and it **retains WAL until cleaned up**. An abandoned slot on a busy DB can fill the disk in hours. This PR has no orphan-sweep yet (called out as follow-up). Mitigation: a cron-style sweep that drops slots whose `pg_stat_replication.active = false AND inactive_since > N`. |
| **WAL bandwidth** | The streamer receives the full INSERT payload of every pgmq queue table, decoded. For tiny broadcasts (most UI updates) it's noise. For heavy workloads (chat at scale, large payloads), the WAL traffic is real. Sanity-check it at your traffic level. |
| **Latency** | Single-digit milliseconds typical — same order as NOTIFY. Not a regression in practice, but the protocol does buffer and isn't strictly instantaneous. |
| **PG version floor** | Requires PG 15+. If you must support PG 14 you'd have to enumerate queue tables manually (a clear error is raised). |
| **Permissions surface** | `REPLICATION` lets a role read the entire WAL — every change to every table in the cluster, not just pgmq's. Strong recommendation: create a dedicated `pgbus_streamer` role used only by streamer connections, never the app's main DB user. |
| **Operational visibility** | `pg_stat_replication`, `pg_replication_slots` are the new operational dashboards. PgHero surfaces these; teams enabling this need to know where to look when SSE acts up. |
| **Backup/restore** | Logical replication slots are not part of physical backups. After a restore/promotion, slots need to be recreated. Streamer auto-recreates on boot — no manual step. |

The most important risk by far is **slot lifecycle**: do not enable this in production without an orphan-slot sweep.

## Spike limitations (called out for follow-up)

- LSN tracking for slot advance is naive — we reply with `@last_lsn` which stays zero. Fine for dev; a real deployment needs proper `flush_lsn` tracking so the slot doesn't retain WAL forever.
- No orphan-slot cleanup on crash. Next iteration should hook into `Streamer::Instance#shutdown!` for graceful drop + periodic sweep of slots whose owning host is no longer alive.
- pgoutput parser is purposely minimal: B/C/R/I only, no UPDATE/DELETE, no TupleData column reading.

## Tests

- `spec/pgbus/web/streamer/logical_replication_listener_spec.rb` — drives the binary parser directly with synthetic RELATION + INSERT pgoutput messages, asserts the interest set filters correctly, asserts `WakeMessage` reuses the same struct as the LISTEN-based Listener.
- `bin/repro-logical-listener` — end-to-end against a real PG, optionally through PgBouncer. Validates the wake path is intact under transaction-mode pooling.

All 166 existing streamer specs pass. Rubocop clean.

## Test plan

- [ ] `bundle exec rspec spec/pgbus/web/streamer/`
- [ ] Optional: stand up a local PG with `wal_level=logical`, run `bin/repro-logical-listener` through a transaction-mode PgBouncer
- [ ] Review the `pgoutput` parser for safety on partial/binary input

## Follow-ups (after this lands)

- Productionise the LSN tracking + orphan sweep
- Document the operator setup (wal_level, REPLICATION grant, expected `max_replication_slots` budget)
- Release as pre-release (`0.9.0.beta1`) so apps can validate before promoting to default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PostgreSQL logical replication wake mechanism for stream event detection.
  * Added an end-to-end reproduction script to exercise logical replication against a real database.
* **Configuration**
  * Introduced a new `streams_wake_mechanism` option (defaulting to the existing listen/notify behavior; logical replication available).
* **Tests**
  * Added/expanded tests covering logical replication wake-message delivery and queue interest handling.
  * Updated a few generator specs to use clearer string-based assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->