### PR TITLE
fix(worker): prevent silent poll stall + add NOTIFY-gated wakeups (#174)

### DIFF
--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -117,6 +117,14 @@ module Pgbus
                   :streams_host, :streams_port, :streams_database_url
     attr_reader :streams_default_broadcast_mode # rubocop:disable Style/AccessorGrouping
 
+    # NOTIFY-gated worker wakeups. When true, each Worker fork owns a
+    # dedicated NotifyListener PG connection that LISTENs on its queues'
+    # INSERT channels and wakes the loop on a real insert. Defaults to the
+    # value of listen_notify. The worker_notify_* overrides mirror
+    # streams_* so the LISTEN connection can bypass PgBouncer.
+    attr_accessor :worker_notify_wakeup,
+                  :worker_notify_host, :worker_notify_port, :worker_notify_database_url
+
     # AppSignal integration (auto-loaded when ::Appsignal is defined and this is true).
     # Set to false to opt out without uninstalling the appsignal gem.
     attr_accessor :appsignal_enabled, :appsignal_probe_enabled
@@ -170,6 +178,11 @@ module Pgbus
       @error_reporters = []
 
       @listen_notify = true
+
+      @worker_notify_wakeup = nil
+      @worker_notify_host = nil
+      @worker_notify_port = nil
+      @worker_notify_database_url = nil
 
       @pgmq_schema_mode = :auto
 
@@ -729,6 +742,41 @@ module Pgbus
         parts.join(" ")
       else
         base
+      end
+    end
+
+    # Connection options for the Worker's dedicated NotifyListener connection.
+    # Mirrors streams_connection_options: defaults to the base connection_options,
+    # overridable via worker_notify_database_url / worker_notify_host /
+    # worker_notify_port so the LISTEN connection can bypass PgBouncer.
+    def worker_notify_connection_options
+      return worker_notify_database_url if worker_notify_database_url
+
+      base = connection_options
+      return base unless worker_notify_host || worker_notify_port
+
+      case base
+      when Hash
+        result = base.dup
+        result[:host] = worker_notify_host if worker_notify_host
+        result[:port] = worker_notify_port if worker_notify_port
+        result
+      when String
+        parts = [base]
+        parts << "host=#{worker_notify_host}" if worker_notify_host
+        parts << "port=#{worker_notify_port}" if worker_notify_port
+        parts.join(" ")
+      else
+        base
+      end
+    end
+
+    # Resolved notify wakeup flag: defaults to listen_notify when nil.
+    def worker_notify_wakeup?
+      if @worker_notify_wakeup.nil?
+        listen_notify
+      else
+        @worker_notify_wakeup
       end
     end
 

--- a/lib/pgbus/process/notify_listener.rb
+++ b/lib/pgbus/process/notify_listener.rb
@@ -117,6 +117,10 @@ module Pgbus
       rescue StandardError => e
         @logger.error { "[Pgbus::NotifyListener] fatal: #{e.class}: #{e.message}" } if running?
       ensure
+        # Clear @running so #start can spawn a fresh thread after a fatal exit
+        # (e.g. build_connection raising at boot). Without this, the dead
+        # thread's @running stays true and #start returns early forever.
+        @state_mutex.synchronize { @running = false }
         safe_unlisten_all
         safe_close
       end
@@ -193,10 +197,16 @@ module Pgbus
           return unless running?
 
           safe_close
+          new_conn = nil
           begin
             new_conn = build_connection
             channels.each { |channel| new_conn.exec(%(LISTEN "#{channel}")) }
           rescue PG::Error => e
+            # build_connection may have succeeded before a later LISTEN raised.
+            # Without this close, the partially-built conn is orphaned and the
+            # next retry just allocates another one — leaking PG connections on
+            # repeated failures.
+            close_quietly(new_conn)
             @logger.error { "[Pgbus::NotifyListener] reconnect failed: #{e.class}: #{e.message}" }
             sleep RECONNECT_BACKOFF_SECONDS
             next
@@ -239,6 +249,12 @@ module Pgbus
           @conn = nil
           c
         end
+        close_quietly(conn)
+      end
+
+      # Close an unpublished PG::Connection (one that never made it into @conn,
+      # e.g. a half-built reconnect attempt where LISTEN raised). Best-effort.
+      def close_quietly(conn)
         conn&.close if conn.respond_to?(:close)
       rescue StandardError
         nil

--- a/lib/pgbus/process/notify_listener.rb
+++ b/lib/pgbus/process/notify_listener.rb
@@ -24,11 +24,17 @@ module Pgbus
     # NOTIFY channel naming (pgmq trigger): PG_NOTIFY('pgmq.' || table || '.' ||
     # TG_OP). For queue `pgbus_default` the table is `q_pgbus_default`, so the
     # channel is `pgmq.q_pgbus_default.INSERT`.
+    #
+    # Thread safety: @running, @conn, and @listening_to are guarded by
+    # @state_mutex. The listener thread owns @conn during wait_for_notify (a
+    # blocking IO call where the mutex MUST NOT be held), so wait_once reads
+    # the connection out of the mutex first and operates on a local. Reconnect
+    # publishes the new connection + channel set under the mutex.
     class NotifyListener
       CHANNEL_PREFIX = "pgmq.q_"
       CHANNEL_SUFFIX = ".INSERT"
 
-      attr_reader :listening_to
+      RECONNECT_BACKOFF_SECONDS = 0.5
 
       def initialize(physical_queues:, on_wake:, connection_options:,
                      health_check_ms: 1000, logger: Pgbus.logger)
@@ -37,6 +43,7 @@ module Pgbus
         @connection_options = connection_options
         @health_check_ms = health_check_ms
         @logger = logger
+        @state_mutex = Mutex.new
         @listening_to = Set.new
         @commands = Queue.new
         @running = false
@@ -44,22 +51,34 @@ module Pgbus
         @conn = nil
       end
 
-      def start
-        return self if @running
+      def listening_to
+        @state_mutex.synchronize { @listening_to.dup }
+      end
 
-        @running = true
+      def start
+        @state_mutex.synchronize do
+          return self if @running
+
+          @running = true
+        end
         @physical_queues.each { |q| @commands << [:listen, q] }
         @thread = Thread.new { run_loop }
         self
       end
 
       def stop
-        return self unless @running
+        conn_to_close = nil
+        @state_mutex.synchronize do
+          return self unless @running
 
-        @running = false
+          @running = false
+          conn_to_close = @conn
+        end
         @commands << [:stop]
+        # Interrupt the blocking wait by closing the socket; the rescue in
+        # wait_once sees @running == false and exits cleanly.
         begin
-          @conn&.close if @conn.respond_to?(:close)
+          conn_to_close&.close if conn_to_close.respond_to?(:close)
         rescue StandardError
           nil
         end
@@ -78,33 +97,41 @@ module Pgbus
 
       private
 
+      def running?
+        @state_mutex.synchronize { @running }
+      end
+
       def run_loop
-        @conn = build_connection
+        conn = build_connection
+        @state_mutex.synchronize { @conn = conn }
         drain_commands
 
         loop do
-          break unless @running
+          break unless running?
 
           drain_commands
-          break unless @running
+          break unless running?
 
           wait_once
         end
       rescue StandardError => e
-        @logger.error { "[Pgbus::NotifyListener] fatal: #{e.class}: #{e.message}" } if @running
+        @logger.error { "[Pgbus::NotifyListener] fatal: #{e.class}: #{e.message}" } if running?
       ensure
         safe_unlisten_all
         safe_close
       end
 
       def wait_once
+        conn = @state_mutex.synchronize { @conn }
+        return reconnect! unless conn
+
         timeout_s = @health_check_ms / 1000.0
-        got_notify = @conn.wait_for_notify(timeout_s) do |_channel, _pid, _payload|
+        got_notify = conn.wait_for_notify(timeout_s) do |_channel, _pid, _payload|
           @on_wake.call
         end
-        run_health_check unless got_notify
+        run_health_check(conn) unless got_notify
       rescue IOError, PG::Error => e
-        return unless @running
+        return unless running?
 
         @logger.warn { "[Pgbus::NotifyListener] connection error (#{e.class}: #{e.message}) — reconnecting" }
         reconnect!
@@ -117,7 +144,7 @@ module Pgbus
           when :listen   then do_listen(cmd[1])
           when :unlisten then do_unlisten(cmd[1])
           when :stop
-            @running = false
+            @state_mutex.synchronize { @running = false }
             return
           end
         rescue ThreadError
@@ -127,36 +154,60 @@ module Pgbus
 
       def do_listen(physical_queue)
         channel = channel_for(physical_queue)
-        return if @listening_to.include?(channel)
+        conn = @state_mutex.synchronize do
+          return if @listening_to.include?(channel)
 
-        @conn.exec(%(LISTEN "#{channel}"))
-        @listening_to.add(channel)
+          @conn
+        end
+        return unless conn
+
+        conn.exec(%(LISTEN "#{channel}"))
+        @state_mutex.synchronize { @listening_to.add(channel) }
       end
 
       def do_unlisten(physical_queue)
         channel = channel_for(physical_queue)
-        return unless @listening_to.include?(channel)
+        conn = @state_mutex.synchronize do
+          return unless @listening_to.include?(channel)
 
-        @conn.exec(%(UNLISTEN "#{channel}"))
-        @listening_to.delete(channel)
-      end
-
-      def run_health_check
-        @conn.exec("SELECT 1")
-      end
-
-      def reconnect!
-        safe_close
-        @conn = build_connection
-        to_relisten = @listening_to.to_a
-        @listening_to = Set.new
-        to_relisten.each do |channel|
-          @conn.exec(%(LISTEN "#{channel}"))
-          @listening_to.add(channel)
+          @conn
         end
-      rescue PG::Error => e
-        @logger.error { "[Pgbus::NotifyListener] reconnect failed: #{e.class}: #{e.message}" }
-        sleep 0.5
+        return unless conn
+
+        conn.exec(%(UNLISTEN "#{channel}"))
+        @state_mutex.synchronize { @listening_to.delete(channel) }
+      end
+
+      def run_health_check(conn)
+        conn.exec("SELECT 1")
+      end
+
+      # Retry reconnect until either we succeed (new conn + every channel
+      # re-LISTENed) or @running flips to false. Without the loop, a single
+      # PG::Error during build/LISTEN left @conn nil and the listener degraded
+      # silently — wait_once would re-enter and fail forever or run with an
+      # incomplete subscription set.
+      def reconnect!
+        channels = @state_mutex.synchronize { @listening_to.to_a }
+        loop do
+          return unless running?
+
+          safe_close
+          begin
+            new_conn = build_connection
+            channels.each { |channel| new_conn.exec(%(LISTEN "#{channel}")) }
+          rescue PG::Error => e
+            @logger.error { "[Pgbus::NotifyListener] reconnect failed: #{e.class}: #{e.message}" }
+            sleep RECONNECT_BACKOFF_SECONDS
+            next
+          end
+
+          @state_mutex.synchronize do
+            @conn = new_conn
+            @listening_to = Set.new(channels)
+          end
+          return
+        end
       end
 
       def build_connection
@@ -173,20 +224,24 @@ module Pgbus
       end
 
       def safe_unlisten_all
-        @listening_to.each do |channel|
-          @conn&.exec(%(UNLISTEN "#{channel}"))
+        channels, conn = @state_mutex.synchronize { [@listening_to.to_a, @conn] }
+        channels.each do |channel|
+          conn&.exec(%(UNLISTEN "#{channel}"))
         rescue PG::Error
           nil
         end
-        @listening_to.clear
+        @state_mutex.synchronize { @listening_to.clear }
       end
 
       def safe_close
-        @conn&.close if @conn.respond_to?(:close)
+        conn = @state_mutex.synchronize do
+          c = @conn
+          @conn = nil
+          c
+        end
+        conn&.close if conn.respond_to?(:close)
       rescue StandardError
         nil
-      ensure
-        @conn = nil
       end
 
       def channel_for(physical_queue)

--- a/lib/pgbus/process/notify_listener.rb
+++ b/lib/pgbus/process/notify_listener.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Process
+    # Owns a single dedicated PG::Connection that LISTENs on the INSERT NOTIFY
+    # channel of every queue a Worker/Consumer reads, and fires a WakeSignal the
+    # moment any of them receives a row. This converts the worker/consumer loop
+    # from "blind-read every polling_interval" into "sleep until a real insert,
+    # poll only as a fallback" — eliminating the empty-read storm that dominates
+    # DB load on idle queues.
+    #
+    # pgmq-ruby's `wait_for_notify(queue, timeout:)` is single-queue and wraps
+    # the wait in `with_connection`, which only watches one channel and holds the
+    # pooled connection for the whole wait. Neither fits a worker that reads N
+    # queues on a small shared pool. So we own ONE raw PG::Connection and
+    # hand-roll per-channel LISTEN on it.
+    #
+    # A persistent LISTEN connection silently dies under a transaction-pool
+    # PgBouncer (LISTEN does not survive COMMIT boundaries). Point this
+    # connection at a DIRECT port via `config.worker_notify_*` overrides.
+    # The health-check-on-timeout catches a connection killed out from under us
+    # and re-LISTENs everything.
+    #
+    # NOTIFY channel naming (pgmq trigger): PG_NOTIFY('pgmq.' || table || '.' ||
+    # TG_OP). For queue `pgbus_default` the table is `q_pgbus_default`, so the
+    # channel is `pgmq.q_pgbus_default.INSERT`.
+    class NotifyListener
+      CHANNEL_PREFIX = "pgmq.q_"
+      CHANNEL_SUFFIX = ".INSERT"
+
+      attr_reader :listening_to
+
+      def initialize(physical_queues:, on_wake:, connection_options:,
+                     health_check_ms: 1000, logger: Pgbus.logger)
+        @physical_queues = Array(physical_queues)
+        @on_wake = on_wake
+        @connection_options = connection_options
+        @health_check_ms = health_check_ms
+        @logger = logger
+        @listening_to = Set.new
+        @commands = Queue.new
+        @running = false
+        @thread = nil
+        @conn = nil
+      end
+
+      def start
+        return self if @running
+
+        @running = true
+        @physical_queues.each { |q| @commands << [:listen, q] }
+        @thread = Thread.new { run_loop }
+        self
+      end
+
+      def stop
+        return self unless @running
+
+        @running = false
+        @commands << [:stop]
+        begin
+          @conn&.close if @conn.respond_to?(:close)
+        rescue StandardError
+          nil
+        end
+        @thread&.join(5)
+        @thread = nil
+        self
+      end
+
+      def add_queue(physical_queue)
+        @commands << [:listen, physical_queue]
+      end
+
+      def remove_queue(physical_queue)
+        @commands << [:unlisten, physical_queue]
+      end
+
+      private
+
+      def run_loop
+        @conn = build_connection
+        drain_commands
+
+        loop do
+          break unless @running
+
+          drain_commands
+          break unless @running
+
+          wait_once
+        end
+      rescue StandardError => e
+        @logger.error { "[Pgbus::NotifyListener] fatal: #{e.class}: #{e.message}" } if @running
+      ensure
+        safe_unlisten_all
+        safe_close
+      end
+
+      def wait_once
+        timeout_s = @health_check_ms / 1000.0
+        got_notify = @conn.wait_for_notify(timeout_s) do |_channel, _pid, _payload|
+          @on_wake.call
+        end
+        run_health_check unless got_notify
+      rescue IOError, PG::Error => e
+        return unless @running
+
+        @logger.warn { "[Pgbus::NotifyListener] connection error (#{e.class}: #{e.message}) — reconnecting" }
+        reconnect!
+      end
+
+      def drain_commands
+        loop do
+          cmd = @commands.pop(true)
+          case cmd[0]
+          when :listen   then do_listen(cmd[1])
+          when :unlisten then do_unlisten(cmd[1])
+          when :stop
+            @running = false
+            return
+          end
+        rescue ThreadError
+          return
+        end
+      end
+
+      def do_listen(physical_queue)
+        channel = channel_for(physical_queue)
+        return if @listening_to.include?(channel)
+
+        @conn.exec(%(LISTEN "#{channel}"))
+        @listening_to.add(channel)
+      end
+
+      def do_unlisten(physical_queue)
+        channel = channel_for(physical_queue)
+        return unless @listening_to.include?(channel)
+
+        @conn.exec(%(UNLISTEN "#{channel}"))
+        @listening_to.delete(channel)
+      end
+
+      def run_health_check
+        @conn.exec("SELECT 1")
+      end
+
+      def reconnect!
+        safe_close
+        @conn = build_connection
+        to_relisten = @listening_to.to_a
+        @listening_to = Set.new
+        to_relisten.each do |channel|
+          @conn.exec(%(LISTEN "#{channel}"))
+          @listening_to.add(channel)
+        end
+      rescue PG::Error => e
+        @logger.error { "[Pgbus::NotifyListener] reconnect failed: #{e.class}: #{e.message}" }
+        sleep 0.5
+      end
+
+      def build_connection
+        require "pg" unless defined?(::PG::Connection)
+        case @connection_options
+        when String then ::PG.connect(@connection_options)
+        when Hash   then ::PG.connect(**@connection_options)
+        else
+          raise Pgbus::ConfigurationError,
+                "NotifyListener cannot build a PG connection from #{@connection_options.class}. " \
+                "Set worker_notify_database_url / worker_notify_host / worker_notify_port, " \
+                "or a base database_url, so the listener owns a dedicated connection."
+        end
+      end
+
+      def safe_unlisten_all
+        @listening_to.each do |channel|
+          @conn&.exec(%(UNLISTEN "#{channel}"))
+        rescue PG::Error
+          nil
+        end
+        @listening_to.clear
+      end
+
+      def safe_close
+        @conn&.close if @conn.respond_to?(:close)
+      rescue StandardError
+        nil
+      ensure
+        @conn = nil
+      end
+
+      def channel_for(physical_queue)
+        "#{CHANNEL_PREFIX}#{physical_queue}#{CHANNEL_SUFFIX}"
+      end
+    end
+  end
+end

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -13,6 +13,7 @@ module Pgbus
                      single_active_consumer: false, consumer_priority: 0,
                      execution_mode: :threads, group_mode: nil)
         @queues = Array(queues)
