### PR TITLE
feat(pgmq): pin released pgmq-ruby v0.7.0 + delegate autovacuum tuning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
-# Track pgmq-ruby main for unreleased 0.7.0 features (grouped reads, wait_for_notify,
-# FIFO indexes, Time delay, archive partitioning). Pin to git until 0.7.0 ships.
-gem "pgmq-ruby", git: "https://github.com/mensfeld/pgmq-ruby.git", branch: "master"
-
 gem "irb"
 gem "rake", "~> 13.0"
 

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -632,11 +632,21 @@ module Pgbus
       false
     end
 
+    # Apply PGMQ-tuned autovacuum + storage parameters to a queue's tables.
+    #
+    # Delegates to pgmq-ruby's tune_autovacuum (v0.7+), which sets the same
+    # queue/archive parameters pgbus used to apply by hand — vacuum scale
+    # factor 0.01/0.05, cost_delay 2/5, analyze scale factor 0.05, and
+    # fillfactor 70 on the queue table — plus a vacuum_threshold floor of 50.
+    # It quotes/lowercases the table name and runs both ALTER TABLEs in one
+    # pooled checkout. Tuning is best-effort: a failure here never blocks a
+    # queue from being usable, so we log and move on.
+    #
+    # Pgbus::AutovacuumTuning is still the source for the migration generators
+    # (sql_for_all_queues, sql_for_high_churn_tables) which tune pgbus-owned
+    # metadata tables the gem doesn't know about.
     def tune_autovacuum(queue_name)
-      with_raw_connection do |conn|
-        conn.exec(AutovacuumTuning.sql_for_queue(queue_name))
-        conn.exec(TableMaintenance.fillfactor_sql_for_queue(queue_name))
-      end
+      @pgmq.tune_autovacuum(queue_name)
     rescue StandardError => e
       Pgbus.logger.debug { "[Pgbus::Client] Autovacuum tuning failed for #{queue_name}: #{e.message}" }
     end

--- a/lib/pgbus/serializer.rb
+++ b/lib/pgbus/serializer.rb
@@ -58,7 +58,7 @@ module Pgbus
       raise ArgumentError, "Invalid GlobalID: #{gid_string.inspect}" unless gid
 
       allowed = Pgbus.configuration.allowed_global_id_models
-      if allowed&.empty?
+      if allowed && allowed.empty?
         raise ArgumentError,
               "GlobalID deserialization is disabled (allowed_global_id_models is empty). " \
               "Set to nil to allow all models, or add permitted classes."

--- a/pgbus.gemspec
+++ b/pgbus.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.2"
   spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
   spec.add_dependency "globalid", "~> 1.0"
-  spec.add_dependency "pgmq-ruby", ">= 0.6", "< 0.8"
+  spec.add_dependency "pgmq-ruby", "~> 0.7"
   spec.add_dependency "railties", ">= 7.1", "< 9.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/pgbus.gemspec
+++ b/pgbus.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.2"
   spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
   spec.add_dependency "globalid", "~> 1.0"
-  spec.add_dependency "pgmq-ruby", "~> 0.7"
+  spec.add_dependency "pgmq-ruby", "~> 0.7.0"
   spec.add_dependency "railties", ">= 7.1", "< 9.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/spec/pgbus/client/new_features_spec.rb
+++ b/spec/pgbus/client/new_features_spec.rb
@@ -257,4 +257,38 @@ RSpec.describe Pgbus::Client do
       end
     end
   end
+
+  describe "#tune_autovacuum (delegates to pgmq-ruby v0.7+)" do
+    subject(:client) do
+      allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+      c = described_class.new(config)
+      c.instance_variable_set(:@schema_ensured, true)
+      c
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:require).with("pgmq").and_return(true)
+      stub_const("PGMQ::Client", Class.new do
+        def initialize(*args, **kwargs); end
+      end)
+    end
+
+    let(:config) do
+      Pgbus::Configuration.new.tap do |c|
+        c.database_url = "postgres://localhost/pgbus_test"
+        c.queue_prefix = "pgbus_test"
+      end
+    end
+    let(:mock_pgmq) { build_mock_pgmq }
+
+    it "delegates to pgmq-ruby tune_autovacuum with the physical queue name" do
+      client.send(:tune_autovacuum, "pgbus_test_jobs")
+      expect(mock_pgmq).to have_received(:tune_autovacuum).with("pgbus_test_jobs")
+    end
+
+    it "swallows tuning failures (best-effort, never blocks queue use)" do
+      allow(mock_pgmq).to receive(:tune_autovacuum).and_raise(StandardError, "boom")
+      expect { client.send(:tune_autovacuum, "pgbus_test_jobs") }.not_to raise_error
+    end
+  end
 end

--- a/spec/pgbus/client/new_features_spec.rb
+++ b/spec/pgbus/client/new_features_spec.rb
@@ -282,13 +282,15 @@ RSpec.describe Pgbus::Client do
     let(:mock_pgmq) { build_mock_pgmq }
 
     it "delegates to pgmq-ruby tune_autovacuum with the physical queue name" do
