### PR TITLE
feat(web): dashboard polish — insights default, DLQ pagination, UX improvements

### DIFF
--- a/app/controllers/pgbus/dead_letter_controller.rb
+++ b/app/controllers/pgbus/dead_letter_controller.rb
@@ -3,7 +3,11 @@
 module Pgbus
   class DeadLetterController < ApplicationController
     def index
-      @messages = data_source.dlq_messages(page: page_param, per_page: per_page)
+      @page = page_param
+      @per_page = per_page
+      @messages = data_source.dlq_messages(page: @page, per_page: @per_page)
+      @total_count = data_source.dlq_total_count
+      @total_pages = (@total_count.to_f / @per_page).ceil
       render_frame("pgbus/dead_letter/messages_table") if params[:frame] == "list"
     end
 

--- a/app/views/pgbus/dashboard/_recent_failures.html.erb
+++ b/app/views/pgbus/dashboard/_recent_failures.html.erb
@@ -19,7 +19,7 @@
           <% @recent_failures.each do |f| %>
             <tr>
               <td data-label="Queue" class="px-4 py-3 text-sm text-gray-700"><%= f["queue_name"] %></td>
-              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 truncate max-w-xs" title="<%= "#{f["error_class"]}: #{f["error_message"]}" %>"><%= f["error_class"] %>: <%= truncate(f["error_message"].to_s, length: 60) %></td>
+              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 truncate max-w-xs" title="<%= f["error_class"] %>: <%= f["error_message"] %>"><%= f["error_class"] %>: <%= truncate(f["error_message"].to_s, length: 60) %></td>
               <td data-label="Time" class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(f["failed_at"]) %></td>
             </tr>
           <% end %>

--- a/app/views/pgbus/dashboard/_recent_failures.html.erb
+++ b/app/views/pgbus/dashboard/_recent_failures.html.erb
@@ -19,7 +19,7 @@
           <% @recent_failures.each do |f| %>
             <tr>
               <td data-label="Queue" class="px-4 py-3 text-sm text-gray-700"><%= f["queue_name"] %></td>
-              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 truncate max-w-xs"><%= f["error_class"] %>: <%= truncate(f["error_message"].to_s, length: 60) %></td>
+              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 truncate max-w-xs" title="<%= "#{f["error_class"]}: #{f["error_message"]}" %>"><%= f["error_class"] %>: <%= truncate(f["error_message"].to_s, length: 60) %></td>
               <td data-label="Time" class="px-4 py-3 text-sm text-gray-500"><%= pgbus_time_ago(f["failed_at"]) %></td>
             </tr>
           <% end %>

--- a/app/views/pgbus/dashboard/_stats_cards.html.erb
+++ b/app/views/pgbus/dashboard/_stats_cards.html.erb
@@ -31,6 +31,7 @@
       <p class="mt-1 text-3xl font-semibold <%= (@stats[:failed_count] + @stats[:dlq_depth]) > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white' %>">
         <%= @stats[:failed_count] %> / <%= @stats[:dlq_depth] %>
       </p>
+      <p class="text-xs text-gray-400 dark:text-gray-500"><%= t("pgbus.dashboard.stats_cards.failed_dlq_labels") %></p>
     </div>
 
     <div class="rounded-lg bg-white dark:bg-gray-800 p-5 shadow ring-1 ring-gray-200 dark:ring-gray-700">

--- a/app/views/pgbus/dead_letter/_messages_table.html.erb
+++ b/app/views/pgbus/dead_letter/_messages_table.html.erb
@@ -91,5 +91,30 @@
         <% end %>
       </tbody>
     </table>
+    <% if @total_count && @total_count > 0 %>
+      <div class="flex items-center justify-between border-t border-gray-200 dark:border-gray-700 px-4 py-3">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          <% from = (@page - 1) * @per_page + 1 %>
+          <% to = [from + @messages.size - 1, @total_count].min %>
+          <%= t("pgbus.helpers.pagination.showing", from: from, to: to, total: @total_count) %>
+        </p>
+        <% if @total_pages > 1 %>
+          <nav class="inline-flex rounded-lg shadow-sm" role="navigation" aria-label="Pagination">
+            <% if @page > 1 %>
+              <%= link_to t("pgbus.helpers.pagination.previous"), pgbus.dead_letter_index_path(page: @page - 1),
+                    class: "px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 rounded-l-lg bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700" %>
+            <% else %>
+              <span class="px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 rounded-l-lg bg-gray-100 dark:bg-gray-900 text-gray-400 dark:text-gray-600 cursor-not-allowed"><%= t("pgbus.helpers.pagination.previous") %></span>
+            <% end %>
+            <% if @page < @total_pages %>
+              <%= link_to t("pgbus.helpers.pagination.next"), pgbus.dead_letter_index_path(page: @page + 1),
+                    class: "-ml-px px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 rounded-r-lg bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700" %>
+            <% else %>
+              <span class="-ml-px px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 rounded-r-lg bg-gray-100 dark:bg-gray-900 text-gray-400 dark:text-gray-600 cursor-not-allowed"><%= t("pgbus.helpers.pagination.next") %></span>
+            <% end %>
+          </nav>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </turbo-frame>

