### PR TITLE
feat(mcp): read-only MCP diagnostic server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,5 +42,6 @@ group :development, :test do
   gem "activejob", ">= 7.1", "< 9.0"
   gem "activerecord", ">= 7.1", "< 9.0"
   gem "globalid", ">= 1.0"
+  gem "mcp", "~> 0.22"
   gem "pg", "~> 1.5"
 end

--- a/README.md
+++ b/README.md
@@ -838,6 +838,60 @@ When `config.metrics_enabled = true` (default), the dashboard exposes Prometheus
 | `pgbus_worker_pool_busy` | Currently busy worker threads |
 | `pgbus_worker_pool_utilization` | Busy / capacity ratio |
 
+### MCP diagnostic server (read-only)
+
+Pgbus ships an optional, **read-only** [MCP](https://modelcontextprotocol.io) server so an AI agent (or any MCP client) can diagnose pgbus directly — "are queues backed up?", "is `read_ct` advancing?", "are workers heart-beating but not claiming?" — instead of hand-writing `pgmq` / `pg_stat_activity` SQL against production. It is a thin adapter over the same read layer the dashboard uses, so it adds no new database access path.
+
+The server never starts unless you ask for it:
+
+```bash
+bundle exec pgbus mcp        # speaks MCP over stdio
+```
+
+Add the optional `mcp` gem to your `Gemfile` first (`gem "mcp"`); the command tells you so if it's missing.
+
+#### Tools
+
+All tools are read-only — no tool mutates state, and there is no raw-SQL passthrough.
+
+| Tool | Purpose |
+|------|---------|
+| `pgbus_health` | One-call verdict: `OK` / `DEGRADED` / `STALLED`. STALLED is the silent-worker-wedge signal (visible backlog while workers heart-beat but don't claim). Suitable for automated alerting. |
+| `pgbus_queues` | All queues: depth, visible count, oldest-message age, paused state. |
+| `pgbus_queue_detail` | Per-queue metrics + paused state + table health (dead tuples, bloat, vacuum age). |
+| `pgbus_processes` | Every process with kind, pid, heartbeat age, and `healthy`/`stale`/`stalled` status. |
+| `pgbus_jobs` / `pgbus_job_detail` | Inspect enqueued messages (`read_ct`, `vt`, `enqueued_at`). Paginated. |
+| `pgbus_dlq` / `pgbus_dlq_detail` | Dead-letter inspection. Paginated. |
+| `pgbus_locks` | Active uniqueness locks (the leaked-lock diagnostic). |
+| `pgbus_throughput` / `pgbus_stats` | Recent throughput time series and status counts. |
+| `pgbus_recurring` | Recurring task schedule + last/next run times. |
+
+#### Security
+
+The server is built to be safe against a production datastore:
+
+- **Read-only by default.** No tool mutates state and no arbitrary-query tool exists.
+- **Payloads redacted.** Message bodies, headers, and job arguments are replaced with `[redacted]` unless you start the server with `PGBUS_MCP_ALLOW_PAYLOADS=1` **and** pass `include_payloads: true` on the call. Both gates must be open.
+- **Bounded queries.** Every list tool paginates with a row cap (`pgbus_jobs` / `pgbus_dlq` cap at 100 rows/page; time windows cap at 1440 minutes).
+- **Reuses your DB credentials.** No new privileged path — it reads through the app's existing connection config.
+- **Optional token gate.** Set `PGBUS_MCP_TOKEN` and the server refuses to start unless `PGBUS_MCP_AUTH_TOKEN` matches (constant-time compare). Run it co-located with the app, not internet-exposed.
+
+#### Client configuration
+
+A minimal MCP client config (Claude Code / Claude Desktop style):
+
+```json
+{
+  "mcpServers": {
+    "pgbus": {
+      "command": "bundle",
+      "args": ["exec", "pgbus", "mcp"],
+      "env": { "RAILS_ENV": "production" }
+    }
+  }
+}
+```
+
 ## Real-time broadcasts (turbo-streams replacement)
 
 Pgbus ships a drop-in replacement for turbo-rails' `turbo_stream_from` helper that fixes several well-known ActionCable correctness bugs by using PGMQ message IDs as a replay cursor. Same API as turbo-rails. No Redis. No ActionCable. No lost messages on reconnect.

--- a/README.md
+++ b/README.md
@@ -842,13 +842,59 @@ When `config.metrics_enabled = true` (default), the dashboard exposes Prometheus
 
 Pgbus ships an optional, **read-only** [MCP](https://modelcontextprotocol.io) server so an AI agent (or any MCP client) can diagnose pgbus directly — "are queues backed up?", "is `read_ct` advancing?", "are workers heart-beating but not claiming?" — instead of hand-writing `pgmq` / `pg_stat_activity` SQL against production. It is a thin adapter over the same read layer the dashboard uses, so it adds no new database access path.
 
-The server never starts unless you ask for it:
+Add the optional `mcp` gem to your `Gemfile` first (`gem "mcp"`); both entry points below tell you if it's missing.
+
+#### Choosing a deployment
+
+There are two ways to run it, depending on **who connects and from where**:
+
+| | **stdio** (`pgbus mcp`) | **HTTP** (mount in Rails) |
+|---|---|---|
+| Who connects | A local operator (Claude Desktop / Claude Code on your machine) | A remote agent or alerting system |
+| Process model | The MCP client **spawns** a short-lived process on demand | Runs **inside your existing Rails server** — no second process |
+| Reaches production? | Only if run where prod DB creds are available | Yes — co-located with the app, same credentials |
+| Use it for | Hands-on, interactive debugging | Automated/remote diagnostics & alerting |
+
+> **Don't start a second `bin/pgbus` instance for HTTP.** The HTTP transport is a Rack app — mount it in the Rails app you already deploy.
+
+##### stdio (local operator)
 
 ```bash
 bundle exec pgbus mcp        # speaks MCP over stdio
 ```
 
-Add the optional `mcp` gem to your `Gemfile` first (`gem "mcp"`); the command tells you so if it's missing.
+##### HTTP (mount in Rails)
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  # ... your routes ...
+  mount Pgbus::MCP.rack_app(token: ENV["PGBUS_MCP_TOKEN"]) => "/pgbus/mcp"
+end
+```
+
+`Pgbus::MCP.rack_app` returns a gated Rack app. It runs the transport in **stateless + JSON-response mode**, so every request is a self-contained POST with no in-memory session — safe behind multiple Puma/Falcon workers (any worker can answer any request). Keep the endpoint on an internal network / behind your VPN; it is not meant to be internet-exposed.
+
+Options:
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `token:` | `nil` | Shared secret. When set, requests must send `Authorization: Bearer <token>` (constant-time compared). |
+| `auth:` | `nil` | A callable `->(rack_request) { ... }` returning truthy to allow — mirrors `config.web_auth`. Wins over `token:`. |
+| `allow_payloads:` | `false` | When true, tools honor a per-call `include_payloads` flag (see Security). |
+
+If you set neither `token:` nor `auth:`, pgbus logs a warning — an unauthenticated diagnostic endpoint exposes operational metadata to anyone who can reach it.
+
+> Clients must send `Accept: application/json` and `Content-Type: application/json` on every POST, or the transport replies `406 Not Acceptable`. MCP clients do this automatically.
+
+Need a **standalone HTTP pod** instead of mounting in your main app? The same Rack app works under any Rack server, e.g. a one-line `config.ru`:
+
+```ruby
+require "pgbus"
+Pgbus::MCP.load!
+run Pgbus::MCP.rack_app(token: ENV["PGBUS_MCP_TOKEN"])
+# rackup -p 9293   (run it in a container that shares the app's DB config)
+```
 
 #### Tools
 
@@ -871,14 +917,16 @@ All tools are read-only — no tool mutates state, and there is no raw-SQL passt
 The server is built to be safe against a production datastore:
 
 - **Read-only by default.** No tool mutates state and no arbitrary-query tool exists.
-- **Payloads redacted.** Message bodies, headers, and job arguments are replaced with `[redacted]` unless you start the server with `PGBUS_MCP_ALLOW_PAYLOADS=1` **and** pass `include_payloads: true` on the call. Both gates must be open.
+- **Payloads redacted.** Message bodies, headers, and job arguments are replaced with `[redacted]` unless payloads are explicitly allowed **and** `include_payloads: true` is passed on the call. Both gates must be open. Allow payloads with `PGBUS_MCP_ALLOW_PAYLOADS=1` (stdio) or `Pgbus::MCP.rack_app(allow_payloads: true)` (HTTP).
 - **Bounded queries.** Every list tool paginates with a row cap (`pgbus_jobs` / `pgbus_dlq` cap at 100 rows/page; time windows cap at 1440 minutes).
 - **Reuses your DB credentials.** No new privileged path — it reads through the app's existing connection config.
-- **Optional token gate.** Set `PGBUS_MCP_TOKEN` and the server refuses to start unless `PGBUS_MCP_AUTH_TOKEN` matches (constant-time compare). Run it co-located with the app, not internet-exposed.
+- **Authentication.**
+  - *HTTP:* set `token:` (clients send `Authorization: Bearer <token>`) or a custom `auth:` callable; unauthenticated requests get `401`.
+  - *stdio:* the channel is local (the client spawns the process), so the gate is a boot-time precondition — set `PGBUS_MCP_TOKEN` and the server refuses to start unless `PGBUS_MCP_AUTH_TOKEN` matches (constant-time compare).
 
 #### Client configuration
 
-A minimal MCP client config (Claude Code / Claude Desktop style):
+For the **stdio** transport, a minimal MCP client config (Claude Code / Claude Desktop style):
 
 ```json
 {
@@ -887,6 +935,19 @@ A minimal MCP client config (Claude Code / Claude Desktop style):
       "command": "bundle",
       "args": ["exec", "pgbus", "mcp"],
       "env": { "RAILS_ENV": "production" }
+    }
+  }
+}
+```
+
+For the **HTTP** transport, point the client at the mounted URL with a streamable-HTTP server config, sending the bearer token, e.g.:
+
+```json
+{
+  "mcpServers": {
+    "pgbus": {
+      "url": "https://your-app.internal/pgbus/mcp",
+      "headers": { "Authorization": "Bearer ${PGBUS_MCP_TOKEN}" }
     }
   }
 }

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -36,11 +36,19 @@ module Pgbus
           "pgbus" => "Pgbus",
           "cli" => "CLI",
           "dsl" => "DSL",
-          "capsule_dsl" => "CapsuleDSL"
+          "capsule_dsl" => "CapsuleDSL",
+          "mcp" => "MCP"
         )
         loader.ignore("#{__dir__}/generators")
         loader.ignore("#{__dir__}/active_job")
         loader.ignore("#{__dir__}/pgbus/testing")
+        # The MCP diagnostic server is optional — its tool classes subclass
+        # MCP::Tool from the (optional) `mcp` gem. Keeping it out of Zeitwerk
+        # means we never reference the gem's constants at autoload time;
+        # `Pgbus::MCP.load!` (called by the `pgbus mcp` CLI command) requires
+        # the gem and loads the subsystem explicitly.
+        loader.ignore("#{__dir__}/pgbus/mcp")
+        loader.ignore("#{__dir__}/pgbus/mcp.rb")
         # Vendor integrations are loaded conditionally (when the vendor gem
         # is present) by lib/pgbus/engine.rb. Keeping them out of Zeitwerk
         # means we don't reference vendor constants at autoload time.
@@ -175,3 +183,8 @@ end
 
 require "active_job/queue_adapters/pgbus_adapter" if defined?(ActiveJob)
 require "pgbus/engine" if defined?(Rails::Engine)
+
+# Define the optional MCP namespace and its `load!` entrypoint. This file is
+# excluded from Zeitwerk (it references the optional `mcp` gem only inside
+# load!), so require it explicitly here. Requiring it does NOT load the gem.
+require "pgbus/mcp"

--- a/lib/pgbus/cli.rb
+++ b/lib/pgbus/cli.rb
@@ -16,6 +16,8 @@ module Pgbus
         show_status
       when "queues"
         list_queues
+      when "mcp"
+        start_mcp_server
       when "version"
         puts "pgbus #{Pgbus::VERSION}"
       when "help", "--help", "-h"
@@ -132,6 +134,13 @@ module Pgbus
       end
     end
 
+    # Boots the read-only MCP diagnostic server over stdio. Loaded lazily so
+    # the optional `mcp` gem is only required when this command is invoked.
+    def start_mcp_server
+      Pgbus::MCP.load!
+      Pgbus::MCP::Runner.run
+    end
+
     def list_queues
       Pgbus.client.list_queues
       metrics = Pgbus.client.metrics
@@ -154,6 +163,7 @@ module Pgbus
           start    Start the Pgbus supervisor (workers + dispatcher)
           status   Show running Pgbus processes
           queues   List queues with metrics
+          mcp      Start the read-only MCP diagnostic server over stdio
           version  Show version
           help     Show this help
 
@@ -172,6 +182,12 @@ module Pgbus
                              pattern)
           --execution-mode   Execution mode: threads (default) or async
                              (fiber-based, lower connection usage)
+
+        Environment for `mcp`:
+          PGBUS_MCP_TOKEN          If set, PGBUS_MCP_AUTH_TOKEN must match for
+                                   the server to start (optional token gate).
+          PGBUS_MCP_ALLOW_PAYLOADS Truthy to let tools return raw message
+                                   bodies/headers (off by default; redacted).
       HELP
     end
   end

--- a/lib/pgbus/mcp.rb
+++ b/lib/pgbus/mcp.rb
@@ -36,15 +36,21 @@ module Pgbus
 
     # Require the `mcp` gem and the whole pgbus MCP subsystem. Idempotent.
     # Raises Pgbus::Error with an actionable message if the gem is missing.
+    #
+    # Only the `require "mcp"` is wrapped — a LoadError from an internal
+    # `pgbus/mcp/...` path (typo, missing file) propagates verbatim so the
+    # real broken require shows up in the message instead of being masked
+    # as "add gem `mcp`".
     def load!
-      require "mcp"
+      begin
+        require "mcp"
+      rescue LoadError
+        raise Pgbus::Error,
+              "The pgbus MCP server requires the `mcp` gem. Add `gem \"mcp\"` to your Gemfile and run `bundle install`."
+      end
+
       REQUIRES.each { |path| require path }
       true
-    rescue LoadError => e
-      raise e unless e.message.include?("mcp")
-
-      raise Pgbus::Error,
-            "The pgbus MCP server requires the `mcp` gem. Add `gem \"mcp\"` to your Gemfile and run `bundle install`."
     end
   end
 end

--- a/lib/pgbus/mcp.rb
+++ b/lib/pgbus/mcp.rb
@@ -29,6 +29,7 @@ module Pgbus
       pgbus/mcp/tools/recurring_tool
       pgbus/mcp/server
       pgbus/mcp/runner
+      pgbus/mcp/rack_app
     ].freeze
 
     module_function

--- a/lib/pgbus/mcp.rb
+++ b/lib/pgbus/mcp.rb
@@ -50,7 +50,6 @@ module Pgbus
       end
 
       REQUIRES.each { |path| require path }
-      true
     end
   end
 end

