### PR TITLE
fix(dashboard): add turbo_frame _top to batch links

### DIFF
--- a/app/views/pgbus/batches/_batches_table.html.erb
+++ b/app/views/pgbus/batches/_batches_table.html.erb
@@ -16,7 +16,8 @@
           <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
             <td data-label="Batch ID" class="px-4 py-3 text-sm">
               <%= link_to batch[:batch_id][0..7], pgbus.batch_path(batch[:batch_id]),
-                    class: "font-mono text-indigo-600 dark:text-indigo-400 hover:underline" %>
+                    class: "font-mono text-indigo-600 dark:text-indigo-400 hover:underline",
+                    data: { turbo_frame: "_top" } %>
             </td>
             <td data-label="Description" class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 max-w-xs truncate">
               <%= batch[:description] || "—" %>

--- a/spec/pgbus/web/dashboard_interaction_spec.rb
+++ b/spec/pgbus/web/dashboard_interaction_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe "Dashboard interaction UX" do # rubocop:disable RSpec/DescribeCla
     end
   end
 
+  describe "batches table links" do
+    let(:batches_table) { views_dir.join("pgbus", "batches", "_batches_table.html.erb").read }
+
+    it "uses turbo_frame _top for batch links to break out of the turbo frame" do
+      expect(batches_table).to include("turbo_frame: \"_top\"")
+    end
+  end
+
   describe "queue show page" do
     let(:queue_show) { views_dir.join("pgbus", "queues", "show.html.erb").read }
 


### PR DESCRIPTION
## Summary

- Batch ID links in `_batches_table.html.erb` were inside a `<turbo-frame id="batches-list">` but lacked `data: { turbo_frame: "_top" }`, causing Turbo to search for a matching frame in the show response instead of performing a full-page navigation
- This produced the "Content missing" error when clicking any batch link
- Every other dashboard table (queues, recurring tasks, jobs, DLQ) already uses `turbo_frame: "_top"` for show-page links — batches was the only one missing it
- Added a regression test in `dashboard_interaction_spec.rb` matching the existing pattern for recurring tasks

## Test plan

- [x] `bundle exec rspec spec/pgbus/web/dashboard_interaction_spec.rb` — 10 examples, 0 failures
- [x] `bundle exec rubocop` — clean
- [ ] Manual: click a batch ID on `/admin/pgbus/batches` → should navigate to the batch show page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batch link navigation behavior to properly break out of Turbo frames, improving user experience when clicking batch IDs in the batches table.

* **Tests**
  * Added test coverage to verify correct Turbo frame handling for batch links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->