### PR TITLE
feat(streams): streams_host / streams_port / streams_database_url overrides

### DIFF
--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -106,7 +106,8 @@ module Pgbus
                   :streams_write_deadline_ms, :streams_falcon_streaming_body,
                   :streams_stats_enabled, :streams_test_mode,
                   :streams_orphan_sweep_interval, :streams_orphan_threshold,
-                  :streams_durable_patterns
+                  :streams_durable_patterns,
+                  :streams_host, :streams_port, :streams_database_url
     attr_reader :streams_default_broadcast_mode # rubocop:disable Style/AccessorGrouping
 
     # AppSignal integration (auto-loaded when ::Appsignal is defined and this is true).
@@ -193,6 +194,22 @@ module Pgbus
       @streams_enabled = true
       @streams_path = nil
       @streams_queue_prefix = "pgbus_stream"
+      # Streamer-only connection overrides. The Streamer's Listener owns a
+      # dedicated long-lived `wait_for_notify` PG connection that can't go
+      # through a PgBouncer in transaction mode (LISTEN/NOTIFY don't survive
+      # transaction-pool COMMIT boundaries — see PlanetScale's docs). Setting
+      # any of these overrides only the Streamer's connection options; the
+      # worker, dispatcher, and client publish paths keep using the regular
+      # `database_url` / `connection_params` (typically pooled).
+      #
+      #   streams_host          — override host only
+      #   streams_port          — override port only (most common case:
+      #                           pooler is on 6432, direct is 5432)
+      #   streams_database_url  — full URL override; takes precedence over
+      #                           the host/port surgicals when set
+      @streams_host = nil
+      @streams_port = nil
+      @streams_database_url = nil
       @streams_signed_name_secret = nil
       @streams_default_retention = 5 * 60 # 5 minutes
       @streams_retention = {}
@@ -605,6 +622,43 @@ module Pgbus
       else
         raise ConfigurationError, "No database connection configured. " \
                                   "Set Pgbus.configuration.database_url, connection_params, or use with Rails."
+      end
+    end
+
+    # Connection options the Streamer's dedicated LISTEN/NOTIFY PG connection
+    # should use. Defaults to `connection_options` (same as workers and the
+    # publish path). If any of `streams_database_url`, `streams_host`, or
+    # `streams_port` is set, the Streamer's connection is reconfigured —
+    # everything else keeps using the base options.
+    #
+    # The typical use is "workers go through PgBouncer, streamer goes direct":
+    #
+    #   c.connects_to = { database: { writing: :pgbus } }   # pooler
+    #   c.streams_port = 5432                               # direct
+    #
+    # Precedence: streams_database_url > streams_host/port override > base.
+    def streams_connection_options
+      return streams_database_url if streams_database_url
+
+      base = connection_options
+      return base unless streams_host || streams_port
+
+      case base
+      when Hash
+        result = base.dup
+        result[:host] = streams_host if streams_host
+        result[:port] = streams_port if streams_port
+        result
+      when String
+        # libpq's conninfo parser takes later key=value pairs as overrides
+        # for earlier ones, so we just append. Handles both URI form
+        # (postgres://...) and key=value form.
+        parts = [base]
+        parts << "host=#{streams_host}" if streams_host
+        parts << "port=#{streams_port}" if streams_port
+        parts.join(" ")
+      else
+        base
       end
     end
 

--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -145,7 +145,7 @@ module Pgbus
 
         def build_pg_connection
           require "pg" unless defined?(::PG::Connection)
-          opts = @config.connection_options
+          opts = @config.streams_connection_options
           case opts
           when String then ::PG.connect(opts)
           when Hash   then ::PG.connect(**opts)

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -1110,4 +1110,107 @@ RSpec.describe Pgbus::Configuration do
       expect { config.validate! }.not_to raise_error
     end
   end