+        @initial_queues = @queues.dup.freeze
         @wildcard = @queues.include?("*")
         @threads = threads
         @config = config
@@ -49,6 +50,7 @@ module Pgbus
         )
         @circuit_breaker = Pgbus::CircuitBreaker.new(config: config)
         @queue_lock = QueueLock.new if @single_active_consumer
+        @notify_listener = nil
       end
 
       def stats
@@ -66,14 +68,17 @@ module Pgbus
         }.merge(@pool.metadata)
       end
 
+      NOTIFY_FALLBACK_POLL_SECONDS = 15
+
       def run
         setup_signals
         start_heartbeat
         resolve_wildcard_queues
+        start_notify_listener
         @lifecycle.transition_to!(:running)
         Pgbus.logger.info do
           "[Pgbus] Worker started: queues=#{queues.join(",")} threads=#{threads} " \
-            "mode=#{@execution_mode} pid=#{::Process.pid}"
+            "mode=#{@execution_mode} notify_wakeup=#{notify_wakeup?} pid=#{::Process.pid}"
         end
 
         loop do
@@ -117,7 +122,7 @@ module Pgbus
       private
 
       def claim_and_execute
-        poll_interval = effective_polling_interval
+        poll_interval = wake_timeout
 
         idle = @pool.available_capacity
         return @wake_signal.wait(timeout: poll_interval) if idle <= 0