--- a/lib/pgbus/mcp.rb
+++ b/lib/pgbus/mcp.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Pgbus
+  # Optional read-only MCP (Model Context Protocol) diagnostic server.
+  #
+  # This namespace is deliberately kept out of pgbus's Zeitwerk loader because
+  # its tool classes subclass `MCP::Tool` from the optional `mcp` gem.
+  # Referencing that gem at autoload time would force every pgbus user to
+  # install it. Instead the subsystem is loaded explicitly via {load!}, which
+  # is called by the `pgbus mcp` CLI command (and by specs).
+  module MCP
+    # Files in dependency order: the gem first, then the base classes the
+    # tools depend on, then the tools, then the server/runner.
+    REQUIRES = %w[
+      pgbus/mcp/redactor
+      pgbus/mcp/base_tool
+      pgbus/mcp/health_analyzer
+      pgbus/mcp/tools/health_tool
+      pgbus/mcp/tools/queues_tool
+      pgbus/mcp/tools/queue_detail_tool
+      pgbus/mcp/tools/processes_tool
+      pgbus/mcp/tools/jobs_tool
+      pgbus/mcp/tools/job_detail_tool
+      pgbus/mcp/tools/dlq_tool
+      pgbus/mcp/tools/dlq_detail_tool
+      pgbus/mcp/tools/locks_tool
+      pgbus/mcp/tools/throughput_tool
+      pgbus/mcp/tools/stats_tool
+      pgbus/mcp/tools/recurring_tool
+      pgbus/mcp/server
+      pgbus/mcp/runner
+    ].freeze
+
+    module_function
+
+    # Require the `mcp` gem and the whole pgbus MCP subsystem. Idempotent.
+    # Raises Pgbus::Error with an actionable message if the gem is missing.
+    def load!
+      require "mcp"
+      REQUIRES.each { |path| require path }
+      true
+    rescue LoadError => e
+      raise e unless e.message.include?("mcp")
+
+      raise Pgbus::Error,
+            "The pgbus MCP server requires the `mcp` gem. Add `gem \"mcp\"` to your Gemfile and run `bundle install`."
+    end
+  end
+end

--- a/lib/pgbus/mcp/base_tool.rb
+++ b/lib/pgbus/mcp/base_tool.rb
@@ -50,9 +50,19 @@ module Pgbus
           !!include_payloads
         end
 
-        # Wrap any Ruby value as a single text-content JSON response.
-        def json_response(value)
-          ::MCP::Tool::Response.new([{ type: "text", text: JSON.pretty_generate(value) }])
+        # Wrap any Ruby value as a single text-content JSON response, applying
+        # payload redaction at this boundary as a fail-safe. Redaction is the
+        # default: a tool returns metadata, and any payload-bearing key (at any
+        # depth) is stripped unless this call is explicitly allowed to include
+        # payloads. A tool author who forgets about redaction therefore cannot
+        # leak message bodies — they have to opt in.
+        #
+        # Pass +server_context+ and the tool's per-call +include_payloads+ flag
+        # to enable payloads; both gates must be open (see #payloads_allowed?).
+        def json_response(value, server_context: nil, include_payloads: false)
+          allow = payloads_allowed?(server_context, include_payloads)
+          redacted = Redactor.deep_redact(value, include_payloads: allow)
+          ::MCP::Tool::Response.new([{ type: "text", text: JSON.generate(redacted) }])
         end
 
         # Wrap an error message as an MCP error response (isError: true) so the

--- a/lib/pgbus/mcp/base_tool.rb
+++ b/lib/pgbus/mcp/base_tool.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Pgbus
+  module MCP
+    # Base class for every pgbus diagnostic tool. Provides the shared
+    # read-only annotation, a JSON response helper, and access to the
+    # DataSource the tool delegates to.
+    #
+    # The DataSource is pulled from +server_context[:data_source]+ so the
+    # server can inject a configured instance (and tests can inject a double).
+    # Every subclass is read-only by contract — see issue #180 security
+    # requirements. Write/admin tools, if ever added, must live in a separate,
+    # explicitly opt-in surface and never inherit from this class.
+    class BaseTool < ::MCP::Tool
+      # Marks the tool read-only and non-destructive so MCP clients can show
+      # the right affordance and never treat a call as a mutation.
+      annotations(
+        read_only_hint: true,
+        destructive_hint: false,
+        idempotent_hint: true,
+        open_world_hint: false
+      )
+
+      class << self
+        # MCP::Tool.inherited resets @annotations_value to nil on every
+        # subclass, so the read_only_hint set on BaseTool would not reach the
+        # concrete tools. Fall back to the nearest ancestor that defined
+        # annotations so all tools inherit the read-only contract without
+        # repeating it. (annotations_value is what MCP::Tool#to_h reads.)
+        def annotations_value
+          super || (superclass.respond_to?(:annotations_value) ? superclass.annotations_value : nil)
+        end
+
+        # Pull the injected DataSource (or build a default one). Kept as a
+        # class method because MCP tool entry points (`self.call`) are class
+        # methods.
+        def data_source_from(server_context)
+          (server_context && server_context[:data_source]) || Pgbus::Web::DataSource.new
+        end
+
+        # Whether payloads may be returned for this call. Honors a per-call
+        # `include_payloads` argument only when the server was started with
+        # payloads globally allowed (`server_context[:allow_payloads]`).
+        # Defaults to false on both axes so nothing leaks by accident.
+        def payloads_allowed?(server_context, include_payloads)
+          return false unless server_context && server_context[:allow_payloads]
+
+          !!include_payloads
+        end
+
+        # Wrap any Ruby value as a single text-content JSON response.
+        def json_response(value)
+          ::MCP::Tool::Response.new([{ type: "text", text: JSON.pretty_generate(value) }])
+        end
+
+        # Wrap an error message as an MCP error response (isError: true) so the
+        # client surfaces it as a tool failure rather than a normal result.
+        def error_response(message)
+          ::MCP::Tool::Response.new(
+            [{ type: "text", text: message }],
+            error: true
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/health_analyzer.rb
+++ b/lib/pgbus/mcp/health_analyzer.rb
@@ -34,11 +34,16 @@ module Pgbus
         processes = @data_source.processes
         health    = safe_queue_health
 
-        reasons = []
-        reasons.concat(stalled_reasons(queues, processes))
-        degraded = degraded_reasons(queues, processes, health)
+        # Partition queues once: non-DLQ (the operational set) and the subset
+        # of those with visible, claimable backlog. Every reason check and the
+        # summary derive from these, so we never re-filter the array.
+        non_dlq = queues.reject { |q| dlq?(q) }
+        backlog = non_dlq.select { |q| q[:queue_visible_length].to_i.positive? }
 
-        status = if reasons.any?
+        stalled  = stalled_reasons(backlog, processes)
+        degraded = degraded_reasons(queues, backlog, processes, health)
+
+        status = if stalled.any?
                    "STALLED"
                  elsif degraded.any?
                    "DEGRADED"
@@ -48,13 +53,17 @@ module Pgbus
 
         {
           status: status,
-          reasons: reasons + degraded,
+          reasons: stalled + degraded,
           checked_at: Time.now.utc.iso8601,
-          summary: build_summary(queues, processes, health)
+          summary: build_summary(queues, non_dlq, processes, health)
         }
       end
 
       private
+
+      def dlq?(queue)
+        queue[:name].to_s.end_with?(Pgbus::DEAD_LETTER_SUFFIX)
+      end
 
       def safe_queue_health
         @data_source.queue_health_stats
@@ -62,10 +71,9 @@ module Pgbus
         {}
       end
 
-      # STALLED detection: a backed-up non-DLQ queue while a worker is in the
-      # :stalled state, or backed up with live-but-idle workers present.
-      def stalled_reasons(queues, processes)
-        backlog = backed_up_queues(queues)
+      # STALLED detection: a backed-up queue while a worker is in the :stalled
+      # state, or backed up with live-but-idle workers present.
+      def stalled_reasons(backlog, processes)
         return [] if backlog.empty?
 
         workers = processes.select { |p| p[:kind] == WORKER_KIND }
@@ -86,28 +94,22 @@ module Pgbus
       end
 
       # DEGRADED detection: conditions worth surfacing that are not the wedge.
-      def degraded_reasons(queues, processes, health)
+      def degraded_reasons(queues, backlog, processes, health)
         reasons = []
 
         stale = processes.select { |p| p[:status].to_s == "stale" }
         reasons << "#{stale.size} process(es) stale (no recent heartbeat)" if stale.any?
 
-        paused_backlog = backed_up_queues(queues).select { |q| q[:paused] }
+        paused_backlog = backlog.select { |q| q[:paused] }
         reasons << "#{paused_backlog.size} paused queue(s) holding a backlog: #{backlog_names(paused_backlog)}" if paused_backlog.any?
 
-        dlq = queues.select { |q| q[:name].to_s.end_with?(Pgbus::DEAD_LETTER_SUFFIX) && q[:queue_length].to_i.positive? }
+        dlq = queues.select { |q| dlq?(q) && q[:queue_length].to_i.positive? }
         reasons << "#{dlq.size} dead-letter queue(s) hold messages" if dlq.any?
 
         age = health[:oldest_transaction_age_sec]
         reasons << "oldest open transaction is #{age}s old (MVCC horizon pinning risk)" if age && age > 300
 
         reasons
-      end
-
-      # Non-DLQ queues with at least one visible (claimable) message.
-      def backed_up_queues(queues)
-        queues.reject { |q| q[:name].to_s.end_with?(Pgbus::DEAD_LETTER_SUFFIX) }
-              .select { |q| q[:queue_visible_length].to_i.positive? }
       end
 
       # The strongest wedge signal: visible messages that have never been read.
@@ -121,15 +123,24 @@ module Pgbus
         queues.map { |q| q[:name] }.join(", ")
       end
 
-      def build_summary(queues, processes, health)
-        non_dlq = queues.reject { |q| q[:name].to_s.end_with?(Pgbus::DEAD_LETTER_SUFFIX) }
+      def build_summary(queues, non_dlq, processes, health)
+        workers = stale = stalled = 0
+        processes.each do |p|
+          status = p[:status].to_s
+          stale += 1 if status == "stale"
+          next unless p[:kind] == WORKER_KIND
+
+          workers += 1
+          stalled += 1 if status == "stalled"
+        end
+
         {
           queues: queues.size,
           total_visible: non_dlq.sum { |q| q[:queue_visible_length].to_i },
           total_depth: non_dlq.sum { |q| q[:queue_length].to_i },
-          workers: processes.count { |p| p[:kind] == WORKER_KIND },
-          stalled_workers: processes.count { |p| p[:status].to_s == "stalled" },
-          stale_processes: processes.count { |p| p[:status].to_s == "stale" },
+          workers: workers,
+          stalled_workers: stalled,
+          stale_processes: stale,
           oldest_transaction_age_sec: health[:oldest_transaction_age_sec]
         }
       end

--- a/lib/pgbus/mcp/health_analyzer.rb
+++ b/lib/pgbus/mcp/health_analyzer.rb
@@ -30,18 +30,20 @@ module Pgbus
       # Returns a machine-readable verdict hash suitable for both interactive
       # agent use and automated alerting.
       def verdict
-        queues    = @data_source.queues_with_metrics
-        processes = @data_source.processes
-        health    = safe_queue_health
+        queues          = @data_source.queues_with_metrics
+        processes       = @data_source.processes
+        health, health_error = safe_queue_health
 
         # Partition queues once: non-DLQ (the operational set) and the subset
-        # of those with visible, claimable backlog. Every reason check and the
-        # summary derive from these, so we never re-filter the array.
+        # of those with visible, claimable backlog. Paused queues are removed
+        # from the STALLED backlog (an intentional pause is not the wedge —
+        # it's reported under DEGRADED), but kept in `non_dlq` for the summary.
         non_dlq = queues.reject { |q| dlq?(q) }
         backlog = non_dlq.select { |q| q[:queue_visible_length].to_i.positive? }
+        active_backlog = backlog.reject { |q| q[:paused] }
 
-        stalled  = stalled_reasons(backlog, processes)
-        degraded = degraded_reasons(queues, backlog, processes, health)
+        stalled  = stalled_reasons(active_backlog, processes)
+        degraded = degraded_reasons(queues, backlog, processes, health, health_error)
 
         status = if stalled.any?
                    "STALLED"
@@ -65,14 +67,20 @@ module Pgbus
         queue[:name].to_s.end_with?(Pgbus::DEAD_LETTER_SUFFIX)
       end
 
+      # Returns [health_hash, error_or_nil]. We never raise — pgbus_health
+      # must always produce a verdict — but we DO surface the failure so the
+      # caller knows the verdict was built from partial data, and we log it
+      # for operators (per the project's no-silent-errors rule).
       def safe_queue_health
-        @data_source.queue_health_stats
-      rescue StandardError
-        {}
+        [@data_source.queue_health_stats, nil]
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus::MCP] queue_health_stats failed: #{e.class}: #{e.message}" }
+        [{}, e]
       end
 
-      # STALLED detection: a backed-up queue while a worker is in the :stalled
-      # state, or backed up with live-but-idle workers present.
+      # STALLED detection: an active (non-paused) backed-up queue while a
+      # worker is in the :stalled state, or backed up with live-but-idle
+      # workers present.
       def stalled_reasons(backlog, processes)
         return [] if backlog.empty?
 
@@ -94,8 +102,10 @@ module Pgbus
       end
 
       # DEGRADED detection: conditions worth surfacing that are not the wedge.
-      def degraded_reasons(queues, backlog, processes, health)
+      def degraded_reasons(queues, backlog, processes, health, health_error)
         reasons = []
+
+        reasons << "queue health stats unavailable: #{health_error.class}: #{health_error.message}" if health_error
 
         stale = processes.select { |p| p[:status].to_s == "stale" }
         reasons << "#{stale.size} process(es) stale (no recent heartbeat)" if stale.any?

