### PR TITLE
feat(perf): continuous-performance discipline and benchmark harness

### DIFF
--- a/.claude/commands/perf.md
+++ b/.claude/commands/perf.md
@@ -1,0 +1,72 @@
+---
+description: "Benchmark the current branch against main. Use when a change touches a hot path (client ops, executor, serialization, polling, connection pool) or when asked to measure performance."
+argument-hint: "optional: a specific bench name (e.g. client_bench)"
+---
+
+# Performance Command
+
+Measure, don't guess. This command produces a **same-machine before/after** so
+any performance claim is backed by numbers.
+
+See `docs/performance.md` for the hot paths and how the harness works.
+
+## The non-negotiable rule
+
+**Measure BEFORE you change.** A delta you didn't baseline is not a delta. If a
+change already landed without a baseline, reconstruct one from `main` in a
+worktree (below) — never report a number against a baseline from another machine
+or another day.
+
+## Workflow
+
+### 1. Baseline `main` (before)
+
+Capture pristine `main` with the SAME bench script you'll run on the branch:
+
+```bash
+git worktree add --detach /tmp/pgbus-baseline main
+cp -r benchmarks /tmp/pgbus-baseline/ && cp Gemfile Rakefile /tmp/pgbus-baseline/
+(cd /tmp/pgbus-baseline && bundle install --quiet && bundle exec rake bench:all) > /tmp/before.txt
+```
+
+### 2. Measure the branch (after)
+
+```bash
+bundle exec rake bench:all > /tmp/after.txt
+diff /tmp/before.txt /tmp/after.txt
+git worktree remove --force /tmp/pgbus-baseline
+```
+
+For a single hot path, use `rake bench:one[client_bench]` in both trees.
+
+### 3. Report HONESTLY
+
+- Give throughput (i/s) AND allocations (obj/call, retained). Retained > 0
+  per operation is a leak — call it out.
+- **Distinguish method-level from system-level wins.** A 2x faster
+  `send_message` does NOT mean 2x faster job processing — PGMQ round-trip +
+  database dominate. Say which the number is.
+- If a number is within run-to-run noise (`benchmark-ips` shows ±%), say
+  "within noise."
+- If you only measured *after* (no clean baseline), say so explicitly.
+
+### 4. Keep perf continuous
+
+- [ ] A bench exists for the changed hot path. Add one if missing.
+- [ ] The before/after numbers are in the PR body.
+- [ ] `docs/performance.md` updated if representative numbers moved.
+
+## The hot paths to watch
+
+| Path | Bench | Note |
+|------|-------|------|
+| `Client#send_message` / `#send_batch` | `client_bench.rb` | The enqueue path — overhead per job. |
+| `Client#read_batch` | `client_bench.rb` | The dequeue path — runs every poll cycle. |
+| `Executor#execute` | `executor_bench.rb` | Per-job execution overhead (deserialization + dispatch). |
+| JSON serialization | `serialization_bench.rb` | Payload encoding/decoding — scales with payload size. |
+| Connection pool checkout | `connection_pool_bench.rb` | Peak connections under concurrency. |
+| Execution pool throughput | `execution_pool_bench.rb` | ThreadPool vs AsyncPool latency + memory. |
+| Streams SSE broadcast | `streams_bench.rb` | Real Puma + SSE fan-out (requires DB). |
+
+Argument (`$ARGUMENTS`): if a specific bench is named, focus with
+`rake bench:one[$ARGUMENTS]`; otherwise run the full suite.

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -1,10 +1,64 @@
 # Performance Rules
 