@@ -147,9 +152,19 @@ module Pgbus
       # Returns an array of [queue_name, message] pairs so we always know
       # which queue each message came from.
       def fetch_messages(qty)
+        restore_evicted_queues if queues.empty? && !@wildcard
+
         active_queues = queues.reject { |q| @circuit_breaker.paused?(q) }
         active_queues = active_queues.select { |q| @queue_lock.try_lock(q) } if @single_active_consumer
-        return [] if active_queues.empty?
+
+        if active_queues.empty?
+          Pgbus.logger.debug do
+            paused = queues.select { |q| @circuit_breaker.paused?(q) }
+            "[Pgbus] Worker fetch: all queues filtered — queues=#{queues.join(",")} " \
+              "paused=#{paused.join(",")}"
+          end
+          return []
+        end
 
         if priority_enabled?
           fetch_prioritized(active_queues, qty)
@@ -295,6 +310,7 @@ module Pgbus
           Pgbus.logger.info { "[Pgbus] Wildcard queue '*' resolved to: #{@queues.join(", ")}" } unless @last_wildcard_resolve
         end
         @last_wildcard_resolve = monotonic_now
+        sync_notify_listener_queues
       rescue StandardError => e
         Pgbus.logger.error { "[Pgbus] Failed to resolve wildcard queues: #{e.message} — falling back to default" }
         @queues = [config.default_queue] unless @last_wildcard_resolve