+
+  describe "#streams_connection_options" do
+    context "when no streams override is set" do
+      it "returns the base connection_options Hash" do
+        config.connection_params = { host: "pooler.example", port: 6432, dbname: "app", user: "app" }
+        expect(config.streams_connection_options).to eq(config.connection_options)
+      end
+
+      it "returns the base connection_options String" do
+        config.database_url = "postgres://app@pooler.example:6432/app"
+        expect(config.streams_connection_options).to eq(config.connection_options)
+      end
+    end
+
+    context "when streams_port is set with a Hash base" do
+      it "overrides only the port, preserves everything else" do
+        config.connection_params = {
+          host: "pooler.example", port: 6432, dbname: "app",
+          user: "app", password: "secret", sslmode: "require"
+        }
+        config.streams_port = 5432
+
+        expect(config.streams_connection_options).to eq(
+          host: "pooler.example", port: 5432, dbname: "app",
+          user: "app", password: "secret", sslmode: "require"
+        )
+      end
+
+      it "does not mutate the base connection_params" do
+        original = { host: "pooler.example", port: 6432, dbname: "app" }
+        config.connection_params = original
+        config.streams_port = 5432
+
+        config.streams_connection_options
+        expect(config.connection_params).to eq(host: "pooler.example", port: 6432, dbname: "app")
+      end
+    end
+
+    context "when streams_host is set with a Hash base" do
+      it "overrides only the host" do
+        config.connection_params = { host: "pooler.example", port: 5432, dbname: "app" }
+        config.streams_host = "direct.example"
+
+        expect(config.streams_connection_options).to eq(
+          host: "direct.example", port: 5432, dbname: "app"
+        )
+      end
+    end
+
+    context "when both streams_host and streams_port are set with a Hash base" do
+      it "overrides both" do
+        config.connection_params = { host: "pooler.example", port: 6432, dbname: "app" }
+        config.streams_host = "direct.example"
+        config.streams_port = 5432
+
+        expect(config.streams_connection_options).to eq(
+          host: "direct.example", port: 5432, dbname: "app"
+        )
+      end
+    end
+
+    context "when streams_port is set with a String base" do
+      it "appends a port=... key=value override" do
+        config.database_url = "host=pooler.example port=6432 dbname=app user=app"
+        config.streams_port = 5432
+
+        expect(config.streams_connection_options).to eq(
+          "host=pooler.example port=6432 dbname=app user=app port=5432"
+        )
+      end
+
+      it "works with a postgres:// URL too" do
+        config.database_url = "postgres://app@pooler.example:6432/app"
+        config.streams_port = 5432
+
+        expect(config.streams_connection_options).to eq(
+          "postgres://app@pooler.example:6432/app port=5432"
+        )
+      end
+    end
+
+    context "when streams_database_url is set" do
+      it "wins over streams_host/streams_port" do
+        config.connection_params = { host: "pooler.example", port: 6432, dbname: "app" }
+        config.streams_host = "ignored"
+        config.streams_port = 9999
+        config.streams_database_url = "postgres://stream@direct.example:5432/app"
+
+        expect(config.streams_connection_options).to eq(
+          "postgres://stream@direct.example:5432/app"
+        )
+      end
+
+      it "wins over the base connection_options entirely" do
+        config.connection_params = { host: "pooler.example", port: 6432, dbname: "app" }
+        config.streams_database_url = "postgres://stream@direct.example:5432/app"
+
+        expect(config.streams_connection_options).to eq(
+          "postgres://stream@direct.example:5432/app"
+        )
+      end
+    end
+  end
 end

--- a/spec/pgbus/web/streamer/instance_spec.rb
+++ b/spec/pgbus/web/streamer/instance_spec.rb
@@ -89,32 +89,29 @@ RSpec.describe Pgbus::Web::Streamer::Instance do
   end
 
   describe "#build_pg_connection" do
+    let(:fake_pg_module_conn) do
+      Class.new do
+        def close; end
+        def reset = nil
+      end.new
+    end
+
+    let(:streamer_config) do
+      Pgbus::Configuration.new.tap do |c|
+        c.connection_params = { host: "pooler.example", port: 6432, dbname: "app", user: "app" }
+        c.streams_port = 5432
+      end
+    end
+
     it "uses streams_connection_options so the listener can be pointed at a different port" do
       require "pg"
-      fake_conn = Class.new do
-        def close; end
-
-        def reset
-          nil
-        end
-      end.new
       captured = nil
       allow(PG).to receive(:connect) do |**kwargs|
         captured = kwargs
-        fake_conn
+        fake_pg_module_conn
       end
 
-      config = Pgbus::Configuration.new
-      config.connection_params = { host: "pooler.example", port: 6432, dbname: "app", user: "app" }
-      config.streams_port = 5432
-
-      # Constructing the Instance triggers build_pg_connection because
-      # pg_connection: is omitted.
-      described_class.new(
-        client: client,
-        config: config,
-        logger: Logger.new(IO::NULL)
-      )
+      described_class.new(client: client, config: streamer_config, logger: Logger.new(IO::NULL))
 
       expect(captured).to eq(host: "pooler.example", port: 5432, dbname: "app", user: "app")
     end

--- a/spec/pgbus/web/streamer/instance_spec.rb
+++ b/spec/pgbus/web/streamer/instance_spec.rb
@@ -88,6 +88,38 @@ RSpec.describe Pgbus::Web::Streamer::Instance do
     [conn, reader_io]
   end
 
