### PR TITLE
Spike: NOTIFY-gated worker/consumer wakeups (off by default)

### DIFF
--- a/docs/design/notify-wakeup.md
+++ b/docs/design/notify-wakeup.md
@@ -1,0 +1,114 @@
+# NOTIFY-gated worker/consumer wakeups (spike)
+
+**Status:** prototype, opt-in, **off by default** (`config.worker_notify_wakeup = false`).
+**Goal:** stop idle queues from issuing a `pgmq.read` on every polling tick.
+
+## The problem
+
+The `Worker` and `Consumer` run loops poll: read a batch, and if it comes back
+empty, sleep `polling_interval` and read again. On an idle queue this is one
+`pgmq.read` per queue per tick, forever. At a 0.1s interval across a handful of
+queues and forks, that read volume can dominate database runtime — in one
+production deployment it reached **~93% of DB runtime, ~1.6M `pgmq.read`
+calls/24h**. The usual mitigation is to raise `polling_interval`, which trades
+pickup latency for read volume.
+
+The PGMQ INSERT NOTIFY trigger is already installed on every queue
+(`Client#enable_notify_if_needed`), but nothing in the job/event loops consumes
+it — the signal goes nowhere for workers and consumers (only the SSE streamer
+listens). This spike consumes it: block until a real insert, poll only as a
+fallback.
+
+## Why the obvious approach does not work
+
+A naive "just call `wait_for_notify` in the loop" fails for three concrete
+reasons, all verified against the gem and pgmq-ruby 0.7.0 source:
+
+1. **`wait_for_notify` is single-queue.** `PGMQ::Client#wait_for_notify(queue,
+   timeout:)` LISTENs on exactly one channel inside one `with_connection` block.
+   A worker watches N queues (six in the motivating deployment); the API can't
+   express that.
+2. **It holds the connection for the whole wait.** `with_connection` keeps the
+   pooled connection checked out for the entire blocking wait — it does not
+   release while idle. Running that on the shared worker pool starves it.
+3. **LISTEN dies under a transaction-pool PgBouncer.** A persistent LISTEN does
+   not survive transaction-pool COMMIT boundaries; the pooler silently unbinds
+   the backend and NOTIFYs never arrive — and it does **not** raise, so a
+   detect-and-retry guard never fires.
+
+The first two rule out using `wait_for_notify` directly in the loop. The third
+is the gating operational constraint (see below).
+
+## The design
+
+Mirror the SSE streamer's proven `Streamer::Listener` shape:
+
+- **`Pgbus::Process::NotifyListener`** — one dedicated thread per Worker/Consumer
+  fork that owns a single raw `PG::Connection` and hand-rolls `LISTEN
+  "pgmq.q_<queue>.INSERT"` for every queue the fork reads. On any NOTIFY it calls
+  an injected `on_wake` callable. On wait-timeout it runs `SELECT 1` (TCP
+  keepalive + dead-connection detection) and re-LISTENs everything after a
+  reconnect. The connection is built from `config.worker_notify_connection_options`.
+- **Worker** passes its existing `WakeSignal#notify!` as `on_wake`. The run loop
+  already waits on the `WakeSignal` after an empty fetch; with the listener
+  active, `wake_timeout` raises that wait to a long fallback ceiling
+  (`NOTIFY_FALLBACK_POLL_SECONDS = 15`), because NOTIFY now provides the pickup
+  latency and the timeout is only a safety net for a missed wakeup.
+- **Consumer** passes `SignalHandler#wake!` (a new helper that writes the
+  existing self-pipe) as `on_wake`, interrupting its `interruptible_sleep` the
+  instant an insert arrives — composing cleanly with signal wakeups.
+
+Net effect on an idle queue: one read, then a NOTIFY-gated wait, instead of a
+read every `polling_interval`. A missed NOTIFY costs at most
+`NOTIFY_FALLBACK_POLL_SECONDS` of extra latency, never a stuck queue.
+
+### Safety properties
+
+- **Single-waiter `WakeSignal` is preserved.** Only the worker's main loop calls
+  `#wait`; the listener thread only calls `#notify!`, which is safe from any
+  thread. No new waiter is introduced.
+- **Listener failure degrades to polling.** If the listener can't start (or its
+  connection can't be built), `@notify_listener` stays nil and `wake_timeout`
+  reverts to `effective_polling_interval` — identical to today's behavior.
+- **Coalescing is intentional.** The listener doesn't care which channel fired;
+  one wake makes the loop re-read all its queues. Wakes coalesce, reads don't
+  amplify.
+
+## The gating constraint: connection budget
+
+A persistent LISTEN connection must bypass a transaction-pool PgBouncer. The
+`worker_notify_*` overrides mirror `streams_*`: point the listener at a **direct
+port** (`worker_notify_port`), while workers keep going through the pooler.
+
+The cost is one direct connection **per fork** (not per host, not per Puma
+worker — `NotifyListener` lives in the worker/consumer processes). For a
+5-worker + 2-consumer × 2-host deployment that is ~14 new direct connections,
+**on top of** the streamer's existing per-Puma-worker direct connection. This is
+the scarce resource (e.g. PlanetScale Postgres' direct-port `max_connections`).
+
+**This is why the feature is off by default and labelled a prototype.** Before
+enabling it in production, validate that the direct-port connection ceiling
+tolerates the added per-fork connections. The connection-math, not the code, is
+the real risk.
+
+## Configuration
+
+```ruby
+Pgbus.configure do |c|
+  c.worker_notify_wakeup = true          # opt in (default false)
+  c.worker_notify_port   = 5432          # pin the LISTEN conn to the direct port
+  # or: c.worker_notify_host / c.worker_notify_database_url
+end
+```
+
+With `worker_notify_wakeup = false` (the default) nothing changes: no listener
+thread, no extra connection, plain polling.
+
+## What this spike does NOT do
+
+- It does not change the *read* primitive (`read_batch`/`read_multi` stay). It
+  only changes *when* the loop decides to read.
+- It does not adopt `read_with_poll` — that blocks the loop's main thread (fatal
+  under `:async` fiber mode) and holds a connection, and its PgBouncer story
+  differs from LISTEN.
+- It does not touch grouped/fair reads (`group_mode`), which are orthogonal.

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -116,6 +116,16 @@ module Pgbus
                   :streams_host, :streams_port, :streams_database_url
     attr_reader :streams_default_broadcast_mode # rubocop:disable Style/AccessorGrouping
 
