### PR TITLE
fix(async): replace blocking sleep with IO pipe wake in reactor (#174)

### DIFF
--- a/lib/pgbus/execution_pools/async_pool.rb
+++ b/lib/pgbus/execution_pools/async_pool.rb
@@ -5,8 +5,6 @@ module Pgbus
     class AsyncPool
       attr_reader :capacity
 
-      IDLE_WAIT_INTERVAL = 0.01
-
       def initialize(capacity:, on_state_change: nil)
         @capacity = capacity
         @on_state_change = on_state_change
@@ -17,6 +15,7 @@ module Pgbus
         @fatal_error = nil
         @boot_queue = Thread::Queue.new
         @pending = Thread::Queue.new
+        @wake_rd, @wake_wr = IO.pipe
 
         validate_dependencies!
         @reactor_thread = start_reactor
@@ -32,6 +31,7 @@ module Pgbus
         reserve_capacity!
         reserved = true
         @pending << block
+        wake_reactor
       rescue StandardError
         restore_capacity if reserved
         raise
@@ -52,6 +52,7 @@ module Pgbus
 
           @shutdown_flag = true
         end
+        wake_reactor
       end
 
       def shutdown?
@@ -96,7 +97,18 @@ module Pgbus
             @boot_queue << :ready
 
             wait_for_executions(semaphore)
-            wait_for_inflight
+            wait_for_inflight(task)
+          ensure
+            begin
+              @wake_rd.close
+            rescue IOError
+              nil
+            end
+            begin
+              @wake_wr.close
+            rescue IOError
+              nil
+            end
           end
         rescue Exception => e
           register_fatal_error(e)
@@ -110,8 +122,33 @@ module Pgbus
           schedule_pending(semaphore)
           break if shutdown? && @pending.empty?
 
-          sleep(IDLE_WAIT_INTERVAL) if @pending.empty?
+          wait_for_wake if @pending.empty?
         end
+      end
+
+      # Fiber-aware wait: yields the reactor fiber until the main thread
+      # writes a wake byte via wake_reactor. IO#wait_readable integrates
+      # with the Async scheduler so other fibers continue running.
+      def wait_for_wake
+        return if @wake_rd.closed?
+
+        @wake_rd.wait_readable
+        drain_wake_pipe
+      rescue IOError, Errno::EBADF
+        nil
+      end
+
+      def drain_wake_pipe
+        @wake_rd.read_nonblock(256)
+      rescue IOError, SystemCallError
+        nil
+      end
+
+      # Thread-safe: called from the main thread to wake the reactor fiber.
+      def wake_reactor
+        @wake_wr.write_nonblock(".")
+      rescue IO::WaitWritable, IOError, Errno::EBADF, Errno::EPIPE
+        nil
       end
 
       def schedule_pending(semaphore)
@@ -160,6 +197,7 @@ module Pgbus
           @available_capacity += 1
           @available_capacity.positive?
         end
+        wake_reactor
         @on_state_change&.call if should_notify
       end
 
@@ -174,8 +212,8 @@ module Pgbus
         raise error if error
       end
 
-      def wait_for_inflight
-        sleep(IDLE_WAIT_INTERVAL) while inflight?
+      def wait_for_inflight(task)
+        task.sleep(0.01) while inflight?
       end
 
       def inflight?

--- a/spec/pgbus/execution_pools/async_pool_reactor_spec.rb
+++ b/spec/pgbus/execution_pools/async_pool_reactor_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::ExecutionPools::AsyncPool do
+  subject(:pool) { described_class.new(capacity: capacity, on_state_change: state_change_cb) }
+
+  let(:capacity) { 5 }
+  let(:state_changes) { Concurrent::AtomicFixnum.new(0) }
+  let(:state_change_cb) { -> { state_changes.increment } }
+
+  after do
+    pool.shutdown
+    pool.wait_for_termination(5)
+  end
+
+  describe "reactor does not use blocking Kernel#sleep" do
+    let(:source) do
+      File.read(
+        File.expand_path("../../../lib/pgbus/execution_pools/async_pool.rb", __dir__)
+      )
+    end
+
+    it "wait_for_executions uses fiber-aware waiting" do
+      wait_method = source[/def wait_for_executions.*?(?=\n      def |\n    end\b)/m]
+      expect(wait_method).not_to be_nil
+      bare_sleeps = wait_method.scan(/(?<!\.)\bsleep\b/)
+      expect(bare_sleeps).to be_empty,
+                             "wait_for_executions must not use blocking Kernel#sleep (issue #174)."
+    end
+
+    it "wait_for_inflight uses fiber-aware waiting" do
+      inflight_method = source[/def wait_for_inflight.*?(?=\n      def |\n    end\b)/m]
+      expect(inflight_method).not_to be_nil
+      bare_sleeps = inflight_method.scan(/(?<!\.)\bsleep\b/)
+      expect(bare_sleeps).to be_empty,
+                             "wait_for_inflight must not use blocking Kernel#sleep (issue #174)."
+    end
+  end
+
+  describe "notification-based wake on post" do
+    it "executes posted work within 5ms even after extended idle" do
+      warmup = Concurrent::IVar.new
+      pool.post { warmup.set(:ok) }
+      warmup.value(5)
+
+      sleep 0.15
+
+      latencies = []
+      10.times do
+        sleep 0.03
+
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        ivar = Concurrent::IVar.new
+        pool.post { ivar.set(Process.clock_gettime(Process::CLOCK_MONOTONIC)) }
+        t1 = ivar.value(5)
+        expect(t1).not_to be_nil, "Posted work was never executed (reactor stalled)"
+        latencies << (t1 - t0)
+      end
+
+      sorted = latencies.sort
+      p90 = sorted[(latencies.size * 0.9).floor]
+      expect(p90).to be < 0.005,
+                     "p90 post-to-execute latency was #{(p90 * 1000).round(2)}ms (expected <5ms)"
+    end
+  end
+
+  describe "sustained burst-idle throughput" do
+    let(:rounds) { 20 }
+    let(:results) { Concurrent::Array.new }
+    let(:stop_polling) { Concurrent::AtomicBoolean.new(false) }
+    let(:poller) { start_contention_poller }
+
+    after do
+      stop_polling.make_true
+      poller.join(1)
+    end
+
+    it "processes all tasks across burst-idle cycles without stalling" do
+      poller # start
+
+      rounds.times do |round|
+        sleep 0.005
+        latch = Concurrent::CountDownLatch.new(capacity)
+
+        capacity.times do
+          pool.post do
+            results << round
+            latch.count_down
+          end
+        end
+
+        expect(latch.wait(2)).to be(true),
+                                 "Round #{round}: stall detected"
+      end
+
+      expect(results.size).to eq(rounds * capacity)
+    end
+
+    private
+
+    def start_contention_poller
+      Thread.new do
+        until stop_polling.true?
+          begin
+            pool.available_capacity
+          rescue RuntimeError
+            nil
+          end
+          Thread.pass
+        end
+      end
+    end
+  end
+end

--- a/spec/pgbus/execution_pools/async_pool_reactor_spec.rb
+++ b/spec/pgbus/execution_pools/async_pool_reactor_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe Pgbus::ExecutionPools::AsyncPool do
     pool.wait_for_termination(5)
   end
 
+  # Block until the pool has a free slot, mirroring the worker's idle<=0
+  # backpressure so a tight post loop never overruns capacity.
+  def wait_for_capacity(pool, timeout: 5)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    Thread.pass until pool.available_capacity.positive? ||
+                      Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+  end
+
   describe "reactor does not use blocking Kernel#sleep" do
     let(:source) do
       File.read(
@@ -58,10 +66,88 @@ RSpec.describe Pgbus::ExecutionPools::AsyncPool do
         latencies << (t1 - t0)
       end
 
+      # Assert on the MEDIAN, not a tail percentile: scheduler jitter on a
+      # loaded CI box inflates the tail, but the median exposes the steady-state
+      # mechanism. Polling sleep(0.01) floors the median near ~5ms (you wait, on
+      # average, half a poll cycle); notification wake pushes it sub-millisecond.
+      # A median < 3ms is unreachable with the old blocking-sleep poll loop.
       sorted = latencies.sort
-      p90 = sorted[(latencies.size * 0.9).floor]
-      expect(p90).to be < 0.005,
-                     "p90 post-to-execute latency was #{(p90 * 1000).round(2)}ms (expected <5ms)"
+      median = sorted[latencies.size / 2]
+      expect(median).to be < 0.003,
+                        "median post-to-execute latency was #{(median * 1000).round(2)}ms " \
+                        "(expected <3ms; blocking-sleep polling floors this near 5ms)"
+    end
+  end
+
+  # The worker's main loop parks in WakeSignal#wait between fetches. The ONLY
+  # thing that wakes it when the pool is saturated is the on_state_change
+  # callback fired as fibers complete and free capacity (Worker wires it to
+  # WakeSignal#notify!). PR #164 (NOTIFY-gated wakeup) raises that wait to a
+  # 15s fallback ceiling, so a missed on_state_change strands work for up to
+  # 15s under execution_mode: :async. These tests pin the wake contract so the
+  # 15s ceiling stays a safety net, never the steady-state latency.
+  describe "on_state_change wake contract (de-risks #164 async fallback)" do
+    it "fires on_state_change for every fiber that frees capacity" do
+      total = 50
+      done = Concurrent::CountDownLatch.new(total)
+
+      # Post within capacity: each task completes quickly and frees a slot
+      # before the next post, mirroring the worker's idle<=0 backpressure.
+      total.times do |i|
+        wait_for_capacity(pool)
+        pool.post do
+          done.count_down
+        end
+        # Yield so the reactor schedules and the fiber completes between posts.
+        Thread.pass if (i % capacity).zero?
+      end
+
+      expect(done.wait(5)).to be(true), "Not all fibers completed"
+
+      # Each completion restores capacity and pokes on_state_change. With
+      # serialized within-capacity posting, every task frees a slot from a
+      # saturated-or-near-saturated state, so the callback must fire at least
+      # once per task — never fewer (a dropped poke = a missed worker wake).
+      expect(state_changes.value).to be >= total
+    end
+
+    it "wakes a saturated worker-style waiter the moment capacity frees" do
+      # Saturate the pool with blocking work, then park a waiter exactly as the
+      # worker loop does: WakeSignal#wait with a long (15s-style) timeout that
+      # must be interrupted early by on_state_change, not by the timeout.
+      wake_signal = Pgbus::Process::WakeSignal.new
+      saturating_pool = described_class.new(capacity: 2, on_state_change: -> { wake_signal.notify! })
+      release = Concurrent::Event.new
+      saturate(saturating_pool, count: 2, release: release)
+
+      woke_after = Concurrent::IVar.new
+      waiter = park_waiter(wake_signal, woke_after, timeout: 15) # the #164 fallback ceiling
+      sleep 0.05
+      release.set # fibers finish → restore_capacity → on_state_change → notify!
+
+      elapsed = woke_after.value(5)
+      expect(elapsed).not_to be_nil, "Waiter never woke (stranded on the 15s ceiling)"
+      expect(elapsed).to be < 1.0,
+                         "Waiter woke after #{elapsed.round(2)}s — on_state_change " \
+                         "did not interrupt the 15s fallback wait (issue #164 risk)"
+    ensure
+      waiter&.kill
+      saturating_pool&.shutdown
+      saturating_pool&.wait_for_termination(2)
+    end
+
+    def saturate(pool, count:, release:)
+      count.times { pool.post { release.wait(5) } }
+      sleep 0.05
+      expect(pool.available_capacity).to eq(0)
+    end
+
+    def park_waiter(wake_signal, woke_after, timeout:)
+      Thread.new do
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        wake_signal.wait(timeout: timeout)
+        woke_after.set(Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes the async (Fiber-based) consumer silently stalling all queue processing ~20-30s after boot while heartbeats keep running (regression in 0.9.0).

**Root cause**: `AsyncPool#wait_for_executions` used `Kernel#sleep(0.01)` to poll for pending work. This blocks the entire reactor thread, preventing the Async scheduler from running other fibers. Under sustained Mutex contention from the worker main thread (which continuously polls `available_capacity`), the reactor thread gets starved and stops scheduling new async tasks — causing a total silent stall where no messages are read from any queue, while heartbeats continue normally.

**Fix**: Replace the blocking `sleep` with an IO pipe mechanism:
- The reactor fiber waits on `IO#wait_readable` which integrates with the Async scheduler (yields the fiber, allows other fibers to run)
- `post()`, `shutdown()`, and `restore_capacity()` write a wake byte from the main thread via `write_nonblock`
- Sub-millisecond wake latency vs the previous 0-10ms polling window
- `wait_for_inflight` also changed from bare `sleep()` to `task.sleep()` for fiber safety

Closes #174

## Test plan
- [x] New `async_pool_reactor_spec.rb` with 4 tests:
  - Source analysis: `wait_for_executions` has no bare `sleep()` calls
  - Source analysis: `wait_for_inflight` has no bare `sleep()` calls
  - Latency: p90 post-to-execute < 5ms after extended idle (was ~11ms with polling)
  - Throughput: 20 burst-idle cycles with concurrent Mutex contention complete without stalling
- [x] All 32 execution pool specs pass
- [x] Full test suite passes (2206 examples, 0 failures)
- [x] Rubocop clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the async execution pool to use an event-driven wake mechanism instead of idle sleeping, improving responsiveness when posting work, restoring capacity, or shutting down.

* **Tests**
  * Added reactor-focused coverage to verify fiber-aware waiting, wake-on-state-change behavior, low post-to-execute latency targets, and sustained throughput across repeated busy/idle workload rounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->