### PR TITLE
feat(dashboard): add Batches tab with progress tracking

### DIFF
--- a/app/controllers/pgbus/batches_controller.rb
+++ b/app/controllers/pgbus/batches_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pgbus
+  class BatchesController < ApplicationController
+    def index
+      @batches = data_source.batches
+      render_frame("pgbus/batches/batches_table") if params[:frame] == "list"
+    end
+
+    def show
+      @batch = data_source.batch_detail(params[:id])
+      redirect_to batches_path, alert: t("pgbus.batches.show.not_found") unless @batch
+    end
+  end
+end

--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -84,6 +84,18 @@ module Pgbus
                class: "inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800")
     end
 
+    BATCH_BADGE_BASE = "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
+    BATCH_BADGE_CSS = {
+      "finished" => "#{BATCH_BADGE_BASE} bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+      "processing" => "#{BATCH_BADGE_BASE} bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+      "pending" => "#{BATCH_BADGE_BASE} bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
+    }.freeze
+
+    def pgbus_batch_status_badge(status)
+      css = BATCH_BADGE_CSS[status] || BATCH_BADGE_CSS["pending"]
+      tag.span(I18n.t("pgbus.helpers.batch_status.#{status}", default: status), class: css)
+    end
+
     def pgbus_parse_message(message)
       return {} unless message
 

--- a/app/views/layouts/pgbus/application.html.erb
+++ b/app/views/layouts/pgbus/application.html.erb
@@ -129,6 +129,7 @@
               <%= pgbus_nav_link t("pgbus.layout.nav.recurring"), pgbus.recurring_tasks_path %>
               <%= pgbus_nav_link t("pgbus.layout.nav.processes"), pgbus.processes_path %>
               <%= pgbus_nav_link t("pgbus.layout.nav.events"), pgbus.events_path %>
+              <%= pgbus_nav_link t("pgbus.layout.nav.batches"), pgbus.batches_path %>
               <%= pgbus_nav_link t("pgbus.layout.nav.dlq"), pgbus.dead_letter_index_path %>
               <%= pgbus_nav_link t("pgbus.layout.nav.outbox"), pgbus.outbox_index_path %>
               <%= pgbus_nav_link t("pgbus.layout.nav.locks"), pgbus.locks_path %>
@@ -188,6 +189,7 @@
           <%= pgbus_mobile_nav_link t("pgbus.layout.nav.recurring"), pgbus.recurring_tasks_path %>
           <%= pgbus_mobile_nav_link t("pgbus.layout.nav.processes"), pgbus.processes_path %>
           <%= pgbus_mobile_nav_link t("pgbus.layout.nav.events"), pgbus.events_path %>
+          <%= pgbus_mobile_nav_link t("pgbus.layout.nav.batches"), pgbus.batches_path %>
           <%= pgbus_mobile_nav_link t("pgbus.layout.nav.dlq"), pgbus.dead_letter_index_path %>
           <%= pgbus_mobile_nav_link t("pgbus.layout.nav.outbox"), pgbus.outbox_index_path %>
           <%= pgbus_mobile_nav_link t("pgbus.layout.nav.locks"), pgbus.locks_path %>

--- a/app/views/pgbus/batches/_batches_table.html.erb
+++ b/app/views/pgbus/batches/_batches_table.html.erb
@@ -1,0 +1,53 @@
+<turbo-frame id="batches-list">
+  <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+    <table class="pgbus-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <thead class="bg-gray-50 dark:bg-gray-900">
+        <tr>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.index.headers.batch_id") %></th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.index.headers.description") %></th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.index.headers.status") %></th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.index.headers.progress") %></th>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.index.headers.jobs") %></th>
+          <th class="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.index.headers.created") %></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+        <% @batches.each do |batch| %>
+          <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+            <td data-label="Batch ID" class="px-4 py-3 text-sm">
+              <%= link_to batch[:batch_id][0..7], pgbus.batch_path(batch[:batch_id]),
+                    class: "font-mono text-indigo-600 dark:text-indigo-400 hover:underline" %>
+            </td>
+            <td data-label="Description" class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 max-w-xs truncate">
+              <%= batch[:description] || "—" %>
+            </td>
+            <td data-label="Status" class="px-4 py-3 text-sm">
+              <%= pgbus_batch_status_badge(batch[:status]) %>
+            </td>
+            <td data-label="Progress" class="px-4 py-3 text-sm">
+              <div class="flex items-center space-x-2">
+                <div class="w-24 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                  <div class="h-2 rounded-full <%= batch[:discarded_jobs].to_i > 0 ? 'bg-amber-500' : 'bg-green-500' %>"
+                       style="width: <%= batch[:progress_pct] %>%"></div>
+                </div>
+                <span class="text-xs text-gray-500 dark:text-gray-400 font-mono"><%= batch[:progress_pct] %>%</span>
+              </div>
+            </td>
+            <td data-label="Jobs" class="px-4 py-3 text-sm text-right font-mono text-gray-500 dark:text-gray-400">
+              <%= batch[:completed_jobs] %>/<%= batch[:total_jobs] %>
+              <% if batch[:discarded_jobs].to_i > 0 %>
+                <span class="text-red-500">(<%= batch[:discarded_jobs] %> dlq)</span>
+              <% end %>
+            </td>
+            <td data-label="Created" class="px-4 py-3 text-sm text-right text-gray-500 dark:text-gray-400">
+              <%= pgbus_time_ago(batch[:created_at]) %>
+            </td>
+          </tr>
+        <% end %>
+        <% if @batches.empty? %>
+          <tr><td colspan="6" class="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500"><%= t("pgbus.batches.index.empty") %></td></tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</turbo-frame>