@@ -321,6 +337,15 @@ module Pgbus
           end
         end
         Pgbus.logger.error { "[Pgbus] Queue table missing: #{error.message}" }
+        restore_evicted_queues if @queues.empty? && !@wildcard
+      end
+
+      def restore_evicted_queues
+        @queues = @initial_queues.dup
+        Pgbus.logger.warn do
+          "[Pgbus] Worker queue list was empty after eviction — " \
+            "restoring initial queues: #{@queues.join(", ")}"
+        end
       end
 
       def detect_zombie(queue_name, message)
@@ -401,6 +426,16 @@ module Pgbus
         end
       end
 
+      def notify_wakeup?
+        config.respond_to?(:worker_notify_wakeup?) && config.worker_notify_wakeup?
+      end
+
+      def wake_timeout
+        return effective_polling_interval unless notify_wakeup? && @notify_listener
+
+        [effective_polling_interval, config.polling_interval, NOTIFY_FALLBACK_POLL_SECONDS].max
+      end
+
       def effective_polling_interval
         return config.polling_interval if @consumer_priority.zero?
 
@@ -411,6 +446,43 @@ module Pgbus
         )
       rescue StandardError
         config.polling_interval
+      end
+
+      def start_notify_listener
+        return unless notify_wakeup?
+
+        @notify_listener = NotifyListener.new(
+          physical_queues: physical_queue_names,
+          on_wake: -> { @wake_signal.notify! },
+          connection_options: config.worker_notify_connection_options,
+          health_check_ms: (config.polling_interval * 1000).to_i.clamp(250, 5_000),
+          logger: Pgbus.logger
+        ).start
+      rescue StandardError => e
+        @notify_listener = nil
+        Pgbus.logger.error do
+          "[Pgbus] NotifyListener failed to start, falling back to polling: #{e.class}: #{e.message}"
+        end
+      end
+
+      def sync_notify_listener_queues
+        return unless @notify_listener
+
+        desired = physical_queue_names.to_set
+        current = @notify_listener.listening_to.to_set { |c| channel_to_physical(c) }
+        (desired - current).each { |q| @notify_listener.add_queue(q) }
+        (current - desired).each { |q| @notify_listener.remove_queue(q) }
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] NotifyListener queue sync failed: #{e.class}: #{e.message}" }
+      end
+
+      def physical_queue_names
+        prefix = "#{config.queue_prefix}_"
+        queues.map { |q| "#{prefix}#{q}" }
+      end
+
+      def channel_to_physical(channel)
+        channel.delete_prefix(NotifyListener::CHANNEL_PREFIX).delete_suffix(NotifyListener::CHANNEL_SUFFIX)
       end
 
       def start_heartbeat