+    # NOTIFY-gated worker/consumer wakeups (SPIKE — off by default).
+    # When true, each Worker/Consumer fork owns a dedicated NotifyListener
+    # connection that LISTENs on its queues' INSERT channels and wakes the
+    # loop on a real insert, so empty queues stop generating a pgmq.read per
+    # polling tick. The worker_notify_* overrides mirror the streams_* ones:
+    # the listener's LISTEN connection can be pinned to a direct port to
+    # survive PgBouncer transaction-pool mode. See docs/design/notify-wakeup.md.
+    attr_accessor :worker_notify_wakeup,
+                  :worker_notify_host, :worker_notify_port, :worker_notify_database_url
+
     # AppSignal integration (auto-loaded when ::Appsignal is defined and this is true).
     # Set to false to opt out without uninstalling the appsignal gem.
     attr_accessor :appsignal_enabled, :appsignal_probe_enabled
@@ -217,6 +227,16 @@ module Pgbus
       @streams_host = nil
       @streams_port = nil
       @streams_database_url = nil
+
+      # NOTIFY-gated wakeup (spike) — disabled by default. Connection
+      # overrides default to the base connection_options; set the port (or
+      # host / full URL) to pin the listener past a transaction-pool PgBouncer,
+      # exactly like streams_port does for the SSE streamer.
+      @worker_notify_wakeup = false
+      @worker_notify_host = nil
+      @worker_notify_port = nil
+      @worker_notify_database_url = nil
+
       @streams_signed_name_secret = nil
       @streams_default_retention = 5 * 60 # 5 minutes
       @streams_retention = {}
@@ -681,6 +701,35 @@ module Pgbus
         parts = [base]
         parts << "host=#{streams_host}" if streams_host
         parts << "port=#{streams_port}" if streams_port
+        parts.join(" ")
+      else
+        base
+      end
+    end
+
+    # Connection options for a Worker/Consumer's dedicated NotifyListener
+    # connection. Mirrors streams_connection_options exactly: defaults to the
+    # base connection_options, overridable via worker_notify_database_url /
+    # worker_notify_host / worker_notify_port so the LISTEN connection can be
+    # pinned to a direct port (workers keep going through the pooler).
+    #
+    # Precedence: worker_notify_database_url > worker_notify_host/port > base.
+    def worker_notify_connection_options
+      return worker_notify_database_url if worker_notify_database_url
+
+      base = connection_options
+      return base unless worker_notify_host || worker_notify_port
+
+      case base
+      when Hash
+        result = base.dup
+        result[:host] = worker_notify_host if worker_notify_host
+        result[:port] = worker_notify_port if worker_notify_port
+        result
+      when String
+        parts = [base]
+        parts << "host=#{worker_notify_host}" if worker_notify_host
+        parts << "port=#{worker_notify_port}" if worker_notify_port
         parts.join(" ")
       else
         base

--- a/lib/pgbus/process/consumer.rb
+++ b/lib/pgbus/process/consumer.rb
@@ -7,6 +7,10 @@ module Pgbus
     class Consumer
       include SignalHandler
 
+      # Fallback poll ceiling when NOTIFY-gated wakeups are active (see
+      # Worker::NOTIFY_FALLBACK_POLL_SECONDS).
+      NOTIFY_FALLBACK_POLL_SECONDS = 15
+
       attr_reader :topics, :threads, :config, :execution_mode
 
       def initialize(topics:, threads: 3, config: Pgbus.configuration, execution_mode: :threads)
@@ -17,13 +21,18 @@ module Pgbus
         @shutting_down = false
         @pool = ExecutionPools.build(mode: @execution_mode, capacity: threads)
         @registry = EventBus::Registry.instance
+        @notify_listener = nil
       end
 
       def run
         setup_signals
         start_heartbeat
         setup_subscriptions
