### PR TITLE
feat(appsignal): add magic dashboard definitions and hostname-tagged probe metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,7 @@ RSpec/DescribeClass:
   Exclude:
     - spec/integration/**/*
     - spec/i18n_spec.rb
+    - spec/pgbus/integrations/appsignal/dashboard_spec.rb
 
 RSpec/AnyInstance:
   Enabled: false

--- a/lib/pgbus/integrations/appsignal.rb
+++ b/lib/pgbus/integrations/appsignal.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "pgbus/integrations/appsignal/subscriber"
 require "pgbus/integrations/appsignal/probe"
 
@@ -24,6 +25,9 @@ module Pgbus
     # All metric names are prefixed `pgbus_` so they group cleanly in
     # AppSignal's custom-metrics view.
     module Appsignal
+      DASHBOARD_PATH = File.expand_path("appsignal/dashboard.json", __dir__).freeze
+      DASHBOARDS_DIR = File.expand_path("appsignal/dashboards", __dir__).freeze
+
       module_function
 
       def install! # rubocop:disable Naming/PredicateMethod
@@ -41,11 +45,24 @@ module Pgbus
         @installed == true
       end
 
+      def dashboard_definition
+        @dashboard_definition ||= JSON.parse(File.read(DASHBOARD_PATH))
+      end
+
+      def dashboard_definitions
+        @dashboard_definitions ||=
+          Dir[File.join(DASHBOARDS_DIR, "*.json")].map do |path|
+            JSON.parse(File.read(path))
+          end
+      end
+
       # Test hook: tear everything down so a fresh install! can run.
       def reset!
         Subscriber.reset! if defined?(Subscriber)
         Probe.reset! if defined?(Probe)
         @installed = false
+        @dashboard_definition = nil
+        @dashboard_definitions = nil
       end
     end
   end

--- a/lib/pgbus/integrations/appsignal/dashboard.json
+++ b/lib/pgbus/integrations/appsignal/dashboard.json
@@ -1,0 +1,377 @@
+{
+  "metric_keys": [
+    "pgbus_queue_job_count"
+  ],
+  "dashboard": {
+    "title": "Pgbus",
+    "description": "PostgreSQL-native job processing and event bus built on PGMQ.\nMonitor job throughput, queue depth, latency, dead letter queues,\nworker processes, event handlers, and stream broadcasts.\n",
+    "visuals": [
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Job status per queue",
+        "description": "Processed, failed, and dead-lettered jobs per queue.",
+        "line_label": "%queue% - %status%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_job_count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "status",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Throughput per job class",
+        "description": "Number of jobs executed per job class.",
+        "line_label": "%namespace% - %action%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "transaction_duration",
+            "fields": [
+              {
+                "field": "count"
+              }
+            ],
+            "tags": [
+              {
+                "key": "namespace",
+                "value": "background"
+              },
+              {
+                "key": "action",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Duration per job class",
+        "description": "Mean execution time per job class.",
+        "line_label": "%namespace% - %action%",
+        "format": "duration",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "transaction_duration",
+            "fields": [
+              {
+                "field": "mean"
+              }
+            ],
+            "tags": [
+              {
+                "key": "namespace",
+                "value": "background"
+              },
+              {
+                "key": "action",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Queue depth",
+        "description": "Total messages waiting in each queue.",
+        "line_label": "%hostname% - %queue%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_depth",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Queue latency",
+        "description": "Age of the oldest message in each queue (milliseconds). High latency means consumers can't keep up.",
+        "line_label": "%hostname% - %queue%",
+        "format": "duration",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_latency",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Dead letter queue depth",
+        "description": "Messages that exceeded max retries and were routed to the DLQ.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_dlq_depth",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Worker / Process count",
+        "description": "Active pgbus supervisor processes.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_active_processes",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Messages sent / read",
+        "description": "PGMQ message throughput: enqueue and dequeue rates.",
+        "line_label": "%name% - %queue%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_messages_sent",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "pgbus_messages_read",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Event handler status",
+        "description": "Processed and failed event handler invocations.",
+        "line_label": "%handler% - %status%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_event_count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "handler",
+                "value": "*"
+              },
+              {
+                "key": "status",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Worker recycling",
+        "description": "Worker recycle events by reason (max_jobs, max_memory, max_lifetime).",
+        "line_label": "%reason%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_worker_recycled",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "reason",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Database health",
+        "description": "Dead tuples and oldest transaction age — indicators of MVCC pressure on queue tables.",
+        "line_label": "%name% - %hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_total_dead_tuples",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "pgbus_tables_needing_vacuum",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Stream broadcasts",
+        "description": "Turbo Stream broadcast count and active SSE connections.",
+        "line_label": "%name% - %hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_stream_broadcasts_60m",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "pgbus_stream_active_connections",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/lib/pgbus/integrations/appsignal/dashboard.json
+++ b/lib/pgbus/integrations/appsignal/dashboard.json
@@ -98,7 +98,7 @@
         "display": "LINE",
         "title": "Queue depth",
         "description": "Total messages waiting in each queue.",
-        "line_label": "%hostname% - %queue%",
+        "line_label": "%queue%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -113,10 +113,6 @@
               {
                 "key": "queue",
                 "value": "*"
-              },
-              {
-                "key": "hostname",
-                "value": "*"
               }
             ]
           }
@@ -127,7 +123,7 @@
         "display": "LINE",
         "title": "Queue latency",
         "description": "Age of the oldest message in each queue (milliseconds). High latency means consumers can't keep up.",
-        "line_label": "%hostname% - %queue%",
+        "line_label": "%queue%",
         "format": "duration",
         "draw_null_as_zero": true,
         "metrics": [
@@ -142,10 +138,6 @@
               {
                 "key": "queue",
                 "value": "*"
-              },
-              {
-                "key": "hostname",
-                "value": "*"
               }
             ]
           }
@@ -156,7 +148,7 @@
         "display": "LINE",
         "title": "Dead letter queue depth",
         "description": "Messages that exceeded max retries and were routed to the DLQ.",
-        "line_label": "%hostname%",
+        "line_label": "DLQ depth",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -167,12 +159,7 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       },
@@ -180,7 +167,7 @@
         "type": "timeseries",
         "display": "LINE",
         "title": "Worker / Process count",
-        "description": "Active pgbus supervisor processes.",
+        "description": "Active pgbus supervisor processes per host.",
         "line_label": "%hostname%",
         "format": "number",
         "draw_null_as_zero": true,
@@ -298,8 +285,8 @@
         "type": "timeseries",
         "display": "LINE",
         "title": "Database health",
-        "description": "Dead tuples and oldest transaction age — indicators of MVCC pressure on queue tables.",
-        "line_label": "%name% - %hostname%",
+        "description": "Dead tuples, tables needing vacuum, and oldest transaction age — indicators of MVCC pressure on queue tables.",
+        "line_label": "%name%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -310,12 +297,7 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           },
           {
             "name": "pgbus_tables_needing_vacuum",
@@ -324,12 +306,16 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
+            "tags": []
+          },
+          {
+            "name": "pgbus_oldest_transaction_age_seconds",
+            "fields": [
               {
-                "key": "hostname",
-                "value": "*"
+                "field": "gauge"
               }
-            ]
+            ],
+            "tags": []
           }
         ]
       },