--- a/lib/pgbus/mcp/health_analyzer.rb
+++ b/lib/pgbus/mcp/health_analyzer.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    # Computes the top-level pgbus health verdict (OK / DEGRADED / STALLED)
+    # from the existing DataSource read layer. This is the single signal that
+    # catches the silent-worker-wedge class of incident (#179, #174, #181):
+    # a queue with visible messages and no claim progress while a subscribing
+    # worker is heart-beating with idle capacity.
+    #
+    # Verdict semantics (issue #180 acceptance criteria):
+    #   STALLED  — backlog (visible > 0) AND at least one worker is heart-beating
+    #              but its claim loop has stopped advancing (status :stalled),
+    #              OR backlog with live-but-idle workers and zero claim progress.
+    #   DEGRADED — something is wrong but not the wedge: stale processes, a
+    #              paused queue holding a backlog, growing DLQ, or MVCC horizon
+    #              pinned by a long-running transaction.
+    #   OK       — draining normally / nothing actionable.
+    class HealthAnalyzer
+      # A worker is considered to have idle capacity unless its metadata
+      # explicitly reports it is saturated. We treat the presence of any live
+      # worker as "has capacity" because a wedged worker reports healthy
+      # heartbeats while doing no work — exactly the case we must catch.
+      WORKER_KIND = "worker"
+
+      def initialize(data_source)
+        @data_source = data_source
+      end
+
+      # Returns a machine-readable verdict hash suitable for both interactive
+      # agent use and automated alerting.
+      def verdict
+        queues    = @data_source.queues_with_metrics
+        processes = @data_source.processes
+        health    = safe_queue_health
+
+        reasons = []
+        reasons.concat(stalled_reasons(queues, processes))
+        degraded = degraded_reasons(queues, processes, health)
+
+        status = if reasons.any?
+                   "STALLED"
+                 elsif degraded.any?
+                   "DEGRADED"
+                 else
+                   "OK"
+                 end
+
+        {
+          status: status,
+          reasons: reasons + degraded,
+          checked_at: Time.now.utc.iso8601,
+          summary: build_summary(queues, processes, health)
+        }
+      end
+
+      private
+
+      def safe_queue_health
+        @data_source.queue_health_stats
+      rescue StandardError
+        {}
+      end
+
+      # STALLED detection: a backed-up non-DLQ queue while a worker is in the
+      # :stalled state, or backed up with live-but-idle workers present.
+      def stalled_reasons(queues, processes)
+        backlog = backed_up_queues(queues)
+        return [] if backlog.empty?
+
+        workers = processes.select { |p| p[:kind] == WORKER_KIND }
+        return [] if workers.empty?
+
+        stalled_workers = workers.select { |w| w[:status].to_s == "stalled" }
+        live_workers    = workers.select { |w| %w[healthy stalled].include?(w[:status].to_s) }
+
+        reasons = []
+        if stalled_workers.any?
+          reasons << "#{stalled_workers.size} worker(s) stalled (heart-beating but claim loop not advancing) " \
+                     "while #{backlog.size} queue(s) have visible backlog: #{backlog_names(backlog)}"
+        elsif live_workers.any? && all_unread?(backlog)
+          reasons << "#{backlog.size} queue(s) have visible messages with read_ct=0 (never claimed) " \
+                     "while #{live_workers.size} worker(s) are alive: #{backlog_names(backlog)}"
+        end
+        reasons
+      end
+
+      # DEGRADED detection: conditions worth surfacing that are not the wedge.
+      def degraded_reasons(queues, processes, health)
+        reasons = []
+
+        stale = processes.select { |p| p[:status].to_s == "stale" }
+        reasons << "#{stale.size} process(es) stale (no recent heartbeat)" if stale.any?
+
+        paused_backlog = backed_up_queues(queues).select { |q| q[:paused] }
+        reasons << "#{paused_backlog.size} paused queue(s) holding a backlog: #{backlog_names(paused_backlog)}" if paused_backlog.any?
+
+        dlq = queues.select { |q| q[:name].to_s.end_with?(Pgbus::DEAD_LETTER_SUFFIX) && q[:queue_length].to_i.positive? }
+        reasons << "#{dlq.size} dead-letter queue(s) hold messages" if dlq.any?
+
+        age = health[:oldest_transaction_age_sec]
+        reasons << "oldest open transaction is #{age}s old (MVCC horizon pinning risk)" if age && age > 300
+
+        reasons
+      end
+
+      # Non-DLQ queues with at least one visible (claimable) message.
+      def backed_up_queues(queues)
+        queues.reject { |q| q[:name].to_s.end_with?(Pgbus::DEAD_LETTER_SUFFIX) }
+              .select { |q| q[:queue_visible_length].to_i.positive? }
+      end
+
+      # The strongest wedge signal: visible messages that have never been read.
+      # When queue metrics don't expose read_ct we conservatively treat the
+      # backlog as unread (the wedge default) so we don't miss the condition.
+      def all_unread?(backlog)
+        backlog.all? { |q| !q.key?(:max_read_ct) || q[:max_read_ct].to_i.zero? }
+      end
+
+      def backlog_names(queues)
+        queues.map { |q| q[:name] }.join(", ")
+      end
+
+      def build_summary(queues, processes, health)
+        non_dlq = queues.reject { |q| q[:name].to_s.end_with?(Pgbus::DEAD_LETTER_SUFFIX) }
+        {
+          queues: queues.size,
+          total_visible: non_dlq.sum { |q| q[:queue_visible_length].to_i },
+          total_depth: non_dlq.sum { |q| q[:queue_length].to_i },
+          workers: processes.count { |p| p[:kind] == WORKER_KIND },
+          stalled_workers: processes.count { |p| p[:status].to_s == "stalled" },
+          stale_processes: processes.count { |p| p[:status].to_s == "stale" },
+          oldest_transaction_age_sec: health[:oldest_transaction_age_sec]
+        }
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/rack_app.rb
+++ b/lib/pgbus/mcp/rack_app.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    # A turnkey, gated Rack app that serves the read-only pgbus diagnostic MCP
+    # server over HTTP. Mount it inside your existing Rails app — no second
+    # process, same DB credentials, same connection pool:
+    #
+    #   # config/routes.rb
+    #   mount Pgbus::MCP.rack_app(token: ENV["PGBUS_MCP_TOKEN"]) => "/pgbus/mcp"
+    #
+    # The underlying transport runs in stateless + JSON-response mode, which:
+    #   * makes every request a self-contained POST returning a single JSON
+    #     object (no in-memory session, no SSE stream, no reaper thread), so it
+    #     is safe behind multiple Puma/Falcon workers — any worker can answer
+    #     any request;
+    #   * is exactly what a read-only diagnostic server needs (it never pushes
+    #     server-initiated messages to the client).
+    #
+    # Security: requests are rejected with 401 unless they carry the configured
+    # token (or pass the supplied auth callable). Run it on an internal network
+    # / behind your VPN, never internet-exposed.
+    class RackApp
+      BEARER_PREFIX = "Bearer "
+      UNAUTHORIZED = [
+        401,
+        { "Content-Type" => "application/json", "WWW-Authenticate" => "Bearer" },
+        [{ jsonrpc: "2.0", id: nil, error: { code: -32_001, message: "Unauthorized" } }.to_json]
+      ].freeze
+
+      # @param data_source [Pgbus::Web::DataSource] read layer the tools query.
+      #   Built once and shared: DataSource acquires Pgbus::BusRecord.connection
+      #   from the ActiveRecord pool on each call, so a single instance is
+      #   request-safe across threads/workers.
+      # @param allow_payloads [Boolean] when true, tools honor a per-call
+      #   include_payloads flag; otherwise message bodies are always redacted.
+      # @param token [String, nil] shared secret. When present, requests must
+      #   send `Authorization: Bearer <token>`. nil disables the built-in gate.
+      # @param auth [#call, nil] custom authenticator taking a Rack::Request and
+      #   returning truthy to allow. Mirrors Pgbus.configuration.web_auth. Takes
+      #   precedence over +token+ when both are given.
+      def initialize(data_source: Pgbus::Web::DataSource.new, allow_payloads: false, token: nil, auth: nil)
+        @token = token
+        @auth = auth
+        @server = Server.build(data_source: data_source, allow_payloads: allow_payloads)
+        @transport = ::MCP::Server::Transports::StreamableHTTPTransport.new(
+          @server, stateless: true, enable_json_response: true
+        )
+        warn_unauthenticated! if @token.nil? && @auth.nil?
+      end
+
+      # Mount THIS object, never the bare transport. The auth gate lives here
+      # and runs before handle_request for *every* HTTP method (POST/GET/
+      # DELETE/...). Mounting @transport directly would skip authorization —
+      # the gem's transport has no auth of its own.
+      def call(env)
+        request = Rack::Request.new(env)
+        return UNAUTHORIZED unless authorized?(request)
+
+        @transport.handle_request(request)
+      end
+
+      private
+
+      # An explicit auth callable wins; otherwise fall back to the bearer token;
+      # otherwise (neither configured) allow — the constructor already warned.
+      def authorized?(request)
+        return !!@auth.call(request) if @auth
+        return bearer_matches?(request) if @token
+
+        true
+      end
+
+      def bearer_matches?(request)
+        header = request.get_header("HTTP_AUTHORIZATION").to_s
+        return false unless header.start_with?(BEARER_PREFIX)
+
+        Runner.secure_compare?(@token, header.delete_prefix(BEARER_PREFIX))
+      end
+
+      def warn_unauthenticated!
+        Pgbus.logger.warn do
+          "[Pgbus::MCP] HTTP diagnostic server mounted without authentication. " \
+            "Pass token: or auth: to Pgbus::MCP.rack_app, and keep it on an internal network."
+        end
+      end
+    end
+
+    module_function
+
+    # Build a gated Rack app serving the read-only diagnostic tools over HTTP.
+    # See {RackApp} for the parameters and deployment guidance.
+    def rack_app(data_source: Pgbus::Web::DataSource.new, allow_payloads: false, token: nil, auth: nil)
+      RackApp.new(data_source: data_source, allow_payloads: allow_payloads, token: token, auth: auth)
+    end
+  end
+end

--- a/lib/pgbus/mcp/redactor.rb
+++ b/lib/pgbus/mcp/redactor.rb
@@ -2,11 +2,15 @@
 
 module Pgbus
   module MCP
-    # Strips message bodies / headers / job arguments from DataSource result
-    # hashes before they leave the process. Job payloads can carry PII or
-    # secrets, so the diagnostic tools return metadata (ids, counts, ages,
-    # read_ct, vt, queue names, job_class) by default and only include the
-    # raw payload when an explicit, separately-gated flag is set.
+    # Strips message bodies / headers / job arguments from tool responses
+    # before they leave the process. Job payloads can carry PII or secrets, so
+    # the diagnostic tools return metadata (ids, counts, ages, read_ct, vt,
+    # queue names, job_class) by default and only include the raw payload when
+    # an explicit, separately-gated flag is set.
+    #
+    # +deep_redact+ is applied centrally at the response boundary
+    # (BaseTool.json_response), so redaction is fail-safe: a tool author cannot
+    # leak a payload by forgetting to redact — they have to opt in.
     #
     # See issue #180: "No sensitive payload leakage — diagnostic tools should
     # return metadata ... and redact or omit message payloads unless an
@@ -22,23 +26,46 @@ module Pgbus
       # rather than the field silently vanishing.
       REDACTED = "[redacted]"
 
-      # Returns a copy of +hash+ with payload-bearing keys replaced by a
-      # redaction marker. When +include_payloads+ is true the hash is returned
-      # untouched. Non-hash arguments pass through unchanged.
-      def redact(hash, include_payloads: false)
-        return hash if include_payloads
-        return hash unless hash.is_a?(Hash)
+      # True if +key+ names a payload-bearing field. Tolerates string or symbol
+      # keys and never raises on a non-symbolizable key.
+      def payload_key?(key)
+        PAYLOAD_KEYS.include?(key.respond_to?(:to_sym) ? key.to_sym : key)
+      end
 
-        hash.each_with_object({}) do |(key, value), result|
-          result[key] = PAYLOAD_KEYS.include?(key.to_sym) && !value.nil? ? REDACTED : value
+      # Recursively redact payload-bearing keys anywhere in a nested structure
+      # of hashes and arrays. This is the fail-safe applied at the response
+      # boundary (BaseTool.json_response): a tool that returns a payload key —
+      # at any depth, even one its author forgot about — has it stripped unless
+      # payloads are explicitly allowed for the call.
+      #
+      # A payload key is redacted only when its value is a leaf (the serialized
+      # message body / headers string). When the value is a Hash or Array the
+      # key is an envelope (e.g. a {message: {...}} detail wrapper, not a raw
+      # body), so we descend into it instead of blanking the whole subtree.
+      def deep_redact(value, include_payloads: false)
+        return value if include_payloads
+
+        case value
+        when Hash
+          value.each_with_object({}) do |(key, nested), result|
+            result[key] =
+              if payload_key?(key) && leaf?(nested) && !nested.nil?
+                REDACTED
+              else
+                deep_redact(nested, include_payloads: include_payloads)
+              end
+          end
+        when Array
+          value.map { |element| deep_redact(element, include_payloads: include_payloads) }
+        else
+          value
         end
       end
 
-      # Redact every hash in an array of DataSource rows.
-      def redact_all(rows, include_payloads: false)
-        return rows if include_payloads
-
-        Array(rows).map { |row| redact(row, include_payloads: include_payloads) }
+      # A leaf is anything that isn't a structure we recurse into — i.e. the
+      # actual serialized payload value rather than an envelope hash/array.
+      def leaf?(value)
+        !value.is_a?(Hash) && !value.is_a?(Array)
       end
     end
   end

--- a/lib/pgbus/mcp/redactor.rb
+++ b/lib/pgbus/mcp/redactor.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    # Strips message bodies / headers / job arguments from DataSource result
+    # hashes before they leave the process. Job payloads can carry PII or
+    # secrets, so the diagnostic tools return metadata (ids, counts, ages,
+    # read_ct, vt, queue names, job_class) by default and only include the
+    # raw payload when an explicit, separately-gated flag is set.
+    #
+    # See issue #180: "No sensitive payload leakage — diagnostic tools should
+    # return metadata ... and redact or omit message payloads unless an
+    # explicit, separately-gated flag is set."
+    module Redactor
+      module_function
+
+      # Keys whose values are message bodies / headers and must never be
+      # returned unless payloads are explicitly allowed.
+      PAYLOAD_KEYS = %i[message headers payload arguments].freeze
+
+      # Replacement marker so the agent can see a field exists but was hidden,
+      # rather than the field silently vanishing.
+      REDACTED = "[redacted]"
+
+      # Returns a copy of +hash+ with payload-bearing keys replaced by a
+      # redaction marker. When +include_payloads+ is true the hash is returned
+      # untouched. Non-hash arguments pass through unchanged.
+      def redact(hash, include_payloads: false)
+        return hash if include_payloads
+        return hash unless hash.is_a?(Hash)
+
+        hash.each_with_object({}) do |(key, value), result|
+          result[key] = PAYLOAD_KEYS.include?(key.to_sym) && !value.nil? ? REDACTED : value
+        end
+      end
+
+      # Redact every hash in an array of DataSource rows.
+      def redact_all(rows, include_payloads: false)
+        return rows if include_payloads
+
+        Array(rows).map { |row| redact(row, include_payloads: include_payloads) }
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/runner.rb
+++ b/lib/pgbus/mcp/runner.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/security_utils"
+
 module Pgbus
   module MCP
     # Boots the pgbus diagnostic MCP server over stdio. This is what
@@ -27,9 +29,10 @@ module Pgbus
       def run(env: ENV)
         authorize!(env)
 
-        server = Server.build(allow_payloads: truthy?(env["PGBUS_MCP_ALLOW_PAYLOADS"]))
+        allow_payloads = truthy?(env["PGBUS_MCP_ALLOW_PAYLOADS"])
+        server = Server.build(allow_payloads: allow_payloads)
         transport = ::MCP::Server::Transports::StdioTransport.new(server)
-        log_start(env)
+        log_start(allow_payloads)
         transport.open
       end
 
@@ -51,17 +54,18 @@ module Pgbus
       end
 
       # Constant-time comparison to avoid leaking the token via timing.
+      # Delegates to ActiveSupport's vetted implementation (railties already
+      # pulls in active_support). secure_compare handles unequal lengths
+      # safely — it compares fixed-length SHA256 digests, then verifies the
+      # raw values match — so it never raises on a length mismatch.
       def secure_compare?(expected, provided)
         return false if provided.nil?
-        return false unless expected.bytesize == provided.bytesize
 
-        left  = expected.unpack("C*")
-        right = provided.unpack("C*")
-        left.zip(right).reduce(0) { |acc, (a, b)| acc | (a ^ b) }.zero?
+        ActiveSupport::SecurityUtils.secure_compare(expected, provided)
       end
 
-      def log_start(env)
-        mode = truthy?(env["PGBUS_MCP_ALLOW_PAYLOADS"]) ? "payloads ALLOWED" : "payloads redacted"
+      def log_start(allow_payloads)
+        mode = allow_payloads ? "payloads ALLOWED" : "payloads redacted"
         Pgbus.logger.info { "[Pgbus::MCP] starting read-only diagnostic server over stdio (#{mode})" }
       end
     end