-        Pgbus.logger.info { "[Pgbus] Consumer started: topics=#{topics.join(",")} threads=#{threads}" }
+        start_notify_listener
+        Pgbus.logger.info do
+          "[Pgbus] Consumer started: topics=#{topics.join(",")} threads=#{threads} " \
+            "notify_wakeup=#{notify_wakeup?}"
+        end
 
         loop do
           break if @shutting_down
@@ -55,7 +64,7 @@ module Pgbus
 
       def consume
         idle = @pool.available_capacity
-        return interruptible_sleep(config.polling_interval) if idle <= 0
+        return interruptible_sleep(consume_wake_timeout) if idle <= 0
 
         tagged_messages = if @queue_names.size == 1
                             queue = @queue_names.first
@@ -119,6 +128,35 @@ module Pgbus
           subscription_pattern.start_with?(topic_filter.delete_suffix(".#"))
       end
 
+      def notify_wakeup?
+        config.respond_to?(:worker_notify_wakeup) && config.worker_notify_wakeup
+      end
+
+      # See Worker#wake_timeout. With the listener active, the consumer's poll
+      # sleep becomes a safety-net ceiling (a missed NOTIFY costs bounded extra
+      # latency); the listener wakes it via wake! on a real insert.
+      def consume_wake_timeout
+        return config.polling_interval unless notify_wakeup? && @notify_listener
+
+        [config.polling_interval, NOTIFY_FALLBACK_POLL_SECONDS].max
+      end
+
+      def start_notify_listener
+        return unless notify_wakeup?
+        return if Array(@queue_names).empty?
+
+        @notify_listener = NotifyListener.new(
+          physical_queues: @queue_names,
+          on_wake: -> { wake! },
+          connection_options: config.worker_notify_connection_options,
+          health_check_ms: (config.polling_interval * 1000).to_i.clamp(250, 5_000),
+          logger: Pgbus.logger
+        ).start
+      rescue StandardError => e
+        @notify_listener = nil
+        Pgbus.logger.error { "[Pgbus] Consumer NotifyListener failed to start, falling back to polling: #{e.class}: #{e.message}" }
+      end
+
       def start_heartbeat
         @heartbeat = Heartbeat.new(
           kind: "consumer",
@@ -128,6 +166,7 @@ module Pgbus
       end
 
       def shutdown
+        @notify_listener&.stop
         @pool.shutdown
         @pool.wait_for_termination(30)
         @heartbeat&.stop

--- a/lib/pgbus/process/notify_listener.rb
+++ b/lib/pgbus/process/notify_listener.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Process
+    # Owns a single dedicated PG::Connection that LISTENs on the INSERT NOTIFY
+    # channel of every queue a Worker/Consumer reads, and fires a WakeSignal the
+    # moment any of them receives a row. This converts the worker/consumer loop
+    # from "blind-read every polling_interval" into "sleep until a real insert,
+    # poll only as a fallback" — eliminating the empty-read storm that dominates
+    # DB load on idle queues (one pgmq.read per queue per polling tick → ~zero).
+    #
+    # This is the SPIKE component for NOTIFY-gated wakeups. It is opt-in via
+    # `config.worker_notify_wakeup` and OFF by default. See
+    # docs/design/notify-wakeup.md for the design, failure modes, and the
+    # connection-budget validation that gates turning it on in production.
+    #
+    # ── Why a dedicated connection on (optionally) a direct port ────────────
+    # pgmq-ruby's `wait_for_notify(queue, timeout:)` is single-queue and wraps
+    # the wait in `with_connection`, which (a) only watches one channel and
+    # (b) HOLDS the pooled connection for the whole wait. Neither fits a worker
+    # that reads N queues and runs on a small shared pool. So, exactly like the
+    # SSE Streamer's Listener, we own ONE raw PG::Connection and hand-roll
+    # per-channel LISTEN on it.
+    #
+    # A persistent LISTEN connection silently dies under a transaction-pool
+    # PgBouncer (LISTEN does not survive COMMIT boundaries). The fix is the same
+    # as the streamer's: point this connection at a DIRECT port via
+    # `config.worker_notify_*` overrides. The health-check-on-timeout below also
+    # catches a connection killed out from under us (NAT/restart/idle reap) and
+    # re-LISTENs everything.
+    #
+    # ── Threading ──────────────────────────────────────────────────────────
+    #   - #start spawns ONE listener thread per Worker/Consumer (i.e. per fork).
+    #   - The thread only ever runs `wait_for_notify`; LISTEN/UNLISTEN SQL for
+    #     queue-set changes (wildcard refresh, circuit-breaker eviction) is fed
+    #     through a command queue drained between waits.
+    #   - On NOTIFY (or a queue going live) it calls `@on_wake.call` — the Worker
+    #     passes its existing single-waiter WakeSignal#notify!. notify! is
+    #     safe from any thread; only the worker's main loop calls #wait.
+    #   - #stop closes the socket to interrupt a blocking wait, then joins.
+    #
+    # NOTIFY channel naming (pgmq trigger): PG_NOTIFY('pgmq.' || table || '.' ||
+    # TG_OP). For queue `pgbus_default` the table is `q_pgbus_default`, so the
+    # channel is `pgmq.q_pgbus_default.INSERT`. The queue names handed in here
+    # are the PHYSICAL names (prefix already applied) so they match the trigger.
+    class NotifyListener
+      CHANNEL_PREFIX = "pgmq.q_"
+      CHANNEL_SUFFIX = ".INSERT"
+
+      attr_reader :listening_to
+
+      # @param physical_queues [Array<String>] prefixed queue names to LISTEN on
+      # @param on_wake [#call] invoked on any INSERT NOTIFY (e.g. wake_signal.notify!)
+      # @param connection_options [String,Hash] libpq conninfo for the dedicated
+      #   connection (typically config.worker_notify_connection_options)
+      # @param health_check_ms [Integer] wait timeout; on expiry we SELECT 1 to
+      #   detect a silently-dead connection, doubling as the poll fallback cadence.
+      def initialize(physical_queues:, on_wake:, connection_options:,
+                     health_check_ms: 1000, logger: Pgbus.logger)
+        @physical_queues = Array(physical_queues)
+        @on_wake = on_wake
+        @connection_options = connection_options
+        @health_check_ms = health_check_ms
+        @logger = logger
+        @listening_to = Set.new
+        @commands = Queue.new
+        @running = false
+        @thread = nil
+        @conn = nil
+      end
+
+      def start
+        return self if @running
+
+        @running = true
+        @physical_queues.each { |q| @commands << [:listen, q] }
+        @thread = Thread.new { run_loop }
+        self
+      end
+
+      def stop
+        return self unless @running
+
+        @running = false
+        @commands << [:stop]
+        # Interrupt the blocking wait_for_notify by closing the socket; the
+        # rescue in run_loop sees @running == false and exits cleanly.
+        begin
+          @conn&.close if @conn.respond_to?(:close)
+        rescue StandardError
+          # best effort — connection may already be gone
+        end
+        @thread&.join(5)
+        @thread = nil
+        self
+      end
+
+      # Add a queue to the LISTEN set at runtime (wildcard refresh picks up a
+      # new queue). Asynchronous: the listener thread executes it before its
+      # next wait. Safe to call from the worker's main loop thread.
+      def add_queue(physical_queue)
+        @commands << [:listen, physical_queue]
+      end
+
+      # Drop a queue from the LISTEN set (queue deleted / evicted).
+      def remove_queue(physical_queue)
+        @commands << [:unlisten, physical_queue]
+      end
+
+      private
+
+      def run_loop
+        @conn = build_connection
+        drain_commands
+
+        loop do
+          break unless @running
+
+          drain_commands
+          break unless @running
+
+          wait_once
+        end
+      rescue StandardError => e
+        @logger.error { "[Pgbus::NotifyListener] fatal: #{e.class}: #{e.message}" } if @running
+      ensure
+        safe_unlisten_all
+        safe_close
+      end
+
+      def wait_once
+        timeout_s = @health_check_ms / 1000.0
+        got_notify = @conn.wait_for_notify(timeout_s) do |_channel, _pid, _payload|
+          # We don't care which queue fired — the worker re-reads all of them.
+          # Coalescing every channel into a single wake is exactly what we want:
+          # one wake, the loop drains whatever is ready across all queues.
+          @on_wake.call
+        end
+        run_health_check unless got_notify
+      rescue IOError, PG::Error => e
+        # #stop closes the connection to interrupt the wait → IOError/PG::Error.
+        return unless @running
+
+        @logger.warn { "[Pgbus::NotifyListener] connection error (#{e.class}: #{e.message}) — reconnecting" }
+        reconnect!
+      end
+
+      def drain_commands
+        loop do
+          cmd = @commands.pop(true)
+          case cmd[0]
+          when :listen   then do_listen(cmd[1])
+          when :unlisten then do_unlisten(cmd[1])
+          when :stop
+            @running = false
+            return
+          end
+        rescue ThreadError
+          return # queue empty
+        end
+      end
+
+      def do_listen(physical_queue)
+        channel = channel_for(physical_queue)
+        return if @listening_to.include?(channel)
+
+        @conn.exec(%(LISTEN "#{channel}"))
+        @listening_to.add(channel)
+      end
+
+      def do_unlisten(physical_queue)
+        channel = channel_for(physical_queue)
+        return unless @listening_to.include?(channel)
+
+        @conn.exec(%(UNLISTEN "#{channel}"))
+        @listening_to.delete(channel)
+      end
+
+      def run_health_check
+        @conn.exec("SELECT 1")
+      end
+
+      def reconnect!
+        safe_close
+        @conn = build_connection
+        # Re-LISTEN everything we were watching. Build the new set first so a
+        # mid-loop failure doesn't lose channels not yet retried.
+        to_relisten = @listening_to.to_a
+        @listening_to = Set.new
+        to_relisten.each do |channel|
+          @conn.exec(%(LISTEN "#{channel}"))
+          @listening_to.add(channel)
+        end
+      rescue PG::Error => e
+        @logger.error { "[Pgbus::NotifyListener] reconnect failed: #{e.class}: #{e.message}" }
+        sleep 0.5
+      end
+
+      def build_connection
+        require "pg" unless defined?(::PG::Connection)
+        case @connection_options
+        when String then ::PG.connect(@connection_options)
+        when Hash   then ::PG.connect(**@connection_options)
+        else
+          raise Pgbus::ConfigurationError,
+                "NotifyListener cannot build a PG connection from #{@connection_options.class}. " \
+                "Set worker_notify_database_url / worker_notify_host / worker_notify_port, " \
+                "or a base database_url, so the listener owns a dedicated connection."
+        end
+      end
+
+      def safe_unlisten_all
+        @listening_to.each do |channel|
+          @conn&.exec(%(UNLISTEN "#{channel}"))
+        rescue PG::Error
+          # connection may be dead; nothing to do
+        end
+        @listening_to.clear
+      end
+
+      def safe_close
+        @conn&.close if @conn.respond_to?(:close)
+      rescue StandardError
+        # best effort
+      ensure
+        @conn = nil
+      end
+
+      def channel_for(physical_queue)
+        "#{CHANNEL_PREFIX}#{physical_queue}#{CHANNEL_SUFFIX}"
+      end
+    end
+  end
+end

--- a/lib/pgbus/process/signal_handler.rb
+++ b/lib/pgbus/process/signal_handler.rb
@@ -51,6 +51,15 @@ module Pgbus
         drain_self_pipe
       end
 
+      # Wake a thread blocked in interruptible_sleep from any other thread.
+      # Used by the NotifyListener (NOTIFY-gated wakeup spike) to interrupt the
+      # consumer's poll sleep the instant an insert arrives. Uses the same
+      # self-pipe the signal traps write, so it composes with signal wakeups.
+      # Best-effort and non-blocking — a full pipe already means "wake pending".
+      def wake!
+        @self_pipe_w&.write_nonblock(".", exception: false)
+      end
+
       def graceful_shutdown
         raise NotImplementedError
       end

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -49,6 +49,7 @@ module Pgbus
         )
         @circuit_breaker = Pgbus::CircuitBreaker.new(config: config)
         @queue_lock = QueueLock.new if @single_active_consumer