@@ -338,7 +324,7 @@
         "display": "LINE",
         "title": "Stream broadcasts",
         "description": "Turbo Stream broadcast count and active SSE connections.",
-        "line_label": "%name% - %hostname%",
+        "line_label": "%name%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -349,12 +335,7 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           },
           {
             "name": "pgbus_stream_active_connections",
@@ -363,12 +344,7 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       }

--- a/lib/pgbus/integrations/appsignal/dashboards/pgbus_health.json
+++ b/lib/pgbus/integrations/appsignal/dashboards/pgbus_health.json
@@ -11,7 +11,7 @@
         "display": "LINE",
         "title": "Queue depth (visible vs total)",
         "description": "Visible depth excludes messages whose VT hasn't expired. A divergence between the two means workers are slow but the queue isn't growing.",
-        "line_label": "%hostname% - %queue%",
+        "line_label": "%name% - %queue%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -25,10 +25,6 @@
             "tags": [
               {
                 "key": "queue",
-                "value": "*"
-              },
-              {
-                "key": "hostname",
                 "value": "*"
               }
             ]
@@ -44,10 +40,6 @@
               {
                 "key": "queue",
                 "value": "*"
-              },
-              {
-                "key": "hostname",
-                "value": "*"
               }
             ]
           }
@@ -58,7 +50,7 @@
         "display": "LINE",
         "title": "Queue latency",
         "description": "Age of the oldest message per queue (milliseconds). High latency means consumers can't keep up.",
-        "line_label": "%hostname% - %queue%",
+        "line_label": "%queue%",
         "format": "duration",
         "draw_null_as_zero": true,
         "metrics": [
@@ -73,10 +65,6 @@
               {
                 "key": "queue",
                 "value": "*"
-              },
-              {
-                "key": "hostname",
-                "value": "*"
               }
             ]
           }
@@ -87,7 +75,7 @@
         "display": "LINE",
         "title": "DLQ depth + failed events",
         "description": "Messages that exceeded max_retries plus the failed-events table. Spikes after a deploy point at a regression.",
-        "line_label": "%hostname%",
+        "line_label": "%name%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -98,12 +86,7 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           },
           {
             "name": "pgbus_failed_events_total",
@@ -112,12 +95,7 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       },
@@ -157,7 +135,7 @@
         "type": "timeseries",
         "display": "LINE",
         "title": "Active processes",
-        "description": "Workers + dispatcher + scheduler currently heartbeating into pgbus_processes.",
+        "description": "Workers + dispatcher + scheduler currently heartbeating, scoped per host.",
         "line_label": "%hostname%",
         "format": "number",
         "draw_null_as_zero": true,
@@ -183,7 +161,7 @@
         "display": "LINE",
         "title": "Dead tuples in queue/archive tables",
         "description": "If autovacuum can't keep up the index gets bloated and lock acquisition slows. Tune autovacuum_vacuum_scale_factor on the offending tables when this climbs.",
-        "line_label": "%hostname%",
+        "line_label": "Dead tuples",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -194,12 +172,7 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       },
@@ -208,7 +181,7 @@
         "display": "LINE",
         "title": "Oldest open transaction (seconds)",
         "description": "MVCC horizon pin. Long-running transactions prevent VACUUM from cleaning the dead tuples above. Anything over 60s is a smell.",
-        "line_label": "%hostname%",
+        "line_label": "Oldest transaction",
         "format": "duration",
         "draw_null_as_zero": true,
         "metrics": [
@@ -219,12 +192,7 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       },