--- a/lib/pgbus/mcp/runner.rb
+++ b/lib/pgbus/mcp/runner.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    # Boots the pgbus diagnostic MCP server over stdio. This is what
+    # `pgbus mcp` invokes. Separated from Server so the server assembly stays
+    # transport-agnostic and unit-testable without touching $stdin/$stdout.
+    #
+    # Security posture (issue #180):
+    #   * Never starts unless explicitly invoked (`pgbus mcp`).
+    #   * Reuses the app's existing DB connection/config — no new privileged
+    #     path is opened.
+    #   * Payloads are redacted unless PGBUS_MCP_ALLOW_PAYLOADS is truthy.
+    #   * Optional token gate: when PGBUS_MCP_TOKEN is set, the same value must
+    #     be present in PGBUS_MCP_AUTH_TOKEN at boot or the server refuses to
+    #     start. stdio is a local, parent-spawned channel, so the gate is a
+    #     boot-time precondition rather than a per-message header.
+    module Runner
+      TRUTHY = %w[1 true yes on].freeze
+
+      module_function
+
+      # Build the server, enforce the optional token gate, and drive the stdio
+      # transport until the client disconnects.
+      #
+      # @param env [Hash] environment to read flags from (injectable for tests).
+      def run(env: ENV)
+        authorize!(env)
+
+        server = Server.build(allow_payloads: truthy?(env["PGBUS_MCP_ALLOW_PAYLOADS"]))
+        transport = ::MCP::Server::Transports::StdioTransport.new(server)
+        log_start(env)
+        transport.open
+      end
+
+      # Raise unless the configured token matches. No-op when PGBUS_MCP_TOKEN
+      # is unset (token gating is opt-in).
+      def authorize!(env)
+        expected = env["PGBUS_MCP_TOKEN"]
+        return if expected.nil? || expected.empty?
+
+        provided = env["PGBUS_MCP_AUTH_TOKEN"]
+        return if secure_compare?(expected, provided)
+
+        raise Pgbus::Error,
+              "pgbus MCP: authentication failed. PGBUS_MCP_TOKEN is set; provide a matching PGBUS_MCP_AUTH_TOKEN."
+      end
+
+      def truthy?(value)
+        TRUTHY.include?(value.to_s.strip.downcase)
+      end
+
+      # Constant-time comparison to avoid leaking the token via timing.
+      def secure_compare?(expected, provided)
+        return false if provided.nil?
+        return false unless expected.bytesize == provided.bytesize
+
+        left  = expected.unpack("C*")
+        right = provided.unpack("C*")
+        left.zip(right).reduce(0) { |acc, (a, b)| acc | (a ^ b) }.zero?
+      end
+
+      def log_start(env)
+        mode = truthy?(env["PGBUS_MCP_ALLOW_PAYLOADS"]) ? "payloads ALLOWED" : "payloads redacted"
+        Pgbus.logger.info { "[Pgbus::MCP] starting read-only diagnostic server over stdio (#{mode})" }
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/server.rb
+++ b/lib/pgbus/mcp/server.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    # Assembles the read-only pgbus diagnostic MCP server: registers every
+    # diagnostic tool and wires a DataSource (plus the payload gate) into the
+    # server context so tools never touch the database directly or leak
+    # payloads by default.
+    #
+    # This class only builds the +MCP::Server+ instance — transport is the
+    # caller's concern (Runner drives stdio). Keeping them separate means the
+    # same server can later be mounted over HTTP without changing tool code.
+    module Server
+      # The fixed, curated tool set. No arbitrary-SQL tool, no mutation tool —
+      # adding one here would violate the issue #180 security contract.
+      TOOLS = [
+        Tools::HealthTool,
+        Tools::QueuesTool,
+        Tools::QueueDetailTool,
+        Tools::ProcessesTool,
+        Tools::JobsTool,
+        Tools::JobDetailTool,
+        Tools::DlqTool,
+        Tools::DlqDetailTool,
+        Tools::LocksTool,
+        Tools::ThroughputTool,
+        Tools::StatsTool,
+        Tools::RecurringTool
+      ].freeze
+
+      INSTRUCTIONS = <<~TEXT
+        Read-only diagnostic tools for a pgbus (PostgreSQL/PGMQ) deployment.
+        Start with pgbus_health for a one-call OK/DEGRADED/STALLED verdict,
+        then drill in with pgbus_queues, pgbus_processes, pgbus_jobs,
+        pgbus_dlq, and pgbus_locks. No tool mutates state. Message payloads
+        are redacted unless the server was started with payloads explicitly
+        allowed.
+      TEXT
+
+      module_function
+
+      # Build an MCP::Server with all diagnostic tools registered.
+      #
+      # @param data_source [Pgbus::Web::DataSource] read layer the tools query.
+      # @param allow_payloads [Boolean] when true, tools honor a per-call
+      #   include_payloads flag; otherwise payloads are always redacted.
+      def build(data_source: Pgbus::Web::DataSource.new, allow_payloads: false)
+        ::MCP::Server.new(
+          name: "pgbus",
+          title: "Pgbus Diagnostics",
+          version: Pgbus::VERSION,
+          instructions: INSTRUCTIONS,
+          tools: TOOLS.dup,
+          server_context: {
+            data_source: data_source,
+            allow_payloads: allow_payloads
+          }
+        )
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/dlq_detail_tool.rb
+++ b/lib/pgbus/mcp/tools/dlq_detail_tool.rb
@@ -32,8 +32,7 @@ module Pgbus
           detail = data_source.dlq_message_detail(msg_id)
           return error_response("Dead-letter message #{msg_id} not found") unless detail
 
-          allow = payloads_allowed?(server_context, include_payloads)
-          json_response(message: Redactor.redact(detail, include_payloads: allow))
+          json_response({ message: detail }, server_context: server_context, include_payloads: include_payloads)
         end
       end
     end

--- a/lib/pgbus/mcp/tools/dlq_detail_tool.rb
+++ b/lib/pgbus/mcp/tools/dlq_detail_tool.rb
@@ -3,21 +3,31 @@
 module Pgbus
   module MCP
     module Tools
-      # Inspect a single dead-letter message by msg_id (searched across all
-      # *_dlq queues). Maps to DataSource#dlq_message_detail. Payload redacted
-      # by default.
+      # Inspect a single dead-letter message. Maps to DataSource#job_detail
+      # against the named DLQ queue when +queue+ is supplied; falls back to a
+      # cross-DLQ scan via DataSource#dlq_message_detail when it is not.
+      # Payload redacted by default.
       class DlqDetailTool < BaseTool
         tool_name "pgbus_dlq_detail"
         title "Pgbus Dead-Letter Detail"
         description <<~DESC
