### PR TITLE
feat(pgmq): upgrade pgmq-ruby and integrate PGMQ v1.11 features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gemspec
 
+# Track pgmq-ruby main for unreleased 0.7.0 features (grouped reads, wait_for_notify,
+# FIFO indexes, Time delay, archive partitioning). Pin to git until 0.7.0 ships.
+gem "pgmq-ruby", git: "https://github.com/mensfeld/pgmq-ruby.git", branch: "master"
+
 gem "irb"
 gem "rake", "~> 13.0"
 

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -351,6 +351,87 @@ module Pgbus
       total
     end
 
+    # --- Grouped reads (PGMQ v1.11.0+) ---
+
+    def read_grouped(queue_name, qty:, vt: nil)
+      full_name = config.queue_name(queue_name)
+      Instrumentation.instrument("pgbus.client.read_grouped", queue: full_name, qty: qty) do
+        with_stale_connection_retry do
+          synchronized { @pgmq.read_grouped(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+        end
+      end
+    end
+
+    def read_grouped_rr(queue_name, qty:, vt: nil)
+      full_name = config.queue_name(queue_name)
+      Instrumentation.instrument("pgbus.client.read_grouped_rr", queue: full_name, qty: qty) do
+        with_stale_connection_retry do
+          synchronized { @pgmq.read_grouped_rr(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+        end
+      end
+    end
+
+    def read_grouped_head(queue_name, qty:, vt: nil)
+      full_name = config.queue_name(queue_name)
+      with_stale_connection_retry do
+        synchronized { @pgmq.read_grouped_head(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+      end
+    end
+
+    # --- FIFO index management (PGMQ v1.11.0+) ---
+
+    def create_fifo_index(queue_name)
+      full_name = config.queue_name(queue_name)
+      with_stale_connection_retry do
+        synchronized { @pgmq.create_fifo_index(full_name) }
+      end
+    end
+
+    def create_fifo_indexes_all
+      with_stale_connection_retry do
+        synchronized { @pgmq.create_fifo_indexes_all }
+      end
+    end
+
+    # --- LISTEN/NOTIFY management (PGMQ v1.11.0+) ---
+
+    def wait_for_notify(queue_name, timeout: nil, &block)
+      full_name = config.queue_name(queue_name)
+      with_stale_connection_retry do
+        synchronized { @pgmq.wait_for_notify(full_name, timeout: timeout, &block) }
+      end
+    end
+
+    def update_notify_insert(queue_name, throttle_interval_ms:)
+      full_name = config.queue_name(queue_name)
+      with_stale_connection_retry do
+        synchronized { @pgmq.update_notify_insert(full_name, throttle_interval_ms: throttle_interval_ms) }
+      end
+    end
+
+    def list_notify_insert_throttles
+      with_stale_connection_retry do
+        synchronized { @pgmq.list_notify_insert_throttles }
+      end
+    end
+
+    # --- Archive partitioning (requires pg_partman extension) ---
+
+    def convert_archive_partitioned(queue_name, partition_interval: "10000", retention_interval: "100000",
+                                    leading_partition: 10)
+      full_name = config.queue_name(queue_name)
+      with_stale_connection_retry do
+        synchronized do
+          @pgmq.convert_archive_partitioned(
+            full_name,
+            partition_interval: partition_interval,
+            retention_interval: retention_interval,
+            leading_partition: leading_partition
+          )
+        end
+      end
+    end
+
     # Topic routing
     def bind_topic(pattern, queue_name)
       full_name = config.queue_name(queue_name)
@@ -503,6 +584,7 @@ module Pgbus
           @pgmq.create(full_name)
           tune_autovacuum(full_name)
           enable_notify_if_needed(full_name, NOTIFY_THROTTLE_MS)
+          create_fifo_index_if_needed(full_name)
         end
         true
       end
@@ -513,6 +595,14 @@ module Pgbus
       return if notify_trigger_current?(full_name, throttle_ms)
 
       @pgmq.enable_notify_insert(full_name, throttle_interval_ms: throttle_ms)
+    end
+
+    def create_fifo_index_if_needed(full_name)
+      return unless config.group_mode
+
+      @pgmq.create_fifo_index(full_name)
+    rescue StandardError => e
+      Pgbus.logger.debug { "[Pgbus::Client] FIFO index creation failed for #{full_name}: #{e.message}" }
     end
 
     # Check whether the NOTIFY trigger already exists on this queue with the

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -601,8 +601,6 @@ module Pgbus
       return unless config.group_mode
 
       @pgmq.create_fifo_index(full_name)
-    rescue StandardError => e
-      Pgbus.logger.debug { "[Pgbus::Client] FIFO index creation failed for #{full_name}: #{e.message}" }
     end
 
     # Check whether the NOTIFY trigger already exists on this queue with the

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -44,6 +44,12 @@ module Pgbus
     # Priority queues
     attr_accessor :priority_levels, :default_priority
 
+    # Grouped reads (PGMQ v1.11.0+ FIFO grouping).
+    # nil = disabled (default read_batch behavior).
+    # :fifo = use read_grouped (drains oldest group first, throughput-optimized).
+    # :round_robin = use read_grouped_rr (fair round-robin across groups).
+    attr_reader :group_mode
+
     # Archive compaction. Only the user-facing retention window is configurable;
     # the loop interval and batch size are tuned via constants on
     # Pgbus::Process::Dispatcher.
@@ -146,6 +152,7 @@ module Pgbus
 
       @priority_levels = nil
       @default_priority = 1
+      @group_mode = nil
 
       @archive_retention = 7 * 24 * 3600 # 7 days
 
@@ -298,6 +305,17 @@ module Pgbus
       end
 
       @streams_default_broadcast_mode = mode
+    end
+
+    VALID_GROUP_MODES = [nil, :fifo, :round_robin].freeze
+
+    def group_mode=(mode)
+      mode = mode&.to_sym
+      unless VALID_GROUP_MODES.include?(mode)
+        raise ArgumentError, "Invalid group_mode: #{mode.inspect}. Must be nil, :fifo, or :round_robin"
+      end
+
+      @group_mode = mode
     end
 
     VALID_PGMQ_SCHEMA_MODES = %i[auto extension embedded].freeze

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -310,12 +310,19 @@ module Pgbus
     VALID_GROUP_MODES = [nil, :fifo, :round_robin].freeze
 
     def group_mode=(mode)
-      mode = mode&.to_sym
-      unless VALID_GROUP_MODES.include?(mode)
-        raise ArgumentError, "Invalid group_mode: #{mode.inspect}. Must be nil, :fifo, or :round_robin"
+      coerced = case mode
+                when nil then nil
+                when Symbol then mode
+                when String then mode.to_sym
+                else
+                  raise ArgumentError,
+                        "Invalid group_mode type: #{mode.class}. Must be nil, String, or Symbol"
+                end
+      unless VALID_GROUP_MODES.include?(coerced)
+        raise ArgumentError, "Invalid group_mode: #{coerced.inspect}. Must be nil, :fifo, or :round_robin"
       end
 
-      @group_mode = mode
+      @group_mode = coerced
     end
 
     VALID_PGMQ_SCHEMA_MODES = %i[auto extension embedded].freeze

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -69,6 +69,7 @@ module Pgbus
         single_active = worker_config[:single_active_consumer] || worker_config["single_active_consumer"] || false
         priority = worker_config[:consumer_priority] || worker_config["consumer_priority"] || 0
         exec_mode = config.execution_mode_for(worker_config)
+        grp_mode = worker_config[:group_mode] || worker_config["group_mode"] || config.group_mode
 
         pid = fork do
           restore_signals
@@ -78,7 +79,7 @@ module Pgbus
           worker = Worker.new(
             queues: queues, threads: threads, config: config,
             single_active_consumer: single_active, consumer_priority: priority,
-            execution_mode: exec_mode
+            execution_mode: exec_mode, group_mode: grp_mode
           )
           worker.run
         end

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -18,6 +18,10 @@ module Pgbus
         @config = config
         @execution_mode = ExecutionPools.normalize_mode(execution_mode)
         @group_mode = group_mode&.to_sym
+        unless Pgbus::Configuration::VALID_GROUP_MODES.include?(@group_mode)
+          raise ArgumentError,
+                "Invalid group_mode: #{@group_mode.inspect}. Must be nil, :fifo, or :round_robin"
+        end
         @single_active_consumer = single_active_consumer
         @consumer_priority = consumer_priority
         @lifecycle = Lifecycle.new

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -11,12 +11,13 @@ module Pgbus
 
       def initialize(queues:, threads: 5, config: Pgbus.configuration,
                      single_active_consumer: false, consumer_priority: 0,
-                     execution_mode: :threads)
+                     execution_mode: :threads, group_mode: nil)
         @queues = Array(queues)
         @wildcard = @queues.include?("*")
         @threads = threads
         @config = config
         @execution_mode = ExecutionPools.normalize_mode(execution_mode)
+        @group_mode = group_mode&.to_sym
         @single_active_consumer = single_active_consumer
         @consumer_priority = consumer_priority
         @lifecycle = Lifecycle.new
@@ -141,6 +142,8 @@ module Pgbus
 
         if priority_enabled?
           fetch_prioritized(active_queues, qty)
+        elsif @group_mode
+          fetch_grouped(active_queues, qty)
         elsif active_queues.size == 1
           queue = active_queues.first
           messages = Pgbus.client.read_batch(queue, qty: qty) || []
@@ -208,6 +211,29 @@ module Pgbus
           logical = m.queue_name&.delete_prefix(prefix) || active_queues.first
           [logical, m]
         end
+      end
+
+      # Use grouped reads for fair or throughput-optimized multi-tenant processing.
+      # Each queue is read independently with the configured group strategy.
+      def fetch_grouped(active_queues, qty)
+        remaining = qty
+        results = []
+
+        active_queues.each do |queue|
+          break if remaining <= 0
+
+          messages = case @group_mode
+                     when :round_robin
+                       Pgbus.client.read_grouped_rr(queue, qty: remaining) || []
+                     else # :fifo
+                       Pgbus.client.read_grouped(queue, qty: remaining) || []
+                     end
+
+          messages.each { |m| results << [queue, m] }
+          remaining -= messages.size
+        end
+
+        results
       end
 
       def priority_enabled?

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -17,7 +17,14 @@ module Pgbus
         @threads = threads
         @config = config
         @execution_mode = ExecutionPools.normalize_mode(execution_mode)
-        @group_mode = group_mode&.to_sym
+        @group_mode = case group_mode
+                      when nil then nil
+                      when Symbol then group_mode
+                      when String then group_mode.to_sym
+                      else
+                        raise ArgumentError,
+                              "Invalid group_mode type: #{group_mode.class}. Must be nil, String, or Symbol"
+                      end
         unless Pgbus::Configuration::VALID_GROUP_MODES.include?(@group_mode)
           raise ArgumentError,
                 "Invalid group_mode: #{@group_mode.inspect}. Must be nil, :fifo, or :round_robin"

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -874,6 +874,33 @@ module Pgbus
         []
       end
 
+      # NOTIFY throttle status for all queues with notifications enabled.
+      # Returns an array of hashes: { queue_name:, throttle_interval_ms:, last_notified_at: }
+      def notify_throttles
+        @client.list_notify_insert_throttles.map do |throttle|
+          {
+            queue_name: throttle.queue_name,
+            throttle_interval_ms: throttle.throttle_interval_ms,
+            last_notified_at: throttle.last_notified_at
+          }
+        end
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching notify throttles: #{e.message}" }
+        []
+      end
+
+      # FIFO group head sampling for a specific queue.
+      # Returns the oldest visible message from each distinct group (up to qty).
+      # Useful for detecting head-of-line stalls in multi-tenant queues.
+      def queue_group_heads(queue_name, qty: 20)
+        logical = logical_queue_name(queue_name)
+        messages = @client.read_grouped_head(logical, qty: qty) || []
+        messages.map { |m| format_pgmq_message(m, queue_name) }
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching group heads for #{queue_name}: #{e.message}" }
+        []
+      end
+
       private
 
       def connection
@@ -1110,6 +1137,19 @@ module Pgbus
           vt: row["vt"],
           message: row["message"],
           headers: row["headers"],
+          queue_name: queue_name
+        }
+      end
+
+      def format_pgmq_message(msg, queue_name)
+        {
+          msg_id: msg.msg_id.to_i,
+          read_ct: msg.read_ct.to_i,
+          enqueued_at: msg.enqueued_at,
+          last_read_at: msg.respond_to?(:last_read_at) ? msg.last_read_at : nil,
+          vt: msg.respond_to?(:vt) ? msg.vt : nil,
+          message: msg.message,
+          headers: msg.headers,
           queue_name: queue_name
         }
       end

--- a/lib/tasks/pgbus_queues.rake
+++ b/lib/tasks/pgbus_queues.rake
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+namespace :pgbus do
+  namespace :queues do
+    desc "Create FIFO indexes on all pgbus queues (required for grouped reads)"
+    task fifo_indexes: :environment do
+      puts "Creating FIFO indexes on all pgbus queues..."
+      Pgbus.client.create_fifo_indexes_all
+      puts "Done. FIFO indexes created on all queues."
+    end
+
+    desc "Create FIFO index on a specific queue (QUEUE=name)"
+    task fifo_index: :environment do
+      queue = ENV.fetch("QUEUE") do
+        abort "Usage: rake pgbus:queues:fifo_index QUEUE=<queue_name>"
+      end
+      puts "Creating FIFO index on queue '#{queue}'..."
+      Pgbus.client.create_fifo_index(queue)
+      puts "Done."
+    end
+  end
+
+  namespace :archives do
+    desc "Convert a queue's archive table to pg_partman-managed partitions (QUEUE=name)"
+    task partition: :environment do
+      queue = ENV.fetch("QUEUE") do
+        abort "Usage: rake pgbus:archives:partition QUEUE=<queue_name> [INTERVAL=daily] [RETENTION='30 days']"
+      end
+      interval = ENV.fetch("INTERVAL", "10000")
+      retention = ENV.fetch("RETENTION", "100000")
+      leading = ENV.fetch("LEADING_PARTITION", "10").to_i
+
+      puts "Converting archive table for queue '#{queue}' to partitioned..."
+      puts "  Partition interval: #{interval}"
+      puts "  Retention interval: #{retention}"
+      puts "  Leading partitions: #{leading}"
+
+      Pgbus.client.convert_archive_partitioned(
+        queue,
+        partition_interval: interval,
+        retention_interval: retention,
+        leading_partition: leading
+      )
+      puts "Done. Archive table is now partitioned."
+    end
+  end
+end

--- a/lib/tasks/pgbus_queues.rake
+++ b/lib/tasks/pgbus_queues.rake
@@ -24,11 +24,18 @@ namespace :pgbus do
     desc "Convert a queue's archive table to pg_partman-managed partitions (QUEUE=name)"
     task partition: :environment do
       queue = ENV.fetch("QUEUE") do
-        abort "Usage: rake pgbus:archives:partition QUEUE=<queue_name> [INTERVAL=daily] [RETENTION='30 days']"
+        abort "Usage: rake pgbus:archives:partition QUEUE=<queue_name> " \
+              "[INTERVAL=10000] [RETENTION=100000] [LEADING_PARTITION=10]"
       end
       interval = ENV.fetch("INTERVAL", "10000")
       retention = ENV.fetch("RETENTION", "100000")
-      leading = ENV.fetch("LEADING_PARTITION", "10").to_i
+      leading_raw = ENV.fetch("LEADING_PARTITION", "10")
+      leading = begin
+        Integer(leading_raw, 10)
+      rescue ArgumentError, TypeError
+        abort "LEADING_PARTITION must be a positive integer, got #{leading_raw.inspect}"
+      end
+      abort "LEADING_PARTITION must be a positive integer" if leading <= 0
 
       puts "Converting archive table for queue '#{queue}' to partitioned..."
       puts "  Partition interval: #{interval}"

--- a/pgbus.gemspec
+++ b/pgbus.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.2"
   spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
   spec.add_dependency "globalid", "~> 1.0"
-  spec.add_dependency "pgmq-ruby", "~> 0.5"
+  spec.add_dependency "pgmq-ruby", ">= 0.6", "< 0.8"
   spec.add_dependency "railties", ">= 7.1", "< 9.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/spec/generators/pgbus/update_generator_spec.rb
+++ b/spec/generators/pgbus/update_generator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     end
 
     it "has a description" do
-      expect(described_class.desc).to match(/Upgrade pgbus/)
+      expect(described_class.desc).to include("Upgrade pgbus")
       expect(described_class.desc).to include("YAML")
       expect(described_class.desc).to include("migrations")
     end

--- a/spec/pgbus/client/new_features_spec.rb
+++ b/spec/pgbus/client/new_features_spec.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Client do
+  describe "pgmq-ruby 0.7.0 features" do
+    subject(:client) do
+      allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+      c = described_class.new(config)
+      c.instance_variable_set(:@schema_ensured, true)
+      allow(c).to receive(:tune_autovacuum)
+      allow(c).to receive(:notify_trigger_current?).and_return(false)
+      c
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:require).with("pgmq").and_return(true)
+      stub_const("PGMQ::Client", Class.new do
+        def initialize(*args, **kwargs); end
+      end)
+    end
+
+    let(:config) do
+      Pgbus::Configuration.new.tap do |c|
+        c.database_url = "postgres://localhost/pgbus_test"
+        c.queue_prefix = "pgbus_test"
+      end
+    end
+    let(:mock_pgmq) { build_mock_pgmq }
+
+    describe "#wait_for_notify" do
+      before do
+        allow(mock_pgmq).to receive(:wait_for_notify).and_return("pgmq.q_pgbus_test_default.INSERT")
+      end
+
+      it "delegates to pgmq-ruby wait_for_notify with the full queue name" do
+        client.wait_for_notify("default", timeout: 5)
+
+        expect(mock_pgmq).to have_received(:wait_for_notify).with("pgbus_test_default", timeout: 5)
+      end
+
+      it "returns the channel name from pgmq" do
+        result = client.wait_for_notify("default", timeout: 5)
+        expect(result).to eq("pgmq.q_pgbus_test_default.INSERT")
+      end
+
+      it "passes nil timeout for indefinite wait" do
+        client.wait_for_notify("default")
+        expect(mock_pgmq).to have_received(:wait_for_notify).with("pgbus_test_default", timeout: nil)
+      end
+
+      it "yields block to pgmq when given" do
+        yielded = nil
+        allow(mock_pgmq).to receive(:wait_for_notify).and_yield("ch", 42, "payload")
+
+        client.wait_for_notify("default", timeout: 1) { |ch, pid, pl| yielded = [ch, pid, pl] }
+
+        expect(yielded).to eq(["ch", 42, "payload"])
+      end
+    end
+
+    describe "#read_grouped" do
+      let(:messages) { [build_message_double(msg_id: 1), build_message_double(msg_id: 2)] }
+
+      before do
+        allow(mock_pgmq).to receive(:read_grouped).and_return(messages)
+      end
+
+      it "delegates to pgmq-ruby read_grouped with full queue name" do
+        client.read_grouped("default", qty: 10)
+
+        expect(mock_pgmq).to have_received(:read_grouped).with(
+          "pgbus_test_default", vt: config.visibility_timeout, qty: 10
+        )
+      end
+
+      it "returns messages from pgmq" do
+        result = client.read_grouped("default", qty: 5)
+        expect(result).to eq(messages)
+      end
+
+      it "allows custom visibility timeout" do
+        client.read_grouped("default", qty: 5, vt: 60)
+        expect(mock_pgmq).to have_received(:read_grouped).with("pgbus_test_default", vt: 60, qty: 5)
+      end
+    end
+
+    describe "#read_grouped_rr" do
+      let(:messages) { [build_message_double(msg_id: 1)] }
+
+      before do
+        allow(mock_pgmq).to receive(:read_grouped_rr).and_return(messages)
+      end
+
+      it "delegates to pgmq-ruby read_grouped_rr with full queue name" do
+        client.read_grouped_rr("default", qty: 10)
+
+        expect(mock_pgmq).to have_received(:read_grouped_rr).with(
+          "pgbus_test_default", vt: config.visibility_timeout, qty: 10
+        )
+      end
+    end
+
+    describe "#read_grouped_head" do
+      let(:messages) { [build_message_double(msg_id: 1)] }
+
+      before do
+        allow(mock_pgmq).to receive(:read_grouped_head).and_return(messages)
+      end
+
+      it "delegates to pgmq-ruby read_grouped_head" do
+        client.read_grouped_head("default", qty: 5)
+
+        expect(mock_pgmq).to have_received(:read_grouped_head).with(
+          "pgbus_test_default", vt: config.visibility_timeout, qty: 5
+        )
+      end
+    end
+
+    describe "#create_fifo_index" do
+      before do
+        allow(mock_pgmq).to receive(:create_fifo_index).and_return(nil)
+      end
+
+      it "delegates to pgmq-ruby with the full queue name" do
+        client.create_fifo_index("default")
+        expect(mock_pgmq).to have_received(:create_fifo_index).with("pgbus_test_default")
+      end
+    end
+
+    describe "#create_fifo_indexes_all" do
+      before do
+        allow(mock_pgmq).to receive(:create_fifo_indexes_all).and_return(nil)
+      end
+
+      it "delegates to pgmq-ruby" do
+        client.create_fifo_indexes_all
+        expect(mock_pgmq).to have_received(:create_fifo_indexes_all)
+      end
+    end
+
+    describe "#update_notify_insert" do
+      before do
+        allow(mock_pgmq).to receive(:update_notify_insert).and_return(nil)
+      end
+
+      it "delegates with full queue name and throttle interval" do
+        client.update_notify_insert("default", throttle_interval_ms: 500)
+
+        expect(mock_pgmq).to have_received(:update_notify_insert).with(
+          "pgbus_test_default", throttle_interval_ms: 500
+        )
+      end
+    end
+
+    describe "#list_notify_insert_throttles" do
+      let(:throttle_data) do
+        [double("NotifyThrottle", queue_name: "pgbus_test_default", throttle_interval_ms: 250, last_notified_at: nil)]
+      end
+
+      before do
+        allow(mock_pgmq).to receive(:list_notify_insert_throttles).and_return(throttle_data)
+      end
+
+      it "delegates to pgmq-ruby" do
+        result = client.list_notify_insert_throttles
+        expect(result).to eq(throttle_data)
+      end
+    end
+
+    describe "#convert_archive_partitioned" do
+      before do
+        allow(mock_pgmq).to receive(:convert_archive_partitioned).and_return(nil)
+      end
+
+      it "delegates with full queue name and options" do
+        client.convert_archive_partitioned(
+          "default",
+          partition_interval: "daily",
+          retention_interval: "30 days"
+        )
+
+        expect(mock_pgmq).to have_received(:convert_archive_partitioned).with(
+          "pgbus_test_default",
+          partition_interval: "daily",
+          retention_interval: "30 days",
+          leading_partition: 10
+        )
+      end
+
+      it "uses default options when not specified" do
+        client.convert_archive_partitioned("default")
+
+        expect(mock_pgmq).to have_received(:convert_archive_partitioned).with(
+          "pgbus_test_default",
+          partition_interval: "10000",
+          retention_interval: "100000",
+          leading_partition: 10
+        )
+      end
+    end
+
+    describe "FIFO index auto-creation during queue bootstrap" do
+      before do
+        allow(mock_pgmq).to receive(:create_fifo_index).and_return(nil)
+      end
+
+      context "when group_mode is :fifo" do
+        before { config.group_mode = :fifo }
+
+        it "creates a FIFO index when ensuring a queue" do
+          client.ensure_queue("default")
+          expect(mock_pgmq).to have_received(:create_fifo_index).with("pgbus_test_default")
+        end
+      end
+
+      context "when group_mode is :round_robin" do
+        before { config.group_mode = :round_robin }
+
+        it "creates a FIFO index when ensuring a queue" do
+          client.ensure_queue("default")
+          expect(mock_pgmq).to have_received(:create_fifo_index).with("pgbus_test_default")
+        end
+      end
+
+      context "when group_mode is nil (default)" do
+        it "does not create a FIFO index" do
+          client.ensure_queue("default")
+          expect(mock_pgmq).not_to have_received(:create_fifo_index)
+        end
+      end
+    end
+
+    describe "Time delay in send_message" do
+      let(:scheduled_at) { Time.utc(2026, 6, 14, 12, 0, 0) }
+
+      it "passes Time objects through to pgmq produce" do
+        client.send_message("default", { "type" => "test" }, delay: scheduled_at)
+
+        expect(mock_pgmq).to have_received(:produce).with(
+          "pgbus_test_default",
+          anything,
+          headers: nil,
+          delay: scheduled_at
+        )
+      end
+
+      it "passes integer delay as before" do
+        client.send_message("default", { "type" => "test" }, delay: 60)
+
+        expect(mock_pgmq).to have_received(:produce).with(
+          "pgbus_test_default",
+          anything,
+          headers: nil,
+          delay: 60
+        )
+      end
+    end
+  end
+end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe Pgbus::Configuration do
       expect(config.default_priority).to eq(1)
     end
 
+    it "has no group_mode by default" do
+      expect(config.group_mode).to be_nil
+    end
+
     it "has default archive retention of 7 days" do
       expect(config.archive_retention).to eq(7 * 24 * 3600)
     end
@@ -855,6 +859,30 @@ RSpec.describe Pgbus::Configuration do
     it "accepts valid priority_levels" do
       config.priority_levels = 3
       expect { config.validate! }.not_to raise_error
+    end
+
+    it "accepts :fifo group_mode" do
+      config.group_mode = :fifo
+      expect(config.group_mode).to eq(:fifo)
+    end
+
+    it "accepts :round_robin group_mode" do
+      config.group_mode = :round_robin
+      expect(config.group_mode).to eq(:round_robin)
+    end
+
+    it "accepts nil group_mode (disabled)" do
+      config.group_mode = nil
+      expect(config.group_mode).to be_nil
+    end
+
+    it "rejects invalid group_mode" do
+      expect { config.group_mode = :invalid }.to raise_error(ArgumentError, /group_mode/)
+    end
+
+    it "coerces string group_mode to symbol" do
+      config.group_mode = "fifo"
+      expect(config.group_mode).to eq(:fifo)
     end
 
     it "rejects non-positive insights_default_minutes" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -885,6 +885,11 @@ RSpec.describe Pgbus::Configuration do
       expect(config.group_mode).to eq(:fifo)
     end
 
+    it "raises ArgumentError (not NoMethodError) for non-string/symbol types" do
+      expect { config.group_mode = 1 }.to raise_error(ArgumentError, /type/)
+      expect { config.group_mode = true }.to raise_error(ArgumentError, /type/)
+    end
+
     it "rejects non-positive insights_default_minutes" do
       config.insights_default_minutes = 0
       expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)

--- a/spec/pgbus/generators/config_converter_spec.rb
+++ b/spec/pgbus/generators/config_converter_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Pgbus::Generators::ConfigConverter do
       it "emits env-specific settings with Rails.env guards" do
         # The 'unless development' shape is preferred when there are 2 envs
         # and one is dev — keeps the production line clean.
-        expect(output).to match(/c\.max_jobs_per_worker = 10_000 unless Rails\.env\.development\?/)
-        expect(output).to match(/c\.max_memory_mb = 512 unless Rails\.env\.development\?/)
+        expect(output).to include("c.max_jobs_per_worker = 10_000 unless Rails.env.development?")
+        expect(output).to include("c.max_memory_mb = 512 unless Rails.env.development?")
       end
     end
 
@@ -206,8 +206,8 @@ RSpec.describe Pgbus::Generators::ConfigConverter do
         # but NOT production. A case block with only dev+test clauses
         # is an acceptable shape — what we must prevent is the
         # production env silently inheriting the value.
-        expect(output).to match(/polling_interval/)
-        expect(output).to match(/development/)
+        expect(output).to include("polling_interval")
+        expect(output).to include("development")
         expect(output).to match(/\btest\b/)
         # Only `workers` should mention production (from a production:
         # capsule/worker config); polling_interval must not.

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -195,6 +195,64 @@ RSpec.describe Pgbus::Process::Worker do
         expect(worker.send(:fetch_messages, 5)).to eq([])
       end
     end
+
+    context "with group_mode: :fifo" do
+      let(:worker) { described_class.new(queues: %w[default], threads: 5, group_mode: :fifo) }
+      let(:messages) { [build_message_double(msg_id: 1), build_message_double(msg_id: 2)] }
+
+      before do
+        allow(mock_client).to receive(:read_grouped).and_return(messages)
+      end
+
+      it "uses read_grouped instead of read_batch" do
+        worker.send(:fetch_messages, 5)
+        expect(mock_client).to have_received(:read_grouped).with("default", qty: 5)
+        expect(mock_client).not_to have_received(:read_batch)
+      end
+
+      it "returns [queue_name, message] pairs" do
+        results = worker.send(:fetch_messages, 5)
+        expect(results).to eq([["default", messages[0]], ["default", messages[1]]])
+      end
+    end
+
+    context "with group_mode: :round_robin" do
+      let(:worker) { described_class.new(queues: %w[default], threads: 5, group_mode: :round_robin) }
+      let(:messages) { [build_message_double(msg_id: 1)] }
+
+      before do
+        allow(mock_client).to receive(:read_grouped_rr).and_return(messages)
+      end
+
+      it "uses read_grouped_rr instead of read_batch" do
+        worker.send(:fetch_messages, 5)
+        expect(mock_client).to have_received(:read_grouped_rr).with("default", qty: 5)
+        expect(mock_client).not_to have_received(:read_batch)
+      end
+    end
+
+    context "with group_mode: :fifo and multiple queues" do
+      let(:worker) { described_class.new(queues: %w[critical default], threads: 5, group_mode: :fifo) }
+      let(:critical_msgs) { [build_message_double(msg_id: 1)] }
+      let(:default_msgs) { [build_message_double(msg_id: 2)] }
+
+      before do
+        allow(mock_client).to receive(:read_grouped) do |queue, **_kwargs|
+          case queue
+          when "critical" then critical_msgs
+          when "default" then default_msgs
+          else []
+          end
+        end
+      end
+
+      it "reads from each queue with grouped reads, respecting qty limit" do
+        results = worker.send(:fetch_messages, 5)
+        expect(results.size).to eq(2)
+        expect(mock_client).to have_received(:read_grouped).with("critical", qty: 5)
+        expect(mock_client).to have_received(:read_grouped).with("default", qty: 4)
+      end
+    end
   end
 
   describe "prefetch flow control" do

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe Pgbus::Process::Worker do
       expect(worker.stats[:mode]).to eq(:threads)
       expect(worker.stats[:capacity]).to eq(5)
     end
+
+    it "raises ArgumentError for an invalid group_mode" do
+      expect do
+        described_class.new(queues: %w[default], threads: 5, group_mode: :nope)
+      end.to raise_error(ArgumentError, /group_mode/)
+    end
   end
 
   describe "#graceful_shutdown" do

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -953,4 +953,47 @@ RSpec.describe Pgbus::Web::DataSource do
       expect(result[:totals]).to eq(broadcasts: 0, active_connections: 0, total_connections: 0, streams: 0)
     end
   end
+
+  describe "#notify_throttles" do
+    it "returns formatted notify throttle data from the client" do
+      throttle = double("NotifyThrottle",
+                        queue_name: "pgbus_default",
+                        throttle_interval_ms: 250,
+                        last_notified_at: "2026-06-14 12:00:00")
+      allow(mock_client).to receive(:list_notify_insert_throttles).and_return([throttle])
+
+      result = data_source.notify_throttles
+      expect(result).to eq([{
+                             queue_name: "pgbus_default",
+                             throttle_interval_ms: 250,
+                             last_notified_at: "2026-06-14 12:00:00"
+                           }])
+    end
+
+    it "returns empty array on error" do
+      allow(mock_client).to receive(:list_notify_insert_throttles).and_raise(StandardError, "boom")
+      expect(data_source.notify_throttles).to eq([])
+    end
+  end
+
+  describe "#queue_group_heads" do
+    it "returns formatted group head messages" do
+      msg = double("PGMQ::Message",
+                   msg_id: 42, message: '{"type":"order"}',
+                   read_ct: 0, headers: nil,
+                   enqueued_at: "2026-06-14T12:00:00.000000Z")
+      allow(msg).to receive(:respond_to?).with(:vt).and_return(false)
+      allow(msg).to receive(:respond_to?).with(:last_read_at).and_return(false)
+      allow(mock_client).to receive(:read_grouped_head).and_return([msg])
+
+      result = data_source.queue_group_heads("pgbus_default", qty: 5)
+      expect(result.size).to eq(1)
+      expect(result.first[:msg_id]).to eq(42)
+    end
+
+    it "returns empty array on error" do
+      allow(mock_client).to receive(:read_grouped_head).and_raise(StandardError, "boom")
+      expect(data_source.queue_group_heads("pgbus_default")).to eq([])
+    end
+  end
 end

--- a/spec/support/pgmq_doubles.rb
+++ b/spec/support/pgmq_doubles.rb
@@ -12,6 +12,9 @@ module PgmqDoubles
         read_batch: [],
         read_with_poll: [],
         read_multi: [],
+        read_grouped: [],
+        read_grouped_rr: [],
+        read_grouped_head: [],
         delete: true,
         archive: true,
         set_vt: nil,
@@ -22,6 +25,12 @@ module PgmqDoubles
         drop_queue: true,
         bind_topic: nil,
         produce_topic: nil,
+        create_fifo_index: nil,
+        create_fifo_indexes_all: nil,
+        wait_for_notify: nil,
+        update_notify_insert: nil,
+        list_notify_insert_throttles: [],
+        convert_archive_partitioned: nil,
         close: nil
       )
       # Batch operations echo back the ids to mirror pgmq-ruby behavior
@@ -43,6 +52,9 @@ module PgmqDoubles
         read_message: nil,
         read_batch: [],
         read_multi: [],
+        read_grouped: [],
+        read_grouped_rr: [],
+        read_grouped_head: [],
         delete_message: true,
         archive_message: true,
         set_visibility_timeout: nil,
@@ -53,6 +65,12 @@ module PgmqDoubles
         drop_queue: true,
         bind_topic: nil,
         publish_to_topic: nil,
+        create_fifo_index: nil,
+        create_fifo_indexes_all: nil,
+        wait_for_notify: nil,
+        update_notify_insert: nil,
+        list_notify_insert_throttles: [],
+        convert_archive_partitioned: nil,
         close: nil,
         transaction: nil
       )


