### PR TITLE
feat(web): filter sensitive data in dashboard payload display

### DIFF
--- a/app/helpers/pgbus/application_helper.rb
+++ b/app/helpers/pgbus/application_helper.rb
@@ -109,11 +109,12 @@ module Pgbus
     def pgbus_parse_message(message)
       return {} unless message
 
-      case message
-      when Hash then message
-      when String then JSON.parse(message)
-      else {}
-      end
+      parsed = case message
+               when Hash then message
+               when String then JSON.parse(message)
+               else {}
+               end
+      Pgbus::Web::PayloadFilter.filter(parsed)
     rescue JSON::ParserError
       {}
     end
@@ -121,7 +122,8 @@ module Pgbus
     def pgbus_json_preview(json_string, max_length: 120)
       return "—" unless json_string
 
-      text = json_string.is_a?(String) ? json_string : JSON.generate(json_string)
+      filtered = Pgbus::Web::PayloadFilter.filter_json(json_string)
+      text = filtered.is_a?(String) ? filtered : JSON.generate(filtered)
       text.length > max_length ? "#{text[0...max_length]}..." : text
     end
 

--- a/app/views/pgbus/jobs/show.html.erb
+++ b/app/views/pgbus/jobs/show.html.erb
@@ -40,7 +40,7 @@
 
   <div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700 p-6 mb-6">
     <h2 class="text-sm font-medium text-gray-500 mb-2"><%= t("pgbus.jobs.show.payload") %></h2>
-    <pre class="text-xs text-gray-600 bg-gray-50 dark:bg-gray-900 rounded p-4 overflow-x-auto"><%= JSON.pretty_generate(JSON.parse(@job["payload"])) rescue @job["payload"] %></pre>
+    <pre class="text-xs text-gray-600 bg-gray-50 dark:bg-gray-900 rounded p-4 overflow-x-auto"><%= JSON.pretty_generate(pgbus_parse_message(@job["payload"])) rescue @job["payload"] %></pre>
   </div>
 
   <div class="flex space-x-2">

--- a/app/views/pgbus/jobs/show.html.erb
+++ b/app/views/pgbus/jobs/show.html.erb
@@ -40,7 +40,7 @@
 
   <div class="rounded-lg bg-white dark:bg-gray-800 shadow ring-1 ring-gray-200 dark:ring-gray-700 p-6 mb-6">
     <h2 class="text-sm font-medium text-gray-500 mb-2"><%= t("pgbus.jobs.show.payload") %></h2>
-    <pre class="text-xs text-gray-600 bg-gray-50 dark:bg-gray-900 rounded p-4 overflow-x-auto"><%= JSON.pretty_generate(pgbus_parse_message(@job["payload"])) rescue @job["payload"] %></pre>
+    <pre class="text-xs text-gray-600 bg-gray-50 dark:bg-gray-900 rounded p-4 overflow-x-auto"><%= JSON.pretty_generate(pgbus_parse_message(@job["payload"])) %></pre>
   </div>
 
   <div class="flex space-x-2">

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -109,7 +109,8 @@ module Pgbus
     # Web dashboard
     attr_accessor :web_auth, :web_refresh_interval, :web_per_page, :web_live_updates, :web_data_source,
                   :insights_default_minutes, :base_controller_class, :return_to_app_url,
-                  :metrics_enabled
+                  :metrics_enabled,
+                  :dashboard_filter_parameters, :dashboard_filter_sensitive
 
     # Streams (turbo-rails replacement, SSE-based)
     attr_accessor :streams_enabled, :streams_path, :streams_queue_prefix, :streams_signed_name_secret,
@@ -220,6 +221,8 @@ module Pgbus
       @base_controller_class = "::ActionController::Base"
       @return_to_app_url = nil
       @metrics_enabled = true
+      @dashboard_filter_parameters = nil # nil = auto-detect from Rails, then fall back to defaults
+      @dashboard_filter_sensitive = true
 
       @streams_enabled = true
       @streams_path = nil