-          Inspect one dead-letter message by its numeric msg_id (searched
-          across all "_dlq" queues): read_ct, vt, enqueued_at, source queue.
-          The message body and headers are redacted unless the server allows
-          payloads and include_payloads is set.
+          Inspect one dead-letter message: read_ct, vt, enqueued_at, source
+          queue. Pass the full physical DLQ queue name (e.g.
+          "pgbus_default_dlq") in +queue+ to disambiguate — msg_ids are only
+          unique within a single DLQ table, so the same id can exist in more
+          than one. Without +queue+ the tool scans every "_dlq" table and
+          returns the FIRST match, which is ambiguous when multiple DLQs
+          contain the id and is reported as an error. The message body and
+          headers are redacted unless the server allows payloads and
+          include_payloads is set.
         DESC
 
         input_schema(
           properties: {
+            queue: {
+              type: "string",
+              description: "Full physical DLQ queue name (e.g. \"pgbus_default_dlq\"). Strongly recommended."
+            },
             msg_id: { type: "integer", description: "Numeric PGMQ message id." },
             include_payloads: {
               type: "boolean",
@@ -27,12 +37,34 @@ module Pgbus
           required: %w[msg_id]
         )
 
-        def self.call(msg_id:, include_payloads: false, server_context: nil)
+        def self.call(msg_id:, queue: nil, include_payloads: false, server_context: nil)
           data_source = data_source_from(server_context)
-          detail = data_source.dlq_message_detail(msg_id)
+          detail =
+            if queue
+              data_source.job_detail(queue, msg_id)
+            else
+              ambiguity_check(data_source, msg_id) || data_source.dlq_message_detail(msg_id)
+            end
           return error_response("Dead-letter message #{msg_id} not found") unless detail
+          return detail if detail.is_a?(::MCP::Tool::Response)
 
           json_response({ message: detail }, server_context: server_context, include_payloads: include_payloads)
+        end
+
+        # When the caller didn't specify a queue, scan every DLQ for the id and
+        # refuse to guess if more than one matches. Returns an error response
+        # on ambiguity, nil otherwise (so the caller proceeds with the normal
+        # first-match lookup).
+        def self.ambiguity_check(data_source, msg_id)
+          dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
+          dlqs = data_source.queues_with_metrics.select { |q| q[:name].to_s.end_with?(dlq_suffix) }
+          matches = dlqs.map { |q| q[:name] }.select { |name| data_source.job_detail(name, msg_id) }
+          return nil if matches.size <= 1
+
+          error_response(
+            "Dead-letter message #{msg_id} is ambiguous — present in #{matches.size} DLQs " \
+            "(#{matches.join(", ")}). Pass `queue:` to disambiguate."
+          )
         end
       end
     end

--- a/lib/pgbus/mcp/tools/dlq_detail_tool.rb
+++ b/lib/pgbus/mcp/tools/dlq_detail_tool.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Inspect a single dead-letter message by msg_id (searched across all
+      # *_dlq queues). Maps to DataSource#dlq_message_detail. Payload redacted
+      # by default.
+      class DlqDetailTool < BaseTool
+        tool_name "pgbus_dlq_detail"
+        title "Pgbus Dead-Letter Detail"
+        description <<~DESC
+          Inspect one dead-letter message by its numeric msg_id (searched
+          across all "_dlq" queues): read_ct, vt, enqueued_at, source queue.
+          The message body and headers are redacted unless the server allows
+          payloads and include_payloads is set.
+        DESC
+
+        input_schema(
+          properties: {
+            msg_id: { type: "integer", description: "Numeric PGMQ message id." },
+            include_payloads: {
+              type: "boolean",
+              description: "Include the raw message body/headers. Only honored when the server allows payloads."
+            }
+          },
+          required: %w[msg_id]
+        )
+
+        def self.call(msg_id:, include_payloads: false, server_context: nil)
+          data_source = data_source_from(server_context)
+          detail = data_source.dlq_message_detail(msg_id)
+          return error_response("Dead-letter message #{msg_id} not found") unless detail
+
+          allow = payloads_allowed?(server_context, include_payloads)
+          json_response(message: Redactor.redact(detail, include_payloads: allow))
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/dlq_tool.rb
+++ b/lib/pgbus/mcp/tools/dlq_tool.rb
@@ -35,11 +35,10 @@ module Pgbus
           page = [page.to_i, 1].max
           rows = data_source.dlq_messages(page: page, per_page: per_page)
 
-          allow = payloads_allowed?(server_context, include_payloads)
           json_response(
-            page: page,
-            per_page: per_page,
-            messages: Redactor.redact_all(rows, include_payloads: allow)
+            { page: page, per_page: per_page, messages: rows },
+            server_context: server_context,
+            include_payloads: include_payloads
           )
         end
       end

--- a/lib/pgbus/mcp/tools/dlq_tool.rb
+++ b/lib/pgbus/mcp/tools/dlq_tool.rb
@@ -16,6 +16,7 @@ module Pgbus
         DESC
 
         MAX_PER_PAGE = 100
+        MAX_PAGE = 1_000
 
         input_schema(
           properties: {
@@ -32,7 +33,7 @@ module Pgbus
         def self.call(page: 1, per_page: 25, include_payloads: false, server_context: nil)
           data_source = data_source_from(server_context)
           per_page = per_page.to_i.clamp(1, MAX_PER_PAGE)
-          page = [page.to_i, 1].max
+          page = page.to_i.clamp(1, MAX_PAGE)
           rows = data_source.dlq_messages(page: page, per_page: per_page)
 
           json_response(

--- a/lib/pgbus/mcp/tools/dlq_tool.rb
+++ b/lib/pgbus/mcp/tools/dlq_tool.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Paginated dead-letter queue inspection across all *_dlq queues.
+      # Maps to DataSource#dlq_messages. Payloads redacted by default.
+      class DlqTool < BaseTool
+        tool_name "pgbus_dlq"
+        title "Pgbus Dead-Letter Queue"
+        description <<~DESC
+          List messages sitting in dead-letter queues (queues whose name ends
+          in "_dlq") with read_ct, vt and enqueued_at. Paginated (default 25,
+          max 100). Message bodies and headers are redacted unless the server
+          allows payloads and include_payloads is set.
+        DESC
+
+        MAX_PER_PAGE = 100
+
+        input_schema(
+          properties: {
+            page: { type: "integer", description: "1-based page number (default 1).", minimum: 1 },
+            per_page: { type: "integer", description: "Rows per page (default 25, max 100).", minimum: 1 },
+            include_payloads: {
+              type: "boolean",
+              description: "Include raw message bodies/headers. Only honored when the server allows payloads."
+            }
+          },
+          required: []
+        )
+
+        def self.call(page: 1, per_page: 25, include_payloads: false, server_context: nil)
+          data_source = data_source_from(server_context)
+          per_page = per_page.to_i.clamp(1, MAX_PER_PAGE)
+          page = [page.to_i, 1].max
+          rows = data_source.dlq_messages(page: page, per_page: per_page)
+
+          allow = payloads_allowed?(server_context, include_payloads)
+          json_response(
+            page: page,
+            per_page: per_page,
+            messages: Redactor.redact_all(rows, include_payloads: allow)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/health_tool.rb
+++ b/lib/pgbus/mcp/tools/health_tool.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Top-level health verdict: OK / DEGRADED / STALLED, with the reasons
+      # that drove it. Delegates the actual analysis to HealthAnalyzer, which
+      # reads the same DataSource surface the dashboard uses. This is the
+      # single tool that catches the silent-worker-wedge class of incident.
+      class HealthTool < BaseTool
+        tool_name "pgbus_health"
+        title "Pgbus Health"
+        description <<~DESC
+          Top-level pgbus health verdict. Returns OK, DEGRADED, or STALLED with
+          the specific reasons. STALLED means the silent-wedge condition:
+          queues have visible backlog while workers are heart-beating but not
+          claiming (or a worker's claim loop has stalled). DEGRADED covers
+          stale processes, paused queues holding a backlog, dead-letter
+          buildup, or a long-running transaction pinning the MVCC horizon. Use
+          this first when triaging — it summarizes the whole system in one call
+          and is suitable for automated alerting.
+        DESC
+
+        input_schema(properties: {}, required: [])
+
+        def self.call(server_context: nil)
+          data_source = data_source_from(server_context)
+          json_response(HealthAnalyzer.new(data_source).verdict)
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/job_detail_tool.rb
+++ b/lib/pgbus/mcp/tools/job_detail_tool.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Inspect a single enqueued message by queue + msg_id. Returns its
+      # metadata (read_ct, vt, enqueued_at, last_read_at); the body and headers
+      # are redacted unless payloads are explicitly allowed. Maps to
+      # DataSource#job_detail.
+      class JobDetailTool < BaseTool
+        tool_name "pgbus_job_detail"
+        title "Pgbus Job Detail"
+        description <<~DESC
+          Inspect one enqueued message: read_ct, visibility timeout (vt),
+          enqueued_at, last_read_at. Pass the full physical queue name and the
+          numeric msg_id. The message body and headers are redacted unless the
+          server allows payloads and include_payloads is set.
+        DESC
+
+        input_schema(
+          properties: {
+            queue: { type: "string", description: "Full physical queue name (e.g. \"pgbus_default\")." },
+            msg_id: { type: "integer", description: "Numeric PGMQ message id." },
+            include_payloads: {
+              type: "boolean",
+              description: "Include the raw message body/headers. Only honored when the server allows payloads."
+            }
+          },
+          required: %w[queue msg_id]
+        )
+
+        def self.call(queue:, msg_id:, include_payloads: false, server_context: nil)
+          data_source = data_source_from(server_context)
+          detail = data_source.job_detail(queue, msg_id)
+          return error_response("Message #{msg_id} not found in #{queue}") unless detail
+
+          allow = payloads_allowed?(server_context, include_payloads)
+          json_response(job: Redactor.redact(detail, include_payloads: allow))
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/job_detail_tool.rb
+++ b/lib/pgbus/mcp/tools/job_detail_tool.rb
@@ -34,8 +34,7 @@ module Pgbus
           detail = data_source.job_detail(queue, msg_id)
           return error_response("Message #{msg_id} not found in #{queue}") unless detail
 
-          allow = payloads_allowed?(server_context, include_payloads)
-          json_response(job: Redactor.redact(detail, include_payloads: allow))
+          json_response({ job: detail }, server_context: server_context, include_payloads: include_payloads)
         end
       end
     end

--- a/lib/pgbus/mcp/tools/jobs_tool.rb
+++ b/lib/pgbus/mcp/tools/jobs_tool.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Paginated list of enqueued jobs/messages for a queue (or across all
+      # non-DLQ queues). Returns metadata — msg_id, read_ct, vt, enqueued_at,
+      # queue_name — with message bodies and headers redacted unless payloads
+      # are explicitly allowed. Maps to DataSource#jobs.
+      class JobsTool < BaseTool
+        tool_name "pgbus_jobs"
+        title "Pgbus Jobs"
+        description <<~DESC
+          List enqueued jobs/messages with read_ct, visibility timeout (vt) and
+          enqueued_at. Pass a full physical queue name to scope to one queue,
+          or omit it to span all non-DLQ queues. Paginated (default 25 per
+          page, capped at 100). Message bodies and headers are redacted unless
+          the server was started with payloads allowed and include_payloads is
+          set.
+        DESC
+
+        MAX_PER_PAGE = 100
+
+        input_schema(
+          properties: {
+            queue: {
+              type: "string",
+              description: "Full physical queue name (e.g. \"pgbus_default\"). Omit to span all non-DLQ queues."
+            },
+            page: { type: "integer", description: "1-based page number (default 1).", minimum: 1 },
+            per_page: { type: "integer", description: "Rows per page (default 25, max 100).", minimum: 1 },
+            include_payloads: {
+              type: "boolean",
+              description: "Include raw message bodies/headers. Only honored when the server allows payloads."
+            }
+          },
+          required: []
+        )
+
+        def self.call(queue: nil, page: 1, per_page: 25, include_payloads: false, server_context: nil)
+          data_source = data_source_from(server_context)
+          per_page = per_page.to_i.clamp(1, MAX_PER_PAGE)
+          page = [page.to_i, 1].max
+          rows = data_source.jobs(queue_name: queue, page: page, per_page: per_page)
+
+          allow = payloads_allowed?(server_context, include_payloads)
+          json_response(
+            queue: queue,
+            page: page,
+            per_page: per_page,
+            jobs: Redactor.redact_all(rows, include_payloads: allow)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/jobs_tool.rb
+++ b/lib/pgbus/mcp/tools/jobs_tool.rb
@@ -20,6 +20,7 @@ module Pgbus
         DESC
 
         MAX_PER_PAGE = 100
+        MAX_PAGE = 1_000
 
         input_schema(
           properties: {
@@ -40,7 +41,7 @@ module Pgbus
         def self.call(queue: nil, page: 1, per_page: 25, include_payloads: false, server_context: nil)
           data_source = data_source_from(server_context)
           per_page = per_page.to_i.clamp(1, MAX_PER_PAGE)
-          page = [page.to_i, 1].max
+          page = page.to_i.clamp(1, MAX_PAGE)
           rows = data_source.jobs(queue_name: queue, page: page, per_page: per_page)
 
           json_response(

--- a/lib/pgbus/mcp/tools/jobs_tool.rb
+++ b/lib/pgbus/mcp/tools/jobs_tool.rb
@@ -43,12 +43,10 @@ module Pgbus
           page = [page.to_i, 1].max
           rows = data_source.jobs(queue_name: queue, page: page, per_page: per_page)
 
-          allow = payloads_allowed?(server_context, include_payloads)
           json_response(
-            queue: queue,
-            page: page,
-            per_page: per_page,
-            jobs: Redactor.redact_all(rows, include_payloads: allow)
+            { queue: queue, page: page, per_page: per_page, jobs: rows },
+            server_context: server_context,
+            include_payloads: include_payloads
           )
         end
       end

--- a/lib/pgbus/mcp/tools/locks_tool.rb
+++ b/lib/pgbus/mcp/tools/locks_tool.rb
@@ -20,7 +20,7 @@ module Pgbus
 
         def self.call(server_context: nil)
           data_source = data_source_from(server_context)
-          json_response(locks: data_source.job_locks)
+          json_response({ locks: data_source.job_locks })
         end
       end
     end

--- a/lib/pgbus/mcp/tools/locks_tool.rb
+++ b/lib/pgbus/mcp/tools/locks_tool.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Lists active job uniqueness locks (the leaked-uniqueness-lock
+      # diagnostic). Maps to DataSource#job_locks — lock_key, queue_name,
+      # msg_id, created_at, age_seconds. No payloads involved.
+      class LocksTool < BaseTool
+        tool_name "pgbus_locks"
+        title "Pgbus Locks"
+        description <<~DESC
+          List active job uniqueness locks with their lock_key, queue_name,
+          msg_id, and age in seconds. A lock that outlives its message
+          indicates a leaked uniqueness key blocking re-enqueues. Returns the
+          100 most recent locks.
+        DESC
+
+        input_schema(properties: {}, required: [])
+
+        def self.call(server_context: nil)
+          data_source = data_source_from(server_context)
+          json_response(locks: data_source.job_locks)
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/processes_tool.rb
+++ b/lib/pgbus/mcp/tools/processes_tool.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Lists every pgbus process (worker/consumer/dispatcher/scheduler/
+      # supervisor/outbox/streamer) with kind, pid, heartbeat age, derived
+      # status and the claim-loop "stalled" verdict. Maps to
+      # DataSource#processes — which already computes :status as :healthy,
+      # :stale, or :stalled (the silent-wedge signal from #179/#181).
+      class ProcessesTool < BaseTool
+        tool_name "pgbus_processes"
+        title "Pgbus Processes"
+        description <<~DESC
+          List every pgbus process with its kind (worker, consumer,
+          dispatcher, scheduler, supervisor, outbox, streamer), hostname, pid,
+          last heartbeat time, and derived status. Status is "healthy",
+          "stale" (no recent heartbeat), or "stalled" (worker heart-beating but
+          its claim loop has stopped advancing — the silent-wedge condition).
+          Use this to answer "are workers alive but not claiming?".
+        DESC
+
+        input_schema(properties: {}, required: [])
+
+        def self.call(server_context: nil)
+          data_source = data_source_from(server_context)
+          json_response(processes: data_source.processes)
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/processes_tool.rb
+++ b/lib/pgbus/mcp/tools/processes_tool.rb
@@ -24,7 +24,7 @@ module Pgbus
 
         def self.call(server_context: nil)
           data_source = data_source_from(server_context)
-          json_response(processes: data_source.processes)
+          json_response({ processes: data_source.processes })
         end
       end
     end

--- a/lib/pgbus/mcp/tools/queue_detail_tool.rb
+++ b/lib/pgbus/mcp/tools/queue_detail_tool.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Per-queue detail: metrics, paused state, and table health (dead tuples,
+      # bloat, vacuum age). Maps to DataSource#queue_detail + #queue_paused? +
+      # #queue_health_detail. The +name+ is the full physical queue name as
+      # returned by pgbus_queues (e.g. "pgbus_default"), not the logical name.
+      class QueueDetailTool < BaseTool
+        tool_name "pgbus_queue_detail"
+        title "Pgbus Queue Detail"
+        description <<~DESC
+          Detailed status for a single queue: depth, visible count, message
+          ages, lifetime total, whether the queue is paused, and per-table
+          health (live/dead tuples, bloat ratio, last vacuum age). Pass the
+          full physical queue name as shown by pgbus_queues (e.g.
+          "pgbus_default").
+        DESC
+
+        input_schema(
+          properties: {
+            name: {
+              type: "string",
+              description: "Full physical queue name, e.g. \"pgbus_default\"."
+            }
+          },
+          required: ["name"]
+        )
+
+        def self.call(name:, server_context: nil)
+          data_source = data_source_from(server_context)
+          detail = data_source.queue_detail(name)
+          return error_response("Queue not found: #{name}") unless detail
+
+          json_response(
+            detail.merge(
+              paused: data_source.queue_paused?(name),
+              health: data_source.queue_health_detail(name)
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/queues_tool.rb
+++ b/lib/pgbus/mcp/tools/queues_tool.rb
@@ -20,7 +20,7 @@ module Pgbus
 
         def self.call(server_context: nil)
           data_source = data_source_from(server_context)
-          json_response(queues: data_source.queues_with_metrics)
+          json_response({ queues: data_source.queues_with_metrics })
         end
       end
     end

--- a/lib/pgbus/mcp/tools/queues_tool.rb
+++ b/lib/pgbus/mcp/tools/queues_tool.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Lists every queue with depth, visible count, oldest-message age and
+      # throughput — the "are queues backed up?" diagnostic. Maps to
+      # DataSource#queues_with_metrics. No payloads are involved.
+      class QueuesTool < BaseTool
+        tool_name "pgbus_queues"
+        title "Pgbus Queues"
+        description <<~DESC
+          List all pgbus queues with their depth (queue_length), visible count
+          (messages whose visibility timeout has expired and are ready to be
+          claimed), oldest/newest message age in seconds, lifetime total, and
+          paused state. Use this to answer "are any queues backed up?".
+        DESC
+
+        input_schema(properties: {}, required: [])
+
+        def self.call(server_context: nil)
+          data_source = data_source_from(server_context)
+          json_response(queues: data_source.queues_with_metrics)
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/recurring_tool.rb
+++ b/lib/pgbus/mcp/tools/recurring_tool.rb
@@ -19,7 +19,7 @@ module Pgbus
 
         def self.call(server_context: nil)
           data_source = data_source_from(server_context)
-          json_response(recurring_tasks: data_source.recurring_tasks)
+          json_response({ recurring_tasks: data_source.recurring_tasks })
         end
       end
     end

--- a/lib/pgbus/mcp/tools/recurring_tool.rb
+++ b/lib/pgbus/mcp/tools/recurring_tool.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Recurring task schedule with last-run / next-run times. Maps to
+      # DataSource#recurring_tasks. The :arguments field is not part of the
+      # list payload, so no redaction is needed here.
+      class RecurringTool < BaseTool
+        tool_name "pgbus_recurring"
+        title "Pgbus Recurring Tasks"
+        description <<~DESC
+          List recurring (cron) tasks with their schedule, human-readable
+          schedule, queue, enabled state, last_run_at and next_run_at. Use this
+          to confirm scheduled work is firing on time.
+        DESC
+
+        input_schema(properties: {}, required: [])
+
+        def self.call(server_context: nil)
+          data_source = data_source_from(server_context)
+          json_response(recurring_tasks: data_source.recurring_tasks)
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/stats_tool.rb
+++ b/lib/pgbus/mcp/tools/stats_tool.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Recent job status counts + summary (success / failed / dead-lettered,
+      # durations). Maps to DataSource#job_status_counts + #job_stats_summary.
+      class StatsTool < BaseTool
+        tool_name "pgbus_stats"
+        title "Pgbus Stats"
+        description <<~DESC
+          Recent job statistics over the last N minutes (default 60, max 1440):
+          status counts (success/failed/dead_lettered) and a summary including
+          average and max duration. Use this to gauge error rates and latency.
+        DESC
+
+        MAX_MINUTES = 1440
+
+        input_schema(
+          properties: {
+            minutes: { type: "integer", description: "Look-back window in minutes (default 60, max 1440).", minimum: 1 }
+          },
+          required: []
+        )
+
+        def self.call(minutes: 60, server_context: nil)
+          data_source = data_source_from(server_context)
+          window = minutes.to_i.clamp(1, MAX_MINUTES)
+          json_response(
+            minutes: window,
+            status_counts: data_source.job_status_counts(minutes: window),
+            summary: data_source.job_stats_summary(minutes: window)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/mcp/tools/stats_tool.rb
+++ b/lib/pgbus/mcp/tools/stats_tool.rb
@@ -27,9 +27,11 @@ module Pgbus
           data_source = data_source_from(server_context)
           window = minutes.to_i.clamp(1, MAX_MINUTES)
           json_response(
-            minutes: window,
-            status_counts: data_source.job_status_counts(minutes: window),
-            summary: data_source.job_stats_summary(minutes: window)
+            {
+              minutes: window,
+              status_counts: data_source.job_status_counts(minutes: window),
+              summary: data_source.job_stats_summary(minutes: window)
+            }
           )
         end
       end

--- a/lib/pgbus/mcp/tools/throughput_tool.rb
+++ b/lib/pgbus/mcp/tools/throughput_tool.rb
@@ -27,7 +27,7 @@ module Pgbus
         def self.call(minutes: 60, server_context: nil)
           data_source = data_source_from(server_context)
           window = minutes.to_i.clamp(1, MAX_MINUTES)
-          json_response(minutes: window, throughput: data_source.job_throughput(minutes: window))
+          json_response({ minutes: window, throughput: data_source.job_throughput(minutes: window) })
         end
       end
     end

--- a/lib/pgbus/mcp/tools/throughput_tool.rb
+++ b/lib/pgbus/mcp/tools/throughput_tool.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module MCP
+    module Tools
+      # Recent job throughput as a time series. Maps to
+      # DataSource#job_throughput. Used to answer "is the system draining?".
+      class ThroughputTool < BaseTool
+        tool_name "pgbus_throughput"
+        title "Pgbus Throughput"
+        description <<~DESC
+          Recent job throughput as a time series of {time, count} buckets over
+          the last N minutes (default 60, max 1440). Use this to confirm the
+          system is draining — a flat-zero series alongside a backlog is the
+          wedge signature.
+        DESC
+
+        MAX_MINUTES = 1440
+
+        input_schema(
+          properties: {
+            minutes: { type: "integer", description: "Look-back window in minutes (default 60, max 1440).", minimum: 1 }
+          },
+          required: []
+        )
+
+        def self.call(minutes: 60, server_context: nil)
+          data_source = data_source_from(server_context)
+          window = minutes.to_i.clamp(1, MAX_MINUTES)
+          json_response(minutes: window, throughput: data_source.job_throughput(minutes: window))
+        end
+      end
+    end
+  end
+end

--- a/spec/pgbus/cli_spec.rb
+++ b/spec/pgbus/cli_spec.rb
@@ -27,6 +27,21 @@ RSpec.describe Pgbus::CLI do
     it "defaults to help when no args" do
       expect { described_class.start([]) }.to output(/Usage: pgbus/).to_stdout
     end
+
+    it "lists the mcp command in help" do
+      expect { described_class.start(["help"]) }.to output(/mcp\s+Start the read-only MCP/).to_stdout
+    end
+
+    it "routes 'mcp' to the MCP runner after loading the subsystem" do
+      Pgbus::MCP.load!
+      allow(Pgbus::MCP).to receive(:load!)
+      allow(Pgbus::MCP::Runner).to receive(:run)
+
+      described_class.start(["mcp"])
+
+      expect(Pgbus::MCP).to have_received(:load!)
+      expect(Pgbus::MCP::Runner).to have_received(:run)
+    end
   end
 
   describe ".start with start command" do

--- a/spec/pgbus/mcp/health_analyzer_spec.rb
+++ b/spec/pgbus/mcp/health_analyzer_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Pgbus::MCP::HealthAnalyzer do
 
       verdict = analyzer.verdict
       expect(verdict[:status]).to eq("STALLED")
-      expect(verdict[:reasons].first).to match(/stalled/)
+      expect(verdict[:reasons].first).to include("stalled")
     end
 
     it "is STALLED when backlog is unread (read_ct 0) and workers are alive" do
@@ -71,7 +71,7 @@ RSpec.describe Pgbus::MCP::HealthAnalyzer do
 
       verdict = analyzer.verdict
       expect(verdict[:status]).to eq("STALLED")
-      expect(verdict[:reasons].first).to match(/never claimed/)
+      expect(verdict[:reasons].first).to include("never claimed")
     end
 
     it "treats backlog without read_ct metric as unread (conservative wedge default)" do
@@ -120,7 +120,7 @@ RSpec.describe Pgbus::MCP::HealthAnalyzer do
 
       verdict = analyzer.verdict
       expect(verdict[:status]).to eq("DEGRADED")
-      expect(verdict[:reasons].first).to match(/stale/)
+      expect(verdict[:reasons].first).to include("stale")
     end
 
     it "is DEGRADED when a paused queue holds a backlog" do
@@ -131,7 +131,7 @@ RSpec.describe Pgbus::MCP::HealthAnalyzer do
 
       verdict = analyzer.verdict
       expect(verdict[:status]).to eq("DEGRADED")
-      expect(verdict[:reasons].join).to match(/paused/)
+      expect(verdict[:reasons].join).to include("paused")
     end
 
     it "is DEGRADED when a dead-letter queue holds messages" do
@@ -142,7 +142,7 @@ RSpec.describe Pgbus::MCP::HealthAnalyzer do
 
       verdict = analyzer.verdict
       expect(verdict[:status]).to eq("DEGRADED")
-      expect(verdict[:reasons].join).to match(/dead-letter/)
+      expect(verdict[:reasons].join).to include("dead-letter")
     end
 
     it "is DEGRADED when the oldest transaction pins the MVCC horizon" do
@@ -154,7 +154,7 @@ RSpec.describe Pgbus::MCP::HealthAnalyzer do
 
       verdict = analyzer.verdict
       expect(verdict[:status]).to eq("DEGRADED")
-      expect(verdict[:reasons].join).to match(/MVCC/)
+      expect(verdict[:reasons].join).to include("MVCC")
     end
 
     it "STALLED takes precedence over DEGRADED conditions" do

--- a/spec/pgbus/mcp/health_analyzer_spec.rb
+++ b/spec/pgbus/mcp/health_analyzer_spec.rb
@@ -169,11 +169,37 @@ RSpec.describe Pgbus::MCP::HealthAnalyzer do
   end
 
   describe "#verdict resilience" do
-    it "tolerates queue_health_stats raising" do
-      allow(data_source).to receive_messages(queues_with_metrics: [], processes: [])
-      allow(data_source).to receive(:queue_health_stats).and_raise(StandardError)
+    before { allow(Pgbus.logger).to receive(:warn) }
 
-      expect(analyzer.verdict[:status]).to eq("OK")
+    it "still produces a verdict when queue_health_stats raises" do
+      allow(data_source).to receive_messages(queues_with_metrics: [], processes: [])
+      allow(data_source).to receive(:queue_health_stats).and_raise(StandardError, "boom")
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("DEGRADED")
+      expect(verdict[:reasons].join).to include("queue health stats unavailable")
+    end
+
+    it "logs the queue_health_stats failure rather than swallowing it" do
+      allow(data_source).to receive_messages(queues_with_metrics: [], processes: [])
+      allow(data_source).to receive(:queue_health_stats).and_raise(StandardError, "boom")
+
+      analyzer.verdict
+
+      expect(Pgbus.logger).to have_received(:warn)
+    end
+  end
+
+  describe "STALLED excludes paused queues" do
+    it "classifies a paused queue with read_ct=0 backlog as DEGRADED, not STALLED" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 5, visible: 5, paused: true, max_read_ct: 0)],
+        processes: [worker(status: :healthy)]
+      )
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("DEGRADED")
+      expect(verdict[:reasons].join).to include("paused")
     end
   end
 end

--- a/spec/pgbus/mcp/health_analyzer_spec.rb
+++ b/spec/pgbus/mcp/health_analyzer_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Pgbus::MCP::HealthAnalyzer do
+  subject(:analyzer) { described_class.new(data_source) }
+
+  let(:data_source) { instance_double(Pgbus::Web::DataSource) }
+
+  def stub_data_source(queues: [], processes: [], health: {})
+    allow(data_source).to receive_messages(queues_with_metrics: queues, processes: processes, queue_health_stats: health)
+  end
+
+  def queue(name:, length: 0, visible: 0, paused: false, max_read_ct: nil)
+    h = { name: name, queue_length: length, queue_visible_length: visible, paused: paused }
+    h[:max_read_ct] = max_read_ct unless max_read_ct.nil?
+    h
+  end
+
+  def worker(status:, kind: "worker")
+    { kind: kind, status: status }
+  end
+
+  describe "#verdict OK path" do
+    it "returns OK when there is no backlog and workers are healthy" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 0, visible: 0)],
+        processes: [worker(status: :healthy)]
+      )
+
+      expect(analyzer.verdict[:status]).to eq("OK")
+    end
+
+    it "returns OK when a queue drains normally with a working worker" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 5, visible: 5, max_read_ct: 2)],
+        processes: [worker(status: :healthy)]
+      )
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("OK")
+      expect(verdict[:reasons]).to be_empty
+    end
+
+    it "includes a machine-readable summary and ISO8601 checked_at" do
+      stub_data_source(processes: [worker(status: :healthy)])
+
+      verdict = analyzer.verdict
+      expect(verdict[:summary]).to include(:queues, :workers, :total_visible)
+      expect(verdict[:checked_at]).to match(/\A\d{4}-\d{2}-\d{2}T/)
+    end
+  end
+
+  describe "#verdict STALLED path (silent wedge)" do
+    it "is STALLED when a worker is stalled while a queue has visible backlog" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 10, visible: 10)],
+        processes: [worker(status: :stalled)]
+      )
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("STALLED")
+      expect(verdict[:reasons].first).to match(/stalled/)
+    end
+
+    it "is STALLED when backlog is unread (read_ct 0) and workers are alive" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 10, visible: 10, max_read_ct: 0)],
+        processes: [worker(status: :healthy)]
+      )
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("STALLED")
+      expect(verdict[:reasons].first).to match(/never claimed/)
+    end
+
+    it "treats backlog without read_ct metric as unread (conservative wedge default)" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 3, visible: 3)],
+        processes: [worker(status: :healthy)]
+      )
+
+      expect(analyzer.verdict[:status]).to eq("STALLED")
+    end
+
+    it "does not flag STALLED when there are no workers at all" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 3, visible: 3)],
+        processes: []
+      )
+
+      expect(analyzer.verdict[:status]).not_to eq("STALLED")
+    end
+
+    it "ignores DLQ backlog for the wedge signal" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default_dlq", length: 5, visible: 5)],
+        processes: [worker(status: :healthy)]
+      )
+
+      expect(analyzer.verdict[:status]).not_to eq("STALLED")
+    end
+
+    it "does not flag STALLED when backlog has been read (read_ct > 0) and no worker is stalled" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 5, visible: 5, max_read_ct: 3)],
+        processes: [worker(status: :healthy)]
+      )
+
+      expect(analyzer.verdict[:status]).to eq("OK")
+    end
+  end
+
+  describe "#verdict DEGRADED path" do
+    it "is DEGRADED when a process is stale" do
+      stub_data_source(
+        queues: [],
+        processes: [worker(status: :stale)]
+      )
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("DEGRADED")
+      expect(verdict[:reasons].first).to match(/stale/)
+    end
+
+    it "is DEGRADED when a paused queue holds a backlog" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 5, visible: 5, paused: true, max_read_ct: 3)],
+        processes: [worker(status: :healthy)]
+      )
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("DEGRADED")
+      expect(verdict[:reasons].join).to match(/paused/)
+    end
+
+    it "is DEGRADED when a dead-letter queue holds messages" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default_dlq", length: 4, visible: 0)],
+        processes: [worker(status: :healthy)]
+      )
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("DEGRADED")
+      expect(verdict[:reasons].join).to match(/dead-letter/)
+    end
+
+    it "is DEGRADED when the oldest transaction pins the MVCC horizon" do
+      stub_data_source(
+        queues: [],
+        processes: [worker(status: :healthy)],
+        health: { oldest_transaction_age_sec: 600 }
+      )
+
+      verdict = analyzer.verdict
+      expect(verdict[:status]).to eq("DEGRADED")
+      expect(verdict[:reasons].join).to match(/MVCC/)
+    end
+
+    it "STALLED takes precedence over DEGRADED conditions" do
+      stub_data_source(
+        queues: [queue(name: "pgbus_default", length: 5, visible: 5, max_read_ct: 0),
+                 queue(name: "pgbus_default_dlq", length: 2, visible: 0)],
+        processes: [worker(status: :stalled), worker(status: :stale)]
+      )
+
+      expect(analyzer.verdict[:status]).to eq("STALLED")
+    end
+  end
+
+  describe "#verdict resilience" do
+    it "tolerates queue_health_stats raising" do
+      allow(data_source).to receive_messages(queues_with_metrics: [], processes: [])
+      allow(data_source).to receive(:queue_health_stats).and_raise(StandardError)
+
+      expect(analyzer.verdict[:status]).to eq("OK")
+    end
+  end
+end