--- a/app/views/pgbus/dead_letter/_messages_table.html.erb
+++ b/app/views/pgbus/dead_letter/_messages_table.html.erb
@@ -1,4 +1,11 @@
-<turbo-frame id="dlq-messages" data-auto-refresh data-src="<%= pgbus.dead_letter_index_path(frame: 'list') %>">
+<turbo-frame id="dlq-messages" data-auto-refresh data-src="<%= pgbus.dead_letter_index_path(frame: 'list', page: @page) %>">
+  <%# Count badge lives inside the frame so it refreshes in lockstep with the table. %>
+  <% if @total_count && @total_count > 0 %>
+    <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+      <span class="inline-flex items-center rounded-full bg-red-100 dark:bg-red-900 px-2.5 py-0.5 text-sm font-medium text-red-800 dark:text-red-200"><%= @total_count %></span>
+      <%= t("pgbus.dead_letter.messages_table.total_label") %>
+    </p>
+  <% end %>
   <%# Bulk form outside table to avoid nested form issues %>
   <form id="bulk-discard-dlq-form" action="<%= pgbus.discard_selected_dead_letter_index_path %>" method="post" data-turbo-frame="_top" class="hidden">
     <%= hidden_field_tag :authenticity_token, form_authenticity_token %>

--- a/app/views/pgbus/dead_letter/index.html.erb
+++ b/app/views/pgbus/dead_letter/index.html.erb
@@ -1,10 +1,5 @@
 <div class="flex items-center justify-between mb-6">
-  <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
-    <%= t("pgbus.dead_letter.index.title") %>
-    <% if @total_count && @total_count > 0 %>
-      <span class="ml-2 inline-flex items-center rounded-full bg-red-100 dark:bg-red-900 px-2.5 py-0.5 text-sm font-medium text-red-800 dark:text-red-200"><%= @total_count %></span>
-    <% end %>
-  </h1>
+  <h1 class="text-2xl font-bold text-gray-900 dark:text-white"><%= t("pgbus.dead_letter.index.title") %></h1>
   <% if @messages.any? %>
     <div class="flex items-center space-x-2">
       <div data-bulk-actions class="hidden flex items-center space-x-2">

--- a/app/views/pgbus/dead_letter/index.html.erb
+++ b/app/views/pgbus/dead_letter/index.html.erb
@@ -1,5 +1,10 @@
 <div class="flex items-center justify-between mb-6">
-  <h1 class="text-2xl font-bold text-gray-900 dark:text-white"><%= t("pgbus.dead_letter.index.title") %></h1>
+  <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+    <%= t("pgbus.dead_letter.index.title") %>
+    <% if @total_count && @total_count > 0 %>
+      <span class="ml-2 inline-flex items-center rounded-full bg-red-100 dark:bg-red-900 px-2.5 py-0.5 text-sm font-medium text-red-800 dark:text-red-200"><%= @total_count %></span>
+    <% end %>
+  </h1>
   <% if @messages.any? %>
     <div class="flex items-center space-x-2">
       <div data-bulk-actions class="hidden flex items-center space-x-2">

--- a/app/views/pgbus/insights/show.html.erb
+++ b/app/views/pgbus/insights/show.html.erb
@@ -4,7 +4,7 @@
     <p class="mt-1 text-sm text-gray-500 dark:text-gray-400"><%= t("pgbus.insights.show.description_html", range: pgbus_time_range_label(@minutes)) %></p>
   </div>
   <nav class="inline-flex rounded-lg shadow-sm" role="group" aria-label="Time range">
