### PR TITLE
test: pin NOTIFY-gated worker wakeup surface (#174 follow-up)

### DIFF
--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe Pgbus::Configuration do
       expect(config.listen_notify).to be true
     end
 
+    it "leaves worker_notify_wakeup unset by default so it inherits listen_notify" do
+      # The raw attribute stays nil; the worker_notify_wakeup? resolver
+      # falls back to listen_notify. This is what makes NOTIFY wakeups
+      # on by default without forcing operators who already turned
+      # listen_notify off to also flip a second flag.
+      expect(config.worker_notify_wakeup).to be_nil
+    end
+
+    it "leaves worker_notify_host/port/database_url unset by default" do
+      expect(config.worker_notify_host).to be_nil
+      expect(config.worker_notify_port).to be_nil
+      expect(config.worker_notify_database_url).to be_nil
+    end
+
     it "has no worker recycling limits by default" do
       expect(config.max_jobs_per_worker).to be_nil
       expect(config.max_memory_mb).to be_nil
@@ -1027,6 +1041,114 @@ RSpec.describe Pgbus::Configuration do
         result = config.connection_options
         expect(result).to be_a(Proc)
         expect(Pgbus.logger).to have_received(:warn)
+      end
+    end
+  end
+
+  describe "#worker_notify_wakeup?" do
+    # Resolver lives at lib/pgbus/configuration.rb:775 and gates the
+    # NotifyListener startup at lib/pgbus/process/worker.rb:430-452.
+    # Flipping it to false must demonstrably keep the listener from
+    # being constructed; nil must inherit listen_notify so a user who
+    # already turned listen_notify off doesn't accidentally still pay
+    # for a dedicated PG connection per worker fork.
+
+    it "inherits from listen_notify when unset (default-on)" do
+      expect(config.worker_notify_wakeup).to be_nil
+      expect(config.listen_notify).to be true
+      expect(config.worker_notify_wakeup?).to be true
+    end
+
+    it "inherits 'off' from listen_notify when listen_notify is false" do
+      config.listen_notify = false
+      expect(config.worker_notify_wakeup?).to be false
+    end
+
+    it "honors an explicit true even if listen_notify is false" do
+      config.listen_notify = false
+      config.worker_notify_wakeup = true
+      expect(config.worker_notify_wakeup?).to be true
+    end
+
+    it "honors an explicit false even if listen_notify is true" do
+      config.listen_notify = true
+      config.worker_notify_wakeup = false
+      expect(config.worker_notify_wakeup?).to be false
+    end
+  end
+
+  describe "#worker_notify_connection_options" do
+    # Mirrors streams_connection_options: defaults to connection_options,
+    # overridable so the listener's persistent LISTEN connection can be
+    # pinned past a transaction-pool PgBouncer (where LISTEN silently
+    # unbinds on COMMIT). Precedence is database_url > host/port > base,
+    # and both Hash and String base shapes have to compose cleanly.
+
+    context "when no overrides are set" do
+      it "returns the base connection_options Hash unchanged" do
+        params = { host: "localhost", dbname: "test" }
+        config.connection_params = params
+        expect(config.worker_notify_connection_options).to eq(params)
+      end
+
+      it "returns the base connection_options String unchanged" do
+        config.database_url = "postgres://localhost/test"
+        expect(config.worker_notify_connection_options).to eq("postgres://localhost/test")
+      end
+    end
+
+    context "with worker_notify_database_url set" do
+      it "returns the override URL even when host/port overrides are also set" do
+        config.database_url = "postgres://pool.example/test"
+        config.worker_notify_database_url = "postgres://direct.example/test"
+        config.worker_notify_host = "ignored"
+        config.worker_notify_port = 9999
+        expect(config.worker_notify_connection_options)
+          .to eq("postgres://direct.example/test")
+      end
+    end
+
+    context "with worker_notify_host / worker_notify_port over a Hash base" do
+      it "overrides only host" do
+        config.connection_params = { host: "pool.example", port: 6432, dbname: "test" }
+        config.worker_notify_host = "direct.example"
+        result = config.worker_notify_connection_options
+        expect(result).to eq(host: "direct.example", port: 6432, dbname: "test")
+      end
+
+      it "overrides only port" do
+        config.connection_params = { host: "shared.example", port: 6432, dbname: "test" }
+        config.worker_notify_port = 5432
+        result = config.worker_notify_connection_options
+        expect(result).to eq(host: "shared.example", port: 5432, dbname: "test")
+      end
+
+      it "overrides both host and port without mutating the base Hash" do
+        base = { host: "pool.example", port: 6432, dbname: "test" }
+        config.connection_params = base
+        config.worker_notify_host = "direct.example"
+        config.worker_notify_port = 5432
+        result = config.worker_notify_connection_options
+        expect(result).to eq(host: "direct.example", port: 5432, dbname: "test")
+        # Mutating the override return value must NOT leak into the base hash.
+        expect(base).to eq(host: "pool.example", port: 6432, dbname: "test")
+      end
+    end
+
+    context "with worker_notify_host / worker_notify_port over a String base" do
+      it "appends host=… as a libpq key=value pair" do
+        config.database_url = "postgres://pool.example/test"
+        config.worker_notify_host = "direct.example"
+        expect(config.worker_notify_connection_options)
+          .to eq("postgres://pool.example/test host=direct.example")
+      end
+
+      it "appends both host=… and port=…" do
+        config.database_url = "postgres://pool.example/test"
+        config.worker_notify_host = "direct.example"
+        config.worker_notify_port = 5432
+        expect(config.worker_notify_connection_options)
+          .to eq("postgres://pool.example/test host=direct.example port=5432")
       end
     end
   end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -589,4 +589,216 @@ RSpec.describe Pgbus::Process::Worker do
       expect(priority_worker.stats[:consumer_priority]).to eq(10)
     end
   end
+
+  describe "NOTIFY-gated wakeup wiring" do
+    # These specs pin the load-bearing private API around the NotifyListener:
+    # construction, queue sync, channel ↔ physical-queue conversion, the
+    # raised wait_timeout when the listener is active, and shutdown cleanup.
+    # The listener itself is stubbed — its internals are covered in
+    # notify_listener_spec.rb; here we only exercise how the worker wires it.
+
+    let(:fake_listener) do
+      instance_double(
+        Pgbus::Process::NotifyListener,
+        start: nil, stop: nil, add_queue: nil, remove_queue: nil,
+        listening_to: []
+      ).tap { |l| allow(l).to receive(:start).and_return(l) }
+    end
+
+    describe "#notify_wakeup?" do
+      it "is true when config.worker_notify_wakeup? is true" do
+        allow(worker.config).to receive(:worker_notify_wakeup?).and_return(true)
+        expect(worker.send(:notify_wakeup?)).to be true
+      end
+
+      it "is false when config.worker_notify_wakeup? is false" do
+        allow(worker.config).to receive(:worker_notify_wakeup?).and_return(false)
+        expect(worker.send(:notify_wakeup?)).to be false
+      end
+
+      it "is false when config does not respond to worker_notify_wakeup? (old configs)" do
+        stripped_config = double("Config")
+        allow(stripped_config).to receive(:respond_to?).with(:worker_notify_wakeup?).and_return(false)
+        worker.instance_variable_set(:@config, stripped_config)
+        expect(worker.send(:notify_wakeup?)).to be false
+      end
+    end
+
+    describe "#physical_queue_names" do
+      let(:prefix) { worker.config.queue_prefix }
+
+      it "prefixes each logical queue with the configured queue_prefix" do
+        multi_worker = described_class.new(queues: %w[default low], threads: 4)
+        expect(multi_worker.send(:physical_queue_names))
+          .to eq(["#{prefix}_default", "#{prefix}_low"])
+      end
+
+      it "uses the current @queues, not the initial set (post-eviction safe)" do
+        worker.instance_variable_set(:@queues, %w[events])
+        expect(worker.send(:physical_queue_names)).to eq(["#{prefix}_events"])
+      end
+    end
+
+    describe "#channel_to_physical" do
+      it "round-trips a channel name back to its physical queue" do
+        prefix = worker.config.queue_prefix
+        channel = "#{Pgbus::Process::NotifyListener::CHANNEL_PREFIX}#{prefix}_default" \
+                  "#{Pgbus::Process::NotifyListener::CHANNEL_SUFFIX}"
+        expect(worker.send(:channel_to_physical, channel)).to eq("#{prefix}_default")
+      end
+    end
+
+    describe "#wake_timeout" do
+      it "returns effective_polling_interval when notify_wakeup? is off" do
+        allow(worker).to receive(:notify_wakeup?).and_return(false)
+        expect(worker.send(:wake_timeout)).to eq(worker.config.polling_interval)
+      end
+
+      it "returns effective_polling_interval when wakeup is on but no listener attached yet" do
+        allow(worker).to receive(:notify_wakeup?).and_return(true)
+        worker.instance_variable_set(:@notify_listener, nil)
+        expect(worker.send(:wake_timeout)).to eq(worker.config.polling_interval)
+      end
+
+      it "raises the wait to the NOTIFY_FALLBACK_POLL_SECONDS ceiling when a listener is active" do
+        # When NOTIFY drives latency, the empty-fetch wait is a safety net,
+        # not the steady-state cadence. The ceiling lets one missed NOTIFY
+        # cost bounded latency, never a stuck queue.
+        allow(worker).to receive(:notify_wakeup?).and_return(true)
+        worker.instance_variable_set(:@notify_listener, fake_listener)
+        expect(worker.send(:wake_timeout))
+          .to eq(described_class::NOTIFY_FALLBACK_POLL_SECONDS)
+      end
+    end
+
+    describe "#start_notify_listener" do
+      it "does not construct a listener when notify_wakeup? is off" do
+        allow(worker).to receive(:notify_wakeup?).and_return(false)
+        allow(Pgbus::Process::NotifyListener).to receive(:new)
+        worker.send(:start_notify_listener)
+        expect(Pgbus::Process::NotifyListener).not_to have_received(:new)
+        expect(worker.instance_variable_get(:@notify_listener)).to be_nil
+      end
+
+      it "constructs and starts a listener for every physical queue when wakeup is on" do
+        prefix = worker.config.queue_prefix
+        allow(worker).to receive(:notify_wakeup?).and_return(true)
+        allow(worker.config).to receive(:worker_notify_connection_options)
+          .and_return({ dbname: "test" })
+        allow(Pgbus::Process::NotifyListener).to receive(:new).and_return(fake_listener)
+
+        worker.send(:start_notify_listener)
+
+        expect(Pgbus::Process::NotifyListener).to have_received(:new).with(
+          physical_queues: ["#{prefix}_default"],
+          on_wake: an_instance_of(Proc),
+          connection_options: { dbname: "test" },
+          health_check_ms: an_instance_of(Integer),
+          logger: Pgbus.logger
+        )
+        expect(fake_listener).to have_received(:start)
+        expect(worker.instance_variable_get(:@notify_listener)).to be(fake_listener)
+      end
+
+      it "clamps health_check_ms below 250ms up to the floor" do
+        # polling_interval 0.1s → 100ms → clamped up to 250ms minimum.
+        worker.config.polling_interval = 0.1
+        allow(worker).to receive(:notify_wakeup?).and_return(true)
+        allow(worker.config).to receive(:worker_notify_connection_options)
+          .and_return({ dbname: "test" })
+        allow(Pgbus::Process::NotifyListener).to receive(:new).and_return(fake_listener)
+
+        worker.send(:start_notify_listener)
+
+        expect(Pgbus::Process::NotifyListener).to have_received(:new)
+          .with(hash_including(health_check_ms: 250))
+      end
+
+      it "clamps health_check_ms above 5000ms down to the ceiling" do
+        # polling_interval 30s → 30000ms → clamped down to 5000ms maximum.
+        # Build a fresh worker since polling_interval mutation must not
+        # leak into other examples.
+        big_poll_worker = described_class.new(queues: %w[default], threads: 5)
+        big_poll_worker.config.polling_interval = 30
+        allow(big_poll_worker).to receive(:notify_wakeup?).and_return(true)
+        allow(big_poll_worker.config).to receive(:worker_notify_connection_options)
+          .and_return({ dbname: "test" })
+        allow(Pgbus::Process::NotifyListener).to receive(:new).and_return(fake_listener)
+
+        big_poll_worker.send(:start_notify_listener)
+
+        expect(Pgbus::Process::NotifyListener).to have_received(:new)
+          .with(hash_including(health_check_ms: 5000))
+      end
+
+      it "swallows listener startup errors and falls back to polling without crashing the worker" do
+        # A NotifyListener failure must NEVER take down the worker — that
+        # was the whole point of making it default-on without a feature
+        # flag at the worker layer. The rescue logs and leaves
+        # @notify_listener nil; wake_timeout reverts to the polling
+        # interval as if NOTIFY had never been enabled.
+        allow(worker).to receive(:notify_wakeup?).and_return(true)
+        allow(worker.config).to receive(:worker_notify_connection_options)
+          .and_raise(StandardError, "no direct port configured")
+        allow(Pgbus.logger).to receive(:error)
+
+        expect { worker.send(:start_notify_listener) }.not_to raise_error
+        expect(worker.instance_variable_get(:@notify_listener)).to be_nil
+        expect(Pgbus.logger).to have_received(:error)
+      end
+    end
+
+    describe "#sync_notify_listener_queues" do
+      let(:multi_worker) { described_class.new(queues: %w[default low], threads: 4) }
+      let(:queue_prefix) { multi_worker.config.queue_prefix }
+
+      before { multi_worker.instance_variable_set(:@notify_listener, fake_listener) }
+
+      it "adds new physical queues and removes dropped ones based on the set difference" do
+        # Listener currently watches default + statistics; @queues is
+        # default + low. Expect statistics to be unlistened and low to
+        # be added; default is untouched because it overlaps both sets.
+        ch_prefix = Pgbus::Process::NotifyListener::CHANNEL_PREFIX
+        ch_suffix = Pgbus::Process::NotifyListener::CHANNEL_SUFFIX
+        allow(fake_listener).to receive(:listening_to).and_return(
+          ["#{ch_prefix}#{queue_prefix}_default#{ch_suffix}",
+           "#{ch_prefix}#{queue_prefix}_statistics#{ch_suffix}"]
+        )
+
+        multi_worker.send(:sync_notify_listener_queues)
+
+        expect(fake_listener).to have_received(:add_queue).with("#{queue_prefix}_low")
+        expect(fake_listener).to have_received(:remove_queue).with("#{queue_prefix}_statistics")
+        expect(fake_listener).not_to have_received(:add_queue).with("#{queue_prefix}_default")
+      end
+
+      it "is a no-op when no listener is attached" do
+        multi_worker.instance_variable_set(:@notify_listener, nil)
+        expect { multi_worker.send(:sync_notify_listener_queues) }.not_to raise_error
+        expect(fake_listener).not_to have_received(:add_queue)
+        expect(fake_listener).not_to have_received(:remove_queue)
+      end
+
+      it "logs and survives a listener error so a sync failure doesn't crash the loop" do
+        allow(fake_listener).to receive(:listening_to).and_raise(StandardError, "listener gone")
+        allow(Pgbus.logger).to receive(:warn)
+
+        expect { multi_worker.send(:sync_notify_listener_queues) }.not_to raise_error
+        expect(Pgbus.logger).to have_received(:warn)
+      end
+    end
+
+    describe "#shutdown" do
+      it "stops the notify listener before draining the pool" do
+        worker.instance_variable_set(:@notify_listener, fake_listener)
+        worker.send(:shutdown)
+        expect(fake_listener).to have_received(:stop)
+      end
+
+      it "is a no-op for the listener when none was started (default-off path)" do
+        worker.instance_variable_set(:@notify_listener, nil)
+        expect { worker.send(:shutdown) }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -672,6 +672,18 @@ RSpec.describe Pgbus::Process::Worker do
     end
 
     describe "#start_notify_listener" do
+      # worker.config is the globally-memoized Pgbus.configuration, so mutating
+      # polling_interval here leaks into any later example whose worker is also
+      # built from the global config (everything in this file). Snapshot and
+      # restore around every example in this block to keep #wake_timeout and
+      # #effective_polling_interval reading the original value.
+      around do |example|
+        original = Pgbus.configuration.polling_interval
+        example.run
+      ensure
+        Pgbus.configuration.polling_interval = original
+      end
+
       it "does not construct a listener when notify_wakeup? is off" do
         allow(worker).to receive(:notify_wakeup?).and_return(false)
         allow(Pgbus::Process::NotifyListener).to receive(:new)
@@ -716,16 +728,14 @@ RSpec.describe Pgbus::Process::Worker do
 
       it "clamps health_check_ms above 5000ms down to the ceiling" do
         # polling_interval 30s → 30000ms → clamped down to 5000ms maximum.
-        # Build a fresh worker since polling_interval mutation must not
-        # leak into other examples.
-        big_poll_worker = described_class.new(queues: %w[default], threads: 5)
-        big_poll_worker.config.polling_interval = 30
-        allow(big_poll_worker).to receive(:notify_wakeup?).and_return(true)
-        allow(big_poll_worker.config).to receive(:worker_notify_connection_options)
+        # The around hook above restores polling_interval after the example.
+        worker.config.polling_interval = 30
+        allow(worker).to receive(:notify_wakeup?).and_return(true)
+        allow(worker.config).to receive(:worker_notify_connection_options)
           .and_return({ dbname: "test" })
         allow(Pgbus::Process::NotifyListener).to receive(:new).and_return(fake_listener)
 
-        big_poll_worker.send(:start_notify_listener)
+        worker.send(:start_notify_listener)
 
         expect(Pgbus::Process::NotifyListener).to have_received(:new)
           .with(hash_including(health_check_ms: 5000))


### PR DESCRIPTION
## Summary

Test-only follow-up to #176. Pins the NOTIFY-gated worker wakeup surface that #176 shipped default-on but left untested. Zero production-code changes.

#164's design-doc analysis flagged that the `worker_notify_wakeup?` resolver and the worker's NOTIFY helpers were load-bearing on a default-on path with no test coverage. This PR closes that gap.

## Coverage added

### `spec/pgbus/configuration_spec.rb` (+14 examples)

- **defaults**: `worker_notify_wakeup` / `_host` / `_port` / `_database_url` are nil so the resolver inherits `listen_notify`.
- **`#worker_notify_wakeup?`** — the gate that flips NOTIFY on by default:
  - nil inherits true from `listen_notify` (the on-by-default path)
  - nil inherits false when `listen_notify` is false
  - explicit `true` wins over a false `listen_notify`
  - explicit `false` wins over a true `listen_notify`
- **`#worker_notify_connection_options`** — the PgBouncer bypass mechanism:
  - no overrides returns the base unchanged (both Hash and String base shapes)
  - `worker_notify_database_url` wins over host/port/base
  - host-only / port-only / both compose into a Hash without mutating the base
  - String base appends `host=…` and `port=…` as libpq key=value pairs

### `spec/pgbus/process/worker_spec.rb` (+19 examples)

- **`#notify_wakeup?`** — reflects `config.worker_notify_wakeup?`, false when the config lacks the resolver (old configs).
- **`#physical_queue_names`** — prefixes with `config.queue_prefix`, uses live `@queues` so post-eviction state stays correct.
- **`#channel_to_physical`** — round-trips a channel name through both affixes.
- **`#wake_timeout`** — returns `polling_interval` when wakeup off or no listener; raises to `NOTIFY_FALLBACK_POLL_SECONDS` only when both wakeup is on AND a listener is attached.
- **`#start_notify_listener`** — skips construction when wakeup off; constructs with prefixed `physical_queues` and clamped `health_check_ms`; swallows construction errors and leaves `@notify_listener` nil (the fall-back-to-polling contract).
- **`health_check_ms` clamping** — `0.1s → 250ms` floor and `30s → 5000ms` ceiling, each in a fresh worker so `polling_interval` mutation doesn't leak.
- **`#sync_notify_listener_queues`** — add/remove via set difference against `listener.listening_to`; no-op when listener nil; rescues listener errors without crashing the loop.
- **`#shutdown`** — stops the listener before draining the pool; no-op when none was started.

## Verification

- `bundle exec rspec spec/pgbus/process/ spec/pgbus/configuration_spec.rb` — **413 examples, 0 failures** (was 380 before, +33 new).
- `bundle exec rubocop spec/pgbus/configuration_spec.rb spec/pgbus/process/worker_spec.rb` — clean.

Refs #164, #174, #176

## Test plan

- [ ] CI green on Ruby 3.3 / 3.4 / 4.0
- [ ] Integration PG 17 / 18 green
- [ ] System tests green
- [ ] Lint / Security green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive RSpec coverage for NOTIFY wakeup behavior, including default inheritance, explicit enable/disable precedence, and connection option override rules.
  * Added worker-level specs for NOTIFY listener wiring, queue/channel name handling, wake timeout fallback behavior, and safe startup/shutdown behavior when listeners are absent or error out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->