+        @notify_listener = nil
       end
 
       def stats
@@ -70,10 +71,11 @@ module Pgbus
         setup_signals
         start_heartbeat
         resolve_wildcard_queues
+        start_notify_listener
         @lifecycle.transition_to!(:running)
         Pgbus.logger.info do
           "[Pgbus] Worker started: queues=#{queues.join(",")} threads=#{threads} " \
-            "mode=#{@execution_mode} pid=#{::Process.pid}"
+            "mode=#{@execution_mode} notify_wakeup=#{notify_wakeup?} pid=#{::Process.pid}"
         end
 
         loop do
@@ -109,6 +111,11 @@ module Pgbus
 
       WILDCARD_REFRESH_INTERVAL = 30 # seconds
 
+      # Fallback poll ceiling when NOTIFY-gated wakeups are active. A missed
+      # NOTIFY (connection drop / throttle coalescing) surfaces as at most this
+      # much extra pickup latency, never a stuck queue.
+      NOTIFY_FALLBACK_POLL_SECONDS = 15
+
       # Matches the physical queue name inside a "relation \"pgmq.q_foo\" does
       # not exist" error. Frozen module constant to avoid recompiling the
       # regex on every queue-missing error in hot fetch/read paths.
@@ -117,7 +124,7 @@ module Pgbus
       private
 
       def claim_and_execute