--- a/app/views/pgbus/batches/index.html.erb
+++ b/app/views/pgbus/batches/index.html.erb
@@ -1,0 +1,8 @@
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white"><%= t("pgbus.batches.index.title") %></h1>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.index.description") %></p>
+  </div>
+</div>
+
+<%= render "pgbus/batches/batches_table" %>

--- a/app/views/pgbus/batches/show.html.erb
+++ b/app/views/pgbus/batches/show.html.erb
@@ -1,0 +1,90 @@
+<div class="mb-6">
+  <div class="flex items-center space-x-2 mb-2">
+    <%= link_to t("pgbus.batches.show.back"), pgbus.batches_path,
+          class: "text-sm text-indigo-600 dark:text-indigo-400 hover:underline" %>
+  </div>
+  <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+    <%= t("pgbus.batches.show.title") %>
+    <span class="font-mono text-lg"><%= @batch[:batch_id][0..7] %></span>
+    <%= pgbus_batch_status_badge(@batch[:status]) %>
+  </h1>
+  <% if @batch[:description] %>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400"><%= @batch[:description] %></p>
+  <% end %>
+</div>
+
+<!-- Progress -->
+<div class="mb-6 overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700 p-6">
+  <h2 class="text-sm font-semibold text-gray-900 dark:text-white mb-4"><%= t("pgbus.batches.show.progress") %></h2>
+
+  <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4 mb-3">
+    <div class="h-4 rounded-full transition-all duration-300 <%= @batch[:discarded_jobs].to_i > 0 ? 'bg-amber-500' : 'bg-green-500' %>"
+         style="width: <%= @batch[:progress_pct] %>%"></div>
+  </div>
+
+  <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+    <div>
+      <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"><%= t("pgbus.batches.show.total_jobs") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white font-mono"><%= @batch[:total_jobs] %></dd>
+    </div>
+    <div>
+      <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"><%= t("pgbus.batches.show.completed") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-green-600 dark:text-green-400 font-mono"><%= @batch[:completed_jobs] %></dd>
+    </div>
+    <div>
+      <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"><%= t("pgbus.batches.show.discarded") %></dt>
+      <dd class="mt-1 text-2xl font-semibold <%= @batch[:discarded_jobs].to_i > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white' %> font-mono"><%= @batch[:discarded_jobs] %></dd>
+    </div>
+    <div>
+      <dt class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"><%= t("pgbus.batches.show.remaining") %></dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white font-mono"><%= @batch[:total_jobs] - @batch[:completed_jobs] - @batch[:discarded_jobs] %></dd>
+    </div>
+  </div>
+</div>
+
+<!-- Details -->
+<div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700">
+  <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+    <h2 class="text-sm font-semibold text-gray-900 dark:text-white"><%= t("pgbus.batches.show.details") %></h2>
+  </div>
+  <dl class="divide-y divide-gray-100 dark:divide-gray-700">
+    <div class="px-4 py-3 sm:grid sm:grid-cols-3 sm:gap-4">
+      <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.show.batch_id") %></dt>
+      <dd class="mt-1 text-sm font-mono text-gray-900 dark:text-white sm:col-span-2 sm:mt-0"><%= @batch[:batch_id] %></dd>
+    </div>
+    <div class="px-4 py-3 sm:grid sm:grid-cols-3 sm:gap-4">
+      <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.show.created_at") %></dt>
+      <dd class="mt-1 text-sm text-gray-900 dark:text-white sm:col-span-2 sm:mt-0"><%= @batch[:created_at] %></dd>
+    </div>
+    <% if @batch[:finished_at] %>
+      <div class="px-4 py-3 sm:grid sm:grid-cols-3 sm:gap-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.show.finished_at") %></dt>
+        <dd class="mt-1 text-sm text-gray-900 dark:text-white sm:col-span-2 sm:mt-0"><%= @batch[:finished_at] %></dd>
+      </div>
+    <% end %>
+    <% if @batch[:on_finish_class] %>
+      <div class="px-4 py-3 sm:grid sm:grid-cols-3 sm:gap-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.show.on_finish") %></dt>
+        <dd class="mt-1 text-sm font-mono text-gray-900 dark:text-white sm:col-span-2 sm:mt-0"><%= @batch[:on_finish_class] %></dd>
+      </div>
+    <% end %>
+    <% if @batch[:on_success_class] %>
+      <div class="px-4 py-3 sm:grid sm:grid-cols-3 sm:gap-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.show.on_success") %></dt>
+        <dd class="mt-1 text-sm font-mono text-gray-900 dark:text-white sm:col-span-2 sm:mt-0"><%= @batch[:on_success_class] %></dd>
+      </div>
+    <% end %>
+    <% if @batch[:on_discard_class] %>
+      <div class="px-4 py-3 sm:grid sm:grid-cols-3 sm:gap-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.show.on_discard") %></dt>
+        <dd class="mt-1 text-sm font-mono text-gray-900 dark:text-white sm:col-span-2 sm:mt-0"><%= @batch[:on_discard_class] %></dd>
+      </div>
+    <% end %>
+    <% if @batch[:properties].present? %>
+      <div class="px-4 py-3 sm:grid sm:grid-cols-3 sm:gap-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("pgbus.batches.show.properties") %></dt>
+        <dd class="mt-1 text-sm font-mono text-gray-900 dark:text-white sm:col-span-2 sm:mt-0 break-all"><%= @batch[:properties] %></dd>
+      </div>
+    <% end %>
+  </dl>
+</div>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,6 +1,35 @@
 ---
 da:
   pgbus:
+    batches:
+      index:
+        description: Jobbatches med fremdriftssporing og callbacks
+        empty: Ingen batches fundet
+        headers:
+          batch_id: Batch-ID
+          created: Oprettet
+          description: Beskrivelse
+          jobs: Jobs
+          progress: Fremgang
+          status: Status
+        title: Batches
+      show:
+        back: Tilbage til batches
+        batch_id: Batch-ID
+        completed: Fuldført
+        created_at: Oprettet den
+        details: Detaljer
+        discarded: Kasseret
+        finished_at: Afsluttet den
+        not_found: Batch ikke fundet
+        on_discard: Ved kassering
+        on_finish: Ved afslutning
+        on_success: Ved succes
+        progress: Fremgang
+        properties: Egenskaber
+        remaining: Resterende
+        title: Batch
+        total_jobs: Samlet antal jobs
     dashboard:
       processes_table:
         empty: Ingen processer kører
@@ -189,6 +218,10 @@ da:
         not_found: Begivenhed ikke fundet
         title: Begivenhed %{event_id}
     helpers:
+      batch_status:
+        finished: Afsluttet
+        pending: Afventer
+        processing: Behandler
       bulk_select_all: Vælg alle
       bulk_select_row: Vælg %{id}
       bulk_selected: valgt
@@ -346,6 +379,7 @@ da:
     layout:
       brand: Pgbus
       nav:
+        batches: Batches
         dashboard: Dashboard
         dlq: DLQ
         events: Begivenheder

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,35 @@
 ---
 de:
   pgbus:
+    batches:
+      index:
+        description: Job-Stapel mit Fortschrittsverfolgung und Callbacks
+        empty: Keine Stapel gefunden
+        headers:
+          batch_id: Stapel-ID
+          created: Erstellt
+          description: Beschreibung
+          jobs: Jobs
+          progress: Fortschritt
+          status: Status
+        title: Stapel
+      show:
+        back: Zurück zu Stapeln
+        batch_id: Stapel-ID
+        completed: Abgeschlossen
+        created_at: Erstellt am
+        details: Details
+        discarded: Verworfen
+        finished_at: Beendet am
+        not_found: Stapel nicht gefunden
+        on_discard: Bei Verwerfung
+        on_finish: Bei Beendigung
+        on_success: Bei Erfolg
+        progress: Fortschritt
+        properties: Eigenschaften
+        remaining: Verbleibend
+        title: Stapel
+        total_jobs: Gesamtanzahl Jobs
     dashboard:
       processes_table:
         empty: Keine Prozesse laufen
@@ -189,6 +218,10 @@ de:
         not_found: Ereignis nicht gefunden
         title: Ereignis %{event_id}
     helpers:
+      batch_status:
+        finished: Abgeschlossen
+        pending: Ausstehend
+        processing: In Bearbeitung
       bulk_select_all: Alle auswählen
       bulk_select_row: "%{id} auswählen"
       bulk_selected: ausgewählt
@@ -346,6 +379,7 @@ de:
     layout:
       brand: Pgbus
       nav:
+        batches: Stapel
         dashboard: Dashboard
         dlq: DLQ
         events: Ereignisse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,35 @@
 ---
 en:
   pgbus:
+    batches:
+      index:
+        description: Job batches with progress tracking and callbacks
+        empty: No batches found
+        headers:
+          batch_id: Batch ID
+          created: Created
+          description: Description
+          jobs: Jobs
+          progress: Progress
+          status: Status
+        title: Batches
+      show:
+        back: Back to batches
+        batch_id: Batch ID
+        completed: Completed
+        created_at: Created At
+        details: Details
+        discarded: Discarded
+        finished_at: Finished At
+        not_found: Batch not found
+        on_discard: On Discard
+        on_finish: On Finish
+        on_success: On Success
+        progress: Progress
+        properties: Properties
+        remaining: Remaining
+        title: Batch
+        total_jobs: Total Jobs
     dashboard:
       processes_table:
         empty: No processes running
