### PR TITLE
chore(claude): tier model pins across commands and add /plan

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -1,6 +1,6 @@
 ---
 description: "Coordinates development across pgbus layers. Use when planning multi-layer features, orchestrating implementation order, or designing new subsystems."
-model: claude-opus-4-6
+model: opus
 argument-hint: "feature or task to coordinate"
 ---
 

--- a/.claude/commands/github-review-comments.md
+++ b/.claude/commands/github-review-comments.md
@@ -1,6 +1,6 @@
 ---
 description: "Use when a PR has unresolved review comments that need responses -- evaluates each comment, implements valid fixes, pushes back on incorrect suggestions, and resolves all threads."
-model: claude-opus-4-6
+model: sonnet
 argument-hint: "PR number (e.g., 123 or #123)"
 allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(git log:*), Bash(git blame:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent
 ---

--- a/.claude/commands/github-review-failures.md
+++ b/.claude/commands/github-review-failures.md
@@ -1,6 +1,6 @@
 ---
 description: "Use when CI checks are failing on a PR — fetches failure logs, diagnoses root causes, implements fixes, and pushes until CI is green."
-model: claude-opus-4-6
+model: sonnet
 argument-hint: "PR number (e.g., 41 or #41)"
 allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(gh run view:*), Bash(git log:*), Bash(git diff:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent
 ---

--- a/.claude/commands/github-review-pr.md
+++ b/.claude/commands/github-review-pr.md
@@ -1,6 +1,6 @@
 ---
 description: "Use when a PR needs full review — fixes CI failures first, then addresses unresolved review comments. Run failures first because comment fixes trigger new CI runs that obscure the original failures."
-model: claude-opus-4-7
+model: opus
 argument-hint: "PR number (e.g., 156 or #156)"
 allowed-tools: Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(gh run view:*), Bash(git log:*), Bash(git blame:*), Bash(git diff:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent
 ---

--- a/.claude/commands/lfg.md
+++ b/.claude/commands/lfg.md
@@ -1,6 +1,6 @@
 ---
 description: "Executes full autonomous engineering workflow with verification. Use when implementing complete features, tackling GitHub issues, or running end-to-end development cycles."
-model: claude-opus-4-6
+model: opus
 argument-hint: "GitHub issue number/URL or feature description"
 allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(bundle exec:*), Bash(git:*), Read, Write, Edit, Glob, Grep, Agent
 ---

--- a/.claude/commands/perf.md
+++ b/.claude/commands/perf.md
@@ -1,5 +1,6 @@
 ---
 description: "Benchmark the current branch against main. Use when a change touches a hot path (client ops, executor, serialization, polling, connection pool) or when asked to measure performance."
+model: sonnet
 argument-hint: "optional: a specific bench name (e.g. client_bench)"
 ---
 

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,78 @@
+---
+description: "Investigates the codebase, designs a solution, and produces a durable plan artifact — a GitHub issue or a plan markdown under docs/plans/. Read-only: never edits application code. Use before /lfg for anything non-trivial."
+model: fable
+argument-hint: "issue <feature or problem> | md <feature or problem> | <feature or problem>"
+allowed-tools: Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh search:*), Bash(gh label list:*), Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(date:*), Read, Grep, Glob, Write, Agent
+---
+
+# Plan — design expensive, execute cheap
+
+You are the planning specialist. This command runs on the most capable model deliberately: the thinking happens here, the execution happens later on cheaper models (`/lfg` on Opus, layer specialists on Sonnet). That split only works if the plan is **self-contained** — an executor with none of this session's context must be able to implement it without guessing.
+
+## Output mode from $ARGUMENTS
+
+| $ARGUMENTS starts with | Artifact |
+|------------------------|----------|
+| `issue` | GitHub issue (default — feeds directly into `/lfg <issue-number>`) |
+| `md` or `file` | Markdown file at `docs/plans/YYYY-MM-DD-<slug>.md` (date from `date +%F`) |
+| anything else | GitHub issue |
+
+## Hard constraints
+
+- **Read-only for source code.** Never edit application code, never commit, never create branches. The only file you may Write is a new plan markdown under `docs/plans/`.
+- **Never reproduce secrets** (keys, tokens, credentials) in the plan, even redacted ones you encounter while reading config.
+- **Dedupe before creating an issue**: `gh issue list --search "<keywords>"` — if an existing issue covers this, extend it in your summary instead of duplicating.
+
+## Phase 1 — Investigate
+
+Protect this session's context: delegate mechanical exploration to cheaper subagents and keep Fable for judgment.
+
+1. Fan out Explore agents (`model: haiku`) for file discovery and naming-convention sweeps; use `model: sonnet` agents when a subsystem needs to be read and summarized. Launch independent explorations in parallel.
+2. Read the load-bearing files yourself — the ones the design decision actually hinges on. Don't design from subagent summaries alone.
+3. Check the architecture layers in `CLAUDE.md` and read the matching source files — past decisions and gotchas live there.
+4. Check `git log` for recent related work; the design should extend it, not fight it.
+
+## Phase 2 — Design
+
+- Develop 2-3 candidate approaches with real tradeoffs. Pick one and say why; record why the others lost.
+- The chosen design must respect project invariants: all PGMQ access through `Pgbus::Client`, queue prefixing via `config.queue_name()`, dead letter routing, visibility timeouts, worker recycling, TDD (specs named before implementation steps), no `Marshal.load`, thread-safe shared state.
+- Decide the test strategy per the testing rules: unit specs for config/event/serializer, integration specs for ActiveJob adapter, mocked client for dashboard DataSource.
+
+## Phase 3 — Emit the plan artifact
+
+Use this structure for the issue body or markdown file. Every section is load-bearing — an executor uses Context to avoid re-discovery, Steps to act, Gates to verify, Boundaries to stop.
+
+```markdown
+# <Title>
+
+## Problem / Goal
+<What's wrong or missing, who it affects, what done looks like.>
+
+## Context (read these first)
+<Bullet list: `path/to/file.rb` — why it matters to this change. Include client, adapter, event bus, process, and web layers as relevant. Self-contained: no references to "as discussed" or this session.>
+
+## Decision
+<Chosen approach and rationale. Then: alternatives considered and why each was rejected.>
+
+## Implementation steps
+<Ordered, small, each mapped to the appropriate architecture layer. Specs come before the code they cover. Name exact files to create or change.>
+
+## Verification gates
+<Exact commands + expected outcome:>
+- `bundle exec rspec <paths>` — all green
+- `bundle exec rubocop` — no offenses
+
+## Out of scope
+<Explicit boundaries — the adjacent things an eager executor must NOT do.>
+
+## Execution
+Execute with `/lfg <issue-number>` (or `/lfg docs/plans/<file>.md`).
+```
+
+For GitHub issues: create with `gh issue create --title "..." --body-file <tmpfile>`. Write the body to a temp file first; do not use inline heredoc with `gh pr create --body` (code fences get mangled by shell interpolation).
+
+For markdown files: Write to `docs/plans/YYYY-MM-DD-<slug>.md`. Leave it uncommitted — committing is the user's call.
+
+## Phase 4 — Handoff
+
+Report back: link to the issue (or file path), the chosen approach in 2-3 sentences, and the exact execute command. Stop there — do not start implementing.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,6 +1,6 @@
 ---
 description: Review a GitHub pull request for code quality, patterns, and best practices
-model: claude-opus-4-6
+model: opus
 argument-hint: "PR URL or number (e.g., 5 or https://github.com/mhenrixon/pgbus/pull/5)"
 ---
 

--- a/.claude/commands/security.md
+++ b/.claude/commands/security.md
@@ -1,6 +1,6 @@
 ---
 description: "Reviews code for security vulnerabilities. Use when auditing PGMQ operations, connection handling, SQL injection risks, or dashboard authentication."
-model: claude-opus-4-6
+model: opus
 argument-hint: "code, feature, or area to review for security"
 ---
 

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when implementing any feature or fixing any bug -- enforces RED-GREEN-REFACTOR: write failing test first, implement minimum code to pass, then refactor."
+model: sonnet
 ---
 
 # TDD Command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,15 @@ bundle exec rake bench:streams            # SSE streaming benchmarks (requires P
 | Command | Purpose |
 |---------|---------|
 | `/lfg` | Full autonomous workflow: branch → understand → explore → plan → TDD → verify → PR |
+| `/plan` | Fable-powered planning → GitHub issue or `docs/plans/` markdown (read-only; execute with `/lfg`) |
 | `/github-review-comments` | Process unresolved PR review comments |
 | `/review-pr` | Review a PR for pattern compliance |
 | `/tdd` | Enforce RED → GREEN → REFACTOR cycle |
 | `/security` | Security audit (PGMQ ops, connections, auth, deserialization) |
 | `/architect` | Coordinate multi-layer development |
 | `/perf` | Benchmark current branch against main (before/after with worktree) |
+
+Commands and agents pin a model tier via frontmatter aliases: `sonnet` for pattern-following implementation (the default), `opus` for orchestration, security, and full PR review, `fable` for read-only planning (`/plan`). Use aliases, not full model IDs, so commands track the latest model in each tier. When spawning subagents for mechanical work (file finding, pattern scans), pass a cheaper model explicitly rather than letting them inherit the session model.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Replaces hardcoded `claude-opus-4-6` / `claude-opus-4-7` model pins on every Claude Code command with tier-based aliases, adds explicit model pins to commands that previously inherited the session model, and introduces a new `/plan` command.

| Tier | Commands | Rationale |
|------|----------|-----------|
| `fable` | `/plan` (new) | Read-only planning: investigates, designs, emits a self-contained GitHub issue or `docs/plans/` markdown for cheaper models to execute |
| `opus` | `/lfg`, `/architect`, `/security`, `/review-pr`, `/github-review-pr` | Orchestration, security, full PR review |
| `sonnet` | `/github-review-comments`, `/github-review-failures`, `/tdd`, `/perf` | Pattern-following implementation with prescriptive prompts |

- Commands forced the same expensive model on every turn regardless of task complexity.
- `/github-review-pr` was stuck on the outdated `claude-opus-4-7`. Tier aliases fix this class of staleness permanently by tracking the latest model per tier.
- `/tdd` and `/perf` had no `model:` field, so they inherited whatever session model was active — potentially the most expensive model for mechanical work.
- `CLAUDE.md` now documents the tier convention for future commands.

### `/plan` (second commit)

Workflow: `/plan add batch retry UI` (Fable) -> `/lfg <issue-number>` (Opus) -> specialists (Sonnet).

Each plan is self-contained — context block with file paths and why they matter, ordered steps mapped to architecture layers, verification gates with exact commands and expected outputs, explicit out-of-scope boundaries — so `/lfg` can execute without any of the planning session's context.

## Test plan

- [x] `grep -rn "claude-opus\|claude-sonnet\|claude-haiku\|claude-fable" .claude/ CLAUDE.md` — no full model IDs remain
- [x] All 10 commands have a `model:` tier alias
- [x] `/plan` registers as an available skill
- [ ] Run a specialist command (e.g. `/tdd`) and confirm the turn runs on Sonnet
- [ ] Run `/plan` on a small feature and execute the resulting issue with `/lfg`

Docs/config only — no application code, no specs affected.