-        poll_interval = effective_polling_interval
+        poll_interval = wake_timeout
 
         idle = @pool.available_capacity
         return @wake_signal.wait(timeout: poll_interval) if idle <= 0
@@ -295,6 +302,7 @@ module Pgbus
           Pgbus.logger.info { "[Pgbus] Wildcard queue '*' resolved to: #{@queues.join(", ")}" } unless @last_wildcard_resolve
         end
         @last_wildcard_resolve = monotonic_now
+        sync_notify_listener_queues
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Failed to resolve wildcard queues: #{e.message} — falling back to default" }
         @queues = [config.default_queue] unless @last_wildcard_resolve
@@ -413,6 +421,63 @@ module Pgbus
         config.polling_interval
       end
 
+      def notify_wakeup?
+        config.respond_to?(:worker_notify_wakeup) && config.worker_notify_wakeup
+      end
+
+      # The empty-fetch wait timeout. Without notify-wakeup this is the primary
+      # poll cadence (read every effective_polling_interval). With notify-wakeup
+      # the NotifyListener fires the WakeSignal on a real insert, so this becomes
+      # a SAFETY-NET ceiling for a missed NOTIFY (connection drop / throttle
+      # coalescing) rather than the steady-state cadence — we can wait much
+      # longer between blind reads on an idle queue. Capped so a dropped wakeup
+      # costs bounded latency, never a stuck queue.
+      def wake_timeout
+        return effective_polling_interval unless notify_wakeup? && @notify_listener
+
+        [effective_polling_interval, config.polling_interval, NOTIFY_FALLBACK_POLL_SECONDS].max
+      end
+
+      def start_notify_listener
+        return unless notify_wakeup?
+
+        @notify_listener = NotifyListener.new(
+          physical_queues: physical_queue_names,
+          on_wake: -> { @wake_signal.notify! },
+          connection_options: config.worker_notify_connection_options,
+          health_check_ms: (config.polling_interval * 1000).to_i.clamp(250, 5_000),
+          logger: Pgbus.logger
+        ).start
+      rescue StandardError => e
+        # A listener failure must never take down the worker — fall back to
+        # plain polling (wake_timeout reverts to effective_polling_interval
+        # because @notify_listener stays nil).
+        @notify_listener = nil
+        Pgbus.logger.error { "[Pgbus] NotifyListener failed to start, falling back to polling: #{e.class}: #{e.message}" }
+      end
+
+      # Re-LISTEN the listener on the current queue set after a wildcard
+      # refresh or eviction. No-op when notify-wakeup is off.
+      def sync_notify_listener_queues
+        return unless @notify_listener
+
+        desired = physical_queue_names.to_set
+        current = @notify_listener.listening_to.to_set { |c| channel_to_physical(c) }
+        (desired - current).each { |q| @notify_listener.add_queue(q) }
+        (current - desired).each { |q| @notify_listener.remove_queue(q) }
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] NotifyListener queue sync failed: #{e.class}: #{e.message}" }
+      end
+
+      def physical_queue_names
+        prefix = "#{config.queue_prefix}_"
+        queues.map { |q| "#{prefix}#{q}" }
+      end
+
+      def channel_to_physical(channel)
+        channel.delete_prefix(NotifyListener::CHANNEL_PREFIX).delete_suffix(NotifyListener::CHANNEL_SUFFIX)
+      end
+
       def start_heartbeat
         @heartbeat = Heartbeat.new(
           kind: "worker",
@@ -427,6 +492,7 @@ module Pgbus
 
       def shutdown
         Pgbus.logger.info { "[Pgbus] Worker draining thread pool..." }
+        @notify_listener&.stop
         @pool.shutdown
         @pool.wait_for_termination(30)
         @stat_buffer&.stop

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -1246,4 +1246,54 @@ RSpec.describe Pgbus::Configuration do
       end
     end
   end
+
+  describe "NOTIFY-gated wakeup (spike) settings" do
+    it "defaults worker_notify_wakeup to false" do
+      expect(config.worker_notify_wakeup).to be false
+    end
+
+    it "leaves the worker_notify connection overrides nil by default" do
+      expect(config.worker_notify_host).to be_nil
+      expect(config.worker_notify_port).to be_nil
+      expect(config.worker_notify_database_url).to be_nil
+    end
+
+    describe "#worker_notify_connection_options" do
+      it "returns the base connection_options when no override is set" do
+        config.connection_params = { host: "pooler.example", port: 6432, dbname: "app" }
+        expect(config.worker_notify_connection_options).to eq(config.connection_options)
+      end
+
+      it "pins the port on a Hash base without mutating the base" do
+        original = { host: "pooler.example", port: 6432, dbname: "app", sslmode: "require" }
+        config.connection_params = original
+        config.worker_notify_port = 5432
+
+        expect(config.worker_notify_connection_options).to eq(
+          host: "pooler.example", port: 5432, dbname: "app", sslmode: "require"
+        )
+        expect(config.connection_params).to eq(original)
+      end
+
+      it "appends a port override on a String/URL base" do
+        config.database_url = "postgres://app@pooler.example:6432/app"
+        config.worker_notify_port = 5432
+
+        expect(config.worker_notify_connection_options).to eq(
+          "postgres://app@pooler.example:6432/app port=5432"
+        )
+      end
+
+      it "lets worker_notify_database_url win over host/port and the base" do
+        config.connection_params = { host: "pooler.example", port: 6432, dbname: "app" }
+        config.worker_notify_host = "ignored"
+        config.worker_notify_port = 9999
+        config.worker_notify_database_url = "postgres://w@direct.example:5432/app"
+
+        expect(config.worker_notify_connection_options).to eq(
+          "postgres://w@direct.example:5432/app"
+        )
+      end
+    end
+  end
 end

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Process::NotifyListener do
+  subject(:listener) do
+    described_class.new(
+      physical_queues: %w[pgbus_default pgbus_low],
+      on_wake: -> { wakes << :woke },
+      connection_options: { dbname: "fake" },
+      health_check_ms: 50,
+      logger: logger
+    )
+  end
+
+  before do
+    stub_const("PG", Module.new) unless defined?(PG)
+    stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
+    # Hand the scripted connection to build_connection instead of real PG.connect.
+    allow_any_instance_of(described_class).to receive(:build_connection).and_return(fake_pg)
+  end
+
+  # Scripted stand-in for PG::Connection. wait_for_notify blocks on an internal
+  # Queue so the listener thread sees real blocking semantics with no Postgres.
+  let(:fake_pg) do
+    Class.new do
+      attr_reader :executed
+
+      def initialize
+        @executed = []
+        @events = Queue.new
+        @closed = false
+      end
+
+      def exec(sql)
+        @executed << sql
+        nil
+      end
+
+      def wait_for_notify(_timeout)
+        event = @events.pop
+        case event[0]
+        when :notify
+          yield event[1], 0, nil
+          event[1]
+        when :timeout
+          nil
+        when :raise
+          raise event[1]
+        when :close
+          raise PG::Error, "connection closed"
+        end
+      end
+
+      def close = (@events << [:close])
+      def push_notify(channel) = @events << [:notify, channel]
+      def push_timeout = @events << [:timeout]
+      def push_error(error) = @events << [:raise, error]
+    end.new
+  end
+
+  let(:wakes)  { Queue.new }
+  let(:logger) { Logger.new(IO::NULL) }
+
+  after { listener.stop }
+
+  def wait_until(timeout: 2)
+    deadline = Time.now + timeout
+    until yield
+      raise "timed out waiting for condition" if Time.now > deadline
+
+      sleep 0.01
+    end
+  end
+
+  describe "#start" do
+    it "LISTENs on pgmq.q_<queue>.INSERT for every queue handed in" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until do
+        fake_pg.executed.include?(%(LISTEN "pgmq.q_pgbus_default.INSERT")) &&
+          fake_pg.executed.include?(%(LISTEN "pgmq.q_pgbus_low.INSERT"))
+      end
+
+      expect(listener.listening_to).to contain_exactly(
+        "pgmq.q_pgbus_default.INSERT",
+        "pgmq.q_pgbus_low.INSERT"
+      )
+    end
+
+    it "is idempotent — start twice does not double-LISTEN" do
+      listener.start
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      listens = fake_pg.executed.count { |s| s.start_with?("LISTEN") }
+      expect(listens).to eq(2)
+    end
+  end
+
+  describe "NOTIFY handling" do
+    it "fires on_wake for any INSERT notification, regardless of which queue" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      fake_pg.push_notify("pgmq.q_pgbus_default.INSERT")
+
+      expect(wakes.pop).to eq(:woke)
+    end
+
+    it "coalesces — a single wake per notification, the loop re-reads everything" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      fake_pg.push_notify("pgmq.q_pgbus_low.INSERT")
+      expect(wakes.pop).to eq(:woke)
+      expect(wakes).to be_empty
+    end
+  end
+
+  describe "health check (poll fallback / dead-connection detection)" do
+    it "runs SELECT 1 when wait_for_notify times out" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { fake_pg.executed.include?("SELECT 1") }
+      expect(fake_pg.executed).to include("SELECT 1")
+    end
+
+    it "does not fire on_wake on a timeout (no spurious reads)" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { fake_pg.executed.include?("SELECT 1") }
+      expect(wakes).to be_empty
+    end
+  end
+
+  describe "runtime queue-set changes" do
+    it "adds a queue via add_queue" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      listener.add_queue("pgbus_webhooks")
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.include?("pgmq.q_pgbus_webhooks.INSERT") }
+
+      expect(fake_pg.executed).to include(%(LISTEN "pgmq.q_pgbus_webhooks.INSERT"))
+    end
+
+    it "drops a queue via remove_queue" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      listener.remove_queue("pgbus_low")
+      fake_pg.push_timeout
+      wait_until { !listener.listening_to.include?("pgmq.q_pgbus_low.INSERT") }
+
+      expect(fake_pg.executed).to include(%(UNLISTEN "pgmq.q_pgbus_low.INSERT"))
+    end
+  end
+
+  describe "reconnect on connection error" do
+    it "rebuilds the connection and re-LISTENs every channel" do
+      # build_connection is called once at startup and again on reconnect.
+      second_pg = fake_pg.clone
+      call_count = 0
+      allow_any_instance_of(described_class).to receive(:build_connection) do
+        call_count += 1
+        call_count == 1 ? fake_pg : second_pg
+      end
+
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      second_pg.push_timeout
+
+      wait_until do
+        second_pg.executed.count { |s| s.start_with?("LISTEN") } >= 2
+      end
+
+      expect(listener.listening_to).to contain_exactly(
+        "pgmq.q_pgbus_default.INSERT",
+        "pgmq.q_pgbus_low.INSERT"
+      )
+    end
+  end
+
+  describe "#stop" do
+    it "interrupts the blocking wait and clears the LISTEN set" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      listener.stop
+      expect(listener.listening_to).to be_empty
+    end
+  end
+end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -554,4 +554,64 @@ RSpec.describe Pgbus::Process::Worker do
       expect(priority_worker.stats[:consumer_priority]).to eq(10)
     end
   end