-    <% ranges = [["1h", 60], ["24h", 1440], ["7d", 10_080], ["30d", 43_200]] %>
+    <% ranges = [["1h", 60], ["4h", 240], ["24h", 1440], ["7d", 10_080], ["30d", 43_200]] %>
     <% ranges.each_with_index do |(label, mins), i| %>
       <%
         active = @minutes == mins

--- a/app/views/pgbus/jobs/_failed_table.html.erb
+++ b/app/views/pgbus/jobs/_failed_table.html.erb
@@ -51,7 +51,7 @@
                 <%= link_to f["id"], pgbus.job_path(f["id"]), class: "text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
               </td>
               <td data-label="Queue" class="px-4 py-3 text-sm text-gray-700"><%= f["queue_name"] %></td>
-              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 max-w-sm truncate" title="<%= "#{f["error_class"]}: #{f["error_message"]}" %>">
+              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 max-w-sm truncate" title="<%= f["error_class"] %>: <%= f["error_message"] %>">
                 <span class="font-medium"><%= f["error_class"] %></span>: <%= truncate(f["error_message"].to_s, length: 80) %>
               </td>
               <td data-label="Retries" class="px-4 py-3 text-sm text-gray-500"><%= f["retry_count"] %></td>

--- a/app/views/pgbus/jobs/_failed_table.html.erb
+++ b/app/views/pgbus/jobs/_failed_table.html.erb
@@ -51,7 +51,7 @@
                 <%= link_to f["id"], pgbus.job_path(f["id"]), class: "text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
               </td>
               <td data-label="Queue" class="px-4 py-3 text-sm text-gray-700"><%= f["queue_name"] %></td>
-              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 max-w-sm truncate">
+              <td data-label="Error" class="px-4 py-3 text-sm text-red-600 max-w-sm truncate" title="<%= "#{f["error_class"]}: #{f["error_message"]}" %>">
                 <span class="font-medium"><%= f["error_class"] %></span>: <%= truncate(f["error_message"].to_s, length: 80) %>
               </td>
               <td data-label="Retries" class="px-4 py-3 text-sm text-gray-500"><%= f["retry_count"] %></td>

--- a/app/views/pgbus/queues/show.html.erb
+++ b/app/views/pgbus/queues/show.html.erb
@@ -1,3 +1,6 @@
+<div class="mb-3">
+  <%= link_to "← #{t("pgbus.queues.show.back")}", pgbus.queues_path, class: "text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400" %>
+</div>
 <div class="flex items-center justify-between mb-6">
   <div>
     <h1 class="text-2xl font-bold text-gray-900 dark:text-white">

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -84,6 +84,7 @@ da:
       stats_cards:
         enqueued: Sat i kø
         failed_dlq: Mislykkedes / DLQ
+        failed_dlq_labels: Fejlet / Dead Lettered
         processes: Processer
         queues: Køer
         recurring: Gentagende
@@ -126,6 +127,7 @@ da:
           queue: 'Kø:'
           visible_at: 'Synlig ved:'
         retry: Forsøg igen
+        total_label: beskeder i dead letter-kø
       show:
         back: Tilbage til DLQ
         discard: Kassér
@@ -225,6 +227,10 @@ da:
       bulk_select_all: Vælg alle
       bulk_select_row: Vælg %{id}
       bulk_selected: valgt
+      pagination:
+        next: Næste
+        previous: Forrige
+        showing: Viser %{from}–%{to} af %{total}
       paused_badge: Pause
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ da:
         resume: Genoptag
       show:
         arguments: Argumenter
+        back: Tilbage til køer
         delete_confirm: Slet denne kø permanent? Dette kan ikke fortrydes.
         delete_queue: Slet kø
         depth: 'Dybde:'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -84,6 +84,7 @@ de:
       stats_cards:
         enqueued: Eingereiht
         failed_dlq: Fehlgeschlagen / DLQ
+        failed_dlq_labels: Fehlgeschlagen / Dead Lettered
         processes: Prozesse
         queues: Warteschlangen
         recurring: Wiederkehrend
@@ -126,6 +127,7 @@ de:
           queue: 'Warteschlange:'
           visible_at: 'Sichtbar um:'
         retry: Erneut versuchen
+        total_label: Nachrichten in der Dead-Letter-Warteschlange
       show:
         back: Zurück zur DLQ
         discard: Verwerfen
@@ -225,6 +227,10 @@ de:
       bulk_select_all: Alle auswählen
       bulk_select_row: "%{id} auswählen"
       bulk_selected: ausgewählt