--- a/lib/pgbus/web/payload_filter.rb
+++ b/lib/pgbus/web/payload_filter.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Pgbus
+  module Web
+    module PayloadFilter
+      module_function
+
+      DEFAULT_FILTER_PATTERNS = [
+        :password, :passphrase, :secret, :token, :authorization,
+        :api_key, :private_key, :access_key, :secret_key,
+        /(_|-)key$/
+      ].freeze
+
+      FILTERED = "[FILTERED]"
+
+      def filter(value)
+        return value unless Pgbus.configuration.dashboard_filter_sensitive
+
+        case value
+        when Hash
+          parameter_filter.filter(value)
+        when Array
+          value.map { |element| filter(element) }
+        else
+          value
+        end
+      end
+
+      def filter_json(value)
+        return value unless Pgbus.configuration.dashboard_filter_sensitive
+
+        case value
+        when nil then nil
+        when Hash
+          JSON.generate(filter(value))
+        when String
+          parsed = JSON.parse(value)
+          JSON.generate(filter(parsed))
+        else
+          value
+        end
+      rescue JSON::ParserError
+        value
+      end
+
+      def parameter_filter
+        patterns = Pgbus.configuration.dashboard_filter_parameters ||
+                   rails_filter_parameters ||
+                   DEFAULT_FILTER_PATTERNS
+        ActiveSupport::ParameterFilter.new(patterns)
+      end
+
+      def rails_filter_parameters
+        return unless defined?(Rails) &&
+                      Rails.respond_to?(:application) &&
+                      Rails.application.respond_to?(:config) &&
+                      Rails.application.config.respond_to?(:filter_parameters)
+
+        params = Rails.application.config.filter_parameters
+        params if params.is_a?(Array) && params.any?
+      end
+
+      private_class_method :parameter_filter, :rails_filter_parameters
+    end
+  end
+end

--- a/lib/pgbus/web/payload_filter.rb
+++ b/lib/pgbus/web/payload_filter.rb
@@ -33,7 +33,7 @@ module Pgbus
 
         case value
         when nil then nil
-        when Hash
+        when Hash, Array
           JSON.generate(filter(value))
         when String
           parsed = JSON.parse(value)

--- a/spec/pgbus/helpers/application_helper_spec.rb
+++ b/spec/pgbus/helpers/application_helper_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 
 require_relative "../../../app/helpers/pgbus/application_helper"
+require_relative "../../../lib/pgbus/web/payload_filter"
 
 RSpec.describe Pgbus::ApplicationHelper do
   let(:helper) { Class.new { include Pgbus::ApplicationHelper }.new }
@@ -165,6 +166,59 @@ RSpec.describe Pgbus::ApplicationHelper do
 
     it "passes short strings through" do
       expect(helper.pgbus_json_preview("short")).to eq("short")