+
+  describe "NOTIFY-gated wakeup integration (spike)" do
+    after { worker.config.worker_notify_wakeup = false }
+
+    it "is off by default" do
+      expect(worker.send(:notify_wakeup?)).to be false
+    end
+
+    it "maps logical queues to physical (prefixed) channel names" do
+      prefix = worker.config.queue_prefix
+      expect(worker.send(:physical_queue_names)).to eq(["#{prefix}_default"])
+    end
+
+    it "round-trips a channel back to its physical queue name" do
+      channel = "pgmq.q_pgbus_default.INSERT"
+      expect(worker.send(:channel_to_physical, channel)).to eq("pgbus_default")
+    end
+
+    context "when wakeup is disabled" do
+      it "does not build a listener and uses the plain poll cadence" do
+        worker.config.worker_notify_wakeup = false
+        worker.send(:start_notify_listener)
+
+        expect(worker.instance_variable_get(:@notify_listener)).to be_nil
+        expect(worker.send(:wake_timeout)).to eq(worker.send(:effective_polling_interval))
+      end
+    end
+
+    context "when wakeup is enabled" do
+      let(:fake_listener) { instance_double(Pgbus::Process::NotifyListener, stop: nil) }
+
+      before do
+        worker.config.worker_notify_wakeup = true
+        allow(fake_listener).to receive(:start).and_return(fake_listener)
+        allow(Pgbus::Process::NotifyListener).to receive(:new).and_return(fake_listener)
+      end
+
+      it "builds a NotifyListener over the worker's physical queues" do
+        worker.send(:start_notify_listener)
+
+        expect(Pgbus::Process::NotifyListener).to have_received(:new).with(
+          hash_including(physical_queues: ["#{worker.config.queue_prefix}_default"])
+        )
+        expect(worker.instance_variable_get(:@notify_listener)).to eq(fake_listener)
+      end
+
+      it "raises the empty-fetch wait to the fallback ceiling (NOTIFY drives latency)" do
+        worker.send(:start_notify_listener)
+        expect(worker.send(:wake_timeout)).to eq(described_class::NOTIFY_FALLBACK_POLL_SECONDS)
+      end
+
+      it "falls back to polling (nil listener) if the listener fails to start" do
+        allow(Pgbus::Process::NotifyListener).to receive(:new).and_raise(StandardError, "boom")
+        worker.send(:start_notify_listener)
+
+        expect(worker.instance_variable_get(:@notify_listener)).to be_nil
+        expect(worker.send(:wake_timeout)).to eq(worker.send(:effective_polling_interval))
+      end
+    end
+  end
 end