-      client.send(:tune_autovacuum, "pgbus_test_jobs")
-      expect(mock_pgmq).to have_received(:tune_autovacuum).with("pgbus_test_jobs")
+      physical_queue = config.queue_name("jobs")
+      client.send(:tune_autovacuum, physical_queue)
+      expect(mock_pgmq).to have_received(:tune_autovacuum).with(physical_queue)
     end
 
     it "swallows tuning failures (best-effort, never blocks queue use)" do
       allow(mock_pgmq).to receive(:tune_autovacuum).and_raise(StandardError, "boom")
-      expect { client.send(:tune_autovacuum, "pgbus_test_jobs") }.not_to raise_error
+      physical_queue = config.queue_name("jobs")
+      expect { client.send(:tune_autovacuum, physical_queue) }.not_to raise_error
     end
   end
 end

--- a/spec/support/pgmq_doubles.rb
+++ b/spec/support/pgmq_doubles.rb
@@ -31,6 +31,7 @@ module PgmqDoubles
         update_notify_insert: nil,
         list_notify_insert_throttles: [],
         convert_archive_partitioned: nil,
+        tune_autovacuum: nil,
         close: nil
       )
       # Batch operations echo back the ids to mirror pgmq-ruby behavior


### PR DESCRIPTION
## Summary

Follow-up to #161, which integrated pgmq-ruby 0.7's features while 0.7.0 was still unreleased (via a git-pin-to-master in the `Gemfile`). v0.7.0 has now shipped to RubyGems, so this PR drops the git pin and switches to the released gem, then takes advantage of one API that landed in the release.

- **Gemfile**: remove the `git: ".../pgmq-ruby.git", branch: "master"` source.
- **gemspec**: `pgmq-ruby ">= 0.6", "< 0.8"` → `"~> 0.7"`. The features #161 integrated — grouped reads, FIFO indexes, `wait_for_notify`, `PGMQ::QueueName`, `tune_autovacuum` — all require 0.7.
- **`Client#tune_autovacuum`** now delegates to pgmq-ruby's released `tune_autovacuum` instead of hand-assembling `AutovacuumTuning.sql_for_queue` + `TableMaintenance.fillfactor_sql_for_queue` on a separate raw connection.

## Why the autovacuum delegation is safe

The released `tune_autovacuum` is a superset of what pgbus applied by hand:

| Param | pgbus (queue / archive) | pgmq-ruby 0.7 (queue / archive) |
|---|---|---|
| `autovacuum_vacuum_scale_factor` | 0.01 / 0.05 | 0.01 / 0.05 |
| `autovacuum_vacuum_cost_delay` | 2 / 5 | 2 / 5 |
| `autovacuum_analyze_scale_factor` | 0.05 / 0.05 | 0.05 / 0.05 |
| `autovacuum_vacuum_threshold` | — | 50 / 50 |
| `fillfactor` (queue only) | 70 (separate `ALTER TABLE`) | 70 (bundled) |

Same values, plus a `vacuum_threshold` floor, and it folds the fillfactor `ALTER TABLE` into a single pooled checkout (pgbus used a separate raw connection). The best-effort `rescue` is kept: pgmq-ruby raises on failure, but autovacuum tuning must never block a queue from being usable.

`Pgbus::AutovacuumTuning` and `TableMaintenance` are **retained** — the migration generators (`sql_for_all_queues`, `sql_for_high_churn_tables`) still tune pgbus-owned metadata tables (`pgbus_semaphores`, `pgbus_uniqueness_keys`, `pgbus_processed_events`) that the gem has no knowledge of.

## What was evaluated and intentionally NOT changed

- **`QueueNameValidator` → `PGMQ::QueueName`**: the released `normalize`/`sanitize!` logic now matches pgbus's, but delegating would (1) break the `ArgumentError` contract (`PGMQ` raises `InvalidQueueNameError < StandardError`, and pgbus's `StreamNameTooLong < ArgumentError` plus the validator specs depend on `ArgumentError`), (2) change `validate!` error messages the specs assert, and (3) introduce a load-order dependency on the lazily-required `pgmq` gem (the validator is zero-dependency and runs in `config.queue_name` before any `Client` exists). Kept as-is.

## Test plan

- [x] `bundle install` resolves pgmq-ruby **0.7.0** from RubyGems (no git checkout)
- [x] Full unit suite: **1915 examples, 0 failures**
- [x] Rubocop clean on changed files
- [x] New specs: `Client#tune_autovacuum` delegates to `@pgmq.tune_autovacuum`; tuning failures are swallowed (best-effort)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the pgmq-ruby dependency to use a `~> 0.7` version constraint (removing the prior Git-pinned reference).

* **Bug Fixes**
  * Improved behavior when global ID model configuration is unset vs. empty, ensuring deserialization enablement is determined correctly.

* **Tests**
  * Added coverage for `tune_autovacuum` delegation to pgmq-ruby (using the fully qualified queue name) and verified tuning errors do not raise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->