+      pagination:
+        next: Weiter
+        previous: Zurück
+        showing: Zeige %{from}–%{to} von %{total}
       paused_badge: Pausiert
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ de:
         resume: Fortsetzen
       show:
         arguments: Argumente
+        back: Zurück zu Warteschlangen
         delete_confirm: Diese Warteschlange dauerhaft löschen? Dies kann nicht rückgängig gemacht werden.
         delete_queue: Warteschlange löschen
         depth: 'Tiefe:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
       stats_cards:
         enqueued: Enqueued
         failed_dlq: Failed / DLQ
+        failed_dlq_labels: Failed / Dead Lettered
         processes: Processes
         queues: Queues
         recurring: Recurring
@@ -218,6 +219,10 @@ en:
         not_found: Event not found
         title: Event %{event_id}
     helpers:
+      pagination:
+        showing: Showing %{from}–%{to} of %{total}
+        next: Next
+        previous: Previous
       batch_status:
         finished: Finished
         pending: Pending
@@ -477,6 +482,7 @@ en:
         resume: Resume
       show:
         arguments: Arguments
+        back: Back to Queues
         delete_confirm: Permanently delete this queue? This cannot be undone.
         delete_queue: Delete Queue
         depth: 'Depth:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,7 @@ en:
           queue: 'Queue:'
           visible_at: 'Visible at:'
         retry: Retry
+        total_label: messages in dead letter queue
       show:
         back: Back to DLQ
         discard: Discard
@@ -219,10 +220,6 @@ en:
         not_found: Event not found
         title: Event %{event_id}
     helpers:
-      pagination:
-        showing: Showing %{from}–%{to} of %{total}
-        next: Next
-        previous: Previous
       batch_status:
         finished: Finished
         pending: Pending
@@ -230,6 +227,10 @@ en:
       bulk_select_all: Select all
       bulk_select_row: Select %{id}
       bulk_selected: selected
+      pagination:
+        next: Next
+        previous: Previous
+        showing: Showing %{from}–%{to} of %{total}
       paused_badge: Paused
       queue_badge:
         dlq: DLQ

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -84,6 +84,7 @@ es:
       stats_cards:
         enqueued: Encolado
         failed_dlq: Fallidos / DLQ
+        failed_dlq_labels: Fallidos / Dead Lettered
         processes: Procesos
         queues: Colas
         recurring: Recurrente
@@ -126,6 +127,7 @@ es:
           queue: 'Cola:'
           visible_at: 'Visible en:'
         retry: Reintentar
+        total_label: mensajes en la cola de mensajes fallidos
       show:
         back: Volver a DLQ
         discard: Descartar
@@ -225,6 +227,10 @@ es:
       bulk_select_all: Seleccionar todo
       bulk_select_row: Seleccionar %{id}
       bulk_selected: seleccionado
+      pagination:
+        next: Siguiente
+        previous: Anterior
+        showing: Mostrando %{from}–%{to} de %{total}
       paused_badge: Pausado
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ es:
         resume: Reanudar
       show:
         arguments: Argumentos
+        back: Volver a colas
         delete_confirm: "¿Eliminar permanentemente esta cola? Esto no se puede deshacer."
         delete_queue: Eliminar cola
         depth: 'Profundidad:'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -84,6 +84,7 @@ fi:
       stats_cards:
         enqueued: Lisätty jonoon
         failed_dlq: Epäonnistuneet / DLQ
+        failed_dlq_labels: Epäonnistuneet / Dead Lettered
         processes: Prosessit
         queues: Jonot
         recurring: Toistuva
@@ -126,6 +127,7 @@ fi:
           queue: 'Jono:'
           visible_at: 'Näkyvissä klo:'
         retry: Yritä uudelleen
+        total_label: viestiä dead letter -jonossa
       show:
         back: Takaisin DLQ:hon
         discard: Hylkää
@@ -225,6 +227,10 @@ fi:
       bulk_select_all: Valitse kaikki
       bulk_select_row: Valitse %{id}
       bulk_selected: valittu
+      pagination:
+        next: Seuraava
+        previous: Edellinen
+        showing: Näytetään %{from}–%{to} / %{total}
       paused_badge: Tauolla
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ fi:
         resume: Jatka
       show:
         arguments: Argumentit
+        back: Takaisin jonoihin
         delete_confirm: Poista tämä jono pysyvästi? Tätä ei voi kumota.
         delete_queue: Poista jono
         depth: 'Syvyys:'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -84,6 +84,7 @@ fr:
       stats_cards:
         enqueued: Enregistré
         failed_dlq: Échoué / DLQ
