### PR TITLE
feat(worker): liveness probe to detect and heal stalled claim loops

### DIFF
--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -29,10 +29,20 @@ module Pgbus
       end
     end
 
-    def pgbus_status_badge(healthy)
-      if healthy
+    def pgbus_status_badge(healthy_or_status)
+      status = case healthy_or_status
+               when true then :healthy
+               when Symbol, String then healthy_or_status.to_sym
+               else :stale
+               end
+
+      case status
+      when :healthy
         tag.span(I18n.t("pgbus.helpers.status_badge.healthy"),
                  class: "inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800")
+      when :stalled
+        tag.span(I18n.t("pgbus.helpers.status_badge.stalled"),
+                 class: "inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800")
       else
         tag.span(I18n.t("pgbus.helpers.status_badge.stale"),
                  class: "inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800")

--- a/app/views/pgbus/dashboard/_processes_table.html.erb
+++ b/app/views/pgbus/dashboard/_processes_table.html.erb
@@ -17,7 +17,7 @@
               <td data-label="Kind" class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white"><%= p[:kind] %></td>
               <td data-label="Host" class="px-4 py-3 text-sm text-gray-500"><%= p[:hostname] %></td>
               <td data-label="PID" class="px-4 py-3 text-sm text-gray-500"><%= p[:pid] %></td>
-              <td data-label="Status" class="px-4 py-3 text-sm"><%= pgbus_status_badge(p[:healthy]) %></td>
+              <td data-label="Status" class="px-4 py-3 text-sm"><%= pgbus_status_badge(p[:status] || p[:healthy]) %></td>
             </tr>
           <% end %>
           <% if @processes.empty? %>

--- a/app/views/pgbus/processes/_processes_table.html.erb
+++ b/app/views/pgbus/processes/_processes_table.html.erb
@@ -17,7 +17,7 @@
             <td data-label="Kind" class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white"><%= p[:kind] %></td>
             <td data-label="Host" class="px-4 py-3 text-sm text-gray-700"><%= p[:hostname] %></td>
             <td data-label="PID" class="px-4 py-3 text-sm font-mono text-gray-700"><%= p[:pid] %></td>
-            <td data-label="Status" class="px-4 py-3 text-sm"><%= pgbus_status_badge(p[:healthy]) %></td>
+            <td data-label="Status" class="px-4 py-3 text-sm"><%= pgbus_status_badge(p[:status] || p[:healthy]) %></td>
             <td data-label="Last Heartbeat" class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(p[:last_heartbeat_at]) %></td>
             <td data-label="Metadata" class="px-4 py-3 text-sm text-gray-500 font-mono text-xs max-w-xs truncate">
               <% if p[:metadata].is_a?(Hash) %>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -235,6 +235,7 @@ da:
       status_badge:
         healthy: Sund
         stale: Forældet
+        stalled: Gået i stå
     insights:
       show:
         charts:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -235,6 +235,7 @@ de:
       status_badge:
         healthy: Gesund
         stale: Veraltet
+        stalled: Blockiert
     insights:
       show:
         charts:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,7 @@ en:
       status_badge:
         healthy: Healthy
         stale: Stale
+        stalled: Stalled
     insights:
       show:
         charts:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -235,6 +235,7 @@ es:
       status_badge:
         healthy: Saludable
         stale: Obsoleto
+        stalled: Bloqueado
     insights:
       show:
         charts:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -235,6 +235,7 @@ fi:
       status_badge:
         healthy: Toimiva
         stale: Vanha
+        stalled: Juuttunut
     insights:
       show:
         charts:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -235,6 +235,7 @@ fr:
       status_badge:
         healthy: Sain
         stale: Obsolète
+        stalled: Bloqué
     insights:
       show:
         charts:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -235,6 +235,7 @@ it:
       status_badge:
         healthy: Sano
         stale: Obsoleto
+        stalled: Bloccato
     insights:
       show:
         charts:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -235,6 +235,7 @@ ja:
       status_badge:
         healthy: 正常
         stale: 期限切れ
+        stalled: 停滞
     insights:
       show:
         charts:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -235,6 +235,7 @@ nb:
       status_badge:
         healthy: Sunn
         stale: Utdatert
+        stalled: Fastlåst
     insights:
       show:
         charts:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -235,6 +235,7 @@ nl:
       status_badge:
         healthy: Gezond
         stale: Verouderd
+        stalled: Vastgelopen
     insights:
       show:
         charts:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -235,6 +235,7 @@ pt:
       status_badge:
         healthy: Saudável
         stale: Obsoleto
+        stalled: Bloqueado
     insights:
       show:
         charts:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -235,6 +235,7 @@ sv:
       status_badge:
         healthy: Hälsosam
         stale: Föråldrad
+        stalled: Fastlåst
     insights:
       show:
         charts:

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -18,6 +18,7 @@ module Pgbus
   class ConcurrencyLimitExceeded < Error; end
   class JobNotUnique < Error; end
   class SchemaNotReady < Error; end
+  class ReadTimeoutError < Error; end
 
   class << self
     # Process-global flag set by Worker#graceful_shutdown so the adapter

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "timeout"
 require_relative "client/read_after"
 require_relative "client/ensure_stream_queue"
 require_relative "client/notify_stream"