@@ -189,6 +218,10 @@ en:
         not_found: Event not found
         title: Event %{event_id}
     helpers:
+      batch_status:
+        finished: Finished
+        pending: Pending
+        processing: Processing
       bulk_select_all: Select all
       bulk_select_row: Select %{id}
       bulk_selected: selected
@@ -346,6 +379,7 @@ en:
     layout:
       brand: Pgbus
       nav:
+        batches: Batches
         dashboard: Dashboard
         dlq: DLQ
         events: Events

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,35 @@
 ---
 es:
   pgbus:
+    batches:
+      index:
+        description: Lotes de trabajos con seguimiento de progreso y callbacks
+        empty: No se encontraron lotes
+        headers:
+          batch_id: ID de lote
+          created: Creado
+          description: Descripción
+          jobs: Trabajos
+          progress: Progreso
+          status: Estado
+        title: Lotes
+      show:
+        back: Volver a lotes
+        batch_id: ID de lote
+        completed: Completados
+        created_at: Creado el
+        details: Detalles
+        discarded: Descartados
+        finished_at: Finalizado el
+        not_found: Lote no encontrado
+        on_discard: Al descartar
+        on_finish: Al finalizar
+        on_success: Al tener éxito
+        progress: Progreso
+        properties: Propiedades
+        remaining: Restantes
+        title: Lote
+        total_jobs: Total de trabajos
     dashboard:
       processes_table:
         empty: No hay procesos en ejecución
@@ -189,6 +218,10 @@ es:
         not_found: Evento no encontrado
         title: Evento %{event_id}
     helpers:
+      batch_status:
+        finished: Finalizado
+        pending: Pendiente
+        processing: Procesando
       bulk_select_all: Seleccionar todo
       bulk_select_row: Seleccionar %{id}
       bulk_selected: seleccionado
@@ -346,6 +379,7 @@ es:
     layout:
       brand: Pgbus
       nav:
+        batches: Lotes
         dashboard: Panel de control
         dlq: DLQ
         events: Eventos

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,6 +1,35 @@
 ---
 fi:
   pgbus:
+    batches:
+      index:
+        description: Tehtäväerät edistymisen seurannalla ja callback-kutsuilla
+        empty: Eriä ei löytynyt
+        headers:
+          batch_id: Erä-ID
+          created: Luotu
+          description: Kuvaus
+          jobs: Tehtävät
+          progress: Edistyminen
+          status: Tila
+        title: Erät
+      show:
+        back: Takaisin eriin
+        batch_id: Erä-ID
+        completed: Valmiit
+        created_at: Luotu
+        details: Tiedot
+        discarded: Hylätyt
+        finished_at: Valmistunut
+        not_found: Erää ei löytynyt
+        on_discard: Hylkäyksessä
+        on_finish: Valmistumisessa
+        on_success: Onnistumisessa
+        progress: Edistyminen
+        properties: Ominaisuudet
+        remaining: Jäljellä
+        title: Erä
+        total_jobs: Tehtäviä yhteensä
     dashboard:
       processes_table:
         empty: Ei käynnissä olevia prosesseja
@@ -189,6 +218,10 @@ fi:
         not_found: Tapahtumaa ei löytynyt
         title: Tapahtuma %{event_id}
     helpers:
+      batch_status:
+        finished: Valmis
+        pending: Odottaa
+        processing: Käsittelyssä
       bulk_select_all: Valitse kaikki
       bulk_select_row: Valitse %{id}
       bulk_selected: valittu
@@ -346,6 +379,7 @@ fi:
     layout:
       brand: Pgbus
       nav:
+        batches: Erät
         dashboard: Hallintapaneeli
         dlq: DLQ
         events: Tapahtumat

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,6 +1,35 @@
 ---
 fr:
   pgbus:
+    batches:
+      index:
+        description: Lots de tâches avec suivi de progression et callbacks
+        empty: Aucun lot trouvé
+        headers:
+          batch_id: ID du lot
+          created: Créé
+          description: Description
+          jobs: Tâches
+          progress: Progression
+          status: Statut
+        title: Lots
+      show:
+        back: Retour aux lots
+        batch_id: ID du lot
+        completed: Terminées
+        created_at: Créé le
+        details: Détails
+        discarded: Rejetées
+        finished_at: Terminé le
+        not_found: Lot non trouvé
+        on_discard: Au rejet
+        on_finish: À la fin
+        on_success: Au succès
+        progress: Progression
+        properties: Propriétés
+        remaining: Restantes
+        title: Lot
+        total_jobs: Total des tâches
     dashboard:
       processes_table:
         empty: Aucun processus en cours d'exécution
@@ -189,6 +218,10 @@ fr:
         not_found: Événement non trouvé
         title: Événement %{event_id}
     helpers:
+      batch_status:
+        finished: Terminé
+        pending: En attente
+        processing: En cours
       bulk_select_all: Tout sélectionner
       bulk_select_row: Sélectionner %{id}
       bulk_selected: sélectionné
@@ -346,6 +379,7 @@ fr:
     layout:
       brand: Pgbus
       nav:
+        batches: Lots
         dashboard: Tableau de bord
         dlq: DLQ
         events: Événements

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,6 +1,35 @@
 ---
 it:
   pgbus:
+    batches:
+      index:
+        description: Lotti di lavori con monitoraggio del progresso e callback
+        empty: Nessun lotto trovato
+        headers:
+          batch_id: ID lotto
+          created: Creato
+          description: Descrizione
+          jobs: Lavori
+          progress: Progresso
+          status: Stato
+        title: Lotti
+      show:
+        back: Torna ai lotti
+        batch_id: ID lotto
+        completed: Completati
+        created_at: Creato il
+        details: Dettagli
+        discarded: Scartati
+        finished_at: Terminato il
+        not_found: Lotto non trovato
+        on_discard: Allo scarto
+        on_finish: Al termine
+        on_success: Al successo
+        progress: Progresso
+        properties: Proprietà
+        remaining: Rimanenti
+        title: Lotto
+        total_jobs: Lavori totali
     dashboard:
       processes_table:
         empty: Nessun processo in esecuzione
@@ -189,6 +218,10 @@ it:
         not_found: Evento non trovato
         title: Evento %{event_id}
     helpers:
+      batch_status:
+        finished: Terminato
+        pending: In sospeso
+        processing: In elaborazione
       bulk_select_all: Seleziona tutto
       bulk_select_row: Seleziona %{id}
       bulk_selected: selezionato
@@ -346,6 +379,7 @@ it:
     layout:
       brand: Pgbus
       nav:
+        batches: Lotti
         dashboard: Cruscotto
         dlq: DLQ
         events: Eventi

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,35 @@
 ---
 ja:
   pgbus:
+    batches:
+      index:
+        description: 進捗追跡とコールバック付きのジョブバッチ
+        empty: バッチが見つかりません
+        headers:
+          batch_id: バッチID
+          created: 作成日
+          description: 説明
+          jobs: ジョブ
+          progress: 進捗
+          status: ステータス
+        title: バッチ
+      show:
+        back: バッチに戻る
+        batch_id: バッチID
+        completed: 完了
+        created_at: 作成日時
+        details: 詳細
+        discarded: 破棄済み
+        finished_at: 完了日時
+        not_found: バッチが見つかりません
+        on_discard: 破棄時
+        on_finish: 完了時
+        on_success: 成功時
+        progress: 進捗
+        properties: プロパティ
+        remaining: 残り
+        title: バッチ
+        total_jobs: 合計ジョブ数
     dashboard:
       processes_table:
         empty: 実行中のプロセスはありません
@@ -189,6 +218,10 @@ ja:
         not_found: イベントが見つかりません
         title: イベント %{event_id}
     helpers:
+      batch_status:
+        finished: 完了
+        pending: 保留中
+        processing: 処理中
       bulk_select_all: すべて選択
       bulk_select_row: "%{id}を選択"
       bulk_selected: 選択済み
@@ -346,6 +379,7 @@ ja:
     layout:
       brand: Pgbus
       nav:
+        batches: バッチ
         dashboard: ダッシュボード
         dlq: DLQ
         events: イベント

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -1,6 +1,35 @@
 ---
 nb:
   pgbus:
+    batches:
+      index:
+        description: Jobbgrupper med fremdriftssporing og tilbakekall
+        empty: Ingen grupper funnet
+        headers:
+          batch_id: Gruppe-ID
+          created: Opprettet
+          description: Beskrivelse
+          jobs: Jobber
+          progress: Fremdrift
+          status: Status
+        title: Grupper
+      show:
+        back: Tilbake til grupper
+        batch_id: Gruppe-ID
+        completed: Fullført
+        created_at: Opprettet den
+        details: Detaljer
+        discarded: Forkastet
+        finished_at: Avsluttet den
+        not_found: Gruppe ikke funnet
+        on_discard: Ved forkastning
+        on_finish: Ved avslutning
+        on_success: Ved suksess
+        progress: Fremdrift
+        properties: Egenskaper
+        remaining: Gjenstående
+        title: Gruppe
+        total_jobs: Totalt antall jobber
     dashboard:
       processes_table:
         empty: Ingen prosesser kjører
@@ -189,6 +218,10 @@ nb:
         not_found: Hendelse ikke funnet
         title: Hendelse %{event_id}
     helpers:
+      batch_status:
+        finished: Fullført
+        pending: Avventer
+        processing: Behandler
       bulk_select_all: Velg alle
       bulk_select_row: Velg %{id}
       bulk_selected: valgt
@@ -346,6 +379,7 @@ nb:
     layout:
       brand: Pgbus
       nav:
+        batches: Grupper
         dashboard: Dashbord
         dlq: DLQ
         events: Hendelser

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,6 +1,35 @@
 ---
 nl:
   pgbus:
+    batches:
+      index:
+        description: Taakgroepen met voortgangsregistratie en callbacks
+        empty: Geen groepen gevonden
+        headers:
+          batch_id: Groep-ID
+          created: Aangemaakt
+          description: Beschrijving
+          jobs: Taken
+          progress: Voortgang
+          status: Status
+        title: Groepen
+      show:
+        back: Terug naar groepen
+        batch_id: Groep-ID
+        completed: Voltooid
+        created_at: Aangemaakt op
+        details: Details
+        discarded: Verworpen
+        finished_at: Voltooid op
+        not_found: Groep niet gevonden
+        on_discard: Bij verwerping
+        on_finish: Bij voltooiing
+        on_success: Bij succes
+        progress: Voortgang
+        properties: Eigenschappen
+        remaining: Resterend
+        title: Groep
+        total_jobs: Totaal taken
     dashboard:
       processes_table:
         empty: Geen processen actief
@@ -189,6 +218,10 @@ nl:
         not_found: Gebeurtenis niet gevonden
         title: Gebeurtenis %{event_id}
     helpers:
+      batch_status:
+        finished: Voltooid
+        pending: In afwachting
+        processing: Bezig
       bulk_select_all: Alles selecteren
       bulk_select_row: Selecteer %{id}
       bulk_selected: geselecteerd
@@ -346,6 +379,7 @@ nl:
     layout:
       brand: Pgbus
       nav:
+        batches: Groepen
         dashboard: Dashboard
         dlq: DLQ
         events: Evenementen

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,6 +1,35 @@
 ---
 pt:
   pgbus:
+    batches:
+      index:
+        description: Lotes de trabalhos com acompanhamento de progresso e callbacks
+        empty: Nenhum lote encontrado
+        headers:
+          batch_id: ID do lote
+          created: Criado
+          description: Descrição
+          jobs: Trabalhos
+          progress: Progresso
+          status: Status
+        title: Lotes
+      show:
+        back: Voltar para lotes
+        batch_id: ID do lote
+        completed: Concluídos
+        created_at: Criado em
+        details: Detalhes
+        discarded: Descartados
+        finished_at: Finalizado em
+        not_found: Lote não encontrado
+        on_discard: Ao descartar
+        on_finish: Ao finalizar
+        on_success: Ao ter sucesso
+        progress: Progresso
+        properties: Propriedades
+        remaining: Restantes
+        title: Lote
+        total_jobs: Total de trabalhos
     dashboard:
       processes_table:
         empty: Nenhum processo em execução
@@ -189,6 +218,10 @@ pt:
         not_found: Evento não encontrado
         title: Evento %{event_id}
     helpers:
+      batch_status:
+        finished: Finalizado
+        pending: Pendente
+        processing: Processando
       bulk_select_all: Selecionar todos
       bulk_select_row: Selecionar %{id}
       bulk_selected: selecionado
@@ -346,6 +379,7 @@ pt:
     layout:
       brand: Pgbus
       nav:
+        batches: Lotes
         dashboard: Painel
         dlq: DLQ
         events: Eventos

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,6 +1,35 @@
 ---
 sv:
   pgbus:
+    batches:
+      index:
+        description: Jobbgrupper med framstegsspårning och callbacks
+        empty: Inga grupper hittades
+        headers:
+          batch_id: Grupp-ID
+          created: Skapad
+          description: Beskrivning
+          jobs: Jobb
+          progress: Framsteg
+          status: Status
+        title: Grupper
+      show:
+        back: Tillbaka till grupper
+        batch_id: Grupp-ID
+        completed: Slutförda
+        created_at: Skapad den
+        details: Detaljer
+        discarded: Kasserade
+        finished_at: Avslutad den
+        not_found: Grupp hittades inte
+        on_discard: Vid kassering
+        on_finish: Vid avslut
+        on_success: Vid framgång
+        progress: Framsteg
+        properties: Egenskaper
+        remaining: Återstående
+        title: Grupp
+        total_jobs: Totalt antal jobb
     dashboard:
       processes_table:
         empty: Inga processer körs
@@ -189,6 +218,10 @@ sv:
         not_found: Händelse hittades inte
         title: Händelse %{event_id}
     helpers:
+      batch_status:
+        finished: Slutförd
+        pending: Väntande
+        processing: Bearbetas
       bulk_select_all: Markera alla
       bulk_select_row: Markera %{id}
       bulk_selected: valda
@@ -346,6 +379,7 @@ sv:
     layout:
       brand: Pgbus
       nav:
+        batches: Grupper
         dashboard: Instrumentpanel
         dlq: DLQ
         events: Händelser

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Pgbus::Engine.routes.draw do
     end
   end
 
+  resources :batches, only: %i[index show]
   resources :processes, only: [:index]
 
   resources :events, only: %i[index show] do

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -590,6 +590,43 @@ module Pgbus
         []
       end
 
+      # Batches
+      def batches(limit: 100)
+        BatchEntry.order(created_at: :desc).limit(limit).map { |r| format_batch(r) }
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching batches: #{e.message}" }
+        []
+      end
+
+      def batch_detail(batch_id)
+        record = BatchEntry.find_by(batch_id: batch_id)
+        return nil unless record
+
+        format_batch(record).merge(
+          properties: record.properties,
+          on_finish_class: record.on_finish_class,
+          on_success_class: record.on_success_class,
+          on_discard_class: record.on_discard_class
+        )
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching batch #{batch_id}: #{e.message}" }
+        nil
+      end
+
+      def batches_count
+        BatchEntry.count
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error counting batches: #{e.message}" }
+        0
+      end
+
+      def active_batches_count
+        BatchEntry.where.not(status: "finished").count
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error counting active batches: #{e.message}" }
+        0
+      end
+
       # Job stats
       def job_stats_summary(minutes: 60)
         JobStat.summary(minutes: minutes)