+  describe "#build_pg_connection" do
+    it "uses streams_connection_options so the listener can be pointed at a different port" do
+      require "pg"
+      fake_conn = Class.new do
+        def close; end
+
+        def reset
+          nil
+        end
+      end.new
+      captured = nil
+      allow(PG).to receive(:connect) do |**kwargs|
+        captured = kwargs
+        fake_conn
+      end
+
+      config = Pgbus::Configuration.new
+      config.connection_params = { host: "pooler.example", port: 6432, dbname: "app", user: "app" }
+      config.streams_port = 5432
+
+      # Constructing the Instance triggers build_pg_connection because
+      # pg_connection: is omitted.
+      described_class.new(
+        client: client,
+        config: config,
+        logger: Logger.new(IO::NULL)
+      )
+
+      expect(captured).to eq(host: "pooler.example", port: 5432, dbname: "app", user: "app")
+    end
+  end
+
   describe "#start" do
     it "starts the listener, dispatcher, and heartbeat threads" do
       streamer.start


### PR DESCRIPTION
## Summary

Adds three streamer-only connection overrides on `Pgbus::Configuration`:

| Setting | What it overrides |
|---|---|
| `streams_host` | host only |
| `streams_port` | port only (most common — pooler on 6432, direct on 5432) |
| `streams_database_url` | full URL — wins over the surgicals |

Set any of these to reconfigure only the Streamer's dedicated `wait_for_notify` PG connection. The worker pool, dispatcher, publish path, and client keep using the regular `connection_options` (typically the pooler).

## Why

The Streamer's Listener owns a long-lived PG connection running `wait_for_notify` against PGMQ NOTIFY channels. PgBouncer in transaction-pool mode silently drops LISTEN at every COMMIT boundary, so the streamer's wake-up signal never arrives.

Several managed Postgres products — notably PlanetScale Postgres — only ship transaction-mode pooling. Apps deploying pgbus behind such a pooler silently lose live SSE delivery; durable broadcasts still recover state on reconnect via the cursor, but live delivery degrades to the streamer's health-check tick.

The fix: give the Streamer's single LISTEN connection a way to bypass the pooler while everything else (workers, publisher, client) keeps using it.

## Typical usage

```ruby
Pgbus.configure do |c|
  c.connects_to = { database: { writing: :pgbus } }  # pooler (e.g. 6432)
  c.streams_port = 5432                              # direct PG port
end
```

One line in the host app. No URL duplication, no permission changes, no schema changes.

## Connection footprint

Compared to routing ALL pgbus traffic over the direct port:

| Approach | Direct connections to PG |
|---|---|
| Everything direct | `web_hosts × puma_workers × thread_pool` ≈ 100+ |
| This PR (Streamer only) | `web_hosts × puma_workers` ≈ one per Streamer::Instance |

For a typical web fleet of 2 hosts × 2-4 Puma workers: 4–8 direct connections total. Fits in any reasonable `max_connections` budget on the direct port.

## End-to-end verified

Local PG with `wal_level=replica` (default), PgBouncer on :6432 in transaction mode forwarding to PG on :5432.

| Configuration | Publisher (broadcast) | Streamer (LISTEN) | Outcome |
|---|---|---|---|
| No override | pooler 6432 | pooler 6432 | ❌ NOTIFY dropped at COMMIT, no WakeMessage |
| `streams_port = 5432` | pooler 6432 | direct 5432 | ✅ NOTIFY survives, WakeMessage delivered |

## Tests

- `spec/pgbus/configuration_spec.rb` — 8 examples covering each precedence path (port override on Hash base, host override, both, port override on String base, URI form, `database_url` winning over host/port surgicals, immutability of `connection_params`).
- `spec/pgbus/web/streamer/instance_spec.rb` — asserts the Streamer's `PG::Connection` is built from `streams_connection_options`, not `connection_options`.

All 335 streamer + configuration specs pass. Rubocop clean.

## Test plan

- [ ] `bundle exec rspec spec/pgbus/configuration_spec.rb spec/pgbus/web/streamer/`
- [ ] Optional: stand up a local PG + PgBouncer (transaction mode), confirm the override flips behaviour as the matrix above shows.

## Relationship to #159

[#159](https://github.com/mhenrixon/pgbus/pull/159) takes the logical-replication route to the same problem. That's the architecturally cleaner answer but adds real operational surface (replication slot lifecycle, WAL retention risks, REPLICATION privilege reading all tables).

This PR is the lighter alternative — ~40 LOC, no new operational surface, no PG version floor, no privilege escalation. If your environment offers a direct port at all, **this is probably what you want**. If you have no direct port (some managed PG products hide it entirely), #159 is still relevant.

I'd recommend landing this one first as the default fix; keep #159 open as the heavier option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new configuration settings—streams_host, streams_port, and streams_database_url—to let streaming/listen-notify use a dedicated database connection with override and precedence handling.

* **Tests**
  * Added comprehensive tests covering default behavior, hash/string connection formats, host/port overrides, and precedence when a streams_database_url is provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mhenrixon/pgbus/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->