@@ -427,6 +499,7 @@ module Pgbus
 
       def shutdown
         Pgbus.logger.info { "[Pgbus] Worker draining thread pool..." }
+        @notify_listener&.stop
         @pool.shutdown
         @pool.wait_for_termination(30)
         @stat_buffer&.stop

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Process::NotifyListener do
+  subject(:listener) do
+    described_class.new(
+      physical_queues: %w[pgbus_default pgbus_low],
+      on_wake: -> { wakes << :woke },
+      connection_options: { dbname: "fake" },
+      health_check_ms: 50,
+      logger: logger
+    )
+  end
+
+  before do
+    stub_const("PG", Module.new) unless defined?(PG)
+    stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
+    allow_any_instance_of(described_class).to receive(:build_connection).and_return(fake_pg)
+  end
+
+  let(:fake_pg) do
+    Class.new do
+      attr_reader :executed
+
+      def initialize
+        @executed = []
+        @events = Queue.new
+      end
+
+      def exec(sql)
+        @executed << sql
+        nil
+      end
+
+      def wait_for_notify(_timeout)
+        event = @events.pop
+        case event[0]
+        when :notify
+          yield event[1], 0, nil
+          event[1]
+        when :timeout
+          nil
+        when :raise
+          raise event[1]
+        when :close
+          raise PG::Error, "connection closed"
+        end
+      end
+
+      def close = (@events << [:close])
+      def push_notify(channel) = @events << [:notify, channel]
+      def push_timeout = @events << [:timeout]
+      def push_error(error) = @events << [:raise, error]
+    end.new
+  end
+
+  let(:wakes)  { Queue.new }
+  let(:logger) { Logger.new(IO::NULL) }
+
+  after { listener.stop }
+
+  def wait_until(timeout: 2)
+    deadline = Time.now + timeout
+    until yield
+      raise "timed out waiting for condition" if Time.now > deadline
+
+      sleep 0.01
+    end
+  end
+
+  describe "#start" do
+    it "LISTENs on pgmq.q_<queue>.INSERT for every queue" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until do
+        fake_pg.executed.include?(%(LISTEN "pgmq.q_pgbus_default.INSERT")) &&
+          fake_pg.executed.include?(%(LISTEN "pgmq.q_pgbus_low.INSERT"))
+      end
+
+      expect(listener.listening_to).to contain_exactly(
+        "pgmq.q_pgbus_default.INSERT",
+        "pgmq.q_pgbus_low.INSERT"
+      )
+    end
+
+    it "is idempotent" do
+      listener.start
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      listens = fake_pg.executed.count { |s| s.start_with?("LISTEN") }
+      expect(listens).to eq(2)
+    end
+  end
+
+  describe "NOTIFY handling" do
+    it "fires on_wake for any INSERT notification" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      fake_pg.push_notify("pgmq.q_pgbus_default.INSERT")
+
+      expect(wakes.pop).to eq(:woke)
+    end
+
+    it "coalesces into a single wake per notification" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      fake_pg.push_notify("pgmq.q_pgbus_low.INSERT")
+      expect(wakes.pop).to eq(:woke)
+      expect(wakes).to be_empty
+    end
+  end
+
+  describe "health check" do
+    it "runs SELECT 1 when wait_for_notify times out" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { fake_pg.executed.include?("SELECT 1") }
+      expect(fake_pg.executed).to include("SELECT 1")
+    end
+
+    it "does not fire on_wake on a timeout" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { fake_pg.executed.include?("SELECT 1") }
+      expect(wakes).to be_empty
+    end
+  end
+
+  describe "runtime queue-set changes" do
+    it "adds a queue via add_queue" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      listener.add_queue("pgbus_webhooks")
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.include?("pgmq.q_pgbus_webhooks.INSERT") }
+
+      expect(fake_pg.executed).to include(%(LISTEN "pgmq.q_pgbus_webhooks.INSERT"))
+    end
+
+    it "drops a queue via remove_queue" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      listener.remove_queue("pgbus_low")
+      fake_pg.push_timeout
+      wait_until { !listener.listening_to.include?("pgmq.q_pgbus_low.INSERT") }
+
+      expect(fake_pg.executed).to include(%(UNLISTEN "pgmq.q_pgbus_low.INSERT"))
+    end
+  end
+
+  describe "reconnect on connection error" do
+    it "rebuilds the connection and re-LISTENs every channel" do
+      second_pg = fake_pg.clone
+      call_count = 0
+      allow_any_instance_of(described_class).to receive(:build_connection) do
+        call_count += 1
+        call_count == 1 ? fake_pg : second_pg
+      end
+
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      second_pg.push_timeout
+
+      wait_until do
+        second_pg.executed.count { |s| s.start_with?("LISTEN") } >= 2
+      end
+
+      expect(listener.listening_to).to contain_exactly(
+        "pgmq.q_pgbus_default.INSERT",
+        "pgmq.q_pgbus_low.INSERT"
+      )
+    end
+  end
+
+  describe "#stop" do
+    it "interrupts the blocking wait and clears the LISTEN set" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      listener.stop
+      expect(listener.listening_to).to be_empty
+    end
+  end
+end

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -21,15 +21,19 @@ RSpec.describe Pgbus::Process::NotifyListener do
 
   let(:fake_pg) do
     Class.new do