### PR DESCRIPTION
## Summary

Upgrades pgmq-ruby from 0.5.0 to the unreleased 0.7.0 (main branch) and integrates all new features from PGMQ v1.11.0/v1.11.1:

- **Grouped reads** — New `group_mode` config option (`:fifo` or `:round_robin`) enables SQS-style grouped message consumption. Workers automatically switch between `read_batch` and `read_grouped`/`read_grouped_rr` based on config. Per-capsule override supported.
- **FIFO index management** — `create_fifo_index`/`create_fifo_indexes_all` exposed through Client. Auto-created during queue bootstrap when `group_mode` is set. Rake task `pgbus:queues:fifo_indexes` for bulk creation.
- **LISTEN/NOTIFY management** — `wait_for_notify` for proper LISTEN/NOTIFY consumption, `update_notify_insert` for runtime throttle tuning, `list_notify_insert_throttles` for health monitoring.
- **Archive partitioning** — `convert_archive_partitioned` for pg_partman-managed archive tables. Rake task `pgbus:archives:partition`.
- **Absolute Time delay** — `send_message(delay: Time.utc(...))` passes Time objects through to pgmq-ruby for scheduled job support.
- **Dashboard** — Notify throttle status view + FIFO group head sampling for detecting head-of-line stalls.

### Configuration