--- a/lib/pgbus/integrations/appsignal/dashboards/pgbus_health.json
+++ b/lib/pgbus/integrations/appsignal/dashboards/pgbus_health.json
@@ -1,87 +1,258 @@
 {
-  "title": "Pgbus — Health",
-  "description": "Backlog, dead-letter activity, dead-tuple growth, and MVCC horizon. The 'should I page someone?' dashboard.",
-  "graphs": [
-    {
-      "title": "Queue depth (visible vs total)",
-      "description": "Visible depth excludes messages whose VT hasn't expired. A divergence between the two means workers are slow but the queue isn't growing.",
-      "line_label": "%queue",
-      "format": "number",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_queue_depth", "fields": ["GAUGE"], "tags": [] },
-        { "name": "pgbus_queue_visible_depth", "fields": ["GAUGE"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Oldest message age (seconds)",
-      "description": "Per-queue head-of-line waiting time. If this climbs while queue depth stays flat, a single poison message is stuck in the VT loop.",
-      "line_label": "%queue",
-      "format": "duration",
-      "format_input": "second",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_queue_oldest_message_age_seconds", "fields": ["GAUGE"], "tags": [] }
-      ]
-    },
-    {
-      "title": "DLQ depth + failed events",
-      "description": "Messages that exceeded max_retries plus the failed-events table. Spikes after a deploy point at a regression.",
-      "format": "number",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_dlq_depth", "fields": ["GAUGE"], "tags": [] },
-        { "name": "pgbus_failed_events_total", "fields": ["GAUGE"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Dead-lettered jobs per minute",
-      "line_label": "%queue %job_class",
-      "format": "number",
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_queue_job_count", "fields": ["COUNTER"], "tags": [{ "key": "status", "value": "dead_lettered" }] }
-      ]
-    },
-    {
-      "title": "Active processes",
-      "description": "Workers + dispatcher + scheduler currently heartbeating into pgbus_processes.",
-      "format": "number",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_active_processes", "fields": ["GAUGE"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Dead tuples in queue/archive tables",
-      "description": "If autovacuum can't keep up the index gets bloated and lock acquisition slows. Tune autovacuum_vacuum_scale_factor on the offending tables when this climbs.",
-      "format": "number",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_total_dead_tuples", "fields": ["GAUGE"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Oldest open transaction (seconds)",
-      "description": "MVCC horizon pin. Long-running transactions prevent VACUUM from cleaning the dead tuples above. Anything over 60s is a smell.",
-      "format": "duration",
-      "format_input": "second",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_oldest_transaction_age_seconds", "fields": ["GAUGE"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Worker recycles per minute",
-      "description": "Recycles by reason. Steady max_jobs is healthy; spiking max_memory means you have a leak.",
-      "line_label": "%reason",
-      "format": "number",
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_worker_recycled", "fields": ["COUNTER"], "tags": [] }
-      ]
-    }
-  ]
+  "metric_keys": [
+    "pgbus_queue_depth"
+  ],
+  "dashboard": {
+    "title": "Pgbus — Health",
+    "description": "Backlog, dead-letter activity, dead-tuple growth, and MVCC horizon.\nThe 'should I page someone?' dashboard.\n",
+    "visuals": [
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Queue depth (visible vs total)",
+        "description": "Visible depth excludes messages whose VT hasn't expired. A divergence between the two means workers are slow but the queue isn't growing.",
+        "line_label": "%hostname% - %queue%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_depth",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "pgbus_queue_visible_depth",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Queue latency",
+        "description": "Age of the oldest message per queue (milliseconds). High latency means consumers can't keep up.",
+        "line_label": "%hostname% - %queue%",
+        "format": "duration",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_latency",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "DLQ depth + failed events",
+        "description": "Messages that exceeded max_retries plus the failed-events table. Spikes after a deploy point at a regression.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_dlq_depth",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "pgbus_failed_events_total",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Dead-lettered jobs per minute",
+        "line_label": "%queue% - %job_class%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_job_count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "status",
+                "value": "dead_lettered"
+              },
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "job_class",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Active processes",
+        "description": "Workers + dispatcher + scheduler currently heartbeating into pgbus_processes.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_active_processes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Dead tuples in queue/archive tables",
+        "description": "If autovacuum can't keep up the index gets bloated and lock acquisition slows. Tune autovacuum_vacuum_scale_factor on the offending tables when this climbs.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_total_dead_tuples",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Oldest open transaction (seconds)",
+        "description": "MVCC horizon pin. Long-running transactions prevent VACUUM from cleaning the dead tuples above. Anything over 60s is a smell.",
+        "line_label": "%hostname%",
+        "format": "duration",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_oldest_transaction_age_seconds",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Worker recycles per minute",
+        "description": "Recycles by reason. Steady max_jobs is healthy; spiking max_memory means you have a leak.",
+        "line_label": "%reason%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_worker_recycled",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "reason",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/lib/pgbus/integrations/appsignal/dashboards/pgbus_streams.json
+++ b/lib/pgbus/integrations/appsignal/dashboards/pgbus_streams.json
@@ -39,7 +39,7 @@
         "display": "LINE",
         "title": "Active SSE connections",
         "description": "Estimated from connect/disconnect events in the last 60 minutes.",
-        "line_label": "%hostname%",
+        "line_label": "Active connections",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -50,12 +50,7 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       },
@@ -64,7 +59,7 @@
         "display": "LINE",
         "title": "Average fanout per broadcast",
         "description": "Mean number of connections that received each broadcast over the last hour.",
-        "line_label": "%hostname%",
+        "line_label": "Avg fanout",
         "format": "number",
         "draw_null_as_zero": false,
         "metrics": [
@@ -75,12 +70,7 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       },

--- a/lib/pgbus/integrations/appsignal/dashboards/pgbus_streams.json
+++ b/lib/pgbus/integrations/appsignal/dashboards/pgbus_streams.json
@@ -1,65 +1,166 @@
 {
-  "title": "Pgbus — Streams",
-  "description": "Real-time SSE pub/sub. Broadcasts, fanout, active connections, and the outbox/recurring scheduler.",
-  "graphs": [
-    {
-      "title": "Stream broadcasts per minute",
-      "line_label": "%stream %deferred",
-      "format": "number",
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_stream_broadcast_count", "fields": ["COUNTER"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Active SSE connections",
-      "description": "Estimated from connect/disconnect events in the last 60 minutes. Use as a rough capacity gauge — exact count requires the SSE process telemetry.",
-      "format": "number",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_stream_active_connections", "fields": ["GAUGE"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Average fanout per broadcast",
-      "description": "Mean number of connections that received each broadcast over the last hour.",
-      "format": "number",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_stream_avg_fanout", "fields": ["GAUGE"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Broadcast payload size (bytes)",
-      "description": "Distribution of payload bytes. Use to spot accidentally-streaming-an-entire-page bugs.",
-      "line_label": "%stream",
-      "format": "size",
-      "format_input": "byte",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_stream_broadcast_bytes", "fields": ["MEAN", "P95"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Outbox publishes per minute",
-      "line_label": "%kind",
-      "format": "number",
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_outbox_published", "fields": ["COUNTER"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Recurring tasks enqueued per minute",
-      "line_label": "%task",
-      "format": "number",
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_recurring_enqueued", "fields": ["COUNTER"], "tags": [] }
-      ]
-    }
-  ]
+  "metric_keys": [
+    "pgbus_stream_broadcast_count"
+  ],
+  "dashboard": {
+    "title": "Pgbus — Streams",
+    "description": "Real-time SSE pub/sub. Broadcasts, fanout, active connections,\nand the outbox/recurring scheduler.\n",
+    "visuals": [
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Stream broadcasts per minute",
+        "line_label": "%stream% - %deferred%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_stream_broadcast_count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "stream",
+                "value": "*"
+              },
+              {
+                "key": "deferred",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Active SSE connections",
+        "description": "Estimated from connect/disconnect events in the last 60 minutes.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_stream_active_connections",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Average fanout per broadcast",
+        "description": "Mean number of connections that received each broadcast over the last hour.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "pgbus_stream_avg_fanout",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Broadcast payload size (bytes)",
+        "description": "Distribution of payload bytes. Use to spot accidentally-streaming-an-entire-page bugs.",
+        "line_label": "%stream%",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "pgbus_stream_broadcast_bytes",
+            "fields": [
+              {
+                "field": "MEAN"
+              },
+              {
+                "field": "P95"
+              }
+            ],
+            "tags": [
+              {
+                "key": "stream",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Outbox publishes per minute",
+        "line_label": "%kind%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_outbox_published",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "kind",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Recurring tasks enqueued per minute",
+        "line_label": "%task%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_recurring_enqueued",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "task",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/lib/pgbus/integrations/appsignal/dashboards/pgbus_throughput.json
+++ b/lib/pgbus/integrations/appsignal/dashboards/pgbus_throughput.json
@@ -1,81 +1,217 @@
 {
-  "title": "Pgbus — Throughput & Latency",
-  "description": "Job and event throughput, perform-duration percentiles, and PGMQ send/read counts. Drives the most common 'is the worker keeping up?' question.",
-  "graphs": [
-    {
-      "title": "Jobs processed per minute",
-      "description": "Successful, failed, and dead-lettered jobs. A spike in failed without a spike in processed usually means a deploy regression.",
-      "line_label": "%queue %job_class %status",
-      "format": "number",
-      "format_input": null,
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_queue_job_count", "fields": ["COUNTER"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Job perform duration (ms)",
-      "description": "Distribution of how long perform_now takes per job class. P95 and P99 are the lines to watch.",
-      "line_label": "%job_class",
-      "format": "duration",
-      "format_input": "millisecond",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_job_duration_ms", "fields": ["MEAN", "P95", "P99"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Events processed per minute",
-      "description": "Event-bus handler invocations grouped by routing key.",
-      "line_label": "%routing_key %handler %status",
-      "format": "number",
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_event_count", "fields": ["COUNTER"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Event handler duration (ms)",
-      "line_label": "%handler",
-      "format": "duration",
-      "format_input": "millisecond",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_event_duration_ms", "fields": ["MEAN", "P95", "P99"], "tags": [] }
-      ]
-    },
-    {
-      "title": "PGMQ messages sent (per minute)",
-      "line_label": "%queue",
-      "format": "number",
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_messages_sent", "fields": ["COUNTER"], "tags": [] }
-      ]
-    },
-    {
-      "title": "Send duration (ms)",
-      "line_label": "%queue",
-      "format": "duration",
-      "format_input": "millisecond",
-      "kind": "timeseries",
-      "metrics": [
-        { "name": "pgbus_send_duration_ms", "fields": ["MEAN", "P95", "P99"], "tags": [] }
-      ]
-    },
-    {
-      "title": "PGMQ messages read (per minute)",
-      "description": "Messages fetched from queues by workers. Compare against 'sent' to spot backlog growth.",
-      "line_label": "%queue",
-      "format": "number",
-      "kind": "timeseries",
-      "draw_null_as_zero": true,
-      "metrics": [
-        { "name": "pgbus_messages_read", "fields": ["COUNTER"], "tags": [] }
-      ]
-    }
-  ]
+  "metric_keys": [
+    "pgbus_queue_job_count"
+  ],
+  "dashboard": {
+    "title": "Pgbus — Throughput & Latency",
+    "description": "Job and event throughput, perform-duration percentiles, and PGMQ send/read counts.\nDrives the most common 'is the worker keeping up?' question.\n",
+    "visuals": [
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Jobs processed per minute",
+        "description": "Successful, failed, and dead-lettered jobs. A spike in failed without a spike in processed usually means a deploy regression.",
+        "line_label": "%queue% - %job_class% - %status%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_job_count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "job_class",
+                "value": "*"
+              },
+              {
+                "key": "status",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Job perform duration (ms)",
+        "description": "Distribution of how long perform_now takes per job class. P95 and P99 are the lines to watch.",
+        "line_label": "%job_class%",
+        "format": "duration",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "pgbus_job_duration_ms",
+            "fields": [
+              {
+                "field": "MEAN"
+              },
+              {
+                "field": "P95"
+              },
+              {
+                "field": "P99"
+              }
+            ],
+            "tags": [
+              {
+                "key": "job_class",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Events processed per minute",
+        "description": "Event-bus handler invocations grouped by routing key.",
+        "line_label": "%routing_key% - %handler% - %status%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_event_count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "routing_key",
+                "value": "*"
+              },
+              {
+                "key": "handler",
+                "value": "*"
+              },
+              {
+                "key": "status",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Event handler duration (ms)",
+        "line_label": "%handler%",
+        "format": "duration",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "pgbus_event_duration_ms",
+            "fields": [
+              {
+                "field": "MEAN"
+              },
+              {
+                "field": "P95"
+              },
+              {
+                "field": "P99"
+              }
+            ],
+            "tags": [
+              {
+                "key": "handler",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "PGMQ messages sent (per minute)",
+        "line_label": "%queue%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_messages_sent",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Send duration (ms)",
+        "line_label": "%queue%",
+        "format": "duration",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "pgbus_send_duration_ms",
+            "fields": [
+              {
+                "field": "MEAN"
+              },
+              {
+                "field": "P95"
+              },
+              {
+                "field": "P99"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "PGMQ messages read (per minute)",
+        "description": "Messages fetched from queues by workers. Compare against 'sent' to spot backlog growth.",
+        "line_label": "%queue%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_messages_read",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/lib/pgbus/integrations/appsignal/dashboards/pgbus_throughput.json
+++ b/lib/pgbus/integrations/appsignal/dashboards/pgbus_throughput.json
@@ -1,6 +1,9 @@
 {
   "metric_keys": [
-    "pgbus_queue_job_count"
+    "pgbus_queue_job_count",
+    "pgbus_event_count",
+    "pgbus_messages_sent",
+    "pgbus_messages_read"
   ],
   "dashboard": {
     "title": "Pgbus — Throughput & Latency",

--- a/lib/pgbus/integrations/appsignal/probe.rb
+++ b/lib/pgbus/integrations/appsignal/probe.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "socket"
+
 module Pgbus
   module Integrations
     module Appsignal
@@ -10,6 +12,9 @@ module Pgbus
       # method rescues StandardError and returns a safe default — but we
       # still wrap each section in our own rescue so a probe iteration
       # never raises out into the AppSignal probe runner.
+      #
+      # Every gauge includes a `hostname` tag so AppSignal magic dashboards
+      # can filter per host (matching the Sidekiq/Puma probe convention).
       module Probe
         METRIC_PREFIX = "pgbus_"
         private_constant :METRIC_PREFIX
@@ -43,6 +48,7 @@ module Pgbus
         class Runner
           def initialize(data_source: nil)
             @data_source = data_source
+            @hostname = Socket.gethostname
           end
 
           def call
@@ -63,34 +69,38 @@ module Pgbus
 
           def track_queues
             data_source.queues_with_metrics.each do |q|
-              tags = { queue: q[:name] }
+              tags = { queue: q[:name], hostname: @hostname }
               gauge "queue_depth", q[:queue_length], tags
               gauge "queue_visible_depth", q[:queue_visible_length], tags
               gauge "queue_paused", q[:paused] ? 1 : 0, tags
               age = q[:oldest_msg_age_sec]
-              gauge "queue_oldest_message_age_seconds", age, tags if age
+              if age
+                gauge "queue_oldest_message_age_seconds", age, tags
+                gauge "queue_latency", age * 1_000, tags
+              end
             end
           rescue StandardError => e
             log_failure("queue metrics", e)
           end
 
           def track_processes
-            gauge "active_processes", data_source.processes.count
+            gauge "active_processes", data_source.processes.count, { hostname: @hostname }
           rescue StandardError => e
             log_failure("process metrics", e)
           end
 
           def track_summary
             stats = data_source.summary_stats
-            gauge "total_queues", stats[:total_queues]
-            gauge "total_depth", stats[:total_depth]
-            gauge "total_visible", stats[:total_visible]
-            gauge "dlq_depth", stats[:dlq_depth]
-            gauge "failed_events_total", stats[:failed_count]
-            gauge "throughput_rate", stats[:throughput_rate]
-            gauge "total_dead_tuples", stats[:total_dead_tuples]
-            gauge "tables_needing_vacuum", stats[:tables_needing_vacuum]
-            gauge "oldest_transaction_age_seconds", stats[:oldest_transaction_age_sec]
+            host = { hostname: @hostname }
+            gauge "total_queues", stats[:total_queues], host
+            gauge "total_depth", stats[:total_depth], host
+            gauge "total_visible", stats[:total_visible], host
+            gauge "dlq_depth", stats[:dlq_depth], host
+            gauge "failed_events_total", stats[:failed_count], host
+            gauge "throughput_rate", stats[:throughput_rate], host
+            gauge "total_dead_tuples", stats[:total_dead_tuples], host
+            gauge "tables_needing_vacuum", stats[:tables_needing_vacuum], host
+            gauge "oldest_transaction_age_seconds", stats[:oldest_transaction_age_sec], host
           rescue StandardError => e
             log_failure("summary metrics", e)
           end
@@ -100,12 +110,13 @@ module Pgbus
                           data_source.stream_stats_available?
 
             summary = data_source.stream_stats_summary
-            gauge "stream_broadcasts_60m", summary[:broadcasts]
-            gauge "stream_connects_60m", summary[:connects]
-            gauge "stream_disconnects_60m", summary[:disconnects]
-            gauge "stream_active_connections", summary[:active_estimate]
-            gauge "stream_avg_fanout", summary[:avg_fanout]
-            gauge "stream_avg_broadcast_ms", summary[:avg_broadcast_ms]
+            host = { hostname: @hostname }
+            gauge "stream_broadcasts_60m", summary[:broadcasts], host
+            gauge "stream_connects_60m", summary[:connects], host
+            gauge "stream_disconnects_60m", summary[:disconnects], host
+            gauge "stream_active_connections", summary[:active_estimate], host
+            gauge "stream_avg_fanout", summary[:avg_fanout], host
+            gauge "stream_avg_broadcast_ms", summary[:avg_broadcast_ms], host
           rescue StandardError => e
             log_failure("stream metrics", e)
           end

--- a/lib/pgbus/integrations/appsignal/probe.rb
+++ b/lib/pgbus/integrations/appsignal/probe.rb
@@ -13,8 +13,13 @@ module Pgbus
       # still wrap each section in our own rescue so a probe iteration
       # never raises out into the AppSignal probe runner.
       #
-      # Every gauge includes a `hostname` tag so AppSignal magic dashboards
-      # can filter per host (matching the Sidekiq/Puma probe convention).
+      # Tagging policy: most pgbus metrics are cluster-wide (the queue
+      # depth in PostgreSQL is the same regardless of which host reads it),
+      # so cluster-wide gauges are emitted WITHOUT a hostname tag — every
+      # host sends the same value and AppSignal's last-write-wins
+      # semantics keep the dashboard correct. The only gauge that is
+      # genuinely per-host is `active_processes`, which the probe filters
+      # to this host before tagging.
       module Probe
         METRIC_PREFIX = "pgbus_"
         private_constant :METRIC_PREFIX
@@ -69,7 +74,7 @@ module Pgbus
 
           def track_queues
             data_source.queues_with_metrics.each do |q|
-              tags = { queue: q[:name], hostname: @hostname }
+              tags = { queue: q[:name] }
               gauge "queue_depth", q[:queue_length], tags
               gauge "queue_visible_depth", q[:queue_visible_length], tags
               gauge "queue_paused", q[:paused] ? 1 : 0, tags
@@ -84,23 +89,23 @@ module Pgbus
           end
 
           def track_processes
-            gauge "active_processes", data_source.processes.count, { hostname: @hostname }
+            local_count = data_source.processes.count { |p| p[:hostname] == @hostname }
+            gauge "active_processes", local_count, { hostname: @hostname }
           rescue StandardError => e
             log_failure("process metrics", e)
           end
 
           def track_summary
             stats = data_source.summary_stats
-            host = { hostname: @hostname }
-            gauge "total_queues", stats[:total_queues], host
-            gauge "total_depth", stats[:total_depth], host
-            gauge "total_visible", stats[:total_visible], host
-            gauge "dlq_depth", stats[:dlq_depth], host
-            gauge "failed_events_total", stats[:failed_count], host
-            gauge "throughput_rate", stats[:throughput_rate], host
-            gauge "total_dead_tuples", stats[:total_dead_tuples], host
-            gauge "tables_needing_vacuum", stats[:tables_needing_vacuum], host
-            gauge "oldest_transaction_age_seconds", stats[:oldest_transaction_age_sec], host
+            gauge "total_queues", stats[:total_queues]
+            gauge "total_depth", stats[:total_depth]
+            gauge "total_visible", stats[:total_visible]
+            gauge "dlq_depth", stats[:dlq_depth]
+            gauge "failed_events_total", stats[:failed_count]
+            gauge "throughput_rate", stats[:throughput_rate]
+            gauge "total_dead_tuples", stats[:total_dead_tuples]
+            gauge "tables_needing_vacuum", stats[:tables_needing_vacuum]
+            gauge "oldest_transaction_age_seconds", stats[:oldest_transaction_age_sec]
           rescue StandardError => e
             log_failure("summary metrics", e)
           end
@@ -110,13 +115,12 @@ module Pgbus
                           data_source.stream_stats_available?
 
             summary = data_source.stream_stats_summary
-            host = { hostname: @hostname }
-            gauge "stream_broadcasts_60m", summary[:broadcasts], host
-            gauge "stream_connects_60m", summary[:connects], host
-            gauge "stream_disconnects_60m", summary[:disconnects], host
-            gauge "stream_active_connections", summary[:active_estimate], host
-            gauge "stream_avg_fanout", summary[:avg_fanout], host
-            gauge "stream_avg_broadcast_ms", summary[:avg_broadcast_ms], host
+            gauge "stream_broadcasts_60m", summary[:broadcasts]
+            gauge "stream_connects_60m", summary[:connects]
+            gauge "stream_disconnects_60m", summary[:disconnects]
+            gauge "stream_active_connections", summary[:active_estimate]
+            gauge "stream_avg_fanout", summary[:avg_fanout]
+            gauge "stream_avg_broadcast_ms", summary[:avg_broadcast_ms]
           rescue StandardError => e
             log_failure("stream metrics", e)
           end

--- a/spec/pgbus/integrations/appsignal/dashboard_spec.rb
+++ b/spec/pgbus/integrations/appsignal/dashboard_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+
+RSpec.describe "Pgbus::Integrations::Appsignal dashboard" do
+  let(:dashboard_path) do
+    File.expand_path("../../../../lib/pgbus/integrations/appsignal/dashboard.json", __dir__)
+  end
+
+  let(:dashboard_json) { JSON.parse(File.read(dashboard_path)) }
+
+  it "exists as a file" do
+    expect(File.exist?(dashboard_path)).to be(true), "dashboard.json not found at #{dashboard_path}"
+  end
+
+  it "has a metric_keys array with at least one key" do
+    expect(dashboard_json["metric_keys"]).to be_an(Array)
+    expect(dashboard_json["metric_keys"]).not_to be_empty
+  end
+
+  it "has a dashboard object with title and description" do
+    dashboard = dashboard_json["dashboard"]
+    expect(dashboard["title"]).to eq("Pgbus")
+    expect(dashboard["description"]).to be_a(String)
+    expect(dashboard["description"].length).to be > 10
+  end
+
+  it "defines visuals as an array of timeseries charts" do
+    visuals = dashboard_json["dashboard"]["visuals"]
+    expect(visuals).to be_an(Array)
+    expect(visuals.length).to be >= 6
+
+    expect(visuals).to all(include("type" => "timeseries"))
+    expect(visuals).to all(include("title" => a_kind_of(String)))
+    expect(visuals).to all(include("metrics" => a_kind_of(Array)))
+  end
+
+  it "only references metrics with the pgbus_ prefix or transaction_duration" do
+    visuals = dashboard_json["dashboard"]["visuals"]
+    metric_names = visuals.flat_map { |v| v["metrics"].map { |m| m["name"] } }.uniq
+
+    expect(metric_names).to all(match(/\A(pgbus_|transaction_duration)/))
+  end
+
+  it "uses valid field types" do
+    valid_fields = %w[gauge counter mean count p90 p95 GAUGE COUNTER MEAN COUNT P90 P95]
+    visuals = dashboard_json["dashboard"]["visuals"]
+    all_fields = visuals.flat_map { |v| v["metrics"].flat_map { |m| m["fields"].map { |f| f["field"] } } }
+
+    expect(all_fields).to all(be_in(valid_fields))
+  end
+
+  it "uses valid format types" do
+    valid_formats = %w[number duration size throughput percent]
+    formats = dashboard_json["dashboard"]["visuals"].map { |v| v["format"] }
+
+    expect(formats).to all(be_in(valid_formats))
+  end
+
+  it "includes essential dashboard panels" do
+    titles = dashboard_json["dashboard"]["visuals"].map { |v| v["title"] }
+
+    expect(titles).to include(
+      a_string_matching(/job.*status/i),
+      a_string_matching(/queue.*depth|queue.*length/i),
+      a_string_matching(/throughput/i),
+      a_string_matching(/duration/i),
+      a_string_matching(/dead.letter|dlq/i),
+      a_string_matching(/worker|process/i)
+    )
+  end
+
+  it "uses metric_keys that match actual probe or subscriber metric names" do
+    keys = dashboard_json["metric_keys"]
+    all_metric_names = dashboard_json["dashboard"]["visuals"]
+                       .flat_map { |v| v["metrics"].map { |m| m["name"] } }.uniq
+
+    expect(keys).to all(be_in(all_metric_names))
+  end
+end

--- a/spec/pgbus/integrations/appsignal/probe_spec.rb
+++ b/spec/pgbus/integrations/appsignal/probe_spec.rb
@@ -26,7 +26,12 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
       end
 
       def processes
-        [{ pid: 1 }, { pid: 2 }]
+        host = Socket.gethostname
+        [
+          { pid: 1, hostname: host },
+          { pid: 2, hostname: host },
+          { pid: 3, hostname: "other.example.com" }
+        ]
       end
 
       def summary_stats
@@ -66,7 +71,7 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
     require "pgbus/integrations/appsignal/probe"
   end
 
-  it "records queue depth gauges per queue with hostname tag" do
+  it "records queue depth gauges per queue without a hostname tag" do
     runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
     runner.call
 
@@ -79,17 +84,17 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
     )
 
     depth_gauge = appsignal_class.gauges.find { |g| g[0] == "pgbus_queue_depth" && g[2][:queue] == "pgbus_default" }
-    expect(depth_gauge[2]).to include(hostname: Socket.gethostname)
+    expect(depth_gauge[2]).to eq(queue: "pgbus_default")
   end
 
-  it "records queue latency gauge per queue" do
+  it "records queue latency gauge per queue without a hostname tag" do
     runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
     runner.call
 
     latency = appsignal_class.gauges.find { |g| g[0] == "pgbus_queue_latency" && g[2][:queue] == "pgbus_default" }
     expect(latency).not_to be_nil
     expect(latency[1]).to eq(5000.0)
-    expect(latency[2]).to include(hostname: Socket.gethostname)
+    expect(latency[2]).to eq(queue: "pgbus_default")
   end
 
   it "skips queue latency when oldest_msg_age_sec is nil" do
@@ -100,16 +105,16 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
     expect(critical_latency).to be_nil
   end
 
-  it "records process count with hostname tag" do
+  it "records active_processes scoped to the current host with hostname tag" do
     runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
     runner.call
 
     process_gauge = appsignal_class.gauges.find { |g| g[0] == "pgbus_active_processes" }
-    expect(process_gauge[1]).to eq(2)
-    expect(process_gauge[2]).to include(hostname: Socket.gethostname)
+    expect(process_gauge[1]).to eq(2) # 2 local + 1 remote in the fake source
+    expect(process_gauge[2]).to eq(hostname: Socket.gethostname)
   end
 
-  it "records summary gauges with hostname tag" do
+  it "records summary gauges without a hostname tag" do
     runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
     runner.call
 
@@ -122,10 +127,10 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
     )
 
     dlq_gauge = appsignal_class.gauges.find { |g| g[0] == "pgbus_dlq_depth" }
-    expect(dlq_gauge[2]).to include(hostname: Socket.gethostname)
+    expect(dlq_gauge[2]).to eq({})
   end
 
-  it "records stream gauges when stream stats are available" do
+  it "records stream gauges without a hostname tag" do
     runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
     runner.call
 
@@ -133,7 +138,7 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
     expect(names).to include("pgbus_stream_active_connections", "pgbus_stream_avg_fanout")
 
     stream_gauge = appsignal_class.gauges.find { |g| g[0] == "pgbus_stream_active_connections" }
-    expect(stream_gauge[2]).to include(hostname: Socket.gethostname)
+    expect(stream_gauge[2]).to eq({})
   end
 
   it "skips stream gauges when stream stats are unavailable" do

--- a/spec/pgbus/integrations/appsignal/probe_spec.rb
+++ b/spec/pgbus/integrations/appsignal/probe_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
     require "pgbus/integrations/appsignal/probe"
   end
 
-  it "records queue depth gauges per queue" do
+  it "records queue depth gauges per queue with hostname tag" do
     runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
     runner.call
 
@@ -77,16 +77,39 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
       "pgbus_queue_paused",
       "pgbus_queue_oldest_message_age_seconds"
     )
+
+    depth_gauge = appsignal_class.gauges.find { |g| g[0] == "pgbus_queue_depth" && g[2][:queue] == "pgbus_default" }
+    expect(depth_gauge[2]).to include(hostname: Socket.gethostname)
   end
 
-  it "records process count" do
+  it "records queue latency gauge per queue" do
     runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
     runner.call
 
-    expect(appsignal_class.gauges).to include(["pgbus_active_processes", 2, {}])
+    latency = appsignal_class.gauges.find { |g| g[0] == "pgbus_queue_latency" && g[2][:queue] == "pgbus_default" }
+    expect(latency).not_to be_nil
+    expect(latency[1]).to eq(5000.0)
+    expect(latency[2]).to include(hostname: Socket.gethostname)
   end
 
-  it "records summary gauges" do
+  it "skips queue latency when oldest_msg_age_sec is nil" do
+    runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
+    runner.call
+
+    critical_latency = appsignal_class.gauges.find { |g| g[0] == "pgbus_queue_latency" && g[2][:queue] == "pgbus_critical" }
+    expect(critical_latency).to be_nil
+  end
+
+  it "records process count with hostname tag" do
+    runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
+    runner.call
+
+    process_gauge = appsignal_class.gauges.find { |g| g[0] == "pgbus_active_processes" }
+    expect(process_gauge[1]).to eq(2)
+    expect(process_gauge[2]).to include(hostname: Socket.gethostname)
+  end
+
+  it "records summary gauges with hostname tag" do
     runner = Pgbus::Integrations::Appsignal::Probe::Runner.new(data_source: fake_data_source)
     runner.call
 
@@ -97,6 +120,9 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
       "pgbus_total_dead_tuples",
       "pgbus_oldest_transaction_age_seconds"
     )
+
+    dlq_gauge = appsignal_class.gauges.find { |g| g[0] == "pgbus_dlq_depth" }
+    expect(dlq_gauge[2]).to include(hostname: Socket.gethostname)
   end
 
   it "records stream gauges when stream stats are available" do
@@ -105,6 +131,9 @@ RSpec.describe "Pgbus::Integrations::Appsignal::Probe" do
 
     names = appsignal_class.gauges.map(&:first)
     expect(names).to include("pgbus_stream_active_connections", "pgbus_stream_avg_fanout")
+
+    stream_gauge = appsignal_class.gauges.find { |g| g[0] == "pgbus_stream_active_connections" }
+    expect(stream_gauge[2]).to include(hostname: Socket.gethostname)
   end
 
   it "skips stream gauges when stream stats are unavailable" do

--- a/spec/pgbus/integrations/appsignal_spec.rb
+++ b/spec/pgbus/integrations/appsignal_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe "Pgbus::Integrations::Appsignal" do
       "Pgbus — Streams"
     )
 
+    throughput = definitions.find { |d| d["dashboard"]["title"] == "Pgbus — Throughput & Latency" }
+    expect(throughput["metric_keys"]).to include(
+      "pgbus_queue_job_count",
+      "pgbus_event_count",
+      "pgbus_messages_sent",
+      "pgbus_messages_read"
+    )
+
     definitions.each do |d|
       expect(d["metric_keys"]).to be_an(Array)
       expect(d["dashboard"]["visuals"]).to be_an(Array)

--- a/spec/pgbus/integrations/appsignal_spec.rb
+++ b/spec/pgbus/integrations/appsignal_spec.rb
@@ -107,4 +107,29 @@ RSpec.describe "Pgbus::Integrations::Appsignal" do
     expect(Pgbus::Integrations::Appsignal.install!).to be(false)
     expect(Pgbus::Integrations::Appsignal.installed?).to be(false)
   end
+
+  it "exposes the dashboard definition as a Hash" do
+    definition = Pgbus::Integrations::Appsignal.dashboard_definition
+    expect(definition).to be_a(Hash)
+    expect(definition["metric_keys"]).to include("pgbus_queue_job_count")
+    expect(definition["dashboard"]["title"]).to eq("Pgbus")
+  end
+
+  it "exposes all dashboard definitions from the dashboards directory" do
+    definitions = Pgbus::Integrations::Appsignal.dashboard_definitions
+    expect(definitions).to be_an(Array)
+    expect(definitions.length).to eq(3)
+
+    titles = definitions.map { |d| d["dashboard"]["title"] }
+    expect(titles).to include(
+      "Pgbus — Health",
+      "Pgbus — Throughput & Latency",
+      "Pgbus — Streams"
+    )
+
+    definitions.each do |d|
+      expect(d["metric_keys"]).to be_an(Array)
+      expect(d["dashboard"]["visuals"]).to be_an(Array)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add AppSignal magic dashboard definitions (main + 3 supplementary) in the `public_config` JSON format so AppSignal auto-creates dashboards when pgbus metrics are detected
- Add `hostname` tag to all probe gauges (matching Sidekiq/Puma convention for per-host filtering)
- Add `pgbus_queue_latency` gauge metric (oldest message age in ms) for queue latency monitoring
- Convert existing supplementary dashboard files from custom format to AppSignal `public_config` format with proper `metric_keys`, `visuals`, and tag filters
- Expose `dashboard_definition` and `dashboard_definitions` methods on `Pgbus::Integrations::Appsignal` for programmatic access

### Dashboard panels provided

**Main dashboard (Pgbus):** Job status, throughput, duration, queue depth, queue latency, DLQ, workers, messages sent/read, event handlers, worker recycling, database health, stream broadcasts

**Pgbus — Health:** Queue depth, latency, DLQ + failed events, dead-lettered jobs, active processes, dead tuples, oldest transaction, worker recycles

**Pgbus — Throughput & Latency:** Jobs per minute, job duration (P95/P99), events per minute, event duration, messages sent/read, send duration

**Pgbus — Streams:** Stream broadcasts, active SSE connections, fanout, payload size, outbox publishes, recurring tasks

### Next step

Open a PR to [appsignal/public_config](https://github.com/appsignal/public_config) adding `dashboards/pgbus/main.json` so dashboards appear automatically for all pgbus users.

## Test plan

- [x] All 36 AppSignal integration specs pass (probe, subscriber, dashboard, top-level)
- [x] Full unit test suite passes (2248 examples, 0 failures)
- [x] RuboCop clean on all changed files
- [x] Probe gauges include `hostname` tag
- [x] `pgbus_queue_latency` gauge emitted for queues with messages
- [x] Dashboard JSON files validate (correct structure, valid field types, pgbus_ prefix)
- [ ] Deploy to staging and verify dashboards appear in AppSignal UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AppSignal dashboard definitions for Pgbus Health, Throughput & Latency, and Streams.
  * Expanded monitoring views with clearer charts for queue depth, latency, throughput, worker activity, database health, and stream activity.

* **Bug Fixes**
  * Metrics now include host-level tagging, improving filtering and drill-down by machine.
  * Queue latency reporting now appears alongside queue age for better visibility.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->