-      attr_reader :executed
+      attr_reader :executed, :close_count
 
       def initialize
         @executed = []
         @events = Queue.new
+        @exec_errors = []
+        @close_count = 0
       end
 
       def exec(sql)
         @executed << sql
+        raise @exec_errors.shift if @exec_errors.any?
+
         nil
       end
 
@@ -48,10 +52,19 @@ RSpec.describe Pgbus::Process::NotifyListener do
         end
       end
 
-      def close = (@events << [:close])
+      def close
+        @close_count += 1
+        @events << [:close]
+      end
+
+      def closed?
+        @close_count.positive?
+      end
+
       def push_notify(channel) = @events << [:notify, channel]
       def push_timeout = @events << [:timeout]
       def push_error(error) = @events << [:raise, error]
+      def push_exec_error(error) = @exec_errors << error
     end.new
   end
 
@@ -186,6 +199,38 @@ RSpec.describe Pgbus::Process::NotifyListener do
         "pgmq.q_pgbus_low.INSERT"
       )
     end
+
+    context "when re-LISTEN fails mid-rebuild (no leaked conn)" do
+      let(:half_built) do
+        fake_pg.class.new.tap { |c| c.push_exec_error(PG::Error.new("listen failed mid-rebuild")) }
+      end
+      let(:good_pg) { fake_pg.class.new }
+
+      before do
+        call_sequence = [fake_pg, half_built, good_pg]
+        allow_any_instance_of(described_class).to receive(:build_connection) { call_sequence.shift }
+        stub_const("Pgbus::Process::NotifyListener::RECONNECT_BACKOFF_SECONDS", 0.01)
+        listener.start
+        fake_pg.push_timeout
+        wait_until { listener.listening_to.size == 2 }
+
+        fake_pg.push_error(PG::Error.new("connection reset"))
+        good_pg.push_timeout
+        wait_until { half_built.closed? }
+        wait_until { good_pg.executed.count { |s| s.start_with?("LISTEN") } >= 2 }
+      end
+
+      it "closes the partially-built conn before retrying" do
+        expect(half_built).to be_closed
+      end
+
+      it "ends up subscribed via the successor connection" do
+        expect(listener.listening_to).to contain_exactly(
+          "pgmq.q_pgbus_default.INSERT",
+          "pgmq.q_pgbus_low.INSERT"
+        )
+      end
+    end
   end
 
   describe "#stop" do