+        failed_dlq_labels: Échoués / Dead Lettered
         processes: Processus
         queues: Files d'attente
         recurring: Récurrent
@@ -126,6 +127,7 @@ fr:
           queue: 'File d''attente :'
           visible_at: 'Visible à :'
         retry: Réessayer
+        total_label: messages dans la file de lettres mortes
       show:
         back: Retour à la DLQ
         discard: Ignorer
@@ -225,6 +227,10 @@ fr:
       bulk_select_all: Tout sélectionner
       bulk_select_row: Sélectionner %{id}
       bulk_selected: sélectionné
+      pagination:
+        next: Suivant
+        previous: Précédent
+        showing: Affichage de %{from}–%{to} sur %{total}
       paused_badge: En pause
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ fr:
         resume: Reprendre
       show:
         arguments: Arguments
+        back: Retour aux files d'attente
         delete_confirm: Supprimer définitivement cette file d'attente ? Cette action est irréversible.
         delete_queue: Supprimer la file d'attente
         depth: 'Profondeur :'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -84,6 +84,7 @@ it:
       stats_cards:
         enqueued: In coda
         failed_dlq: Falliti / DLQ
+        failed_dlq_labels: Falliti / Dead Lettered
         processes: Processi
         queues: Code
         recurring: Ricorrente
@@ -126,6 +127,7 @@ it:
           queue: 'Coda:'
           visible_at: 'Visibile alle:'
         retry: Riprova
+        total_label: messaggi nella coda dei messaggi non recapitati
       show:
         back: Torna a DLQ
         discard: Scarta
@@ -225,6 +227,10 @@ it:
       bulk_select_all: Seleziona tutto
       bulk_select_row: Seleziona %{id}
       bulk_selected: selezionato
+      pagination:
+        next: Avanti
+        previous: Indietro
+        showing: Visualizzazione %{from}–%{to} di %{total}
       paused_badge: In pausa
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ it:
         resume: Riprendi
       show:
         arguments: Argomenti
+        back: Torna alle code
         delete_confirm: Eliminare permanentemente questa coda? Questa azione non può essere annullata.
         delete_queue: Elimina coda
         depth: 'Profondità:'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -84,6 +84,7 @@ ja:
       stats_cards:
         enqueued: キューに追加済み
         failed_dlq: 失敗 / DLQ
+        failed_dlq_labels: 失敗 / Dead Lettered
         processes: プロセス
         queues: キュー
         recurring: 繰り返し
@@ -126,6 +127,7 @@ ja:
           queue: 'キュー:'
           visible_at: '表示日時:'
         retry: 再試行
+        total_label: デッドレターキュー内のメッセージ
       show:
         back: DLQに戻る
         discard: 破棄
@@ -225,6 +227,10 @@ ja:
       bulk_select_all: すべて選択
       bulk_select_row: "%{id}を選択"
       bulk_selected: 選択済み
+      pagination:
+        next: 次へ
+        previous: 前へ
+        showing: "%{total} 件中 %{from}–%{to} 件を表示"
       paused_badge: 一時停止中
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ ja:
         resume: 再開
       show:
         arguments: 引数
+        back: キューに戻る
         delete_confirm: このキューを完全に削除しますか？この操作は取り消せません。
         delete_queue: キューを削除
         depth: 深さ：

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -84,6 +84,7 @@ nb:
       stats_cards:
         enqueued: I kø
         failed_dlq: Mislyktes / DLQ
+        failed_dlq_labels: Mislyktes / Dead Lettered
         processes: Prosesser
         queues: Køer
         recurring: Gjentakende
@@ -126,6 +127,7 @@ nb:
           queue: 'Kø:'
           visible_at: 'Synlig ved:'
         retry: Prøv igjen
+        total_label: meldinger i dead letter-kø
       show:
         back: Tilbake til DLQ
         discard: Forkast
@@ -225,6 +227,10 @@ nb:
       bulk_select_all: Velg alle
       bulk_select_row: Velg %{id}
       bulk_selected: valgt
+      pagination:
+        next: Neste
+        previous: Forrige
+        showing: Viser %{from}–%{to} av %{total}
       paused_badge: Pause
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ nb:
         resume: Gjenoppta
       show:
         arguments: Argumenter