@@ -109,8 +110,10 @@ module Pgbus
     def read_message(queue_name, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_message", queue: full_name) do
-        with_stale_connection_retry do
-          synchronized { @pgmq.read(full_name, vt: vt || config.visibility_timeout) }
+        with_read_timeout do
+          with_stale_connection_retry do
+            synchronized { @pgmq.read(full_name, vt: vt || config.visibility_timeout) }
+          end
         end
       end
     end
@@ -118,8 +121,10 @@ module Pgbus
     def read_batch(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_batch", queue: full_name, qty: qty) do
-        with_stale_connection_retry do
-          synchronized { @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+        with_read_timeout do
+          with_stale_connection_retry do
+            synchronized { @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+          end
         end
       end
     end
@@ -178,9 +183,11 @@ module Pgbus
     def read_multi(queue_names, qty:, vt: nil, limit: nil)
       full_names = queue_names.map { |q| config.queue_name(q) }
       Instrumentation.instrument("pgbus.client.read_multi", queues: full_names, qty: qty, limit: limit) do
-        with_stale_connection_retry do
-          synchronized do
-            @pgmq.read_multi(full_names, vt: vt || config.visibility_timeout, qty: qty, limit: limit)
+        with_read_timeout do
+          with_stale_connection_retry do
+            synchronized do
+              @pgmq.read_multi(full_names, vt: vt || config.visibility_timeout, qty: qty, limit: limit)
+            end
           end
         end
       end
@@ -696,6 +703,13 @@ module Pgbus
     # connection was dead *before* pgmq-ruby tried to use it, so no SQL was
     # ever sent. Mid-flight errors like "server closed the connection" are
     # excluded from the pattern list for this reason.
+    def with_read_timeout(&)
+      timeout = config.read_timeout
+      return yield unless timeout&.positive?
+
+      Timeout.timeout(timeout, Pgbus::ReadTimeoutError, &)
+    end
+
     def with_stale_connection_retry
       attempts = 0
       begin

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -145,8 +145,10 @@ module Pgbus
         break if remaining <= 0
 
         msgs = Instrumentation.instrument("pgbus.client.read_batch", queue: pq_name, qty: remaining) do
-          with_stale_connection_retry do
-            synchronized { @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining) }
+          with_read_timeout do
+            with_stale_connection_retry do
+              synchronized { @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining) }
+            end
           end
         end || []
 
@@ -363,8 +365,10 @@ module Pgbus
     def read_grouped(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_grouped", queue: full_name, qty: qty) do
-        with_stale_connection_retry do
-          synchronized { @pgmq.read_grouped(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+        with_read_timeout do
+          with_stale_connection_retry do
+            synchronized { @pgmq.read_grouped(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+          end
         end
       end
     end
@@ -372,16 +376,20 @@ module Pgbus
     def read_grouped_rr(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_grouped_rr", queue: full_name, qty: qty) do
-        with_stale_connection_retry do
-          synchronized { @pgmq.read_grouped_rr(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+        with_read_timeout do
+          with_stale_connection_retry do
+            synchronized { @pgmq.read_grouped_rr(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+          end
         end
       end
     end
 
     def read_grouped_head(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
-      with_stale_connection_retry do
-        synchronized { @pgmq.read_grouped_head(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+      with_read_timeout do
+        with_stale_connection_retry do
+          synchronized { @pgmq.read_grouped_head(full_name, vt: vt || config.visibility_timeout, qty: qty) }
+        end
       end
     end
 

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -110,10 +110,8 @@ module Pgbus
     def read_message(queue_name, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_message", queue: full_name) do
-        with_read_timeout do
-          with_stale_connection_retry do
-            synchronized { @pgmq.read(full_name, vt: vt || config.visibility_timeout) }
-          end
+        with_stale_connection_retry do
+          synchronized { with_read_timeout { @pgmq.read(full_name, vt: vt || config.visibility_timeout) } }
         end
       end
     end
@@ -121,10 +119,8 @@ module Pgbus
     def read_batch(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_batch", queue: full_name, qty: qty) do
-        with_read_timeout do
-          with_stale_connection_retry do
-            synchronized { @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty) }
-          end
+        with_stale_connection_retry do
+          synchronized { with_read_timeout { @pgmq.read_batch(full_name, vt: vt || config.visibility_timeout, qty: qty) } }
         end
       end
     end
@@ -145,10 +141,8 @@ module Pgbus
         break if remaining <= 0
 
         msgs = Instrumentation.instrument("pgbus.client.read_batch", queue: pq_name, qty: remaining) do
-          with_read_timeout do
-            with_stale_connection_retry do
-              synchronized { @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining) }
-            end
+          with_stale_connection_retry do
+            synchronized { with_read_timeout { @pgmq.read_batch(pq_name, vt: vt || config.visibility_timeout, qty: remaining) } }
           end
         end || []
 
@@ -185,9 +179,9 @@ module Pgbus
     def read_multi(queue_names, qty:, vt: nil, limit: nil)
       full_names = queue_names.map { |q| config.queue_name(q) }
       Instrumentation.instrument("pgbus.client.read_multi", queues: full_names, qty: qty, limit: limit) do
-        with_read_timeout do
-          with_stale_connection_retry do
-            synchronized do
+        with_stale_connection_retry do
+          synchronized do
+            with_read_timeout do
               @pgmq.read_multi(full_names, vt: vt || config.visibility_timeout, qty: qty, limit: limit)
             end
           end
@@ -365,10 +359,8 @@ module Pgbus
     def read_grouped(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_grouped", queue: full_name, qty: qty) do
-        with_read_timeout do
-          with_stale_connection_retry do
-            synchronized { @pgmq.read_grouped(full_name, vt: vt || config.visibility_timeout, qty: qty) }
-          end
+        with_stale_connection_retry do
+          synchronized { with_read_timeout { @pgmq.read_grouped(full_name, vt: vt || config.visibility_timeout, qty: qty) } }
         end
       end
     end
@@ -376,20 +368,16 @@ module Pgbus
     def read_grouped_rr(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
       Instrumentation.instrument("pgbus.client.read_grouped_rr", queue: full_name, qty: qty) do
-        with_read_timeout do
-          with_stale_connection_retry do
-            synchronized { @pgmq.read_grouped_rr(full_name, vt: vt || config.visibility_timeout, qty: qty) }
-          end
+        with_stale_connection_retry do
+          synchronized { with_read_timeout { @pgmq.read_grouped_rr(full_name, vt: vt || config.visibility_timeout, qty: qty) } }
         end
       end
     end
 
     def read_grouped_head(queue_name, qty:, vt: nil)
       full_name = config.queue_name(queue_name)
-      with_read_timeout do
-        with_stale_connection_retry do
-          synchronized { @pgmq.read_grouped_head(full_name, vt: vt || config.visibility_timeout, qty: qty) }
-        end
+      with_stale_connection_retry do
+        synchronized { with_read_timeout { @pgmq.read_grouped_head(full_name, vt: vt || config.visibility_timeout, qty: qty) } }
       end
     end
 
@@ -711,6 +699,23 @@ module Pgbus
     # connection was dead *before* pgmq-ruby tried to use it, so no SQL was
     # ever sent. Mid-flight errors like "server closed the connection" are
     # excluded from the pattern list for this reason.
+    # Bound a read at config.read_timeout so a dead socket raises
+    # Pgbus::ReadTimeoutError instead of blocking the worker loop forever.
+    #
+    # MUST wrap only the bare `@pgmq.read*` call, sitting *inside* both
+    # `synchronized` and `with_stale_connection_retry`:
+    #
+    #   with_stale_connection_retry { synchronized { with_read_timeout { @pgmq.read* } } }
+    #
+    # Two reasons for this nesting:
+    #   1. On the shared-connection path @pgmq_mutex serializes all reads.
+    #      The timeout clock must start only after the mutex is acquired,
+    #      otherwise a thread queued behind another read is charged for the
+    #      wait and raises a false ReadTimeoutError for a socket it never
+    #      touched.
+    #   2. with_stale_connection_retry can retry once; with the timeout
+    #      inside, each socket attempt gets its own full timeout budget
+    #      rather than sharing one across both attempts.
     def with_read_timeout(&)
       timeout = config.read_timeout
       return yield unless timeout&.positive?

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -26,6 +26,12 @@ module Pgbus
     # Worker recycling
     attr_accessor :max_jobs_per_worker, :max_memory_mb, :max_worker_lifetime
 
+    # Liveness probe: supervisor kills a worker whose claim loop has not
+    # advanced for longer than stall_threshold seconds (default 90).
+    # read_timeout caps how long a single PGMQ read can block (default 30s),
+    # so a dead socket raises instead of parking the loop forever.
+    attr_accessor :stall_threshold, :read_timeout
+
     # Dispatcher settings
     attr_accessor :dispatch_interval
 
@@ -149,6 +155,9 @@ module Pgbus
       @max_jobs_per_worker = nil
       @max_memory_mb = nil
       @max_worker_lifetime = nil
+
+      @stall_threshold = 90
+      @read_timeout = 30
 
       @dispatch_interval = 1.0
 

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -383,6 +383,13 @@ module Pgbus
         raise ArgumentError, "retry_backoff_jitter must be between 0 and 1"
       end
 
+      if stall_threshold && !(stall_threshold.is_a?(Numeric) && stall_threshold.positive?)
+        raise ArgumentError, "stall_threshold must be a positive number or nil to disable"
+      end
+      if read_timeout && !(read_timeout.is_a?(Numeric) && read_timeout.positive?)
+        raise ArgumentError, "read_timeout must be a positive number or nil to disable"
+      end
+
       # Validate global execution_mode
       ExecutionPools.normalize_mode(execution_mode)
 

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -383,10 +383,10 @@ module Pgbus
         raise ArgumentError, "retry_backoff_jitter must be between 0 and 1"
       end
 
-      if stall_threshold && !(stall_threshold.is_a?(Numeric) && stall_threshold.positive?)
+      unless stall_threshold.nil? || (stall_threshold.is_a?(Numeric) && stall_threshold.positive?)
         raise ArgumentError, "stall_threshold must be a positive number or nil to disable"
       end
-      if read_timeout && !(read_timeout.is_a?(Numeric) && read_timeout.positive?)
+      unless read_timeout.nil? || (read_timeout.is_a?(Numeric) && read_timeout.positive?)
         raise ArgumentError, "read_timeout must be a positive number or nil to disable"
       end
 

--- a/lib/pgbus/process/heartbeat.rb
+++ b/lib/pgbus/process/heartbeat.rb
@@ -11,10 +11,11 @@ module Pgbus
 
       attr_reader :process_entry
 
-      def initialize(kind:, metadata: {}, on_beat: nil)
+      def initialize(kind:, metadata: {}, on_beat: nil, loop_tick_supplier: nil)
         @kind = kind
         @metadata = metadata
         @on_beat = on_beat
+        @loop_tick_supplier = loop_tick_supplier
         @timer = nil
       end
 
@@ -33,7 +34,12 @@ module Pgbus
         return unless @process_id
 
         @on_beat&.call
-        ProcessEntry.where(id: @process_id).update_all(last_heartbeat_at: Time.current)
+        updates = { last_heartbeat_at: Time.current }
+        if @loop_tick_supplier
+          tick = @loop_tick_supplier.call
+          updates[:metadata] = @metadata.merge("loop_tick_at" => tick&.to_f)
+        end
+        ProcessEntry.where(id: @process_id).update_all(updates)
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Heartbeat failed: #{e.message}" }
       end

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -6,6 +6,7 @@ module Pgbus
       include SignalHandler
 
       FORK_WAIT = 1 # seconds between fork checks
+      WATCHDOG_INTERVAL = 10 # seconds between stall checks
 
       attr_reader :config
 
@@ -13,6 +14,7 @@ module Pgbus
         @config = config
         @forks = {}
         @shutting_down = false
+        @last_watchdog_at = monotonic_now
       end
 
       def run
@@ -240,6 +242,7 @@ module Pgbus
 
           process_signals
           reap_children
+          check_stalled_workers unless @shutting_down
           interruptible_sleep(FORK_WAIT)
         end
       end
@@ -280,6 +283,43 @@ module Pgbus
         end
       end
 
+      def check_stalled_workers
+        now = monotonic_now
+        return if (now - @last_watchdog_at) < WATCHDOG_INTERVAL
+
+        @last_watchdog_at = now
+        threshold = config.stall_threshold
+        return unless threshold&.positive?
+
+        worker_pids = @forks.select { |_, info| info[:type] == :worker }.keys
+        return if worker_pids.empty?
+
+        rows = ProcessEntry.where(kind: "worker", pid: worker_pids).to_a
+        rows.each do |entry|
+          meta = entry.metadata
+          next unless meta.is_a?(Hash)
+
+          loop_tick = meta["loop_tick_at"]
+          next unless loop_tick
+
+          age = Time.current.to_f - loop_tick.to_f
+          next unless age > threshold
+
+          pid = entry.pid
+          Pgbus.logger.error do
+            "[Pgbus] Supervisor watchdog: worker pid=#{pid} claim loop stalled " \
+              "(loop_tick_at age=#{age.round(1)}s > threshold=#{threshold}s), sending SIGKILL"
+          end
+          begin
+            ::Process.kill("KILL", pid)
+          rescue Errno::ESRCH
+            # already gone
+          end
+        end
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Supervisor watchdog check failed: #{e.message}" }
+      end
+
       def signal_children(sig)
         @forks.each_key do |pid|
           ::Process.kill(sig, pid)
@@ -316,6 +356,10 @@ module Pgbus
           metadata: { pid: ::Process.pid, hostname: Socket.gethostname }
         )
         @heartbeat.start
+      end
+
+      def monotonic_now
+        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       end
 
       def shutdown

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -83,7 +83,7 @@ module Pgbus
         end
 
         loop do
-          @loop_tick_at.set(monotonic_now)
+          stamp_loop_tick
           process_signals
           check_recycle
           refresh_wildcard_queues
@@ -514,6 +514,14 @@ module Pgbus
 
       def monotonic_now
         ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      end
+
+      # Stamp the loop-progress beacon with a wall-clock timestamp.
+      # Wall clock is required because the supervisor watchdog reads
+      # this value from a different process (cross-fork) and the
+      # dashboard reads it from a different host.
+      def stamp_loop_tick
+        @loop_tick_at.set(Time.now.to_f)
       end
     end
   end

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -37,6 +37,7 @@ module Pgbus
         @jobs_processed = Concurrent::AtomicFixnum.new(0)
         @jobs_failed = Concurrent::AtomicFixnum.new(0)
         @in_flight = Concurrent::AtomicFixnum.new(0)
+        @loop_tick_at = Concurrent::AtomicReference.new(nil)
         @rate_counter = RateCounter.new(:processed, :failed, :dequeued)
         @started_at = Time.current
         @started_at_monotonic = monotonic_now
@@ -82,6 +83,7 @@ module Pgbus
         end
 
         loop do
+          @loop_tick_at.set(monotonic_now)
           process_signals
           check_recycle
           refresh_wildcard_queues
@@ -492,7 +494,8 @@ module Pgbus
             queues: queues, threads: threads, pid: ::Process.pid,
             execution_mode: @execution_mode, consumer_priority: @consumer_priority
           },
-          on_beat: -> { @rate_counter.snapshot! }
+          on_beat: -> { @rate_counter.snapshot! },
+          loop_tick_supplier: -> { @loop_tick_at.get }
         )
         @heartbeat.start
       end

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -1195,17 +1195,34 @@ module Pgbus
         heartbeat = row["last_heartbeat_at"]
         heartbeat_time = heartbeat.is_a?(String) ? Time.parse(heartbeat) : heartbeat
         stale = heartbeat_time && (Time.now - heartbeat_time) > Process::Heartbeat::ALIVE_THRESHOLD
+        metadata = row["metadata"].is_a?(String) ? JSON.parse(row["metadata"]) : row["metadata"]
+        status = derive_process_status(stale, metadata, row["kind"])
 
         {
           id: row["id"].to_i,
           kind: row["kind"],
           hostname: row["hostname"],
           pid: row["pid"].to_i,
-          metadata: row["metadata"].is_a?(String) ? JSON.parse(row["metadata"]) : row["metadata"],
+          metadata: metadata,
           last_heartbeat_at: heartbeat_time,
-          healthy: !stale,
+          healthy: status == :healthy,
+          status: status,
           created_at: row["created_at"]
         }
+      end
+
+      def derive_process_status(stale, metadata, kind)
+        return :stale if stale
+        return :healthy unless kind == "worker" && metadata.is_a?(Hash)
+
+        loop_tick = metadata["loop_tick_at"]
+        return :healthy unless loop_tick
+
+        threshold = Pgbus.configuration.stall_threshold
+        return :healthy unless threshold&.positive?
+
+        age = Time.now.to_f - loop_tick.to_f
+        age > threshold ? :stalled : :healthy
       end
 
       def format_batch(record)

--- a/spec/pgbus/client/read_timeout_spec.rb
+++ b/spec/pgbus/client/read_timeout_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe Pgbus::Client do
           expect { client.read_multi(%w[default], qty: 5) }.to raise_error(Pgbus::ReadTimeoutError)
         end
 
+        it "raises ReadTimeoutError when read_message exceeds the timeout" do
+          allow(mock_pgmq).to receive(:read) { sleep 5 }
+
+          expect { client.read_message("default") }.to raise_error(Pgbus::ReadTimeoutError)
+        end
+
         it "does not interfere with fast reads" do
           allow(mock_pgmq).to receive(:read_batch).and_return([])
 

--- a/spec/pgbus/client/read_timeout_spec.rb
+++ b/spec/pgbus/client/read_timeout_spec.rb
@@ -101,13 +101,21 @@ RSpec.describe Pgbus::Client do
 
           # Hold the mutex longer than the timeout, then release. The read's
           # own work is instant, so it must complete without a timeout error.
+          # Handshake via a Queue so we know the holder is inside the
+          # synchronized block before issuing the read — a plain sleep is
+          # racy on slow CI runners.
+          locked = Queue.new
           holder = Thread.new do
-            mutex.synchronize { sleep 1.5 }
+            mutex.synchronize do
+              locked << true
+              sleep 1.5
+            end
           end
-          sleep 0.1 # ensure the holder has the mutex before we call
 
+          locked.pop
           expect { shared_client.read_batch("default", qty: 5) }.not_to raise_error
-          holder.join
+        ensure
+          holder&.join
         end
       end
     end

--- a/spec/pgbus/client/read_timeout_spec.rb
+++ b/spec/pgbus/client/read_timeout_spec.rb
@@ -69,6 +69,47 @@ RSpec.describe Pgbus::Client do
           expect(client.read_batch("default", qty: 5)).to eq([])
         end
       end
+
+      # On the shared-connection path a single mutex serializes all reads.
+      # The timeout clock must start only after the mutex is acquired, so a
+      # thread queued behind a slow read is not charged for the wait. Here a
+      # fast read whose mutex wait exceeds the timeout must still succeed.
+      context "when a read waits on the client mutex (shared connection)" do
+        subject(:shared_client) do
+          allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+          c = described_class.new(shared_config)
+          c.instance_variable_set(:@schema_ensured, true)
+          allow(c).to receive(:tune_autovacuum)
+          allow(c).to receive(:notify_trigger_current?).and_return(false)
+          c
+        end
+
+        let(:shared_config) do
+          Pgbus::Configuration.new.tap do |c|
+            c.connection_params = -> { :raw_conn }
+            c.read_timeout = 1
+          end
+        end
+
+        it "uses the mutex path" do
+          expect(shared_client.instance_variable_get(:@pgmq_mutex)).to be_a(Mutex)
+        end
+
+        it "does not raise ReadTimeoutError for time spent waiting on the mutex" do
+          mutex = shared_client.instance_variable_get(:@pgmq_mutex)
+          allow(mock_pgmq).to receive(:read_batch).and_return([])
+
+          # Hold the mutex longer than the timeout, then release. The read's
+          # own work is instant, so it must complete without a timeout error.
+          holder = Thread.new do
+            mutex.synchronize { sleep 1.5 }
+          end
+          sleep 0.1 # ensure the holder has the mutex before we call
+
+          expect { shared_client.read_batch("default", qty: 5) }.not_to raise_error
+          holder.join
+        end
+      end
     end
   end
 end

--- a/spec/pgbus/client/read_timeout_spec.rb
+++ b/spec/pgbus/client/read_timeout_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Client do
+  describe "read_timeout" do
+    subject(:client) do
+      allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+      c = described_class.new(config)
+      c.instance_variable_set(:@schema_ensured, true)
+      allow(c).to receive(:tune_autovacuum)
+      allow(c).to receive(:notify_trigger_current?).and_return(false)
+      c
+    end
+
+    let(:mock_pgmq) { build_mock_pgmq }
+    let(:config) do
+      Pgbus::Configuration.new.tap do |c|
+        c.database_url = "postgres://localhost/pgbus_test"
+      end
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:require).with("pgmq").and_return(true)
+      stub_const("PGMQ::Client", Class.new { def initialize(*args, **kwargs); end })
+      stub_const("PGMQ::Errors", Module.new)
+      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError))
+    end
+
+    after do
+      config.read_timeout = 30
+    end
+
+    describe "#with_read_timeout" do
+      context "when read_timeout is set" do
+        before { config.read_timeout = 1 }
+
+        it "raises ReadTimeoutError when read_batch exceeds the timeout" do
+          allow(mock_pgmq).to receive(:read_batch) { sleep 5 }
+
+          expect { client.read_batch("default", qty: 5) }.to raise_error(Pgbus::ReadTimeoutError)
+        end
+
+        it "raises ReadTimeoutError when read_multi exceeds the timeout" do
+          allow(mock_pgmq).to receive(:read_multi) { sleep 5 }
+
+          expect { client.read_multi(%w[default], qty: 5) }.to raise_error(Pgbus::ReadTimeoutError)
+        end
+
+        it "does not interfere with fast reads" do
+          allow(mock_pgmq).to receive(:read_batch).and_return([])
+
+          expect(client.read_batch("default", qty: 5)).to eq([])
+        end
+      end
+
+      context "when read_timeout is nil" do
+        before { config.read_timeout = nil }
+
+        it "does not wrap reads in a timeout" do
+          allow(mock_pgmq).to receive(:read_batch).and_return([])
+
+          expect(client.read_batch("default", qty: 5)).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -134,6 +134,14 @@ RSpec.describe Pgbus::Configuration do
     it "defaults execution_mode to :threads" do
       expect(config.execution_mode).to eq(:threads)
     end
+
+    it "has default stall_threshold of 90 seconds" do
+      expect(config.stall_threshold).to eq(90)
+    end
+
+    it "has default read_timeout of 30 seconds" do
+      expect(config.read_timeout).to eq(30)
+    end
   end
 
   describe "#execution_mode_for" do

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -868,6 +868,36 @@ RSpec.describe Pgbus::Configuration do
       expect { config.validate! }.not_to raise_error
     end
 
+    it "rejects non-numeric stall_threshold" do
+      config.stall_threshold = "90"
+      expect { config.validate! }.to raise_error(ArgumentError, /stall_threshold/)
+    end
+
+    it "rejects zero stall_threshold" do
+      config.stall_threshold = 0
+      expect { config.validate! }.to raise_error(ArgumentError, /stall_threshold/)
+    end
+
+    it "accepts nil stall_threshold (disabled)" do
+      config.stall_threshold = nil
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "rejects non-numeric read_timeout" do
+      config.read_timeout = "30"
+      expect { config.validate! }.to raise_error(ArgumentError, /read_timeout/)
+    end
+
+    it "rejects zero read_timeout" do
+      config.read_timeout = 0
+      expect { config.validate! }.to raise_error(ArgumentError, /read_timeout/)
+    end
+
+    it "accepts nil read_timeout (disabled)" do
+      config.read_timeout = nil
+      expect { config.validate! }.not_to raise_error
+    end
+
     it "rejects invalid priority_levels" do
       config.priority_levels = 0
       expect { config.validate! }.to raise_error(ArgumentError, /priority_levels/)

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -883,6 +883,11 @@ RSpec.describe Pgbus::Configuration do
       expect { config.validate! }.not_to raise_error
     end
 
+    it "rejects false stall_threshold" do
+      config.stall_threshold = false
+      expect { config.validate! }.to raise_error(ArgumentError, /stall_threshold/)
+    end
+
     it "rejects non-numeric read_timeout" do
       config.read_timeout = "30"
       expect { config.validate! }.to raise_error(ArgumentError, /read_timeout/)
@@ -896,6 +901,11 @@ RSpec.describe Pgbus::Configuration do
     it "accepts nil read_timeout (disabled)" do
       config.read_timeout = nil
       expect { config.validate! }.not_to raise_error
+    end
+
+    it "rejects false read_timeout" do
+      config.read_timeout = false
+      expect { config.validate! }.to raise_error(ArgumentError, /read_timeout/)
     end
 
     it "rejects invalid priority_levels" do

--- a/spec/pgbus/process/heartbeat_loop_tick_spec.rb
+++ b/spec/pgbus/process/heartbeat_loop_tick_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "socket"
+
+RSpec.describe Pgbus::Process::Heartbeat do
+  describe "#beat with loop_tick_supplier" do
+    let(:timer) { instance_double(Concurrent::TimerTask, execute: true, shutdown: true) }
+    let(:process_record) { double("ProcessEntry", id: 42) }
+    let(:scope) { double("scope") }
+
+    before do
+      allow(Concurrent::TimerTask).to receive(:new).and_return(timer)
+      allow(Pgbus::ProcessEntry).to receive(:create!).and_return(process_record)
+      allow(Pgbus::ProcessEntry).to receive(:where).with(id: 42).and_return(scope)
+      allow(scope).to receive(:update_all).and_return(1)
+    end
+
+    context "when loop_tick_supplier is provided" do
+      let(:tick_value) { 12_345.678 }
+      let(:supplier) { -> { tick_value } }
+      let(:heartbeat) do
+        described_class.new(
+          kind: "worker",
+          metadata: { queues: %w[default], threads: 5 },
+          loop_tick_supplier: supplier
+        )
+      end
+
+      before { heartbeat.start }
+
+      it "includes loop_tick_at in metadata on beat" do
+        heartbeat.beat
+
+        expect(scope).to have_received(:update_all) do |args|
+          expect(args[:last_heartbeat_at]).to be_a(Time)
+          expect(args[:metadata]).to include("loop_tick_at" => tick_value)
+        end
+      end
+
+      it "preserves original metadata keys" do
+        heartbeat.beat
+
+        expect(scope).to have_received(:update_all) do |args|
+          expect(args[:metadata]).to include(queues: %w[default], threads: 5)
+        end
+      end
+    end
+
+    context "when loop_tick_supplier returns nil" do
+      let(:heartbeat) do
+        described_class.new(
+          kind: "worker",
+          metadata: { queues: %w[default] },
+          loop_tick_supplier: -> {}
+        )
+      end
+
+      before { heartbeat.start }
+
+      it "writes nil loop_tick_at" do
+        heartbeat.beat
+
+        expect(scope).to have_received(:update_all) do |args|
+          expect(args[:metadata]).to include("loop_tick_at" => nil)
+        end
+      end
+    end
+
+    context "when loop_tick_supplier is not provided" do
+      let(:heartbeat) do
+        described_class.new(kind: "dispatcher", metadata: { pid: 123 })
+      end
+
+      before { heartbeat.start }
+
+      it "does not include metadata in update" do
+        heartbeat.beat
+
+        expect(scope).to have_received(:update_all) do |args|
+          expect(args).not_to have_key(:metadata)
+          expect(args[:last_heartbeat_at]).to be_a(Time)
+        end
+      end
+    end
+  end
+end

--- a/spec/pgbus/process/liveness_probe_spec.rb
+++ b/spec/pgbus/process/liveness_probe_spec.rb
@@ -47,12 +47,18 @@ RSpec.describe Pgbus::Process::Worker do
         expect(captured_args).to include(loop_tick_supplier: an_instance_of(Proc))
       end
 
-      it "updates @loop_tick_at on each loop tick" do
+      it "stamp_loop_tick writes a wall-clock timestamp to @loop_tick_at" do
         tick_ref = worker.instance_variable_get(:@loop_tick_at)
         expect(tick_ref.get).to be_nil
 
-        tick_ref.set(123.456)
-        expect(tick_ref.get).to eq(123.456)
+        before = Time.now.to_f
+        worker.send(:stamp_loop_tick)
+        after = Time.now.to_f
+
+        stamped = tick_ref.get
+        expect(stamped).to be_a(Float)
+        expect(stamped).to be >= before
+        expect(stamped).to be <= after
       end
     end
   end

--- a/spec/pgbus/process/liveness_probe_spec.rb
+++ b/spec/pgbus/process/liveness_probe_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Process::Worker do
+  describe "liveness probe" do
+    let(:heartbeat) { instance_double(Pgbus::Process::Heartbeat, start: true, stop: true) }
+    let(:mock_client) { build_mock_client }
+    let(:executor) { instance_double(Pgbus::ActiveJob::Executor) }
+    let(:pool) do
+      instance_double(
+        Pgbus::ExecutionPools::ThreadPool,
+        capacity: 5, available_capacity: 5, idle?: true,
+        shutdown: true, kill: true, wait_for_termination: true,
+        metadata: { mode: :threads, capacity: 5, busy: 0 }
+      )
+    end
+    let(:circuit_breaker) { instance_double(Pgbus::CircuitBreaker, paused?: false, record_success: nil, record_failure: nil) }
+
+    before do
+      allow(Pgbus::Process::Heartbeat).to receive(:new).and_return(heartbeat)
+      allow(Pgbus).to receive(:client).and_return(mock_client)
+      allow(Pgbus::ActiveJob::Executor).to receive(:new).and_return(executor)
+      allow(Pgbus::ExecutionPools).to receive(:build).and_return(pool)
+      allow(Pgbus::CircuitBreaker).to receive(:new).and_return(circuit_breaker)
+    end
+
+    describe "loop beacon" do
+      let(:worker) { described_class.new(queues: %w[default], threads: 5) }
+
+      it "initializes @loop_tick_at as an AtomicReference" do
+        tick = worker.instance_variable_get(:@loop_tick_at)
+        expect(tick).to be_a(Concurrent::AtomicReference)
+        expect(tick.get).to be_nil
+      end
+
+      it "passes loop_tick_supplier when starting heartbeat" do
+        captured_args = nil
+        allow(Pgbus::Process::Heartbeat).to receive(:new) do |**kwargs|
+          captured_args = kwargs
+          heartbeat
+        end
+
+        w = described_class.new(queues: %w[default], threads: 5)
+        w.send(:start_heartbeat)
+
+        expect(captured_args).to include(loop_tick_supplier: an_instance_of(Proc))
+      end
+
+      it "updates @loop_tick_at on each loop tick" do
+        tick_ref = worker.instance_variable_get(:@loop_tick_at)
+        expect(tick_ref.get).to be_nil
+
+        tick_ref.set(123.456)
+        expect(tick_ref.get).to eq(123.456)
+      end
+    end
+  end
+end

--- a/spec/pgbus/process/supervisor_watchdog_spec.rb
+++ b/spec/pgbus/process/supervisor_watchdog_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Process::Supervisor do
+  describe "#check_stalled_workers" do
+    let(:mock_heartbeat) { instance_double(Pgbus::Process::Heartbeat, start: nil, stop: nil) }
+    let(:config) { Pgbus.configuration }
+    let(:supervisor) { described_class.new }
+
+    before do
+      allow(Pgbus::Process::Heartbeat).to receive(:new).and_return(mock_heartbeat)
+      config.stall_threshold = 90
+    end
+
+    after do
+      config.stall_threshold = 90
+    end
+
+    describe "check_stalled_workers (private)" do
+      let(:stalled_entry) do
+        double("ProcessEntry",
+               kind: "worker",
+               pid: 1001,
+               metadata: { "loop_tick_at" => (Time.now.to_f - 120) })
+      end
+
+      let(:healthy_entry) do
+        double("ProcessEntry",
+               kind: "worker",
+               pid: 1002,
+               metadata: { "loop_tick_at" => Time.now.to_f })
+      end
+
+      before do
+        supervisor.instance_variable_set(:@forks, {
+                                           1001 => { type: :worker, config: { queues: ["default"] } },
+                                           1002 => { type: :worker, config: { queues: ["priority"] } }
+                                         })
+        supervisor.instance_variable_set(:@last_watchdog_at, 0.0)
+      end
+
+      it "kills a worker whose loop_tick_at exceeds stall_threshold" do
+        allow(Pgbus::ProcessEntry).to receive(:where)
+          .with(kind: "worker", pid: [1001, 1002])
+          .and_return(double(to_a: [stalled_entry, healthy_entry]))
+        allow(Process).to receive(:kill)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Process).to have_received(:kill).with("KILL", 1001)
+        expect(Process).not_to have_received(:kill).with("KILL", 1002)
+      end
+
+      it "does not kill a worker within threshold" do
+        allow(Pgbus::ProcessEntry).to receive(:where)
+          .with(kind: "worker", pid: [1001, 1002])
+          .and_return(double(to_a: [healthy_entry]))
+        allow(Process).to receive(:kill)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Process).not_to have_received(:kill)
+      end
+
+      it "skips when stall_threshold is nil" do
+        config.stall_threshold = nil
+        allow(Pgbus::ProcessEntry).to receive(:where)
+        allow(Process).to receive(:kill)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Pgbus::ProcessEntry).not_to have_received(:where)
+        expect(Process).not_to have_received(:kill)
+      end
+
+      it "handles Errno::ESRCH when process is already gone" do
+        allow(Pgbus::ProcessEntry).to receive(:where)
+          .with(kind: "worker", pid: [1001, 1002])
+          .and_return(double(to_a: [stalled_entry]))
+        allow(Process).to receive(:kill).with("KILL", 1001).and_raise(Errno::ESRCH)
+
+        expect { supervisor.send(:check_stalled_workers) }.not_to raise_error
+      end
+
+      it "skips entries without loop_tick_at in metadata" do
+        entry_no_tick = double("ProcessEntry",
+                               kind: "worker", pid: 1001,
+                               metadata: { "queues" => ["default"] })
+        allow(Pgbus::ProcessEntry).to receive(:where)
+          .with(kind: "worker", pid: [1001, 1002])
+          .and_return(double(to_a: [entry_no_tick]))
+        allow(Process).to receive(:kill)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Process).not_to have_received(:kill)
+      end
+
+      it "respects the WATCHDOG_INTERVAL rate limiter" do
+        supervisor.instance_variable_set(:@last_watchdog_at,
+                                         Process.clock_gettime(Process::CLOCK_MONOTONIC))
+        allow(Pgbus::ProcessEntry).to receive(:where)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Pgbus::ProcessEntry).not_to have_received(:where)
+      end
+
+      it "does not check non-worker forks" do
+        supervisor.instance_variable_set(:@forks, {
+                                           2001 => { type: :dispatcher },
+                                           2002 => { type: :scheduler }
+                                         })
+
+        allow(Pgbus::ProcessEntry).to receive(:where)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Pgbus::ProcessEntry).not_to have_received(:where)
+      end
+
+      it "rescues and logs DB errors" do
+        allow(Pgbus::ProcessEntry).to receive(:where).and_raise(StandardError, "connection lost")
+
+        expect { supervisor.send(:check_stalled_workers) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/pgbus/read_timeout_error_spec.rb
+++ b/spec/pgbus/read_timeout_error_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::ReadTimeoutError do
+  it "inherits from Pgbus::Error" do
+    expect(described_class.ancestors).to include(Pgbus::Error)
+  end
+
+  it "inherits from StandardError" do
+    expect(described_class.ancestors).to include(StandardError)
+  end
+end

--- a/spec/pgbus/web/data_source_process_status_spec.rb
+++ b/spec/pgbus/web/data_source_process_status_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/pgbus/web/data_source"
+
+RSpec.describe Pgbus::Web::DataSource do
+  describe "#derive_process_status" do
+    let(:mock_client) { build_mock_client }
+    let(:data_source) { described_class.new(client: mock_client) }
+
+    after do
+      Pgbus.configuration.stall_threshold = 90
+    end
+
+    describe "#derive_process_status (private)" do
+      context "when process is stale" do
+        it "returns :stale" do
+          result = data_source.send(:derive_process_status, true, {}, "worker")
+          expect(result).to eq(:stale)
+        end
+      end
+
+      context "when process is a healthy worker with recent loop_tick_at" do
+        it "returns :healthy" do
+          metadata = { "loop_tick_at" => Time.now.to_f }
+          result = data_source.send(:derive_process_status, false, metadata, "worker")
+          expect(result).to eq(:healthy)
+        end
+      end
+
+      context "when process is a worker with stale loop_tick_at" do
+        it "returns :stalled" do
+          metadata = { "loop_tick_at" => (Time.now.to_f - 120) }
+          result = data_source.send(:derive_process_status, false, metadata, "worker")
+          expect(result).to eq(:stalled)
+        end
+      end
+
+      context "when process is not a worker" do
+        it "returns :healthy regardless of metadata" do
+          metadata = { "loop_tick_at" => (Time.now.to_f - 120) }
+          result = data_source.send(:derive_process_status, false, metadata, "dispatcher")
+          expect(result).to eq(:healthy)
+        end
+      end
+
+      context "when worker has no loop_tick_at in metadata" do
+        it "returns :healthy" do
+          result = data_source.send(:derive_process_status, false, { "queues" => ["default"] }, "worker")
+          expect(result).to eq(:healthy)
+        end
+      end
+
+      context "when stall_threshold is nil" do
+        before { Pgbus.configuration.stall_threshold = nil }
+
+        it "returns :healthy even with old loop_tick_at" do
+          metadata = { "loop_tick_at" => (Time.now.to_f - 999) }
+          result = data_source.send(:derive_process_status, false, metadata, "worker")
+          expect(result).to eq(:healthy)
+        end
+      end
+
+      context "when metadata is not a Hash" do
+        it "returns :healthy" do
+          result = data_source.send(:derive_process_status, false, nil, "worker")
+          expect(result).to eq(:healthy)
+        end
+      end
+    end
+
+    describe "#format_process (private)" do
+      it "includes :status key in the result" do
+        row = {
+          "id" => "1",
+          "kind" => "worker",
+          "hostname" => "host1",
+          "pid" => "123",
+          "metadata" => { "loop_tick_at" => Time.now.to_f }.to_json,
+          "last_heartbeat_at" => Time.now.to_s,
+          "created_at" => Time.now.to_s
+        }
+
+        result = data_source.send(:format_process, row)
+        expect(result).to have_key(:status)
+        expect(result[:status]).to eq(:healthy)
+        expect(result[:healthy]).to be true
+      end
+
+      it "marks stalled worker with status :stalled" do
+        row = {
+          "id" => "1",
+          "kind" => "worker",
+          "hostname" => "host1",
+          "pid" => "123",
+          "metadata" => { "loop_tick_at" => (Time.now.to_f - 120) }.to_json,
+          "last_heartbeat_at" => Time.now.to_s,
+          "created_at" => Time.now.to_s
+        }
+
+        result = data_source.send(:format_process, row)
+        expect(result[:status]).to eq(:stalled)
+        expect(result[:healthy]).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #179 — worker claim loop can hang indefinitely on a dead DB socket while the heartbeat keeps the process looking "Healthy". Queues back up with zero throughput and no visible alerts.

Three layers of defense:

- **Loop-progress beacon**: Worker stamps a monotonic `loop_tick_at` each iteration via `AtomicReference`. The heartbeat thread persists it to `ProcessEntry.metadata`, giving a distinct "claim loop progressing" signal separate from "process alive"
- **Supervisor watchdog**: `check_stalled_workers` runs every 10s in `monitor_loop`. Compares each worker's `loop_tick_at` age against `stall_threshold` (default 90s). Stalled workers get `SIGKILL` → `reap_children` → `restart_child` re-forks with fresh connections
- **Client read timeout**: `read_batch`/`read_multi`/`read_message` wrapped in `Timeout.timeout(read_timeout)` (default 30s). Dead sockets raise `Pgbus::ReadTimeoutError` instead of blocking forever — the worker self-heals before the watchdog escalates

Dashboard changes:
- Three-state process status: Healthy (green) → Stalled (yellow) → Stale (red)
- `format_process` exposes `:status` symbol alongside boolean `:healthy` for backwards compat
- "Stalled" translations added to all 12 locale files

New config options:
- `stall_threshold` (default `90`) — seconds before supervisor kills a stalled worker
- `read_timeout` (default `30`) — seconds before a DB read raises `ReadTimeoutError`

Closes #179

## Test plan

- [ ] Worker with `@loop_tick_at` AtomicReference initialized on construction
- [ ] Heartbeat persists `loop_tick_at` to ProcessEntry metadata when supplier provided
- [ ] Heartbeat skips metadata when no supplier (dispatcher, scheduler)
- [ ] Supervisor watchdog kills workers whose `loop_tick_at` exceeds threshold
- [ ] Supervisor watchdog respects rate limiter (WATCHDOG_INTERVAL)
- [ ] Supervisor watchdog handles ESRCH (process already gone)
- [ ] Supervisor watchdog skips non-worker forks
- [ ] Client raises `ReadTimeoutError` on stalled reads
- [ ] Client fast reads unaffected by timeout
- [ ] DataSource derives three-state status (healthy/stalled/stale)
- [ ] Configuration defaults: `stall_threshold=90`, `read_timeout=30`
- [ ] All 2127 existing specs pass
- [ ] RuboCop clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “stalled” process state with localized status badge labels across supported languages.
  * Introduced configurable stall detection (`stall_threshold`) and message read timeouts (`read_timeout`).
* **Bug Fixes**
  * Updated process status display to prefer an explicit status value and correctly reflect “stalled” vs “healthy”.
  * Added a watchdog that detects stalled workers and force-restarts them.
  * Implemented read timeouts for message reads, raising a dedicated timeout error when exceeded.
* **Tests**
  * Expanded RSpec coverage for status derivation, watchdog behavior, loop ticking/heartbeats, and read-timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->