### PR TITLE
feat(streams): forward exclude:/visible_to:/event: through Turbo broadcast helpers

### DIFF
--- a/lib/pgbus/streams/broadcastable_override.rb
+++ b/lib/pgbus/streams/broadcastable_override.rb
@@ -36,17 +36,23 @@ module Pgbus
         broadcast_action_to
       ].freeze
 
+      # pgbus-specific broadcast options that Turbo's own broadcast helpers
+      # don't understand. We pull them out of kwargs (so they never reach
+      # turbo-rails' renderer) and thread them to broadcast_stream_to via
+      # thread-locals, mirroring the original durable: shim.
+      PGBUS_BROADCAST_OPTS = %i[durable exclude visible_to event].freeze
+
       BROADCAST_METHODS.each do |method_name|
         define_method(method_name) do |*streamables, **kwargs|
-          durable = kwargs.delete(:durable)
-          with_pgbus_durable(durable) { super(*streamables, **kwargs) }
+          opts = extract_pgbus_broadcast_opts(kwargs)
+          with_pgbus_broadcast_opts(**opts) { super(*streamables, **kwargs) }
         end
       end
 
       BROADCAST_ACTION_METHODS.each do |method_name|
         define_method(method_name) do |*streamables, action:, **kwargs|
-          durable = kwargs.delete(:durable)
-          with_pgbus_durable(durable) { super(*streamables, action: action, **kwargs) }
+          opts = extract_pgbus_broadcast_opts(kwargs)
+          with_pgbus_broadcast_opts(**opts) { super(*streamables, action: action, **kwargs) }
         end
       end
 
@@ -121,14 +127,41 @@ module Pgbus
 
       private
 
-      def with_pgbus_durable(value)
-        return yield if value.nil?
+      def extract_pgbus_broadcast_opts(kwargs)
+        PGBUS_BROADCAST_OPTS.each_with_object({}) do |key, opts|
+          opts[key] = kwargs.delete(key) if kwargs.key?(key)
+        end
+      end
 
-        previous = Thread.current[:pgbus_broadcast_durable]
-        Thread.current[:pgbus_broadcast_durable] = value
+      # Set the pgbus broadcast thread-locals for the duration of the block,
+      # restoring previous values afterwards (nested/concurrent-safe). Only
+      # keys actually passed are touched, so unrelated outer broadcasts keep
+      # their values.
+      def with_pgbus_broadcast_opts(durable: :__unset__, exclude: :__unset__, visible_to: :__unset__, event: :__unset__)
+        previous = {}
+        set = lambda do |tl_key, value|
+          next if value == :__unset__
+
+          previous[tl_key] = Thread.current[tl_key]
+          Thread.current[tl_key] = value
+        end
+
+        set.call(:pgbus_broadcast_durable, durable)
+        set.call(:pgbus_broadcast_exclude, exclude)
+        set.call(:pgbus_broadcast_visible_to, visible_to)
+        set.call(:pgbus_broadcast_event, event)
+
         yield
       ensure
-        Thread.current[:pgbus_broadcast_durable] = previous unless value.nil?
+        previous.each { |tl_key, value| Thread.current[tl_key] = value }
+      end
+
+      # Kept for backward compatibility — the class-level durable callbacks
+      # (broadcasts_to with durable:) and any external callers may still use it.
+      def with_pgbus_durable(value, &)
+        return yield if value.nil?
+
+        with_pgbus_broadcast_opts(durable: value, &)
       end
     end
   end

--- a/lib/pgbus/streams/turbo_broadcastable.rb
+++ b/lib/pgbus/streams/turbo_broadcastable.rb
@@ -42,7 +42,12 @@ module Pgbus
                   else
                     override
                   end
-        Pgbus.stream(name, durable: durable).broadcast(content)
+        Pgbus.stream(name, durable: durable).broadcast(
+          content,
+          exclude: Thread.current[:pgbus_broadcast_exclude],
+          visible_to: Thread.current[:pgbus_broadcast_visible_to],
+          event: Thread.current[:pgbus_broadcast_event]
+        )
       end
     end
 

--- a/spec/pgbus/streams/broadcastable_override_spec.rb
+++ b/spec/pgbus/streams/broadcastable_override_spec.rb
@@ -154,6 +154,9 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
 
   after do
     Thread.current[:pgbus_broadcast_durable] = nil
+    Thread.current[:pgbus_broadcast_exclude] = nil
+    Thread.current[:pgbus_broadcast_visible_to] = nil
+    Thread.current[:pgbus_broadcast_event] = nil
   end
 
   describe "instance-level durable: kwarg" do