+    end
+
+    it "filters sensitive keys in JSON string input" do
+      json = '{"password":"s3cret","name":"Alice"}'
+      result = helper.pgbus_json_preview(json)
+      expect(result).to include("[FILTERED]")
+      expect(result).not_to include("s3cret")
+      expect(result).to include("Alice")
+    end
+
+    it "filters sensitive keys in Hash input" do
+      hash = { "password" => "s3cret", "name" => "Alice" }
+      result = helper.pgbus_json_preview(hash)
+      expect(result).to include("[FILTERED]")
+      expect(result).not_to include("s3cret")
+    end
+  end
+
+  describe "#pgbus_parse_message (filtering)" do
+    it "filters sensitive keys in parsed hash" do
+      message = '{"job_class":"MyJob","arguments":[{"password":"s3cret","user":"alice"}]}'
+      result = helper.pgbus_parse_message(message)
+
+      expect(result["job_class"]).to eq("MyJob")
+      expect(result["arguments"].first["password"]).to eq("[FILTERED]")
+      expect(result["arguments"].first["user"]).to eq("alice")
+    end
+
+    it "filters sensitive keys in hash input" do
+      message = { "token" => "abc123", "name" => "visible" }
+      result = helper.pgbus_parse_message(message)
+
+      expect(result["token"]).to eq("[FILTERED]")
+      expect(result["name"]).to eq("visible")
+    end
+
+    it "returns {} for nil without filtering" do
+      expect(helper.pgbus_parse_message(nil)).to eq({})
+    end
+
+    it "returns {} for unparseable JSON" do
+      expect(helper.pgbus_parse_message("not json")).to eq({})
+    end
+
+    context "when filtering is disabled" do
+      before { Pgbus.configuration.dashboard_filter_sensitive = false }
+      after { Pgbus.configuration.dashboard_filter_sensitive = true }
+
+      it "does not filter sensitive keys" do
+        message = { "password" => "s3cret" }
+        result = helper.pgbus_parse_message(message)
+        expect(result["password"]).to eq("s3cret")
+      end
     end
   end
 end

--- a/spec/pgbus/web/payload_filter_spec.rb
+++ b/spec/pgbus/web/payload_filter_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Pgbus::Web::PayloadFilter do
       end
 
       it "matches regex patterns" do
-        payload = { "credit_card_number" => "4111111111111111", "amount" => 99 }
+        payload = { "credit_card_number" => "test-card-token", "amount" => 99 }
         result = described_class.filter(payload)
 
         expect(result["credit_card_number"]).to eq("[FILTERED]")
@@ -174,6 +174,16 @@ RSpec.describe Pgbus::Web::PayloadFilter do
       expect(parsed["password"]).to eq("[FILTERED]")
       expect(parsed["name"]).to eq("Alice")
     end
+
+    it "filters top-level array input" do
+      array = [{ "password" => "s3cret", "name" => "Alice" }, { "token" => "abc" }]
+      result = described_class.filter_json(array)
+
+      parsed = JSON.parse(result)
+      expect(parsed[0]["password"]).to eq("[FILTERED]")
+      expect(parsed[0]["name"]).to eq("Alice")
+      expect(parsed[1]["token"]).to eq("[FILTERED]")
+    end
   end
 
   describe "default filter patterns" do
@@ -194,7 +204,8 @@ RSpec.describe Pgbus::Web::PayloadFilter do
   end
 
   describe ".rails_filter_parameters" do
-    it "returns nil when Rails is not defined with filter_parameters" do
+    it "returns nil when Rails constant is absent" do
+      hide_const("Rails") if defined?(Rails)
       expect(described_class.send(:rails_filter_parameters)).to be_nil
     end
   end