@@ -1168,6 +1205,25 @@ module Pgbus
           last_heartbeat_at: heartbeat_time,
           healthy: !stale,
           created_at: row["created_at"]
+        }
+      end
+
+      def format_batch(record)
+        total = record.total_jobs
+        done = record.completed_jobs + record.discarded_jobs
+        pct = total.positive? ? ((done * 100) / total) : 100
+
+        {
+          batch_id: record.batch_id,
+          description: record.description,
+          status: record.status,
+          total_jobs: total,
+          completed_jobs: record.completed_jobs,
+          discarded_jobs: record.discarded_jobs,
+          failed_jobs: record.failed_jobs,
+          progress_pct: pct,
+          created_at: record.created_at,
+          finished_at: record.finished_at
         }
       end
 

--- a/spec/dummy/lib/stub_data_source.rb
+++ b/spec/dummy/lib/stub_data_source.rb
@@ -140,6 +140,35 @@ module DummyApp
     def processed_event(_id) = nil
     def registered_subscribers = []
 
+    def batches(limit: 100) # rubocop:disable Lint/UnusedMethodArgument
+      [
+        { batch_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", description: "Import users from CSV",
+          status: "processing", total_jobs: 250, completed_jobs: 180, discarded_jobs: 3, failed_jobs: 0,
+          progress_pct: 73, created_at: 45.minutes.ago, finished_at: nil },
+        { batch_id: "b2c3d4e5-f6a7-8901-bcde-f12345678901", description: "Send welcome emails",
+          status: "finished", total_jobs: 50, completed_jobs: 50, discarded_jobs: 0, failed_jobs: 0,
+          progress_pct: 100, created_at: 2.hours.ago, finished_at: 1.hour.ago },
+        { batch_id: "c3d4e5f6-a7b8-9012-cdef-123456789012", description: nil,
+          status: "pending", total_jobs: 0, completed_jobs: 0, discarded_jobs: 0, failed_jobs: 0,
+          progress_pct: 100, created_at: 5.minutes.ago, finished_at: 5.minutes.ago }
+      ]
+    end
+
+    def batch_detail(batch_id)
+      batch = batches.find { |b| b[:batch_id] == batch_id }
+      return nil unless batch
+
+      batch.merge(
+        properties: '{"source":"admin","user_id":42}',
+        on_finish_class: "BatchFinishJob",
+        on_success_class: "BatchSuccessNotifyJob",
+        on_discard_class: nil
+      )
+    end
+
+    def batches_count = 3
+    def active_batches_count = 1
+
     def job_locks
       [
         { lock_key: "uniqueness:ProcessPaymentJob:abc123", queue_name: "pgbus_default",

--- a/spec/pgbus/web/batches_data_source_spec.rb
+++ b/spec/pgbus/web/batches_data_source_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require_relative "../../../lib/pgbus/web/data_source"
+
+RSpec.describe Pgbus::Web::DataSource do
+  subject(:data_source) { described_class.new(client: mock_client) }
+
+  let(:mock_client) { double("Pgbus::Client", pgmq: double("pgmq")) }
+
+  describe "#batches" do
+    let(:now) { Time.current }
+    let(:batch_attrs) do
+      { on_finish_class: nil, on_success_class: nil, on_discard_class: nil }
+    end
+    let(:records) do
+      [
+        double("BatchEntry", batch_attrs.merge(batch_id: "aaa", description: "Import users",
+                                               status: "processing", total_jobs: 100, completed_jobs: 50,
+                                               discarded_jobs: 2, failed_jobs: 0,
+                                               created_at: now - 3600, finished_at: nil)),
+        double("BatchEntry", batch_attrs.merge(batch_id: "bbb", description: "Send emails",
+                                               status: "finished", total_jobs: 10, completed_jobs: 10,
+                                               discarded_jobs: 0, failed_jobs: 0,
+                                               created_at: now - 7200, finished_at: now - 3600))
+      ]
+    end
+
+    before do
+      scope = double("scope")
+      allow(Pgbus::BatchEntry).to receive(:order).with(created_at: :desc).and_return(scope)
+      allow(scope).to receive(:limit).with(100).and_return(records)
+    end
+
+    it "returns all batches ordered by most recent first" do
+      result = data_source.batches
+
+      expect(result.size).to eq(2)
+      expect(result.first[:batch_id]).to eq("aaa")
+      expect(result.first[:status]).to eq("processing")
+      expect(result.first[:progress_pct]).to eq(52)
+      expect(result.second[:batch_id]).to eq("bbb")
+      expect(result.second[:progress_pct]).to eq(100)
+    end
+
+    it "returns empty array on error" do
+      allow(Pgbus::BatchEntry).to receive(:order).and_raise(StandardError, "boom")
+
+      expect(data_source.batches).to eq([])
+    end
+
+    it "handles zero total_jobs without division error" do
+      record = double("BatchEntry", batch_id: "ccc", description: nil, status: "finished",
+                                    total_jobs: 0, completed_jobs: 0, discarded_jobs: 0, failed_jobs: 0,
+                                    on_finish_class: nil, on_success_class: nil, on_discard_class: nil,
+                                    created_at: Time.current, finished_at: Time.current)
+      scope = double("scope")
+      allow(Pgbus::BatchEntry).to receive(:order).with(created_at: :desc).and_return(scope)
+      allow(scope).to receive(:limit).with(100).and_return([record])
+
+      result = data_source.batches
+      expect(result.first[:progress_pct]).to eq(100)
+    end
+  end
+
+  describe "#batch_detail" do
+    it "returns a single batch by batch_id" do
+      record = double("BatchEntry", batch_id: "aaa", description: "Import users", status: "processing",
+                                    total_jobs: 100, completed_jobs: 50, discarded_jobs: 2, failed_jobs: 0,
+                                    on_finish_class: "FinishJob", on_success_class: "SuccessJob",
+                                    on_discard_class: "DiscardJob", properties: '{"user_id":1}',
+                                    created_at: Time.current - 3600, finished_at: nil)
+      allow(Pgbus::BatchEntry).to receive(:find_by).with(batch_id: "aaa").and_return(record)
+
+      result = data_source.batch_detail("aaa")
+
+      expect(result[:batch_id]).to eq("aaa")
+      expect(result[:description]).to eq("Import users")
+      expect(result[:on_finish_class]).to eq("FinishJob")
+      expect(result[:properties]).to eq('{"user_id":1}')
+      expect(result[:progress_pct]).to eq(52)
+    end
+
+    it "returns nil when batch not found" do
+      allow(Pgbus::BatchEntry).to receive(:find_by).with(batch_id: "missing").and_return(nil)
+
+      expect(data_source.batch_detail("missing")).to be_nil
+    end
+
+    it "returns nil on error" do
+      allow(Pgbus::BatchEntry).to receive(:find_by).and_raise(StandardError, "boom")
+
+      expect(data_source.batch_detail("err")).to be_nil
+    end
+  end
+
+  describe "#batches_count" do
+    it "returns the total count of batches" do
+      allow(Pgbus::BatchEntry).to receive(:count).and_return(42)
+
+      expect(data_source.batches_count).to eq(42)
+    end
+
+    it "returns zero on error" do
+      allow(Pgbus::BatchEntry).to receive(:count).and_raise(StandardError, "boom")
+
+      expect(data_source.batches_count).to eq(0)
+    end
+  end
+
+  describe "#active_batches_count" do
+    it "returns count of non-finished batches" do
+      not_scope = double("not_scope", count: 5)
+      where_scope = double("where_scope", not: not_scope)
+      allow(Pgbus::BatchEntry).to receive(:where).and_return(where_scope)
+
+      expect(data_source.active_batches_count).to eq(5)
+    end
+
+    it "returns zero on error" do
+      allow(Pgbus::BatchEntry).to receive(:where).and_raise(StandardError, "boom")
+
+      expect(data_source.active_batches_count).to eq(0)
+    end
+  end
+end

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -51,6 +51,10 @@ module Pgbus
       def processed_event(id) = @events_list.find { |e| e["id"].to_s == id.to_s }
       def registered_subscribers = @subscribers_list
       def jobs(queue_name: nil, page: 1, per_page: 25) = @jobs_list
+      def batches(limit: 100) = []
+      def batch_detail(batch_id) = nil
+      def batches_count = 0
+      def active_batches_count = 0
       def job_locks = @locks_list
       def queue_paused?(name) = @paused_queues.include?(name)
       def recurring_tasks = @recurring_tasks_list


### PR DESCRIPTION
## Summary

- Add dedicated **Batches** tab to the dashboard with index (list) and show (detail) views
- Index shows all batches with status badges, progress bars, job counts (completed/total + discarded), and creation timestamps
- Detail view shows full progress breakdown (total, completed, discarded, remaining), callback class configuration (`on_finish`, `on_success`, `on_discard`), properties JSON, and timestamps
- Add `batches`, `batch_detail`, `batches_count`, `active_batches_count` methods to `Web::DataSource`
- Add `pgbus_batch_status_badge` helper with pending/processing/finished states
- Add i18n translations for all 12 supported locales (da, de, en, es, fi, fr, it, ja, nb, nl, pt, sv)
- Add stub data to both dummy app and system test data source stubs

## Test plan

- [x] 10 new specs for data source batch methods pass
- [x] Existing 13 batch_spec.rb tests pass (no regressions)
- [x] i18n normalization test passes
- [x] RuboCop clean on all changed files
- [ ] Manual: visit `/pgbus/batches` — see batch list with progress bars
- [ ] Manual: click a batch ID — see detail view with progress breakdown
- [ ] Manual: verify nav link appears between Events and DLQ