+        back: Tilbake til køer
         delete_confirm: Slette denne køen permanent? Dette kan ikke angres.
         delete_queue: Slett kø
         depth: 'Dybde:'

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -84,6 +84,7 @@ nl:
       stats_cards:
         enqueued: In de wachtrij geplaatst
         failed_dlq: Mislukt / DLQ
+        failed_dlq_labels: Mislukt / Dead Lettered
         processes: Processen
         queues: Wachtrijen
         recurring: Terugkerend
@@ -126,6 +127,7 @@ nl:
           queue: 'Wachtrij:'
           visible_at: 'Zichtbaar op:'
         retry: Opnieuw proberen
+        total_label: berichten in dead letter-wachtrij
       show:
         back: Terug naar DLQ
         discard: Verwerpen
@@ -225,6 +227,10 @@ nl:
       bulk_select_all: Alles selecteren
       bulk_select_row: Selecteer %{id}
       bulk_selected: geselecteerd
+      pagination:
+        next: Volgende
+        previous: Vorige
+        showing: "%{from}–%{to} van %{total} weergegeven"
       paused_badge: Gepauzeerd
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ nl:
         resume: Hervatten
       show:
         arguments: Argumenten
+        back: Terug naar wachtrijen
         delete_confirm: Deze wachtrij permanent verwijderen? Dit kan niet ongedaan worden gemaakt.
         delete_queue: Wachtrij verwijderen
         depth: 'Diepte:'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -84,6 +84,7 @@ pt:
       stats_cards:
         enqueued: Enfileirado
         failed_dlq: Falhou / DLQ
+        failed_dlq_labels: Falhados / Dead Lettered
         processes: Processos
         queues: Filas
         recurring: Recorrente
@@ -126,6 +127,7 @@ pt:
           queue: 'Fila:'
           visible_at: 'Visível em:'
         retry: Tentar novamente
+        total_label: mensagens na fila de mensagens mortas
       show:
         back: Voltar para DLQ
         discard: Descartar
@@ -225,6 +227,10 @@ pt:
       bulk_select_all: Selecionar todos
       bulk_select_row: Selecionar %{id}
       bulk_selected: selecionado
+      pagination:
+        next: Próximo
+        previous: Anterior
+        showing: Mostrando %{from}–%{to} de %{total}
       paused_badge: Pausado
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ pt:
         resume: Retomar
       show:
         arguments: Argumentos
+        back: Voltar às filas
         delete_confirm: Excluir permanentemente esta fila? Esta ação não pode ser desfeita.
         delete_queue: Excluir fila
         depth: 'Profundidade:'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -84,6 +84,7 @@ sv:
       stats_cards:
         enqueued: Inlagda
         failed_dlq: Misslyckade / DLQ
+        failed_dlq_labels: Misslyckade / Dead Lettered
         processes: Processer
         queues: Köer
         recurring: Återkommande
@@ -126,6 +127,7 @@ sv:
           queue: 'Kö:'
           visible_at: 'Synlig vid:'
         retry: Försök igen
+        total_label: meddelanden i dead letter-kö
       show:
         back: Tillbaka till DLQ
         discard: Kassera
@@ -225,6 +227,10 @@ sv:
       bulk_select_all: Markera alla
       bulk_select_row: Markera %{id}
       bulk_selected: valda
+      pagination:
+        next: Nästa
+        previous: Föregående
+        showing: Visar %{from}–%{to} av %{total}
       paused_badge: Pausad
       queue_badge:
         dlq: DLQ
@@ -477,6 +483,7 @@ sv:
         resume: Återuppta
       show:
         arguments: Argument
+        back: Tillbaka till köer
         delete_confirm: Ta bort denna kö permanent? Detta kan inte ångras.
         delete_queue: Ta bort kö
         depth: 'Djup:'

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -216,7 +216,7 @@ module Pgbus
       @web_per_page = 25
       @web_live_updates = true
       @web_data_source = nil
-      @insights_default_minutes = 30 * 24 * 60 # 30 days
+      @insights_default_minutes = 60 # 1 hour
       @base_controller_class = "::ActionController::Base"
       @return_to_app_url = nil
       @metrics_enabled = true

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -41,7 +41,17 @@ module Pgbus
       # Queues — query via ActiveRecord for reliability in web processes
       # (avoids PGMQ client connection issues when the web server uses a
       # different connection lifecycle than the worker processes).