--- a/spec/pgbus/mcp/rack_app_spec.rb
+++ b/spec/pgbus/mcp/rack_app_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "json"
+require "rack/mock"
+require_relative "spec_helper"
+
+RSpec.describe Pgbus::MCP::RackApp do
+  let(:data_source) { instance_double(Pgbus::Web::DataSource) }
+
+  let(:json_headers) do
+    { "CONTENT_TYPE" => "application/json", "HTTP_ACCEPT" => "application/json" }
+  end
+
+  let(:health_call) do
+    { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "pgbus_health", arguments: {} } }.to_json
+  end
+
+  before do
+    allow(data_source).to receive_messages(queues_with_metrics: [], processes: [], queue_health_stats: {})
+  end
+
+  def mock_for(**kwargs)
+    Rack::MockRequest.new(described_class.new(data_source: data_source, **kwargs))
+  end
+
+  describe "responds to #call as a Rack app" do
+    it "answers a tools/list POST with the curated tool set" do
+      app = mock_for
+      body = { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }.to_json
+
+      response = app.post("/", input: body, **json_headers)
+      names = JSON.parse(response.body).dig("result", "tools").map { |t| t["name"] }
+
+      expect(response.status).to eq(200)
+      expect(names).to include("pgbus_health", "pgbus_queues", "pgbus_processes")
+    end
+
+    it "answers a tools/call POST with a verdict from the injected data source" do
+      app = mock_for
+      response = app.post("/", input: health_call, **json_headers)
+
+      inner = JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))
+      expect(response.status).to eq(200)
+      expect(inner["status"]).to eq("OK")
+    end
+
+    it "returns 406 when the client omits Accept: application/json (documented gotcha)" do
+      app = mock_for
+      response = app.post("/", input: health_call, "CONTENT_TYPE" => "application/json")
+
+      expect(response.status).to eq(406)
+    end
+  end
+
+  describe "token gate" do
+    it "rejects requests with no Authorization header" do
+      app = mock_for(token: "s3cret")
+      response = app.post("/", input: health_call, **json_headers)
+
+      expect(response.status).to eq(401)
+      expect(JSON.parse(response.body).dig("error", "message")).to eq("Unauthorized")
+    end
+
+    it "rejects a wrong bearer token" do
+      app = mock_for(token: "s3cret")
+      response = app.post("/", input: health_call, "HTTP_AUTHORIZATION" => "Bearer nope", **json_headers)
+
+      expect(response.status).to eq(401)
+    end
+
+    it "rejects a non-bearer Authorization scheme" do
+      app = mock_for(token: "s3cret")
+      response = app.post("/", input: health_call, "HTTP_AUTHORIZATION" => "Basic s3cret", **json_headers)
+
+      expect(response.status).to eq(401)
+    end
+
+    it "allows a matching bearer token" do
+      app = mock_for(token: "s3cret")
+      response = app.post("/", input: health_call, "HTTP_AUTHORIZATION" => "Bearer s3cret", **json_headers)
+
+      expect(response.status).to eq(200)
+    end
+
+    it "sends a WWW-Authenticate: Bearer challenge on 401" do
+      app = mock_for(token: "s3cret")
+      response = app.post("/", input: health_call, **json_headers)
+
+      expect(response.headers["WWW-Authenticate"]).to eq("Bearer")
+    end
+  end
+
+  describe "custom auth callable" do
+    it "delegates to the auth proc, which receives a Rack::Request" do
+      seen = nil
+      auth = lambda do |req|
+        seen = req
+        req.get_header("HTTP_X_OK") == "yes"
+      end
+      app = mock_for(auth: auth)
+
+      ok = app.post("/", input: health_call, "HTTP_X_OK" => "yes", **json_headers)
+      denied = app.post("/", input: health_call, **json_headers)
+
+      expect(ok.status).to eq(200)
+      expect(denied.status).to eq(401)
+      expect(seen).to be_a(Rack::Request)
+    end
+
+    it "takes precedence over token when both are given" do
+      app = mock_for(token: "s3cret", auth: ->(_req) { true })
+      # No bearer token sent, but the auth proc allows it.
+      response = app.post("/", input: health_call, **json_headers)
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "unauthenticated mounting" do
+    it "warns when neither token nor auth is configured" do
+      allow(Pgbus.logger).to receive(:warn)
+
+      described_class.new(data_source: data_source)
+
+      expect(Pgbus.logger).to have_received(:warn)
+    end
+
+    it "does not warn when a token is configured" do
+      allow(Pgbus.logger).to receive(:warn)
+
+      described_class.new(data_source: data_source, token: "s3cret")
+
+      expect(Pgbus.logger).not_to have_received(:warn)
+    end
+  end
+
+  describe "payload redaction over HTTP" do
+    let(:rows) { [{ msg_id: 1, read_ct: 0, message: "{\"pii\":\"x\"}", headers: "{}" }] }
+
+    def jobs_call(include_payloads)
+      {
+        jsonrpc: "2.0", id: 9, method: "tools/call",
+        params: { name: "pgbus_jobs", arguments: { queue: "pgbus_default", include_payloads: include_payloads } }
+      }.to_json
+    end
+
+    before { allow(data_source).to receive(:jobs).and_return(rows) }
+
+    it "redacts message bodies by default even when include_payloads is requested" do
+      app = mock_for
+      response = app.post("/", input: jobs_call(true), **json_headers)
+
+      inner = JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))
+      expect(inner["jobs"].first["message"]).to eq(Pgbus::MCP::Redactor::REDACTED)
+    end
+
+    it "returns payloads when the app allows them and include_payloads is set" do
+      app = mock_for(allow_payloads: true)
+      response = app.post("/", input: jobs_call(true), **json_headers)
+
+      inner = JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))
+      expect(inner["jobs"].first["message"]).to eq("{\"pii\":\"x\"}")
+    end
+  end
+
+  describe "Pgbus::MCP.rack_app" do
+    it "returns a RackApp instance" do
+      app = Pgbus::MCP.rack_app(data_source: data_source, token: "s3cret")
+      expect(app).to be_a(described_class)
+    end
+  end
+end

--- a/spec/pgbus/mcp/redactor_spec.rb
+++ b/spec/pgbus/mcp/redactor_spec.rb
@@ -13,64 +13,88 @@ RSpec.describe Pgbus::MCP::Redactor do
     }
   end
 