@@ -196,6 +241,17 @@ RSpec.describe Pgbus::Process::NotifyListener do
 
       listener.stop
       expect(listener.listening_to).to be_empty
+    end
+
+    it "clears @running after the thread exits so start can spawn a fresh thread" do
+      allow_any_instance_of(described_class).to receive(:build_connection)
+        .and_raise(PG::Error.new("boot failed"))
+
+      listener.start
+      # Thread crashes immediately on build_connection.
+      wait_until { !listener.instance_variable_get(:@thread)&.alive? }
+
+      expect(listener.instance_variable_get(:@running)).to be(false)
     end
   end
 end

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -161,7 +161,9 @@ RSpec.describe Pgbus::Process::NotifyListener do
 
   describe "reconnect on connection error" do
     it "rebuilds the connection and re-LISTENs every channel" do
-      second_pg = fake_pg.clone
+      # Don't use Object#clone — it shallow-copies @events/@executed, so a
+      # missed reconnect could pass by reading channels from the first conn.
+      second_pg = fake_pg.class.new
       call_count = 0
       allow_any_instance_of(described_class).to receive(:build_connection) do
         call_count += 1

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -202,6 +202,41 @@ RSpec.describe Pgbus::Process::Worker do
       end
     end
 
+    context "when eviction removes ALL queues (regression: issue #174)" do
+      let(:prefix) { worker.config.queue_prefix }
+
+      before do
+        worker.instance_variable_set(:@queues, %w[only_queue])
+        error_message = "Database connection error: ERROR:  relation \"pgmq.q_#{prefix}_only_queue\" does not exist"
+        allow(mock_client).to receive(:read_batch)
+          .and_raise(StandardError, error_message)
+      end
+
+      it "recovers by falling back to the default queue" do
+        worker.send(:fetch_messages, 5)
+        expect(worker.queues).not_to be_empty
+        expect(worker.queues).to eq([worker.config.default_queue])
+      end
+    end
+
+    context "when circuit breaker pauses all queues (#174 diagnostic)" do
+      let(:worker) { described_class.new(queues: %w[default low], threads: 5) }
+      let(:warn_messages) { [] }
+
+      before do
+        allow(circuit_breaker).to receive(:paused?).and_return(true)
+        allow(Pgbus.logger).to receive(:debug) do |&block|
+          warn_messages << block.call if block
+        end
+      end
+
+      it "logs which queues were filtered out" do
+        worker.send(:fetch_messages, 5)
+        filtered_log = warn_messages.find { |m| m.include?("all queues filtered") }
+        expect(filtered_log).not_to be_nil
+      end
+    end
+
     context "with group_mode: :fifo" do
       let(:worker) { described_class.new(queues: %w[default], threads: 5, group_mode: :fifo) }
       let(:messages) { [build_message_double(msg_id: 1), build_message_double(msg_id: 2)] }