+      # Memoized for the lifetime of this data-source instance (one per web
+      # request — see ApplicationController#data_source). A single page can ask
+      # for queue metrics more than once (e.g. the DLQ page reads both the
+      # message rows and the total count); without the memo each call re-runs
+      # the meta query + batched metrics. Mutations redirect to a fresh request
+      # with a new instance, so a per-request memo never serves stale data.
       def queues_with_metrics
+        @queues_with_metrics ||= fetch_queues_with_metrics
+      end
+
+      def fetch_queues_with_metrics
         queue_names = connection.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
         return [] if queue_names.empty?
 
@@ -53,6 +63,7 @@ module Pgbus
         Pgbus.logger.error { "[Pgbus::Web] Error fetching queue metrics: #{e.class}: #{e.message}" }
         []
       end
+      private :fetch_queues_with_metrics
 
       # name is the full PGMQ queue name (e.g. "pgbus_default") as returned
       # by queues_with_metrics. No prefix is added.

--- a/lib/pgbus/web/data_source.rb
+++ b/lib/pgbus/web/data_source.rb
@@ -276,6 +276,16 @@ module Pgbus
         []
       end
 
+      def dlq_total_count
+        dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
+        queues_with_metrics
+          .select { |q| q[:name].end_with?(dlq_suffix) }
+          .sum { |q| q[:queue_length] }
+      rescue StandardError => e
+        Pgbus.logger.debug { "[Pgbus::Web] Error fetching DLQ count: #{e.message}" }
+        0
+      end
+
       def dlq_message_detail(msg_id)
         dlq_suffix = Pgbus::DEAD_LETTER_SUFFIX
         queues = queues_with_metrics.select { |q| q[:name].end_with?(dlq_suffix) }

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -104,8 +104,8 @@ RSpec.describe Pgbus::Configuration do
       expect(config.zombie_detection).to be true
     end
 
-    it "has insights_default_minutes of 30 days" do
-      expect(config.insights_default_minutes).to eq(30 * 24 * 60)
+    it "has insights_default_minutes of 1 hour" do
+      expect(config.insights_default_minutes).to eq(60)
     end
 
     it "has outbox disabled by default" do

--- a/spec/pgbus/web/data_source_spec.rb
+++ b/spec/pgbus/web/data_source_spec.rb
@@ -917,6 +917,51 @@ RSpec.describe Pgbus::Web::DataSource do
     end
   end
 
+  describe "#dlq_total_count" do
+    let(:queue_metrics) do
+      [
+        { name: "pgbus_default_dlq", queue_length: 5 },
+        { name: "pgbus_low_dlq", queue_length: 2 },
+        { name: "pgbus_default", queue_length: 10 }
+      ]
+    end
+
+    it "sums queue_length across DLQ queues only" do
+      allow(data_source).to receive(:queues_with_metrics).and_return(queue_metrics)
+
+      expect(data_source.dlq_total_count).to eq(7)
+    end
+
+    it "returns 0 when there are no DLQ queues" do
+      allow(data_source).to receive(:queues_with_metrics).and_return([{ name: "pgbus_default", queue_length: 10 }])
+
+      expect(data_source.dlq_total_count).to eq(0)
+    end
+  end
+
+  describe "queue-metrics memoization" do
+    it "fetches queue metrics only once across repeated calls in one request" do
+      allow(mock_connection).to receive(:select_values).and_return(["pgbus_default_dlq"])
+      allow(mock_connection).to receive(:quote) { |v| "'#{v}'" }
+      allow(mock_connection).to receive(:select_all)
+        .with(anything, "Pgbus Batched Queue Metrics")
+        .and_return(double(to_a: [{
+                             "queue_name" => "pgbus_default_dlq",
+                             "queue_length" => 4, "queue_visible_length" => 4,
+                             "oldest_msg_age_sec" => nil, "newest_msg_age_sec" => nil,
+                             "total_messages" => 4
+                           }]))
+
+      # The DLQ page reads both the rows and the total count; the meta query
+      # must run once, not once per call.
+      data_source.queues_with_metrics
+      data_source.dlq_total_count
+
+      expect(mock_connection).to have_received(:select_values)
+        .with(a_string_matching(/pgmq\.meta/)).once
+    end
+  end
+
   describe "#live_stream_metrics" do
     let(:counter) { Pgbus::Web::Streamer::StreamCounter.new }
 

--- a/spec/system/dead_letter_spec.rb
+++ b/spec/system/dead_letter_spec.rb
@@ -18,12 +18,13 @@ RSpec.describe "Dead Letter Queue", type: :system do
       ]
     end
 