-  describe ".redact" do
-    it "replaces payload-bearing keys with the redaction marker by default" do
-      result = described_class.redact(row)
+  describe ".payload_key?" do
+    it "recognizes payload-bearing keys as symbols or strings" do
+      expect(described_class.payload_key?(:message)).to be(true)
+      expect(described_class.payload_key?("headers")).to be(true)
+      expect(described_class.payload_key?(:payload)).to be(true)
+      expect(described_class.payload_key?(:arguments)).to be(true)
+    end
+
+    it "rejects non-payload keys and never raises on odd keys" do
+      expect(described_class.payload_key?(:msg_id)).to be(false)
+      expect(described_class.payload_key?(42)).to be(false)
+    end
+  end
+
+  describe ".deep_redact" do
+    it "redacts payload-bearing keys with the marker by default" do
+      result = described_class.deep_redact(row)
 
       expect(result[:message]).to eq(described_class::REDACTED)
       expect(result[:headers]).to eq(described_class::REDACTED)
     end
 
     it "preserves non-payload metadata" do
-      result = described_class.redact(row)
+      result = described_class.deep_redact(row)
 
       expect(result[:msg_id]).to eq(42)
       expect(result[:read_ct]).to eq(1)
       expect(result[:queue_name]).to eq("pgbus_default")
     end
 
-    it "returns the hash untouched when payloads are allowed" do
-      result = described_class.redact(row, include_payloads: true)
-
-      expect(result[:message]).to eq("{\"secret\":\"hunter2\"}")
-      expect(result[:headers]).to eq("{\"trace\":\"abc\"}")
-    end
-
     it "leaves nil payload values as nil rather than the marker" do
-      result = described_class.redact(row.merge(headers: nil))
+      result = described_class.deep_redact(row.merge(headers: nil))
 
       expect(result[:headers]).to be_nil
     end
 
     it "redacts string-keyed payloads too" do
-      result = described_class.redact({ "message" => "x", "msg_id" => 1 })
+      result = described_class.deep_redact({ "message" => "x", "msg_id" => 1 })
 
       expect(result["message"]).to eq(described_class::REDACTED)
       expect(result["msg_id"]).to eq(1)
     end
 
-    it "passes non-hash arguments through unchanged" do
-      expect(described_class.redact("plain")).to eq("plain")
-    end
-
     it "does not mutate the input hash" do
-      described_class.redact(row)
+      described_class.deep_redact(row)
 
       expect(row[:message]).to eq("{\"secret\":\"hunter2\"}")
     end
-  end
 
-  describe ".redact_all" do
-    it "redacts every row in the collection" do
-      result = described_class.redact_all([row, row])
+    it "redacts payload keys nested inside an envelope hash" do
+      result = described_class.deep_redact({ job: row })
 
-      expect(result.map { |r| r[:message] }).to all(eq(described_class::REDACTED))
+      expect(result[:job][:message]).to eq(described_class::REDACTED)
+      expect(result[:job][:msg_id]).to eq(42)
     end
 
-    it "returns rows untouched when payloads are allowed" do
-      result = described_class.redact_all([row], include_payloads: true)
+    it "redacts payload keys inside an array of rows under an envelope key" do
+      result = described_class.deep_redact({ jobs: [row, row] })
 
-      expect(result.first[:message]).to eq("{\"secret\":\"hunter2\"}")
+      expect(result[:jobs].map { |r| r[:message] }).to all(eq(described_class::REDACTED))
+    end
+
+    it "descends into an envelope key that shares a payload name instead of blanking it" do
+      # {message: {...}} is a detail wrapper, not a raw body — recurse, then
+      # redact the leaf :message inside.
+      result = described_class.deep_redact({ message: row })
+
+      expect(result[:message]).to be_a(Hash)
+      expect(result[:message][:message]).to eq(described_class::REDACTED)
+      expect(result[:message][:msg_id]).to eq(42)
+    end
+
+    it "returns the structure untouched when payloads are allowed" do
+      result = described_class.deep_redact({ jobs: [row] }, include_payloads: true)
+
+      expect(result[:jobs].first[:message]).to eq("{\"secret\":\"hunter2\"}")
+    end
+
+    it "passes scalars through" do
+      expect(described_class.deep_redact("OK")).to eq("OK")
+      expect(described_class.deep_redact(42)).to eq(42)
+      expect(described_class.deep_redact(nil)).to be_nil
     end
   end
 end

--- a/spec/pgbus/mcp/redactor_spec.rb
+++ b/spec/pgbus/mcp/redactor_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Pgbus::MCP::Redactor do
+  let(:row) do
+    {
+      msg_id: 42,
+      read_ct: 1,
+      queue_name: "pgbus_default",
+      message: "{\"secret\":\"hunter2\"}",
+      headers: "{\"trace\":\"abc\"}"
+    }
+  end
+
+  describe ".redact" do
+    it "replaces payload-bearing keys with the redaction marker by default" do
+      result = described_class.redact(row)
+
+      expect(result[:message]).to eq(described_class::REDACTED)
+      expect(result[:headers]).to eq(described_class::REDACTED)
+    end
+
+    it "preserves non-payload metadata" do
+      result = described_class.redact(row)
+
+      expect(result[:msg_id]).to eq(42)
+      expect(result[:read_ct]).to eq(1)
+      expect(result[:queue_name]).to eq("pgbus_default")
+    end
+
+    it "returns the hash untouched when payloads are allowed" do
+      result = described_class.redact(row, include_payloads: true)
+
+      expect(result[:message]).to eq("{\"secret\":\"hunter2\"}")
+      expect(result[:headers]).to eq("{\"trace\":\"abc\"}")
+    end
+
+    it "leaves nil payload values as nil rather than the marker" do
+      result = described_class.redact(row.merge(headers: nil))
+
+      expect(result[:headers]).to be_nil
+    end
+
+    it "redacts string-keyed payloads too" do
+      result = described_class.redact({ "message" => "x", "msg_id" => 1 })
+
+      expect(result["message"]).to eq(described_class::REDACTED)
+      expect(result["msg_id"]).to eq(1)
+    end
+
+    it "passes non-hash arguments through unchanged" do
+      expect(described_class.redact("plain")).to eq("plain")
+    end
+
+    it "does not mutate the input hash" do
+      described_class.redact(row)
+
+      expect(row[:message]).to eq("{\"secret\":\"hunter2\"}")
+    end
+  end
+
+  describe ".redact_all" do
+    it "redacts every row in the collection" do
+      result = described_class.redact_all([row, row])
+
+      expect(result.map { |r| r[:message] }).to all(eq(described_class::REDACTED))
+    end
+
+    it "returns rows untouched when payloads are allowed" do
+      result = described_class.redact_all([row], include_payloads: true)
+
+      expect(result.first[:message]).to eq("{\"secret\":\"hunter2\"}")
+    end
+  end
+end

--- a/spec/pgbus/mcp/runner_spec.rb
+++ b/spec/pgbus/mcp/runner_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Pgbus::MCP::Runner do
+  describe ".authorize!" do
+    it "is a no-op when no token is configured" do
+      expect { described_class.authorize!({}) }.not_to raise_error
+    end
+
+    it "is a no-op when PGBUS_MCP_TOKEN is empty" do
+      expect { described_class.authorize!({ "PGBUS_MCP_TOKEN" => "" }) }.not_to raise_error
+    end
+
+    it "raises when the token is set but the auth token is missing" do
+      expect do
+        described_class.authorize!({ "PGBUS_MCP_TOKEN" => "s3cret" })
+      end.to raise_error(Pgbus::Error, /authentication failed/)
+    end
+
+    it "raises when the auth token does not match" do
+      expect do
+        described_class.authorize!({ "PGBUS_MCP_TOKEN" => "s3cret", "PGBUS_MCP_AUTH_TOKEN" => "wrong" })
+      end.to raise_error(Pgbus::Error, /authentication failed/)
+    end
+
+    it "passes when the auth token matches" do
+      env = { "PGBUS_MCP_TOKEN" => "s3cret", "PGBUS_MCP_AUTH_TOKEN" => "s3cret" }
+      expect { described_class.authorize!(env) }.not_to raise_error
+    end
+  end
+
+  describe ".truthy?" do
+    it "recognizes truthy strings" do
+      %w[1 true yes on TRUE On].each do |v|
+        expect(described_class.truthy?(v)).to be(true)
+      end
+    end
+
+    it "treats everything else as false" do
+      [nil, "", "0", "false", "no", "maybe"].each do |v|
+        expect(described_class.truthy?(v)).to be(false)
+      end
+    end
+  end
+
+  describe ".secure_compare?" do
+    it "is true for equal strings" do
+      expect(described_class.secure_compare?("abc", "abc")).to be(true)
+    end
+
+    it "is false for differing strings of equal length" do
+      expect(described_class.secure_compare?("abc", "abd")).to be(false)
+    end
+
+    it "is false for differing lengths" do
+      expect(described_class.secure_compare?("abc", "abcd")).to be(false)
+    end
+
+    it "is false when the provided value is nil" do
+      expect(described_class.secure_compare?("abc", nil)).to be(false)
+    end
+  end
+
+  describe ".run" do
+    it "enforces the token gate before opening a transport" do
+      env = { "PGBUS_MCP_TOKEN" => "s3cret" }
+      expect { described_class.run(env: env) }.to raise_error(Pgbus::Error, /authentication failed/)
+    end
+
+    it "builds a payload-redacted server and drives the stdio transport" do
+      transport = instance_double(MCP::Server::Transports::StdioTransport, open: nil)
+      allow(Pgbus::MCP::Server).to receive(:build).and_call_original
+      allow(MCP::Server::Transports::StdioTransport).to receive(:new).and_return(transport)
+
+      described_class.run(env: {})
+
+      expect(Pgbus::MCP::Server).to have_received(:build).with(allow_payloads: false)
+      expect(transport).to have_received(:open)
+    end
+
+    it "passes allow_payloads through when the env flag is truthy" do
+      transport = instance_double(MCP::Server::Transports::StdioTransport, open: nil)
+      allow(Pgbus::MCP::Server).to receive(:build).and_call_original
+      allow(MCP::Server::Transports::StdioTransport).to receive(:new).and_return(transport)
+
+      described_class.run(env: { "PGBUS_MCP_ALLOW_PAYLOADS" => "true" })
+
+      expect(Pgbus::MCP::Server).to have_received(:build).with(allow_payloads: true)
+    end
+  end
+end

--- a/spec/pgbus/mcp/server_spec.rb
+++ b/spec/pgbus/mcp/server_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "spec_helper"
+
+RSpec.describe Pgbus::MCP::Server do
+  let(:data_source) { instance_double(Pgbus::Web::DataSource) }
+
+  describe ".build" do
+    subject(:server) { described_class.build(data_source: data_source) }
+
+    it "names the server pgbus and stamps the gem version" do
+      expect(server.name).to eq("pgbus")
+      expect(server.version).to eq(Pgbus::VERSION)
+    end
+
+    it "registers exactly the curated diagnostic tool set" do
+      expect(server.tools.keys).to match_array(described_class::TOOLS.map(&:tool_name))
+    end
+
+    it "injects the data source and defaults payloads to disallowed" do
+      expect(server.server_context[:data_source]).to eq(data_source)
+      expect(server.server_context[:allow_payloads]).to be(false)
+    end
+
+    it "honors allow_payloads when requested" do
+      server = described_class.build(data_source: data_source, allow_payloads: true)
+      expect(server.server_context[:allow_payloads]).to be(true)
+    end
+
+    it "every registered tool is read-only and non-destructive" do
+      described_class::TOOLS.each do |tool|
+        annotations = tool.annotations_value.to_h
+        expect(annotations[:readOnlyHint]).to be(true), "#{tool.tool_name} is not read-only"
+        expect(annotations[:destructiveHint]).to be(false), "#{tool.tool_name} is destructive"
+      end
+    end
+
+    it "exposes no tool that accepts raw SQL or mutates state" do
+      names = described_class::TOOLS.map(&:tool_name)
+      expect(names).to all(start_with("pgbus_"))
+      expect(names).not_to include(a_string_matching(/sql|query|exec|purge|retry|discard|delete|drop|pause|resume/))
+    end
+  end
+
+  describe "tool listing over the protocol" do
+    subject(:server) { described_class.build(data_source: data_source) }
+
+    it "lists all tools via a tools/list JSON-RPC request" do
+      request = { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }
+      response = JSON.parse(server.handle_json(JSON.generate(request)))
+
+      tool_names = response.dig("result", "tools").map { |t| t["name"] }
+      expect(tool_names).to include("pgbus_health", "pgbus_queues", "pgbus_processes")
+    end
+
+    it "calls pgbus_health end-to-end through the server" do
+      allow(data_source).to receive_messages(queues_with_metrics: [], processes: [], queue_health_stats: {})
+
+      request = {
+        jsonrpc: "2.0", id: 2, method: "tools/call",
+        params: { name: "pgbus_health", arguments: {} }
+      }
+      response = JSON.parse(server.handle_json(JSON.generate(request)))
+
+      text = response.dig("result", "content").first["text"]
+      expect(JSON.parse(text)["status"]).to eq("OK")
+    end
+  end
+end

--- a/spec/pgbus/mcp/spec_helper.rb
+++ b/spec/pgbus/mcp/spec_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# The MCP subsystem is loaded explicitly (it's excluded from Zeitwerk because
+# its tools subclass the optional `mcp` gem's MCP::Tool). Load it once for the
+# whole MCP spec suite.
+require "spec_helper"
+Pgbus::MCP.load!

--- a/spec/pgbus/mcp/tools_spec.rb
+++ b/spec/pgbus/mcp/tools_spec.rb
@@ -213,4 +213,25 @@ RSpec.describe "Pgbus MCP tools" do # rubocop:disable RSpec/DescribeClass
       expect(body(Pgbus::MCP::Tools::LocksTool.call(server_context: nil))).to eq({ "locks" => [] })
     end
   end
+
+  describe "fail-safe redaction at the response boundary" do
+    # A tool that returns a payload-bearing key without remembering to redact
+    # is still safe: BaseTool.json_response strips payloads by default.
+    let(:leaky_tool) do
+      Class.new(Pgbus::MCP::BaseTool) do
+        def self.call(server_context: nil)
+          json_response({ rows: [{ msg_id: 1, message: "secret-body", headers: "h" }] }, server_context: server_context)
+        end
+      end
+    end
+
+    it "redacts payloads even when the tool never calls Redactor itself" do
+      result = body(leaky_tool.call(server_context: context))
+      row = result["rows"].first
+
+      expect(row["message"]).to eq(Pgbus::MCP::Redactor::REDACTED)
+      expect(row["headers"]).to eq(Pgbus::MCP::Redactor::REDACTED)
+      expect(row["msg_id"]).to eq(1)
+    end
+  end
 end

--- a/spec/pgbus/mcp/tools_spec.rb
+++ b/spec/pgbus/mcp/tools_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe "Pgbus MCP tools" do # rubocop:disable RSpec/DescribeClass
       body(described_class.call(page: 0, per_page: 0, server_context: context))
       expect(data_source).to have_received(:jobs).with(queue_name: nil, page: 1, per_page: 1)
     end
+
+    it "caps page at MAX_PAGE so OFFSET can't be driven to an unbounded scan" do
+      allow(data_source).to receive(:jobs)
+        .with(queue_name: nil, page: described_class::MAX_PAGE, per_page: 25)
+        .and_return([])
+
+      body(described_class.call(page: 10_000_000, server_context: context))
+      expect(data_source).to have_received(:jobs)
+        .with(queue_name: nil, page: described_class::MAX_PAGE, per_page: 25)
+    end
   end
 
   describe Pgbus::MCP::Tools::JobDetailTool do