### PR DESCRIPTION
## Summary

Fixes the worker job-queue poll loop that silently stops reading messages (`read_ct=0`) while heartbeats and pub/sub handlers remain healthy.

Three independent fixes:

- **Queue list recovery after eviction**: `evict_missing_queues` could remove ALL queues from the worker's active list, leaving `@queues = []`. The worker would then silently skip all reads forever since `active_queues.empty?` returned `[]` without logging. Now restores from the initial configured queue set.

- **Diagnostic logging**: `fetch_messages` previously returned `[]` silently when circuit breaker filtering eliminated all active queues. Now logs which queues were filtered and why at DEBUG level, making silent stalls diagnosable.

- **NOTIFY-gated worker wakeups** (`NotifyListener`): Each worker fork owns a dedicated `PG::Connection` that `LISTEN`s on its queues' INSERT channels (via PGMQ's `enable_notify_insert` trigger). On insert, the listener fires `WakeSignal#notify!` to wake the worker immediately instead of waiting for the next polling tick. Includes health checking, reconnect on connection drop, and runtime queue-set sync for wildcard workers.

  Configuration:
  - `worker_notify_wakeup` — defaults to `listen_notify` value (true). Set to `false` to disable.
  - `worker_notify_host` / `worker_notify_port` / `worker_notify_database_url` — pin the LISTEN connection to a direct port past PgBouncer (mirrors `streams_*` overrides).

Refs #174

## Existing enqueued jobs

The stalled messages with `read_ct=0` will be picked up automatically once this fix is deployed — no manual intervention needed. The queue list recovery ensures `@queues` is never empty, and the NOTIFY listener provides instant wakeup when the worker starts polling again.

## Test plan

- [ ] `bundle exec rspec spec/pgbus/process/worker_spec.rb` — 53 examples pass including 2 new regression tests
- [ ] `bundle exec rspec spec/pgbus/process/notify_listener_spec.rb` — 10 examples covering LISTEN, NOTIFY wake, health check, reconnect, runtime add/remove, stop
- [ ] `bundle exec rubocop` — clean on all changed files
- [ ] Deploy to staging with `execution_mode: :async` and verify `read_ct` increments on standard job queues
- [ ] Verify pub/sub event handlers continue working
- [ ] Optionally disable with `config.worker_notify_wakeup = false` and verify polling fallback still works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Workers now optionally use a dedicated PostgreSQL NOTIFY listener for event-driven wakeups, with separate enablement from existing notify/listen settings
* Added configurable NOTIFY listener connection overrides (host/port/database URL)
* Worker now syncs NOTIFY subscriptions as queue sets change, including wildcard-resolved queues

## Bug Fixes
* Improved resilience when queue eviction removes all queues and during NOTIFY listener startup/reconnect failures (with automatic polling fallback)
* Updated wake timing and added periodic health checks on notify timeouts

## Tests
* Added full coverage for NOTIFY listener lifecycle, wake/timeout/error handling, and dynamic subscription updates
* Extended worker tests for eviction recovery and paused-queue filtering/logging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->