-    it "displays DLQ messages" do
+    it "displays DLQ messages with total count" do
       visit "/pgbus/dlq"
 
       expect(page).to have_text("99")
       expect(page).to have_text("pgbus_default")
       expect(page).to have_text("FailedJob")
+      expect(page).to have_text("Showing 1–1 of 1")
     end
 
     it "shows bulk action buttons" do

--- a/spec/system/insights_spec.rb
+++ b/spec/system/insights_spec.rb
@@ -20,11 +20,12 @@ RSpec.describe "Insights", type: :system do
       expect(page).to have_text("DEAD LETTERED")
     end
 
-    it "shows the time range selector" do
+    it "shows the time range selector with 4h option" do
       visit "/pgbus/insights"
 
       within("nav[aria-label='Time range']") do
         expect(page).to have_link("1h")
+        expect(page).to have_link("4h")
         expect(page).to have_link("24h")
         expect(page).to have_link("7d")
         expect(page).to have_link("30d")

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -44,7 +44,12 @@ module Pgbus
       def failed_events(page: 1, per_page: 25) = @failed_events_list
       def failed_events_count = @failed_events_list.size
       def failed_event(id) = @failed_events_list.find { |e| e["id"].to_s == id.to_s }
-      def dlq_messages(page: 1, per_page: 25) = @dlq_messages_list
+
+      def dlq_messages(page: 1, per_page: 25)
+        offset = (page - 1) * per_page
+        @dlq_messages_list.slice(offset, per_page) || []
+      end
+
       def dlq_total_count = @dlq_messages_list.size
       def dlq_message_detail(msg_id) = @dlq_messages_list.find { |m| m[:msg_id].to_s == msg_id.to_s }
       def processed_events(page: 1, per_page: 25) = @events_list

--- a/spec/system/support/data_source_stub.rb
+++ b/spec/system/support/data_source_stub.rb
@@ -45,6 +45,7 @@ module Pgbus
       def failed_events_count = @failed_events_list.size
       def failed_event(id) = @failed_events_list.find { |e| e["id"].to_s == id.to_s }
       def dlq_messages(page: 1, per_page: 25) = @dlq_messages_list
+      def dlq_total_count = @dlq_messages_list.size
       def dlq_message_detail(msg_id) = @dlq_messages_list.find { |m| m[:msg_id].to_s == msg_id.to_s }
       def processed_events(page: 1, per_page: 25) = @events_list
       def processed_events_count = @events_list.size


### PR DESCRIPTION
## Summary

Dashboard polish addressing three areas:

### 1. Insights default time range (1h + 4h option)
- Default changed from 30 days → **1 hour** — after a deploy you need to see the last hour, not the last month
- Added **4h** time range button (matches AppSignal's pattern: 1h, 4h, 24h, 7d, 30d)
- `config.insights_default_minutes` changed from `30 * 24 * 60` to `60`

### 2. DLQ pagination with total count
- **Total count badge** in the page header: "Dead Letter Queue (142)"
- **"Showing 1–25 of 142"** at the bottom of the table
- **Previous / Next** pagination buttons when there are multiple pages
- `data_source.dlq_total_count` derives count from PGMQ queue metrics (no extra DB query)

### 3. UX polish
- **Failed / DLQ stats card**: added sub-label "Failed / Dead Lettered" so the `3 / 2` numbers have context
- **Error tooltips**: truncated error messages in the failed jobs table and recent failures section now show the full error on hover (`title` attribute)
- **Queue detail back link**: "← Back to Queues" on the queue show page

## Test plan
- [x] `bundle exec rspec spec/pgbus/configuration_spec.rb` — 205 examples, 0 failures
- [x] `bundle exec rspec spec/system/insights_spec.rb spec/system/dead_letter_spec.rb spec/system/dashboard_spec.rb` — 26 examples, 0 failures
- [x] `bundle exec rspec spec/system/queues_spec.rb` — 19 examples, 0 failures
- [x] `bundle exec rubocop` — 408 files, 0 offenses
- [x] Visual check: dummy server confirms 1h default (active button), 5 time range buttons, DLQ count badge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dead-letter queue totals and page navigation, including a clearer “showing X–Y of Z” summary.
  * Added a back link on the queue details page.
  * Added a 4h time-range option on the insights page.
  * Improved error visibility with hover tooltips showing full details.
  * Added a small label beneath failed DLQ stats.

* **Bug Fixes**
  * Updated the default insights time range to 1 hour for a more focused view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->