@@ -244,6 +247,60 @@ RSpec.describe Pgbus::Streams::BroadcastableOverride do
       end.to raise_error(RuntimeError, "boom")
 
       expect(Thread.current[:pgbus_broadcast_durable]).to be_nil
+    end
+  end
+
+  describe "instance-level exclude: / visible_to: / event: kwargs" do
+    it "forwards exclude: to Stream#broadcast (actor-echo suppression)" do
+      model.broadcast_replace_to("room:42", exclude: "conn-abc", html: "<div/>")
+
+      expect(fake_stream).to have_received(:broadcast)
+        .with(anything, hash_including(exclude: "conn-abc"))
+    end
+
+    it "forwards visible_to: to Stream#broadcast" do
+      model.broadcast_replace_to("room:42", visible_to: :admins, html: "<div/>")
+
+      expect(fake_stream).to have_received(:broadcast)
+        .with(anything, hash_including(visible_to: :admins))
+    end
+
+    it "forwards event: to Stream#broadcast" do
+      model.broadcast_replace_to("room:42", event: "presence", html: "<div/>")
+
+      expect(fake_stream).to have_received(:broadcast)
+        .with(anything, hash_including(event: "presence"))
+    end
+
+    it "composes exclude: with durable: (both reach their destinations)" do
+      model.broadcast_append_to("room:42", durable: true, exclude: "conn-9", html: "<div/>")
+
+      expect(Pgbus).to have_received(:stream).with("room:42", durable: true)
+      expect(fake_stream).to have_received(:broadcast)
+        .with(anything, hash_including(exclude: "conn-9"))
+    end
+
+    it "passes nil for the opts when none are given (unchanged default path)" do
+      model.broadcast_replace_to("room:42", html: "<div/>")
+
+      expect(fake_stream).to have_received(:broadcast)
+        .with(anything, hash_including(exclude: nil, visible_to: nil, event: nil))
+    end
+
+    it "does NOT leak exclude: into turbo-rails rendering kwargs" do
+      # The override must delete :exclude from kwargs before calling super,
+      # so it never reaches Turbo's renderer (which would error on it).
+      expect do
+        model.broadcast_replace_to("room:42", exclude: "conn-abc", html: "<div/>")
+      end.not_to raise_error
+    end
+
+    it "cleans up the exclude/visible_to/event thread-locals after the broadcast" do
+      model.broadcast_replace_to("room:42", exclude: "conn-abc", visible_to: :admins, event: "x", html: "<div/>")
+
+      expect(Thread.current[:pgbus_broadcast_exclude]).to be_nil
+      expect(Thread.current[:pgbus_broadcast_visible_to]).to be_nil
+      expect(Thread.current[:pgbus_broadcast_event]).to be_nil
     end
   end
 


### PR DESCRIPTION
## What

`Pgbus::Streams::Stream#broadcast` already accepts `exclude:` (actor-echo suppression), `visible_to:`, and `event:`, and the dispatcher already skips excluded connections. But the `Turbo::Broadcastable` override only threaded `durable:` through to `broadcast_stream_to` — so `broadcast_replace_to(..., exclude: conn_id)` dropped the kwarg before it reached `Pgbus.stream.broadcast`.

This generalizes the thread-local shim to extract **all four** pgbus opts from kwargs (keeping them out of turbo-rails' renderer, which would otherwise choke on them) and forward them via `broadcast_stream_to`.

## Why

Completes the actor-echo loop for the standard Turbo broadcast API — which is what gems like [phlex-reactive](https://github.com/mhenrixon/phlex-reactive) use. Without this, `exclude:` only works via the explicit `Pgbus.stream(...).broadcast(...)` API, not `broadcast_*_to`.

## Changes

- `broadcastable_override.rb`: `extract_pgbus_broadcast_opts` + `with_pgbus_broadcast_opts` (durable/exclude/visible_to/event); `with_pgbus_durable` kept for back-compat
- `turbo_broadcastable.rb`: `broadcast_stream_to` forwards exclude/visible_to/event (nil when unset → unchanged default path)
- specs: exclude/visible_to/event forwarding, composition with durable, no-leak-into-rendering-kwargs, thread-local cleanup

No behavior change when no pgbus opts are passed (the common path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Broadcast operations now accept additional parameters for granular control over message delivery.
  * Added exclude, visible_to, and event options to support recipient filtering and custom event handling.

* **Improvements**
  * Enhanced broadcast functionality maintains full backward compatibility with existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->