### PR DESCRIPTION
> **Draft / prototype.** Off by default (`worker_notify_wakeup = false`). The architecture is proven and tested, but turning it on in production is gated on a connection-budget validation (see below) that can't be settled from the diff alone.

## Problem

The `Worker` and `Consumer` run loops poll: read a batch, and if empty, sleep `polling_interval` and read again. On an idle queue that's one `pgmq.read` per queue per tick, forever. In one production deployment this reached **~93% of DB runtime, ~1.6M `pgmq.read`/24h**; the only lever today is raising `polling_interval` (trading pickup latency for read volume).

The PGMQ INSERT NOTIFY trigger is already installed on every queue (`Client#enable_notify_if_needed`) but **nothing in the job/event loops consumes it** — only the SSE streamer does. This spike consumes it for workers and consumers.

## Design

Mirrors the proven `Streamer::Listener`:

- **`Pgbus::Process::NotifyListener`** — one dedicated thread per fork owning a raw `PG::Connection`, hand-rolling `LISTEN "pgmq.q_<queue>.INSERT"` for every queue the fork reads, firing an injected `on_wake` on any NOTIFY, with `SELECT 1` health-check + reconnect on timeout/drop.
- **Worker** passes `WakeSignal#notify!`; the loop already waits on the signal after an empty fetch, so `wake_timeout` just raises that wait to a 15s fallback ceiling when the listener is active (NOTIFY drives latency, the timeout is a safety net).
- **Consumer** passes `SignalHandler#wake!` (new self-pipe helper) to interrupt its `interruptible_sleep`.
- **Config**: `worker_notify_wakeup` + `worker_notify_host/port/database_url` and `worker_notify_connection_options`, mirroring the `streams_*` overrides so the LISTEN connection can be pinned to a direct port.