```ruby
Pgbus.configure do |c|
  # Global grouped read mode (applies to all workers)
  c.group_mode = :fifo          # or :round_robin, or nil (default)

  # Per-capsule override
  c.capsule :multi_tenant, queues: %w[orders], threads: 10, group_mode: :round_robin
end
```

### PGMQ Version Requirements

| Feature | PGMQ SQL Version |
|---------|-----------------|
| Grouped reads, FIFO indexes, notify management | v1.11.0+ |
| `read_grouped_head` | v1.11.1+ |
| Archive partitioning | pg_partman extension |

### Dependency Change

- Gemspec: `pgmq-ruby ~> 0.5` → `pgmq-ruby >= 0.6, < 0.8`
- Gemfile: pins to `mensfeld/pgmq-ruby` main branch until 0.7.0 ships

## Test plan

- [x] 1901 existing specs pass (0 failures)
- [x] 20 new client feature specs (wait_for_notify, grouped reads, FIFO indexes, notify management, archive partitioning, Time delay, bootstrap behavior)
- [x] 5 new worker grouped read specs (fifo, round_robin, multi-queue)
- [x] 5 new configuration specs (group_mode validation)
- [x] 4 new dashboard DataSource specs (notify_throttles, queue_group_heads)
- [x] Rubocop clean on all changed files
- [ ] Integration test with real PostgreSQL + PGMQ v1.11 (manual)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grouped message reads (FIFO and round-robin), including notify/wait support and archive partition conversion.
  * Queue bootstrap can now auto-create FIFO indexes when grouping is enabled.
  * Added Rake tasks for FIFO index creation and archive partition maintenance.
  * Enhanced the web dashboard with grouped-head sampling and notification throttle details.
* **Configuration**
  * Added `group_mode` setting (`nil`, `fifo`, `round_robin`).
* **Dependencies**
  * Updated `pgmq-ruby` compatibility to `>= 0.6, < 0.8`.
* **Tests**
  * Added/extended specs for grouped reads, FIFO index creation, and new web endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->