+Pgbus must be fast in the places that run on every job enqueue, dequeue, and
+execute cycle. These rules make performance a standing part of every change.
+See `docs/performance.md` for the harness and current numbers.
+
+## The prime directive
+
+**Measure before you change. Measure after. Report both, honestly.**
+
+A performance claim without a same-machine before/after is not allowed in a PR
+or a commit message. If you didn't baseline, you don't have a delta — say
+"measured after only" or capture the baseline (`/perf` automates this with a
+worktree).
+
+## When performance is in scope
+
+Any change to a **hot path** must come with a bench and a before/after:
+
+| Hot path | File | Bench |
+|----------|------|-------|
+| Message enqueue | `lib/pgbus/client.rb` (`send_message`, `send_batch`) | `client_bench.rb` |
+| Message dequeue | `lib/pgbus/client.rb` (`read_batch`) | `client_bench.rb` |
+| Job execution | `lib/pgbus/active_job/executor.rb` | `executor_bench.rb` |
+| JSON serialization | payload encoding/decoding | `serialization_bench.rb` |
+| Connection pool | `lib/pgbus/execution_pools/` | `connection_pool_bench.rb`, `execution_pool_bench.rb` |
+| SSE streaming | `lib/pgbus/streams/` | `streams_bench.rb` |
+
+A pure docs/test/refactor change with no hot-path edit does not need a bench.
+
+## Always Do
+
+1. **Baseline first** — capture `main` numbers BEFORE editing.
+   Run `rake bench:all` or `rake bench:one[name]` for a focused check.
+2. **Add a bench for a new hot path** — `benchmarks/<name>_bench.rb` using the
+   shared `BenchSupport` harness. `rake bench:all` discovers unit benches automatically.
+3. **Report throughput AND allocations** — i/s + obj/call. Flag any non-zero
+   *retained* per operation (a leak).
+4. **Distinguish method-level from system-level wins** — a 2x faster
+   `send_message` does NOT mean 2x faster job processing (PGMQ round-trip +
+   database dominate); it means less gem overhead per enqueue. Say which.
+5. **Update docs + CHANGELOG** — if representative numbers moved, update
+   `docs/performance.md`; note the change under a `perf:` CHANGELOG entry.
+
+## Never Do
+
+1. **Never claim a speedup without a measured before/after.** No "this should be
+   faster." Prove it or don't say it.
+2. **Never optimize a cold path** the bench shows isn't hot — three clear lines
+   beat a clever micro-optimization that obscures behavior for no measured gain.
+3. **Never break a correctness invariant for speed** — the PGMQ client wrapper,
+   queue prefixing, dead letter routing, and visibility timeout are not
+   negotiable. A faster wrong answer is wrong.
+4. **Never trade carefully-tested behavior for a marginal allocation win.** If
+   the bench doesn't prove it matters and the tests don't still pass, don't ship.
+5. **Never add a hard CI perf gate on a flaky threshold** — the `bench` CI job is
+   run-and-report (uploads an artifact), not a merge blocker. Shared runners are
+   too noisy for a hard cutoff.
+
 ## Context Window Management
 
-**Critical**: Your context window can shrink significantly with many tools enabled.
-
-Guidelines:
 - Keep under 10 MCPs enabled per project
 - Avoid loading large files unnecessarily
 - Use targeted searches over broad exploration
@@ -114,8 +168,16 @@ max_worker_lifetime: 3600
 - More threads = more PGMQ connections needed
 - Monitor with `pool.queue_length` vs `pool.max_length`
 
-## Performance Checklist
+## Performance Checklist (before marking perf work complete)
 
+- [ ] Baseline captured BEFORE the change (same machine, same script)
+- [ ] After numbers captured; before/after in the PR body
+- [ ] A bench exists for every hot path touched
+- [ ] Throughput + allocations reported; retained-per-operation is 0
+- [ ] Method-level vs system-level framing is honest
+- [ ] `docs/performance.md` + CHANGELOG updated if numbers moved
+- [ ] `bundle exec rspec` still green
+- [ ] No correctness invariant traded for speed
 - [ ] LISTEN/NOTIFY enabled for active queues
 - [ ] Batch reads used where possible
 - [ ] Connection pool sized appropriately

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,29 @@ jobs:
       - name: Verify gem builds
         run: bundle exec rake build
 