@@ -147,10 +157,21 @@ RSpec.describe "Pgbus MCP tools" do # rubocop:disable RSpec/DescribeClass
       result = body(described_class.call(server_context: context))
       expect(result["messages"].first["message"]).to eq(Pgbus::MCP::Redactor::REDACTED)
     end
+
+    it "caps page at MAX_PAGE so OFFSET can't be driven to an unbounded scan" do
+      allow(data_source).to receive(:dlq_messages)
+        .with(page: described_class::MAX_PAGE, per_page: 25)
+        .and_return([])
+
+      body(described_class.call(page: 10_000_000, server_context: context))
+      expect(data_source).to have_received(:dlq_messages)
+        .with(page: described_class::MAX_PAGE, per_page: 25)
+    end
   end
 
   describe Pgbus::MCP::Tools::DlqDetailTool do
-    it "returns a redacted detail" do
+    it "returns a redacted detail when only one DLQ is present" do
+      allow(data_source).to receive_messages(queues_with_metrics: [])
       allow(data_source).to receive(:dlq_message_detail).with(5)
                                                         .and_return({ msg_id: 5, message: "secret" })
 
@@ -159,9 +180,32 @@ RSpec.describe "Pgbus MCP tools" do # rubocop:disable RSpec/DescribeClass
     end
 
     it "errors when not found" do
-      allow(data_source).to receive(:dlq_message_detail).and_return(nil)
+      allow(data_source).to receive_messages(queues_with_metrics: [], dlq_message_detail: nil)
 
       expect(described_class.call(msg_id: 5, server_context: context).error?).to be(true)
+    end
+
+    it "queries the named DLQ directly when queue: is supplied (no cross-scan)" do
+      allow(data_source).to receive(:job_detail).with("pgbus_orders_dlq", 5)
+                                                .and_return({ msg_id: 5, message: "secret" })
+
+      result = body(described_class.call(msg_id: 5, queue: "pgbus_orders_dlq", server_context: context))
+
+      expect(result["message"]["msg_id"]).to eq(5)
+      expect(data_source).not_to have_received(:job_detail).with("pgbus_default_dlq", 5)
+    end
+
+    it "refuses to guess when msg_id is ambiguous across multiple DLQs" do
+      allow(data_source).to receive_messages(queues_with_metrics: [
+                                               { name: "pgbus_default_dlq" },
+                                               { name: "pgbus_orders_dlq" }
+                                             ])
+      allow(data_source).to receive(:job_detail).and_return({ msg_id: 5, message: "x" })
+
+      response = described_class.call(msg_id: 5, server_context: context)
+
+      expect(response.error?).to be(true)
+      expect(response.content.first[:text]).to include("ambiguous")
     end
   end
 

--- a/spec/pgbus/mcp/tools_spec.rb
+++ b/spec/pgbus/mcp/tools_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "spec_helper"
+
+# Exercises every diagnostic tool: correct DataSource delegation, JSON
+# response shape, payload redaction, pagination caps, and error responses.
+# Covers the whole tool family in one file, so the outer describe is a string.
+RSpec.describe "Pgbus MCP tools" do # rubocop:disable RSpec/DescribeClass
+  let(:data_source) { instance_double(Pgbus::Web::DataSource) }
+  let(:context) { { data_source: data_source, allow_payloads: false } }
+  let(:context_with_payloads) { { data_source: data_source, allow_payloads: true } }
+
+  def body(response)
+    JSON.parse(response.content.first[:text])
+  end
+
+  describe Pgbus::MCP::Tools::QueuesTool do
+    it "delegates to queues_with_metrics" do
+      allow(data_source).to receive(:queues_with_metrics)
+        .and_return([{ name: "pgbus_default", queue_length: 3 }])
+
+      result = body(described_class.call(server_context: context))
+      expect(result["queues"].first["name"]).to eq("pgbus_default")
+    end
+
+    it "is read-only" do
+      expect(described_class.annotations_value.to_h).to include(readOnlyHint: true)
+    end
+  end
+
+  describe Pgbus::MCP::Tools::QueueDetailTool do
+    it "merges detail, paused state, and health" do
+      allow(data_source).to receive(:queue_detail).with("pgbus_default")
+                                                  .and_return({ name: "pgbus_default", queue_length: 1 })
+      allow(data_source).to receive(:queue_paused?).with("pgbus_default").and_return(true)
+      allow(data_source).to receive(:queue_health_detail).with("pgbus_default")
+                                                         .and_return({ tables: [] })
+
+      result = body(described_class.call(name: "pgbus_default", server_context: context))
+      expect(result["paused"]).to be(true)
+      expect(result["health"]).to eq({ "tables" => [] })
+    end
+
+    it "returns an error response when the queue is missing" do
+      allow(data_source).to receive(:queue_detail).and_return(nil)
+
+      response = described_class.call(name: "nope", server_context: context)
+      expect(response.error?).to be(true)
+    end
+  end
+
+  describe Pgbus::MCP::Tools::ProcessesTool do
+    it "delegates to processes" do
+      allow(data_source).to receive(:processes)
+        .and_return([{ kind: "worker", status: :stalled }])
+
+      result = body(described_class.call(server_context: context))
+      expect(result["processes"].first["status"]).to eq("stalled")
+    end
+  end
+
+  describe Pgbus::MCP::Tools::HealthTool do
+    it "returns a verdict computed by HealthAnalyzer" do
+      allow(data_source).to receive_messages(queues_with_metrics: [], processes: [], queue_health_stats: {})
+
+      result = body(described_class.call(server_context: context))
+      expect(result["status"]).to eq("OK")
+    end
+  end
+
+  describe Pgbus::MCP::Tools::JobsTool do
+    let(:rows) do
+      [{ msg_id: 1, read_ct: 0, message: "{\"pii\":\"x\"}", headers: "{}" }]
+    end
+
+    it "redacts payloads by default" do
+      allow(data_source).to receive(:jobs)
+        .with(queue_name: "pgbus_default", page: 1, per_page: 25)
+        .and_return(rows)
+
+      result = body(described_class.call(queue: "pgbus_default", server_context: context))
+      job = result["jobs"].first
+      expect(job["message"]).to eq(Pgbus::MCP::Redactor::REDACTED)
+      expect(job["read_ct"]).to eq(0)
+    end
+
+    it "returns payloads when allowed and include_payloads is set" do
+      allow(data_source).to receive(:jobs).and_return(rows)
+
+      result = body(
+        described_class.call(queue: "pgbus_default", include_payloads: true, server_context: context_with_payloads)
+      )
+      expect(result["jobs"].first["message"]).to eq("{\"pii\":\"x\"}")
+    end
+
+    it "ignores include_payloads when the server disallows payloads" do
+      allow(data_source).to receive(:jobs).and_return(rows)
+
+      result = body(
+        described_class.call(queue: "pgbus_default", include_payloads: true, server_context: context)
+      )
+      expect(result["jobs"].first["message"]).to eq(Pgbus::MCP::Redactor::REDACTED)
+    end
+
+    it "caps per_page at 100" do
+      allow(data_source).to receive(:jobs)
+        .with(queue_name: nil, page: 1, per_page: 100)
+        .and_return([])
+
+      body(described_class.call(per_page: 5000, server_context: context))
+      expect(data_source).to have_received(:jobs).with(queue_name: nil, page: 1, per_page: 100)
+    end
+
+    it "floors page and per_page at 1" do
+      allow(data_source).to receive(:jobs)
+        .with(queue_name: nil, page: 1, per_page: 1)
+        .and_return([])
+
+      body(described_class.call(page: 0, per_page: 0, server_context: context))
+      expect(data_source).to have_received(:jobs).with(queue_name: nil, page: 1, per_page: 1)
+    end
+  end
+
+  describe Pgbus::MCP::Tools::JobDetailTool do
+    it "redacts the payload by default" do
+      allow(data_source).to receive(:job_detail).with("pgbus_default", 7)
+                                                .and_return({ msg_id: 7, message: "secret", headers: "h" })
+
+      result = body(described_class.call(queue: "pgbus_default", msg_id: 7, server_context: context))
+      expect(result["job"]["message"]).to eq(Pgbus::MCP::Redactor::REDACTED)
+    end
+
+    it "errors when the message is missing" do
+      allow(data_source).to receive(:job_detail).and_return(nil)
+
+      response = described_class.call(queue: "pgbus_default", msg_id: 99, server_context: context)
+      expect(response.error?).to be(true)
+    end
+  end
+
+  describe Pgbus::MCP::Tools::DlqTool do
+    it "redacts payloads and paginates" do
+      allow(data_source).to receive(:dlq_messages).with(page: 1, per_page: 25)
+                                                  .and_return([{ msg_id: 5, message: "secret" }])
+
+      result = body(described_class.call(server_context: context))
+      expect(result["messages"].first["message"]).to eq(Pgbus::MCP::Redactor::REDACTED)
+    end
+  end
+
+  describe Pgbus::MCP::Tools::DlqDetailTool do
+    it "returns a redacted detail" do
+      allow(data_source).to receive(:dlq_message_detail).with(5)
+                                                        .and_return({ msg_id: 5, message: "secret" })
+
+      result = body(described_class.call(msg_id: 5, server_context: context))
+      expect(result["message"]["message"]).to eq(Pgbus::MCP::Redactor::REDACTED)
+    end
+
+    it "errors when not found" do
+      allow(data_source).to receive(:dlq_message_detail).and_return(nil)
+
+      expect(described_class.call(msg_id: 5, server_context: context).error?).to be(true)
+    end
+  end
+
+  describe Pgbus::MCP::Tools::LocksTool do
+    it "delegates to job_locks" do
+      allow(data_source).to receive(:job_locks)
+        .and_return([{ lock_key: "k", age_seconds: 10 }])
+
+      result = body(described_class.call(server_context: context))
+      expect(result["locks"].first["lock_key"]).to eq("k")
+    end
+  end
+
+  describe Pgbus::MCP::Tools::ThroughputTool do
+    it "delegates with a clamped window" do
+      allow(data_source).to receive(:job_throughput).with(minutes: 1440).and_return([])
+
+      result = body(described_class.call(minutes: 99_999, server_context: context))
+      expect(result["minutes"]).to eq(1440)
+    end
+  end
+
+  describe Pgbus::MCP::Tools::StatsTool do
+    it "returns status counts and summary" do
+      allow(data_source).to receive(:job_status_counts).with(minutes: 60).and_return({ "success" => 5 })
+      allow(data_source).to receive(:job_stats_summary).with(minutes: 60).and_return({ total: 5 })
+
+      result = body(described_class.call(server_context: context))
+      expect(result["status_counts"]["success"]).to eq(5)
+      expect(result["summary"]["total"]).to eq(5)
+    end
+  end
+
+  describe Pgbus::MCP::Tools::RecurringTool do
+    it "delegates to recurring_tasks" do
+      allow(data_source).to receive(:recurring_tasks)
+        .and_return([{ key: "cleanup", schedule: "0 * * * *" }])
+
+      result = body(described_class.call(server_context: context))
+      expect(result["recurring_tasks"].first["key"]).to eq("cleanup")
+    end
+  end
+
+  describe "default data source" do
+    it "builds a DataSource when none is injected" do
+      allow(Pgbus::Web::DataSource).to receive(:new).and_return(data_source)
+      allow(data_source).to receive(:job_locks).and_return([])
+
+      expect(body(Pgbus::MCP::Tools::LocksTool.call(server_context: nil))).to eq({ "locks" => [] })
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an official, **read-only** [MCP](https://modelcontextprotocol.io) diagnostic server for pgbus (issue #180). An AI agent — or any MCP client — can now diagnose pgbus directly ("are queues backed up?", "is `read_ct` advancing?", "are workers heart-beating but not claiming?") instead of hand-writing `pgmq` / `pg_stat_activity` SQL against production.

Started only via `bundle exec pgbus mcp` (stdio). The 12 tools are a thin adapter over `lib/pgbus/web/data_source.rb` — the dashboard's proven read layer — so no new database access path is introduced.

The headline is `pgbus_health`, which returns an **OK / DEGRADED / STALLED** verdict. STALLED is the silent-worker-wedge signal (#179 / #174 / #181): visible backlog while workers heart-beat but never advance `read_ct`. It is suitable for both interactive agent use and automated alerting.

## Tools (all read-only)

| Tool | Maps to |
|------|---------|
| `pgbus_health` | `HealthAnalyzer` over `queues_with_metrics` + `processes` + `queue_health_stats` |
| `pgbus_queues` | `queues_with_metrics` |
| `pgbus_queue_detail` | `queue_detail` + `queue_paused?` + `queue_health_detail` |
| `pgbus_processes` | `processes` (incl. `healthy`/`stale`/`stalled`) |
| `pgbus_jobs` / `pgbus_job_detail` | `jobs` / `job_detail` |
| `pgbus_dlq` / `pgbus_dlq_detail` | `dlq_messages` / `dlq_message_detail` |
| `pgbus_locks` | `job_locks` |
| `pgbus_throughput` / `pgbus_stats` | `job_throughput` / `job_status_counts` + `job_stats_summary` |
| `pgbus_recurring` | `recurring_tasks` |

## Security (the "secure way" the issue asks for)

- **Read-only by contract.** `BaseTool` sets `read_only_hint`; there is no mutation tool and no raw-SQL passthrough — the tool set is fixed and curated.
- **Payloads redacted.** Message bodies / headers / job arguments become `[redacted]` unless **both** `PGBUS_MCP_ALLOW_PAYLOADS=1` and a per-call `include_payloads: true` are set (double gate).
- **Bounded queries.** List tools cap at 100 rows/page; time windows cap at 1440 minutes.
- **Reuses the app's DB credentials** — no new privileged path.
- **Optional token gate.** Set `PGBUS_MCP_TOKEN` and the server refuses to start unless `PGBUS_MCP_AUTH_TOKEN` matches (constant-time compare).

## Packaging

`mcp` is an **optional** dependency loaded lazily by `Pgbus::MCP.load!`. The subsystem is excluded from Zeitwerk (its `MCP::Tool` subclasses would otherwise reference the gem at autoload time), mirroring how vendor integrations are handled. Users who never run the server don't have to install the gem; the `pgbus mcp` command tells them how if it's missing.

## How this maps to the acceptance criteria

- ✅ An MCP client can list and call the read-only tools and get structured JSON (verified with a real `initialize` + `tools/list` stdio handshake).
- ✅ The #179 diagnostic path is reproducible through the MCP alone: `pgbus_queues` (backed up), `pgbus_jobs` (`read_ct = 0`), `pgbus_processes` (heart-beating), `pgbus_queue_detail` (nothing paused), `pgbus_locks` (nothing locked) — no raw SQL.
- ✅ `pgbus_health` returns STALLED for the silent-wedge condition and OK when draining normally.
- ✅ No tool mutates state; no tool returns payloads unless the explicit double gate is open.

## Test plan

- [x] `bundle exec rubocop lib/` — no offenses
- [x] `bundle exec rspec spec/pgbus/mcp spec/pgbus/cli_spec.rb` — 91 examples, 0 failures
- [x] Non-system suite: 2379 examples, 0 new failures (the 2 i18n failures pre-exist on `main`)
- [x] stdio `initialize` + `tools/list` handshake smoke test returns the server info and all 12 tools

Closes #180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional read-only MCP diagnostic server accessible from the CLI.
  * Introduced MCP tools for health, queues, jobs, DLQ, locks, throughput, recurring tasks, and detailed queue/job inspection.
  * Added payload redaction and optional payload visibility controls for diagnostics.

* **Documentation**
  * Updated the README with startup instructions, safety notes, and a sample client configuration.

* **Tests**
  * Expanded coverage for CLI startup, MCP server behavior, payload redaction, authorization, health analysis, and tool responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->