--- a/spec/pgbus/web/payload_filter_spec.rb
+++ b/spec/pgbus/web/payload_filter_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "active_support"
+require "active_support/parameter_filter"
+require_relative "../../../lib/pgbus/web/payload_filter"
+
+RSpec.describe Pgbus::Web::PayloadFilter do
+  after do
+    Pgbus.configuration.dashboard_filter_parameters = nil
+    Pgbus.configuration.dashboard_filter_sensitive = true
+  end
+
+  describe ".filter" do
+    context "with default filter patterns" do
+      it "redacts password fields" do
+        payload = { "job_class" => "UserJob", "arguments" => [{ "password" => "s3cret" }] }
+        result = described_class.filter(payload)
+
+        expect(result["arguments"].first["password"]).to eq("[FILTERED]")
+      end
+
+      it "redacts token fields" do
+        payload = { "token" => "abc123", "user_id" => 42 }
+        result = described_class.filter(payload)
+
+        expect(result["token"]).to eq("[FILTERED]")
+        expect(result["user_id"]).to eq(42)
+      end
+
+      it "redacts secret fields" do
+        payload = { "secret" => "mysecret", "name" => "visible" }
+        result = described_class.filter(payload)
+
+        expect(result["secret"]).to eq("[FILTERED]")
+        expect(result["name"]).to eq("visible")
+      end
+
+      it "preserves non-sensitive fields" do
+        payload = { "job_class" => "MyJob", "queue_name" => "default", "job_id" => "abc-123" }
+        result = described_class.filter(payload)
+
+        expect(result).to eq(payload)
+      end
+    end
+
+    context "with nested hashes" do
+      it "filters deeply nested sensitive keys" do
+        payload = {
+          "arguments" => [{
+            "user" => {
+              "name" => "Alice",
+              "credentials" => {
+                "password" => "deep_secret",
+                "api_key" => "key123"
+              }
+            }
+          }]
+        }
+        result = described_class.filter(payload)
+
+        creds = result["arguments"].first["user"]["credentials"]
+        expect(creds["password"]).to eq("[FILTERED]")
+        expect(creds["api_key"]).to eq("[FILTERED]")
+        expect(result["arguments"].first["user"]["name"]).to eq("Alice")
+      end
+    end
+
+    context "with arrays" do
+      it "filters sensitive keys within array elements" do
+        payload = {
+          "arguments" => [
+            { "password" => "one", "name" => "Alice" },
+            { "password" => "two", "name" => "Bob" }
+          ]
+        }
+        result = described_class.filter(payload)
+
+        expect(result["arguments"][0]["password"]).to eq("[FILTERED]")
+        expect(result["arguments"][0]["name"]).to eq("Alice")
+        expect(result["arguments"][1]["password"]).to eq("[FILTERED]")
+        expect(result["arguments"][1]["name"]).to eq("Bob")
+      end
+    end
+
+    context "with symbol keys" do
+      it "filters symbol-keyed hashes" do
+        payload = { password: "s3cret", name: "Alice" }
+        result = described_class.filter(payload)
+
+        expect(result[:password]).to eq("[FILTERED]")
+        expect(result[:name]).to eq("Alice")
+      end
+    end
+
+    context "with non-hash input" do
+      it "returns nil as-is" do
+        expect(described_class.filter(nil)).to be_nil
+      end
+
+      it "returns strings as-is" do
+        expect(described_class.filter("raw string")).to eq("raw string")
+      end
+
+      it "filters hashes within arrays" do
+        payload = [{ "password" => "s3cret" }, "plain"]
+        result = described_class.filter(payload)
+
+        expect(result[0]["password"]).to eq("[FILTERED]")
+        expect(result[1]).to eq("plain")
+      end
+    end
+
+    context "with custom filter patterns" do
+      before do
+        Pgbus.configuration.dashboard_filter_parameters = [:ssn, /credit_card/]
+      end
+
+      it "uses custom patterns" do
+        payload = { "ssn" => "123-45-6789", "name" => "Alice" }
+        result = described_class.filter(payload)
+
+        expect(result["ssn"]).to eq("[FILTERED]")
+        expect(result["name"]).to eq("Alice")
+      end
+
+      it "matches regex patterns" do
+        payload = { "credit_card_number" => "4111111111111111", "amount" => 99 }
+        result = described_class.filter(payload)
+
+        expect(result["credit_card_number"]).to eq("[FILTERED]")
+        expect(result["amount"]).to eq(99)
+      end
+    end
+
+    context "when filtering is disabled" do
+      before do
+        Pgbus.configuration.dashboard_filter_sensitive = false
+      end
+
+      it "returns payload unmodified" do
+        payload = { "password" => "s3cret", "token" => "abc123" }
+        result = described_class.filter(payload)
+
+        expect(result).to eq(payload)
+      end
+    end
+  end
+
+  describe ".filter_json" do
+    it "parses, filters, and re-serializes JSON strings" do
+      json = '{"password":"s3cret","name":"Alice"}'
+      result = described_class.filter_json(json)
+
+      parsed = JSON.parse(result)
+      expect(parsed["password"]).to eq("[FILTERED]")
+      expect(parsed["name"]).to eq("Alice")
+    end
+
+    it "returns non-JSON strings as-is" do
+      expect(described_class.filter_json("not json")).to eq("not json")
+    end
+
+    it "returns nil as-is" do
+      expect(described_class.filter_json(nil)).to be_nil
+    end
+
+    it "handles hash input by filtering and serializing" do
+      hash = { "password" => "s3cret", "name" => "Alice" }
+      result = described_class.filter_json(hash)
+
+      parsed = JSON.parse(result)
+      expect(parsed["password"]).to eq("[FILTERED]")
+      expect(parsed["name"]).to eq("Alice")
+    end
+  end
+
+  describe "default filter patterns" do
+    described_class::DEFAULT_FILTER_PATTERNS.each do |pattern|
+      it "includes #{pattern.inspect} as a default" do
+        expect(described_class::DEFAULT_FILTER_PATTERNS).to include(pattern)
+      end
+    end
+
+    %w[password token secret authorization api_key private_key].each do |sensitive_key|
+      it "filters '#{sensitive_key}' by default" do
+        payload = { sensitive_key => "value" }
+        result = described_class.filter(payload)
+
+        expect(result[sensitive_key]).to eq("[FILTERED]")
+      end
+    end
+  end
+
+  describe ".rails_filter_parameters" do
+    it "returns nil when Rails is not defined with filter_parameters" do
+      expect(described_class.send(:rails_filter_parameters)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Pgbus::Web::PayloadFilter` that wraps `ActiveSupport::ParameterFilter` to redact sensitive keys in dashboard payload displays
- Sensitive field values (password, token, secret, api_key, etc.) show as `[FILTERED]` while all other fields remain fully visible
- Auto-detects filter list from `Rails.application.config.filter_parameters` when available, with sensible built-in defaults
- Configurable via `dashboard_filter_parameters` (custom patterns) and `dashboard_filter_sensitive` (on/off toggle)
- Applied at two display-only chokepoints (`pgbus_parse_message` + `pgbus_json_preview`), so all 9 affected views inherit filtering without per-view changes
- Complements the existing `MCP::Redactor` (envelope-level, all-or-nothing for MCP tools) with key-level filtering for the dashboard

### Design decisions

- **Helper-layer filtering, not DataSource-layer**: DataSource methods are used by operational paths (retry, discard, lock release) that need real payload values. Filtering only in the display helpers avoids corrupting operational data.
- **Edit payload textarea shows `[FILTERED]`**: The events edit form is behind a collapsed `<details>` element. Showing filtered values is safer than creating a separate unfiltered data path. Operators who need to edit payloads with sensitive keys can use the database directly.
- **Separate from `MCP::Redactor`**: Two complementary tools serving different consumers with different granularity requirements — not merged into one.

Closes #186

## Test plan

- [x] 34 unit tests for `Web::PayloadFilter` (key patterns, nested hashes, arrays, regex, disable toggle, JSON round-trip)
- [x] 7 integration tests for helper-level filtering (`pgbus_parse_message`, `pgbus_json_preview`)
- [x] 2262 existing specs pass (0 failures, excluding pre-existing appsignal spec failures on another branch)
- [x] RuboCop clean on all changed files
- [ ] Manual: verify `[FILTERED]` appears in queue detail, DLQ, jobs, events views for payloads containing sensitive keys
- [ ] Manual: verify retry/discard operations still work correctly (no `[FILTERED]` in re-enqueued payloads)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic filtering of sensitive values in dashboard payload previews and parsed message views.
  * Introduced configurable redaction settings with sensible defaults for common secret fields.

* **Bug Fixes**
  * Payload previews now handle JSON strings and structured data more reliably while preserving existing truncation behavior.
  * Message display now safely falls back to the original content if parsing or formatting fails.

* **Tests**
  * Expanded coverage for sensitive-data redaction, nested values, arrays, and disabled filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->