+  bench:
+    runs-on: ubuntu-latest
+    name: Benchmarks (report only)
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Unit benchmarks
+        continue-on-error: true
+        run: bundle exec rake bench:all
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: benchmarks
+          path: tmp/benchmarks/*.txt
+          if-no-files-found: warn
+
   test:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ PostgreSQL-native job processing and event bus for Rails, built on PGMQ.
 4. **LISTEN/NOTIFY**: Use `enable_notify_insert` for instant wake-up
 5. **Queue prefix**: All queues through `config.queue_name()`
 6. **Visibility timeout**: Always pass `vt:` parameter on reads
+7. **Performance**: Measure before/after for hot-path changes (`/perf`); see `docs/performance.md`
 
 ## Commands
 
@@ -36,6 +37,11 @@ PostgreSQL-native job processing and event bus for Rails, built on PGMQ.
 bundle exec rspec          # Run tests
 bundle exec rubocop        # Lint
 bundle exec rake           # Both
+bundle exec rake bench     # Unit benchmarks (serialization, client, executor)
+bundle exec rake bench:one[client_bench]  # Single benchmark by name
+bundle exec rake bench:memory             # Detailed memory profiling
+bundle exec rake bench:integration        # Real DB benchmarks (requires PGBUS_DATABASE_URL)
+bundle exec rake bench:streams            # SSE streaming benchmarks (requires PGBUS_DATABASE_URL)
 ```
 
 ## Slash Commands
@@ -48,6 +54,7 @@ bundle exec rake           # Both
 | `/tdd` | Enforce RED → GREEN → REFACTOR cycle |
 | `/security` | Security audit (PGMQ ops, connections, auth, deserialization) |
 | `/architect` | Coordinate multi-layer development |
+| `/perf` | Benchmark current branch against main (before/after with worktree) |
 
 ## Architecture
 
@@ -146,5 +153,8 @@ DLQ queues append `_dlq` suffix.
 ## More Documentation
 
 See `.claude/` directory:
-- `commands/` — Slash command definitions
+- `commands/` — Slash command definitions (including `/perf` for benchmarking)
 - `rules/` — Coding style, git workflow, testing, agents, performance, security
+
+See `docs/` directory:
+- `docs/performance.md` — Hot paths, measuring guide, allocation budgets, CI integration

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,17 @@ RuboCop::RakeTask.new
 
 namespace :bench do
   bench_dir = "benchmarks"
-  unit_benches = %w[serialization_bench client_bench executor_bench].freeze
+  # Benches that need a real PostgreSQL/PGMQ (or boot Puma) — excluded from the
+  # no-DB unit suite that bench:all runs in CI.
+  db_benches = %w[connection_pool_bench integration_bench streams_bench].freeze
+  # The unit suite is every *_bench.rb that doesn't need a database, derived
+  # from the directory so a new unit bench is picked up automatically (kept in
+  # sync with bench:one, which globs the same files).
+  unit_benches = Dir["#{bench_dir}/*_bench.rb"]
+                 .map { |f| File.basename(f, ".rb") }
+                 .reject { |name| db_benches.include?(name) }
+                 .sort
+                 .freeze
 
   desc "Run serialization benchmarks"
   task :serialization do
@@ -55,8 +65,14 @@ namespace :bench do
   desc "Run all unit-level benchmarks, save report to tmp/benchmarks/"
   task :all do
     require "fileutils"
+    require "open3"
+    require "rbconfig"
     FileUtils.mkdir_p("tmp/benchmarks")
 
+    # Run each bench under the SAME Ruby + gemset as this Rake process, not a
+    # bare `ruby` from PATH — otherwise before/after numbers are unreliable and
+    # gem loading can break under a different interpreter.
+    ruby = RbConfig.ruby
     failed = []
 
     File.open("tmp/benchmarks/unit.txt", "w") do |report|
@@ -66,13 +82,13 @@ namespace :bench do
         puts "\e[1;35m#{header}\e[0m"
         report.puts header
 
-        result = `ruby #{file} 2>&1`
+        result, status = Open3.capture2e(ruby, file)
         puts result
         report.puts result.gsub(/\e\[[0-9;]*m/, "")
 
-        unless $?.success? # rubocop:disable Style/SpecialGlobalVars
+        unless status.success?
           failed << file
-          report.puts "!!! FAILED (exit #{$?.exitstatus})" # rubocop:disable Style/SpecialGlobalVars
+          report.puts "!!! FAILED (exit #{status.exitstatus})"
         end
       end
     end

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,9 @@ require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
 namespace :bench do
+  bench_dir = "benchmarks"
+  unit_benches = %w[serialization_bench client_bench executor_bench].freeze
+
   desc "Run serialization benchmarks"
   task :serialization do
     ruby "benchmarks/serialization_bench.rb"
@@ -41,11 +44,45 @@ namespace :bench do
     ruby "benchmarks/streams_bench.rb"
   end
 
-  desc "Run all benchmarks (unit-level, no DB required)"
-  task all: %i[serialization client executor]
+  desc "Run a single benchmark: rake bench:one[client_bench]"
+  task :one, [:name] do |_t, args|
+    name = args[:name] or abort "Usage: rake bench:one[serialization_bench|client_bench|...]"
+    available = Dir["#{bench_dir}/*_bench.rb"].map { |f| File.basename(f, ".rb") }
+    abort "No such benchmark: #{name}. Available: #{available.sort.join(", ")}" unless available.include?(name)
+    ruby "#{bench_dir}/#{name}.rb"
+  end
+
+  desc "Run all unit-level benchmarks, save report to tmp/benchmarks/"
+  task :all do
+    require "fileutils"
+    FileUtils.mkdir_p("tmp/benchmarks")
+
+    failed = []
+
+    File.open("tmp/benchmarks/unit.txt", "w") do |report|
+      unit_benches.each do |name|
+        file = "#{bench_dir}/#{name}.rb"
+        header = "\n### #{file} ###"
+        puts "\e[1;35m#{header}\e[0m"
+        report.puts header
+
+        result = `ruby #{file} 2>&1`
+        puts result
+        report.puts result.gsub(/\e\[[0-9;]*m/, "")
+
+        unless $?.success? # rubocop:disable Style/SpecialGlobalVars
+          failed << file
+          report.puts "!!! FAILED (exit #{$?.exitstatus})" # rubocop:disable Style/SpecialGlobalVars
+        end
+      end
+    end
+
+    puts "\nSaved report to tmp/benchmarks/unit.txt"
+    abort "\nBenchmark(s) failed: #{failed.join(", ")}" if failed.any?
+  end
 end
 
-desc "Run all benchmarks"
+desc "Run all benchmarks (alias for bench:all)"
 task bench: "bench:all"
 
 desc "Build gem and verify contents"

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "benchmark/ips"
-require "memory_profiler"
+require_relative "bench_support"
 require "json"
 require "securerandom"
 require "concurrent"
@@ -54,35 +53,6 @@ module BenchStubs
     def produce_topic(...) = nil
     def close(...) = nil
     def transaction(...) = yield(self)
-  end
-end
-
-# Shared harness for consistent benchmark reporting across all benchmarks.
-# Provides throughput (benchmark-ips) + allocation tracking (memory_profiler)
-# in a uniform format that the CI report-capture task can parse.
-module BenchSupport # rubocop:disable Style/OneClassPerFile
-  module_function
-
-  def ips(time: 2, warmup: 1, &)
-    Benchmark.ips do |x|
-      x.config(time: time, warmup: warmup)
-      yield x
-      x.compare!
-    end
-  end
-
-  def allocations(label, &)
-    report = MemoryProfiler.report(&)
-    puts format(
-      "  %-32s %8d objects  %10d bytes (retained: %d objects)",
-      label, report.total_allocated, report.total_allocated_memsize, report.total_retained
-    )
-    report
-  end
-
-  def header(title)
-    puts "\n\e[1;36m#{title}\e[0m"
-    puts "─" * title.length
   end
 end
 

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -57,6 +57,35 @@ module BenchStubs
   end
 end
 
+# Shared harness for consistent benchmark reporting across all benchmarks.
+# Provides throughput (benchmark-ips) + allocation tracking (memory_profiler)
+# in a uniform format that the CI report-capture task can parse.
+module BenchSupport # rubocop:disable Style/OneClassPerFile
+  module_function
+
+  def ips(time: 2, warmup: 1, &)
+    Benchmark.ips do |x|
+      x.config(time: time, warmup: warmup)
+      yield x
+      x.compare!
+    end
+  end
+
+  def allocations(label, &)
+    report = MemoryProfiler.report(&)
+    puts format(
+      "  %-32s %8d objects  %10d bytes (retained: %d objects)",
+      label, report.total_allocated, report.total_allocated_memsize, report.total_retained
+    )
+    report
+  end
+
+  def header(title)
+    puts "\n\e[1;36m#{title}\e[0m"
+    puts "─" * title.length
+  end
+end
+
 # Sample payloads of varying sizes
 SMALL_PAYLOAD = { "job_class" => "SmallJob", "job_id" => SecureRandom.uuid,
                   "queue_name" => "default", "arguments" => [1] }.freeze

--- a/benchmarks/bench_support.rb
+++ b/benchmarks/bench_support.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "memory_profiler"
+
+# Shared harness for consistent benchmark reporting across all benchmarks.
+# Provides throughput (benchmark-ips) + allocation tracking (memory_profiler)
+# in a uniform format that the CI report-capture task can parse.
+#
+# Pure module — no side effects on require, so it's safe to load from specs.
+# bench_helper.rb (which mutates Pgbus.configuration) is for benchmark scripts
+# only and should never be required from the spec suite.
+module BenchSupport
+  module_function
+
+  def ips(time: 2, warmup: 1, &)
+    Benchmark.ips do |x|
+      x.config(time: time, warmup: warmup)
+      yield x
+      x.compare!
+    end
+  end
+
+  def allocations(label, &)
+    report = MemoryProfiler.report(&)
+    puts format(
+      "  %-32s %8d objects  %10d bytes (retained: %d objects)",
+      label, report.total_allocated, report.total_allocated_memsize, report.total_retained
+    )
+    report
+  end
+
+  def header(title)
+    puts "\n\e[1;36m#{title}\e[0m"
+    puts "─" * title.length
+  end
+end

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,117 @@
+# Performance
+
+Pgbus aims to be fast in the places that run on every job: the enqueue path
+(`Client#send_message`), the dequeue path (`Client#read_batch`), and the
+execution path (`Executor#execute`). This page documents how those paths are
+kept fast, how to measure them yourself, and how performance is part of every
+change.
+
+The honest summary: **the gem overhead (serialization, queue routing, stats) is
+what we control; the PGMQ round-trip and database I/O dominate end-to-end
+latency.** So the unit benchmarks isolate gem overhead with a mocked PGMQ
+client, while the integration benchmarks (when available) measure the full
+stack. Measure before you optimize; the harness below exists so you never have
+to guess.
+
+## The hot paths
+
+| Path | When it runs | Bench |
+|------|--------------|-------|
+| `Client#send_message` / `#send_batch` | every job enqueue | `client_bench.rb` |
+| `Client#read_batch` | every worker poll cycle | `client_bench.rb` |
+| `Executor#execute` | every job execution (deserialize + dispatch + archive) | `executor_bench.rb` |
+| JSON serialization | every enqueue/dequeue (payload encoding) | `serialization_bench.rb` |
+| Connection pool checkout | every PGMQ operation under concurrency | `connection_pool_bench.rb` |
+| Execution pool dispatch | every job dispatched to thread/async pool | `execution_pool_bench.rb` |
+| SSE streaming | every Turbo Stream broadcast | `streams_bench.rb` |
+
+## Measuring
+
+Everything is driven from `rake`:
+
+```bash
+rake bench              # the unit benchmark suite (alias for bench:all)
+rake bench:all          # serialization, client, executor — saves report to tmp/benchmarks/
+rake bench:one[name]    # a single benchmark by name (e.g. client_bench)
+rake bench:memory       # detailed memory profiling with allocation breakdown
+rake bench:integration  # real PostgreSQL + PGMQ (requires PGBUS_DATABASE_URL)
+rake bench:streams      # real Puma + SSE fan-out (requires PGBUS_DATABASE_URL)
+```
+
+- **Unit benches** (`benchmarks/*_bench.rb`) isolate gem overhead with a mocked
+  PGMQ client using [`benchmark-ips`](https://github.com/evanphx/benchmark-ips)
+  (throughput) and [`memory_profiler`](https://github.com/SamSaffron/memory_profiler)
+  (allocations).
+- **Integration benches** (`benchmarks/integration_bench.rb`) hit a real
+  PostgreSQL + PGMQ instance for end-to-end latency.
+- **Streams benches** (`benchmarks/streams_bench.rb`) boot a real Puma server
+  and measure SSE broadcast fan-out.
+
+### Reading the output
+
+`benchmark-ips` reports **i/s** (iterations per second — higher is better).
+`memory_profiler` reports **objects/bytes allocated** (transient GC pressure) and
+**retained** (objects that survive — a steady climb here is a leak). For a
+`send_message` call, *retained should be 0*; non-zero retained is the smell the
+allocation budget specs catch.
+
+### Measure BEFORE you change
+
+The first rule: capture the baseline **before** touching code, or you can't
+claim a delta. The cleanest way is an isolated worktree so `main` and your
+branch run the *same script* on the *same machine*:
+
+```bash
+git worktree add --detach /tmp/pgbus-baseline main
+cp -r benchmarks /tmp/pgbus-baseline/ && cp Gemfile Rakefile /tmp/pgbus-baseline/
+(cd /tmp/pgbus-baseline && bundle install --quiet && bundle exec rake bench:all) > /tmp/before.txt
+bundle exec rake bench:all > /tmp/after.txt
+diff /tmp/before.txt /tmp/after.txt
+git worktree remove --force /tmp/pgbus-baseline
+```
+
+There is no committed baseline file (shared CI runners are too noisy for a hard
+regression gate), which is exactly why the before/after has to be a deliberate
+same-machine measurement, not a comparison against a number from another box.
+
+## Allocation budgets
+
+The spec suite includes allocation budget tests (`spec/pgbus/allocation_budget_spec.rb`)
+that enforce hard limits:
+
+| Operation | Budget |
+|-----------|--------|
+| `Client#send_message` | < 50 objects/call |
+| `Client#send_batch` (per item) | < 25 objects/item |
+| `Client#read_batch` | < 30 objects/call |
+| JSON round-trip | < 20 objects |
+| Retained objects (leak detection) | 0 across 100 cycles |
+
+These run as part of `bundle exec rspec` on every PR. They are hard gates — a
+regression that exceeds the budget fails the build.
+
+## CI
+
+The `bench` job in `.github/workflows/main.yml` runs the unit benchmark suite
+on every PR and **uploads the report as the `benchmarks` artifact**. It is
+**run-and-report, never a hard fail** — it surfaces trends, it does not gate
+merges on a flaky threshold. Download the artifact from the PR's checks tab to
+see the numbers for that branch.
+
+The allocation budget specs in the `test` job ARE a hard gate — those fail the
+build if allocations regress past the budget.
+
+## Adding a benchmark
+
+A new hot path gets a new `benchmarks/<name>_bench.rb`. Use the shared harness:
+
+```ruby
+require_relative "bench_helper"
+
+BenchSupport.header("my hot path")
+BenchSupport.ips { |x| x.report("thing") { thing_under_test } }
+BenchSupport.allocations("thing") { thing_under_test }
+```
+
+For unit-level benches that should run in CI, add the filename to the
+`unit_benches` list in the `Rakefile`'s `bench` namespace.

--- a/spec/integration/timezone_spec.rb
+++ b/spec/integration/timezone_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "Timezone handling (integration)", :integration do
 
       allow(ActiveJob::Base).to receive(:deserialize).and_return(job_double)
       allow(Pgbus::Concurrency).to receive(:extract_key).and_return(nil)
-      stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
+      stub_const("Pgbus::JobStat", Class.new)
       allow(Pgbus::JobStat).to receive(:record!)
 
       enqueued_at = (Time.now.utc - 1).strftime("%Y-%m-%d %H:%M:%S.%6N")

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Pgbus::ActiveJob::Executor do
     # By default, no concurrency key in payloads
     allow(Pgbus::Concurrency).to receive(:extract_key).and_return(nil)
     # Stub stat recording
-    stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
+    stub_const("Pgbus::JobStat", Class.new)
     allow(Pgbus::JobStat).to receive_messages(record!: nil, table_exists?: true)
     # Stub failure tracking
     allow(Pgbus::FailedEventRecorder).to receive_messages(record!: nil, clear!: nil)

--- a/spec/pgbus/bench_support_spec.rb
+++ b/spec/pgbus/bench_support_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative "../../benchmarks/bench_support"
 
 RSpec.describe "BenchSupport" do
-  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
-    require_relative "../../benchmarks/bench_helper"
-  end
-
   describe ".header" do
     it "prints a colored title with underline" do
       output = capture_stdout { BenchSupport.header("Test Title") }

--- a/spec/pgbus/bench_support_spec.rb
+++ b/spec/pgbus/bench_support_spec.rb
@@ -6,46 +6,28 @@ require_relative "../../benchmarks/bench_support"
 RSpec.describe "BenchSupport" do
   describe ".header" do
     it "prints a colored title with underline" do
-      output = capture_stdout { BenchSupport.header("Test Title") }
-      expect(output).to include("Test Title")
-      expect(output).to include("─" * "Test Title".length)
+      expect { BenchSupport.header("Test Title") }
+        .to output(/Test Title.*#{"─" * "Test Title".length}/m).to_stdout
     end
   end
 
   describe ".allocations" do
     it "reports allocated and retained objects" do
-      output = capture_stdout do
-        report = BenchSupport.allocations("test alloc") { "hello" * 10 }
-        expect(report).to be_a(MemoryProfiler::Results)
-      end
-      expect(output).to include("test alloc")
-      expect(output).to match(/\d+ objects/)
-      expect(output).to match(/\d+ bytes/)
-      expect(output).to include("retained:")
+      report = nil
+      expect { report = BenchSupport.allocations("test alloc") { "hello" * 10 } }
+        .to output(/test alloc\s+\d+ objects\s+\d+ bytes \(retained: \d+ objects\)/).to_stdout
+      expect(report).to be_a(MemoryProfiler::Results)
     end
   end
 
   describe ".ips" do
     it "runs benchmark-ips with comparison" do
-      output = capture_stdout do
+      expect do
         BenchSupport.ips(time: 0.1, warmup: 0.05) do |x|
           x.report("fast") { 1 + 1 }
           x.report("slow") { (1..100).to_a }
         end
-      end
-      expect(output).to include("fast")
-      expect(output).to include("slow")
+      end.to output(/fast.*slow/m).to_stdout
     end
-  end
-
-  private
-
-  def capture_stdout
-    original = $stdout
-    $stdout = StringIO.new
-    yield
-    $stdout.string
-  ensure
-    $stdout = original
   end
 end

--- a/spec/pgbus/bench_support_spec.rb
+++ b/spec/pgbus/bench_support_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "BenchSupport" do
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    require_relative "../../benchmarks/bench_helper"
+  end
+
+  describe ".header" do
+    it "prints a colored title with underline" do
+      output = capture_stdout { BenchSupport.header("Test Title") }
+      expect(output).to include("Test Title")
+      expect(output).to include("─" * "Test Title".length)
+    end
+  end
+
+  describe ".allocations" do
+    it "reports allocated and retained objects" do
+      output = capture_stdout do
+        report = BenchSupport.allocations("test alloc") { "hello" * 10 }
+        expect(report).to be_a(MemoryProfiler::Results)
+      end
+      expect(output).to include("test alloc")
+      expect(output).to match(/\d+ objects/)
+      expect(output).to match(/\d+ bytes/)
+      expect(output).to include("retained:")
+    end
+  end
+
+  describe ".ips" do
+    it "runs benchmark-ips with comparison" do
+      output = capture_stdout do
+        BenchSupport.ips(time: 0.1, warmup: 0.05) do |x|
+          x.report("fast") { 1 + 1 }
+          x.report("slow") { (1..100).to_a }
+        end
+      end
+      expect(output).to include("fast")
+      expect(output).to include("slow")
+    end
+  end
+
+  private
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+end

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
 
   describe "#cleanup_stats (private)" do
     before do
-      stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
+      stub_const("Pgbus::JobStat", Class.new)
       allow(Pgbus::JobStat).to receive(:cleanup!).and_return(10)
     end
 

--- a/spec/pgbus/stat_buffer_spec.rb
+++ b/spec/pgbus/stat_buffer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Pgbus::StatBuffer do
   end
 
   before do
-    stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
+    stub_const("Pgbus::JobStat", Class.new)
     allow(Pgbus::JobStat).to receive_messages(table_exists?: true, latency_columns?: true, insert_all: nil)
   end
 

--- a/spec/pgbus/timezone_handling_spec.rb
+++ b/spec/pgbus/timezone_handling_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Pgbus do
     before do
       allow(ActiveJob::Base).to receive(:deserialize).and_return(job_double)
       allow(Pgbus::Concurrency).to receive(:extract_key).and_return(nil)
-      stub_const("Pgbus::JobStat", Class.new) unless defined?(Pgbus::JobStat)
+      stub_const("Pgbus::JobStat", Class.new)
       allow(Pgbus::JobStat).to receive(:record!)
     end
 

--- a/spec/pgbus/timezone_handling_spec.rb
+++ b/spec/pgbus/timezone_handling_spec.rb
@@ -89,6 +89,9 @@ RSpec.describe Pgbus do
     before do
       allow(ActiveJob::Base).to receive(:deserialize).and_return(job_double)
       allow(Pgbus::Concurrency).to receive(:extract_key).and_return(nil)
+      # Make stats observable regardless of global config state — record_stat
+      # returns early unless stats_enabled, so assert on a known-true value.
+      allow(config).to receive(:stats_enabled).and_return(true)
       stub_const("Pgbus::JobStat", Class.new)
       allow(Pgbus::JobStat).to receive(:record!)
     end


### PR DESCRIPTION
## Summary

Borrows the continuous-performance discipline pattern from [phlex-reactive PR #33](https://github.com/mhenrixon/phlex-reactive/commit/f08dfd5) and adapts it for pgbus:

- **BenchSupport harness** (`benchmarks/bench_helper.rb`) — shared `ips()`, `allocations()`, `header()` methods for consistent benchmark reporting across all bench files
- **`rake bench:one[name]`** — run a single benchmark by name with input validation (prevents shell injection)
- **`rake bench:all` report capture** — saves ANSI-stripped plaintext to `tmp/benchmarks/unit.txt` for CI artifact upload; crashes are surfaced, not silent
- **CI benchmark job** (`.github/workflows/main.yml`) — runs unit benchmarks on every PR, uploads report as artifact, **never blocks merges** (shared runners are too noisy for hard thresholds)
- **`/perf` slash command** (`.claude/commands/perf.md`) — worktree-based before/after workflow: baseline `main` in an isolated worktree, measure the branch, diff honestly
- **Performance rules** (`.claude/rules/performance.md`) — prime directive ("measure before you change"), hot-path table mapping code to benchmarks, always/never rules, expanded checklist
- **Performance docs** (`docs/performance.md`) — user-facing guide: hot paths, measuring, allocation budgets, CI integration, adding new benchmarks
- **CLAUDE.md updates** — bench commands, `/perf` in slash command table, "measure before/after" in Always Do

### What's NOT in this PR

No benchmark optimizations or benchmark file refactors — this is purely infrastructure. The existing benchmarks (`client_bench.rb`, `serialization_bench.rb`, `executor_bench.rb`, etc.) are untouched and continue to work as before. The `BenchSupport` harness is available for new benchmarks or future refactors of existing ones.

### Key design decisions (borrowed from phlex-reactive)

1. **CI benchmarks are report-only** — `continue-on-error: true` + artifact upload. No hard regression gates on flaky shared runners.
2. **Allocation budgets ARE a hard gate** — the existing `allocation_budget_spec.rb` runs in the `test` job and fails the build. This is the right split: allocation counts are deterministic, throughput is noisy.
3. **Honest framing required** — distinguish method-level wins (gem overhead per `send_message`) from system-level wins (end-to-end job latency where PGMQ/DB dominate).

## Test plan

- [x] `bundle exec rspec spec/pgbus/bench_support_spec.rb` — 3 examples, 0 failures
- [x] `bundle exec rspec spec/pgbus/allocation_budget_spec.rb` — 5 examples, 0 failures
- [x] `bundle exec rubocop` — 407 files, 0 offenses
- [x] `rake bench:one[serialization_bench]` — runs correctly
- [x] `rake bench:one[nonexistent]` — aborts with available list
- [x] Full test suite: 2232 passed, 3 pre-existing order-dependent failures (unrelated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new performance strategy docs, including hot paths, benchmarking commands, and guidance for interpreting throughput and allocation results.
  * Updated developer workflow and benchmarking policies with explicit “measure before optimizing” checklists.
* **New Features**
  * Expanded benchmark tooling with `rake bench:one[name]` and an updated `rake bench:all` that runs/summarizes unit benches.
  * Added a CI benchmarks job that runs benchmarks (report-only) and uploads output artifacts.
* **Tests**
  * Added specs for shared benchmark output helpers and adjusted benchmark-related test stubbing to be consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->