Net effect on an idle queue: one read, then a NOTIFY-gated wait, instead of a read every `polling_interval`.

## Why not just call `wait_for_notify` in the loop?

Three blockers, all verified against pgmq-ruby 0.7.0 source and documented in `docs/design/notify-wakeup.md`:

1. `wait_for_notify` is **single-queue**; workers watch N queues.
2. It **holds the pooled connection** for the whole wait (doesn't release while idle).
3. **LISTEN dies silently under a transaction-pool PgBouncer** (doesn't survive COMMIT boundaries, doesn't raise).

So we own a dedicated direct-port connection per fork, exactly like the streamer.

## The gating constraint (why this is a draft)

One direct connection **per fork** bypassing PgBouncer — ~14 for a 5-worker + 2-consumer × 2-host deployment, on top of the streamer's per-Puma-worker direct connection. The direct-port `max_connections` ceiling must be validated before enabling in production. The connection math, not the code, is the risk.

## Safety

- Single-waiter `WakeSignal` contract preserved (listener only calls `notify!`).
- Listener failure degrades to plain polling (`@notify_listener` stays nil → `wake_timeout` reverts).
- `worker_notify_wakeup = false` (default) = zero behavior change.

## Tests

- `spec/pgbus/process/notify_listener_spec.rb` — 10 examples (LISTEN set, coalesced wakes, health check, runtime add/remove, reconnect, stop)
- Worker + configuration specs extended
- Full process + configuration suite: **388 examples, 0 failures**; rubocop clean

## Validation plan before un-drafting

- [ ] Measure idle `pgmq.read` rate before/after on a staging fork with the flag on
- [ ] Confirm direct-port connection count under full fork topology stays within the ceiling
- [ ] Soak test: kill the LISTEN connection (PgBouncer restart / network blip) and confirm health-check reconnect + fallback poll keep pickup working
- [ ] Verify behaviour under `execution_mode: :async`