### PR TITLE
feat(stability): self-healing improvements — restart backoff, bounded drain, archive retry, config typo warnings

### DIFF
--- a/lib/pgbus/active_job/executor.rb
+++ b/lib/pgbus/active_job/executor.rb
@@ -296,12 +296,33 @@ module Pgbus
         Pgbus.logger.warn { "[Pgbus] Batch discard signal failed: #{e.message}" }
       end
 
+      # Archiving is idempotent — archiving an already-archived message is a
+      # no-op — so a connection error here is safe to retry once, unlike sends
+      # where a retry could duplicate the message. Without the retry, a job
+      # that succeeded but failed to archive redelivers after VT expiry and
+      # runs twice. If the retry also fails, fall through to the normal
+      # failure path (recorded failure + VT-based redelivery).
       def archive_from(queue_name, msg_id, source_queue: nil)
-        if source_queue
-          client.archive_message(source_queue, msg_id, prefixed: false)
-        else
-          client.archive_message(queue_name, msg_id)
+        attempts = 0
+        begin
+          if source_queue
+            client.archive_message(source_queue, msg_id, prefixed: false)
+          else
+            client.archive_message(queue_name, msg_id)
+          end
+        rescue StandardError => e
+          attempts += 1
+          raise unless attempts == 1 && connection_error?(e)
+
+          Pgbus.logger.warn do
+            "[Pgbus::Executor] Archive failed on connection error, retrying once: #{e.message}"
+          end
+          retry
         end
+      end
+
+      def connection_error?(error)
+        defined?(PGMQ::Errors::ConnectionError) && error.is_a?(PGMQ::Errors::ConnectionError)
       end
 
       def handle_dead_letter(message, queue_name, payload, source_queue: nil)

--- a/lib/pgbus/config_loader.rb
+++ b/lib/pgbus/config_loader.rb
@@ -11,17 +11,24 @@ module Pgbus
       env ||= (defined?(Rails) && Rails.respond_to?(:env) && Rails.env) || ENV.fetch("PGBUS_ENV", "development")
       raw = File.read(path)
       parsed = YAML.safe_load(ERB.new(raw).result, permitted_classes: [Symbol], aliases: true)
-      config_hash = parsed.fetch(env, parsed)
-      apply(config_hash)
+      if parsed.key?(env)
+        apply(parsed.fetch(env))
+      else
+        # No section for this env — treat the file as flat (un-sectioned)
+        # config. Suppress unknown-key warnings here: if the file IS
+        # env-sectioned and this env just isn't in it, every other env name
+        # ("production", "staging", ...) would be flagged as a typo.
+        apply(parsed, warn_unknown: false)
+      end
     end
 
-    def apply(hash)
+    def apply(hash, warn_unknown: true)
       config = Pgbus.configuration
       hash.each do |key, value|
         setter = :"#{key}="
         if config.respond_to?(setter)
           config.public_send(setter, value)
-        else
+        elsif warn_unknown
           config.logger.warn { "[Pgbus] Unknown configuration key ignored: #{key.inspect} — check for typos in pgbus.yml" }
         end
       end

--- a/lib/pgbus/config_loader.rb
+++ b/lib/pgbus/config_loader.rb
@@ -11,15 +11,19 @@ module Pgbus
       env ||= (defined?(Rails) && Rails.respond_to?(:env) && Rails.env) || ENV.fetch("PGBUS_ENV", "development")
       raw = File.read(path)
       parsed = YAML.safe_load(ERB.new(raw).result, permitted_classes: [Symbol], aliases: true)
-      if parsed.key?(env)
-        apply(parsed.fetch(env))
+      # Distinguish sectioned (top-level env keys mapping to Hashes) from
+      # flat (top-level setter keys mapping to scalars/arrays). parsed.key?(env)
+      # alone can't tell them apart, so a flat file silently lost its typo
+      # warnings whenever no env section happened to match its keys.
+      if sectioned?(parsed)
+        apply(parsed.fetch(env)) if parsed.key?(env)
       else
-        # No section for this env — treat the file as flat (un-sectioned)
-        # config. Suppress unknown-key warnings here: if the file IS
-        # env-sectioned and this env just isn't in it, every other env name
-        # ("production", "staging", ...) would be flagged as a typo.
-        apply(parsed, warn_unknown: false)
+        apply(parsed)
       end
+    end
+
+    def sectioned?(parsed)
+      parsed.is_a?(Hash) && parsed.any? && parsed.values.all?(Hash)
     end
 
     def apply(hash, warn_unknown: true)

--- a/lib/pgbus/config_loader.rb
+++ b/lib/pgbus/config_loader.rb
@@ -19,7 +19,11 @@ module Pgbus
       config = Pgbus.configuration
       hash.each do |key, value|
         setter = :"#{key}="
-        config.public_send(setter, value) if config.respond_to?(setter)
+        if config.respond_to?(setter)
+          config.public_send(setter, value)
+        else
+          config.logger.warn { "[Pgbus] Unknown configuration key ignored: #{key.inspect} — check for typos in pgbus.yml" }
+        end
       end
       config
     end

--- a/lib/pgbus/execution_pools/async_pool.rb
+++ b/lib/pgbus/execution_pools/async_pool.rb
@@ -46,6 +46,13 @@ module Pgbus
         available_capacity.positive?
       end
 
+      # True only when every slot is free — all in-flight work has finished.
+      # idle? answers "can this pool accept work?"; quiesced? answers
+      # "has this pool drained?". The worker drain loop needs the latter.
+      def quiesced?
+        available_capacity >= @capacity
+      end
+
       def shutdown
         @state_mutex.synchronize do
           return false if @shutdown_flag

--- a/lib/pgbus/execution_pools/thread_pool.rb
+++ b/lib/pgbus/execution_pools/thread_pool.rb
@@ -37,6 +37,13 @@ module Pgbus
         available_capacity.positive?
       end
 
+      # True only when every slot is free — all in-flight work has finished.
+      # idle? answers "can this pool accept work?"; quiesced? answers
+      # "has this pool drained?". The worker drain loop needs the latter.
+      def quiesced?
+        available_capacity >= @capacity
+      end
+
       def shutdown
         @pool.shutdown
       end

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -69,7 +69,12 @@ module Pgbus
         # --dispatcher-only CLI flags). Each role is gated by
         # config.role_enabled?, which returns true unless +config.roles+ has
         # been narrowed.
-        Array(config.workers).each { |worker_config| fork_worker(worker_config) } if config.role_enabled?(:workers)
+        if config.role_enabled?(:workers)
+          # slot is the child's position in the config array — it keys the
+          # crash-streak tracking so identically-configured siblings don't
+          # share (and reset) each other's restart backoff.
+          Array(config.workers).each_with_index { |worker_config, slot| fork_worker(worker_config, slot: slot) }
+        end
 
         fork_dispatcher if config.role_enabled?(:dispatcher)
         boot_scheduler if config.role_enabled?(:scheduler)
@@ -77,7 +82,7 @@ module Pgbus
         boot_outbox_poller if config.role_enabled?(:outbox)
       end
 
-      def fork_worker(worker_config)
+      def fork_worker(worker_config, slot: nil)
         queues = worker_config[:queues] || worker_config["queues"] || [config.default_queue]
         threads = worker_config[:threads] || worker_config["threads"] || 5
         single_active = worker_config[:single_active_consumer] || worker_config["single_active_consumer"] || false
@@ -103,7 +108,7 @@ module Pgbus
           return
         end
 
-        @forks[pid] = { type: :worker, config: worker_config, spawned_at: monotonic_now }
+        @forks[pid] = { type: :worker, config: worker_config, slot: slot, spawned_at: monotonic_now }
         Pgbus.logger.info { "[Pgbus] Forked worker pid=#{pid} queues=#{queues.join(",")} mode=#{exec_mode}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
         ErrorReporter.report(e, { action: "fork_worker", queues: queues })
@@ -194,12 +199,12 @@ module Pgbus
       def boot_consumers
         return unless config.event_consumers
 
-        config.event_consumers.each do |consumer_config|
-          fork_consumer(consumer_config)
+        config.event_consumers.each_with_index do |consumer_config, slot|
+          fork_consumer(consumer_config, slot: slot)
         end
       end
 
-      def fork_consumer(consumer_config)
+      def fork_consumer(consumer_config, slot: nil)
         topics = consumer_config[:topics] || consumer_config["topics"]
         threads = consumer_config[:threads] || consumer_config["threads"] || 3
 
@@ -216,7 +221,7 @@ module Pgbus
           return
         end
 
-        @forks[pid] = { type: :consumer, config: consumer_config, spawned_at: monotonic_now }
+        @forks[pid] = { type: :consumer, config: consumer_config, slot: slot, spawned_at: monotonic_now }
         Pgbus.logger.info { "[Pgbus] Forked consumer pid=#{pid} topics=#{topics.join(",")}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
         ErrorReporter.report(e, { action: "fork_consumer", topics: topics })
@@ -291,7 +296,10 @@ module Pgbus
       # A child with no spawned_at (never set in practice) restarts
       # immediately, preserving the pre-backoff behavior.
       def schedule_restart(info, status)
-        key = [info[:type], info[:config]]
+        # Keyed on [type, slot], NOT the config hash — identically-configured
+        # sibling workers would otherwise share one streak, letting one
+        # sibling's clean recycle reset another sibling's crash backoff.
+        key = [info[:type], info[:slot]]
         uptime = info[:spawned_at] ? monotonic_now - info[:spawned_at] : nil
 
         if status&.success? || uptime.nil? || uptime >= RESTART_STABLE_UPTIME
@@ -318,13 +326,13 @@ module Pgbus
       def restart_child(info)
         case info[:type]
         when :worker
-          fork_worker(info[:config])
+          fork_worker(info[:config], slot: info[:slot])
         when :dispatcher
           fork_dispatcher
         when :scheduler
           fork_scheduler
         when :consumer
-          fork_consumer(info[:config])
+          fork_consumer(info[:config], slot: info[:slot])
         when :outbox_poller
           fork_outbox_poller
         end

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -8,6 +8,16 @@ module Pgbus
       FORK_WAIT = 1 # seconds between fork checks
       WATCHDOG_INTERVAL = 10 # seconds between stall checks
 
+      # A child that crashes within this many seconds of forking is treated
+      # as crash-looping and restarted with exponential backoff (base
+      # RESTART_BACKOFF_BASE, doubling per consecutive crash, capped at
+      # RESTART_BACKOFF_MAX). A child that ran at least this long — or that
+      # exited cleanly, like a recycling worker — restarts immediately and
+      # resets its crash streak.
+      RESTART_STABLE_UPTIME = 30
+      RESTART_BACKOFF_BASE = 1
+      RESTART_BACKOFF_MAX = 60
+
       attr_reader :config
 
       def initialize(config: Pgbus.configuration)
@@ -15,6 +25,8 @@ module Pgbus
         @forks = {}
         @shutting_down = false
         @last_watchdog_at = monotonic_now
+        @pending_restarts = []
+        @crash_counts = Hash.new(0)
       end
 
       def run
@@ -91,7 +103,7 @@ module Pgbus
           return
         end
 
-        @forks[pid] = { type: :worker, config: worker_config }
+        @forks[pid] = { type: :worker, config: worker_config, spawned_at: monotonic_now }
         Pgbus.logger.info { "[Pgbus] Forked worker pid=#{pid} queues=#{queues.join(",")} mode=#{exec_mode}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
         ErrorReporter.report(e, { action: "fork_worker", queues: queues })
@@ -111,7 +123,7 @@ module Pgbus
           return
         end
 
-        @forks[pid] = { type: :dispatcher }
+        @forks[pid] = { type: :dispatcher, spawned_at: monotonic_now }
         Pgbus.logger.info { "[Pgbus] Forked dispatcher pid=#{pid}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
         ErrorReporter.report(e, { action: "fork_dispatcher" })
@@ -140,7 +152,7 @@ module Pgbus
           return
         end
 
-        @forks[pid] = { type: :scheduler }
+        @forks[pid] = { type: :scheduler, spawned_at: monotonic_now }
         Pgbus.logger.info { "[Pgbus] Forked scheduler pid=#{pid}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
         ErrorReporter.report(e, { action: "fork_scheduler" })
@@ -204,7 +216,7 @@ module Pgbus
           return
         end
 
-        @forks[pid] = { type: :consumer, config: consumer_config }
+        @forks[pid] = { type: :consumer, config: consumer_config, spawned_at: monotonic_now }
         Pgbus.logger.info { "[Pgbus] Forked consumer pid=#{pid} topics=#{topics.join(",")}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
         ErrorReporter.report(e, { action: "fork_consumer", topics: topics })
@@ -230,7 +242,7 @@ module Pgbus
           return
         end
 
-        @forks[pid] = { type: :outbox_poller }
+        @forks[pid] = { type: :outbox_poller, spawned_at: monotonic_now }
         Pgbus.logger.info { "[Pgbus] Forked outbox poller pid=#{pid}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
         ErrorReporter.report(e, { action: "fork_outbox_poller" })
@@ -242,7 +254,10 @@ module Pgbus
 
           process_signals
           reap_children
-          check_stalled_workers unless @shutting_down
+          unless @shutting_down
+            process_pending_restarts
+            check_stalled_workers
+          end
           interruptible_sleep(FORK_WAIT)
         end
       end
@@ -259,13 +274,45 @@ module Pgbus
             Pgbus.logger.info { "[Pgbus] Child #{info[:type]} pid=#{pid} exited (status=#{status.exitstatus})" }
           else
             Pgbus.logger.warn do
-              "[Pgbus] Child #{info[:type]} pid=#{pid} exited unexpectedly (status=#{status&.exitstatus}), restarting..."
+              "[Pgbus] Child #{info[:type]} pid=#{pid} exited unexpectedly (status=#{status&.exitstatus})"
             end
-            restart_child(info)
+            schedule_restart(info, status)
           end
         rescue Errno::ECHILD
           break
         end
+      end
+
+      # Restart policy: a clean exit (worker recycling) or a crash after a
+      # stable run restarts immediately with a fresh crash streak. A crash
+      # within RESTART_STABLE_UPTIME of forking is a crash loop — the child
+      # is dying on boot (bad config, unreachable DB, raising initializer) —
+      # so back off exponentially instead of fork-crash-forking at full speed.
+      # A child with no spawned_at (never set in practice) restarts
+      # immediately, preserving the pre-backoff behavior.
+      def schedule_restart(info, status)
+        key = [info[:type], info[:config]]
+        uptime = info[:spawned_at] ? monotonic_now - info[:spawned_at] : nil
+
+        if status&.success? || uptime.nil? || uptime >= RESTART_STABLE_UPTIME
+          @crash_counts.delete(key)
+          return restart_child(info)
+        end
+
+        crashes = @crash_counts[key] += 1
+        backoff = [RESTART_BACKOFF_BASE * (2**(crashes - 1)), RESTART_BACKOFF_MAX].min
+        Pgbus.logger.warn do
+          "[Pgbus] Child #{info[:type]} crashed after #{uptime.round(1)}s uptime " \
+            "(crash ##{crashes}) — restarting in #{backoff}s"
+        end
+        @pending_restarts << { info: info, at: monotonic_now + backoff }
+      end
+
+      def process_pending_restarts
+        now = monotonic_now
+        due, pending = @pending_restarts.partition { |r| r[:at] <= now }
+        @pending_restarts = pending
+        due.each { |r| restart_child(r[:info]) }
       end
 
       def restart_child(info)

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -50,6 +50,7 @@ module Pgbus
           on_state_change: -> { @wake_signal.notify! }
         )
         @circuit_breaker = Pgbus::CircuitBreaker.new(config: config)
+        @drain_started_at = nil
         @queue_lock = QueueLock.new if @single_active_consumer
         @notify_listener = nil
       end
@@ -71,6 +72,16 @@ module Pgbus
 
       NOTIFY_FALLBACK_POLL_SECONDS = 15
 
+      # Upper bound on the drain phase. Waiting for quiesced? must be
+      # bounded: a permanently-stuck job would otherwise hold the loop open
+      # forever — recycling never completes, TERM shutdown hangs the whole
+      # process tree, and the loop keeps stamping loop_tick so the
+      # supervisor watchdog never intervenes. After this many seconds the
+      # loop falls through to shutdown, whose wait_for_termination(30)
+      # bounds the remaining in-flight work. Tuned via constant rather than
+      # configuration, matching CircuitBreaker/Dispatcher precedent.
+      DRAIN_TIMEOUT = 30
+
       def run
         setup_signals
         start_heartbeat
@@ -91,8 +102,9 @@ module Pgbus
           break if @lifecycle.stopped?
           # quiesced? (all slots free), not idle? (any slot free) — exiting
           # with work still in flight abandons those jobs to the 30s
-          # wait_for_termination timeout in shutdown.
-          break if @lifecycle.draining? && @pool.quiesced?
+          # wait_for_termination timeout in shutdown. Bounded by
+          # DRAIN_TIMEOUT so a stuck job can't wedge the loop forever.
+          break if @lifecycle.draining? && (@pool.quiesced? || drain_deadline_exceeded?)
 
           claim_and_execute if @lifecycle.can_process?
           @stat_buffer&.flush_if_due
@@ -366,6 +378,20 @@ module Pgbus
         end
       rescue StandardError => e
         Pgbus.logger.debug { "[Pgbus] Zombie detection failed: #{e.class}: #{e.message}" }
+      end
+
+      # Lazily stamps the drain start on first call — the predicate is only
+      # reached while draining, so this covers every path into the drain
+      # state (graceful_shutdown, recycling) without hooking each one.
+      def drain_deadline_exceeded?
+        @drain_started_at ||= monotonic_now
+        return false unless monotonic_now - @drain_started_at > DRAIN_TIMEOUT
+
+        Pgbus.logger.warn do
+          "[Pgbus] Worker drain deadline (#{DRAIN_TIMEOUT}s) reached with #{@in_flight.value} job(s) " \
+            "still in flight — proceeding to shutdown"
+        end
+        true
       end
 
       def check_recycle

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -89,7 +89,10 @@ module Pgbus
           refresh_wildcard_queues
 
           break if @lifecycle.stopped?
-          break if @lifecycle.draining? && @pool.idle?
+          # quiesced? (all slots free), not idle? (any slot free) — exiting
+          # with work still in flight abandons those jobs to the 30s
+          # wait_for_termination timeout in shutdown.
+          break if @lifecycle.draining? && @pool.quiesced?
 
           claim_and_execute if @lifecycle.can_process?
           @stat_buffer&.flush_if_due

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -105,6 +105,67 @@ RSpec.describe Pgbus::ActiveJob::Executor do
       end
     end
 
+    # A job that succeeded but failed to archive redelivers after VT expiry
+    # and runs twice. Archiving is idempotent (archiving an already-archived
+    # message is a no-op), so a connection error on archive is safe to retry
+    # once — unlike sends, where a retry could duplicate the message.
+    context "when archive fails with a connection error after the job succeeded" do
+      let(:message) { build_message_double(msg_id: 9, message: message_json, read_ct: 1) }
+
+      before do
+        stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      end
+
+      it "retries the archive once and returns :success" do
+        calls = 0
+        allow(mock_client).to receive(:archive_message) do
+          calls += 1
+          raise PGMQ::Errors::ConnectionError, "server closed the connection unexpectedly" if calls == 1
+
+          true
+        end
+
+        result = executor.execute(message, queue_name)
+
+        expect(mock_client).to have_received(:archive_message).with(queue_name, 9).twice
+        expect(result).to eq(:success)
+      end
+
+      it "falls through to the failure path when the retry also fails" do
+        allow(mock_client).to receive(:archive_message)
+          .and_raise(PGMQ::Errors::ConnectionError, "server closed the connection unexpectedly")
+
+        result = executor.execute(message, queue_name)
+
+        expect(mock_client).to have_received(:archive_message).twice
+        expect(result).to eq(:failed)
+      end
+
+      it "does not retry archive errors that are not connection errors" do
+        allow(mock_client).to receive(:archive_message).and_raise(StandardError, "boom")
+
+        result = executor.execute(message, queue_name)
+
+        expect(mock_client).to have_received(:archive_message).once
+        expect(result).to eq(:failed)
+      end
+
+      it "retries archive on the source_queue path too" do
+        calls = 0
+        allow(mock_client).to receive(:archive_message) do
+          calls += 1
+          raise PGMQ::Errors::ConnectionError, "connection reset by peer" if calls == 1
+
+          true
+        end
+
+        result = executor.execute(message, queue_name, source_queue: "pgbus_default_p0")
+
+        expect(mock_client).to have_received(:archive_message).with("pgbus_default_p0", 9, prefixed: false).twice
+        expect(result).to eq(:success)
+      end
+    end
+
     # Regression: issue #126. Under `execution_mode: :async` the reactor or a
     # nested Async/Sync block can raise Async::Stop / Async::Cancel, both of
     # which inherit from Exception (NOT StandardError). A `rescue StandardError`

--- a/spec/pgbus/config_loader_spec.rb
+++ b/spec/pgbus/config_loader_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe Pgbus::ConfigLoader do
       expect(io.string).to include("pooling_interval")
     end
 
+    # A flat (un-sectioned) config file has top-level setter keys, not env
+    # names, so parsed.key?(env) is false — but that is not the same as
+    # "sectioned config missing this env." Detecting on Hash-valued top
+    # levels distinguishes the two, so typos in flat configs still warn.
+    it "warns about typos in a flat (un-sectioned) config file" do
+      io = StringIO.new
+      Pgbus.configuration.logger = Logger.new(io)
+
+      content = <<~YAML
+        queue_prefix: my_app
+        pooling_interval: 0.5
+      YAML
+      with_temp_config(content) do |path|
+        described_class.load(path, env: "development")
+      end
+
+      expect(io.string).to include("Unknown configuration key")
+      expect(io.string).to include("pooling_interval")
+    end
+
     def with_temp_config(content)
       file = Tempfile.new(["pgbus", ".yml"])
       file.write(content)

--- a/spec/pgbus/config_loader_spec.rb
+++ b/spec/pgbus/config_loader_spec.rb
@@ -40,6 +40,57 @@ RSpec.describe Pgbus::ConfigLoader do
     end
   end
 
+  describe ".load with env sections" do
+    let(:sectioned_content) do
+      <<~YAML
+        development:
+          queue_prefix: pgbus_dev
+        production:
+          queue_prefix: pgbus_prod
+      YAML
+    end
+
+    # When the running env has no section, load falls back to applying the
+    # whole file (flat-config support). The env names themselves must not be
+    # flagged as typos.
+    it "does not warn about env section names when falling back to the whole file" do
+      io = StringIO.new
+      Pgbus.configuration.logger = Logger.new(io)
+
+      with_temp_config(sectioned_content) do |path|
+        described_class.load(path, env: "staging")
+      end
+
+      expect(io.string).not_to include("Unknown configuration key")
+    end
+
+    it "still warns about typos inside a matched env section" do
+      io = StringIO.new
+      Pgbus.configuration.logger = Logger.new(io)
+
+      content = <<~YAML
+        test:
+          pooling_interval: 0.5
+      YAML
+      with_temp_config(content) do |path|
+        described_class.load(path, env: "test")
+      end
+
+      expect(io.string).to include("Unknown configuration key")
+      expect(io.string).to include("pooling_interval")
+    end
+
+    def with_temp_config(content)
+      file = Tempfile.new(["pgbus", ".yml"])
+      file.write(content)
+      file.rewind
+      yield file.path
+    ensure
+      file.close
+      file.unlink
+    end
+  end
+
   describe ".apply" do
     it "sets configuration values from a hash" do
       Pgbus.reset!

--- a/spec/pgbus/config_loader_spec.rb
+++ b/spec/pgbus/config_loader_spec.rb
@@ -59,5 +59,24 @@ RSpec.describe Pgbus::ConfigLoader do
         described_class.apply({ "nonexistent_setting" => "value" })
       end.not_to raise_error
     end
+
+    it "logs a warning naming each unknown key" do
+      io = StringIO.new
+      Pgbus.configuration.logger = Logger.new(io)
+
+      described_class.apply({ "pooling_interval" => 0.5, "queue_prefix" => "ok" })
+
+      expect(io.string).to include("Unknown configuration key")
+      expect(io.string).to include("pooling_interval")
+    end
+
+    it "does not warn for valid keys" do
+      io = StringIO.new
+      Pgbus.configuration.logger = Logger.new(io)
+
+      described_class.apply({ "queue_prefix" => "custom", "max_retries" => 3 })
+
+      expect(io.string).not_to include("Unknown configuration key")
+    end
   end
 end

--- a/spec/pgbus/execution_pools/async_pool_spec.rb
+++ b/spec/pgbus/execution_pools/async_pool_spec.rb
@@ -96,6 +96,34 @@ RSpec.describe Pgbus::ExecutionPools::AsyncPool do
     end
   end
 
+  # idle? means "has at least one free slot"; quiesced? means "every slot
+  # is free". The worker drain loop must use quiesced? — see thread_pool_spec.
+  describe "#quiesced?" do
+    it "is true when nothing is running" do
+      expect(pool).to be_quiesced
+    end
+
+    it "is false while any fiber is in flight, even with free capacity" do
+      barrier = Concurrent::Event.new
+
+      pool.post { barrier.wait(5) }
+      sleep 0.05
+
+      expect(pool).to be_idle
+      expect(pool).not_to be_quiesced
+      barrier.set
+    end
+
+    it "becomes true again after in-flight fibers complete" do
+      done = Concurrent::Event.new
+      pool.post { done.set }
+      done.wait(5)
+      sleep 0.05
+
+      expect(pool).to be_quiesced
+    end
+  end
+
   describe "#on_state_change callback" do
     it "fires when a fiber completes" do
       callback_called = Concurrent::Event.new

--- a/spec/pgbus/execution_pools/thread_pool_spec.rb
+++ b/spec/pgbus/execution_pools/thread_pool_spec.rb
@@ -92,6 +92,36 @@ RSpec.describe Pgbus::ExecutionPools::ThreadPool do
     end
   end
 
+  # idle? means "has at least one free slot" (can accept work);
+  # quiesced? means "every slot is free" (all in-flight work finished).
+  # The worker drain loop must use quiesced? — exiting on idle? abandons
+  # in-flight jobs to the shutdown timeout.
+  describe "#quiesced?" do
+    it "is true when nothing is running" do
+      expect(pool).to be_quiesced
+    end
+
+    it "is false while any work is in flight, even with free capacity" do
+      barrier = Concurrent::Event.new
+
+      pool.post { barrier.wait(5) }
+      sleep 0.05
+
+      expect(pool).to be_idle
+      expect(pool).not_to be_quiesced
+      barrier.set
+    end
+
+    it "becomes true again after in-flight work completes" do
+      done = Concurrent::Event.new
+      pool.post { done.set }
+      done.wait(2)
+      sleep 0.05
+
+      expect(pool).to be_quiesced
+    end
+  end
+
   describe "#shutdown" do
     it "finishes in-progress work" do
       result = Concurrent::IVar.new

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Pgbus::Process::Supervisor do
 
   describe "reap_children (private)" do
     let(:supervisor) { described_class.new }
-    let(:status_double) { instance_double(Process::Status, exitstatus: 1) }
+    let(:status_double) { instance_double(Process::Status, exitstatus: 1, success?: false) }
 
     before do
       supervisor.instance_variable_set(:@forks, { 3001 => { type: :worker, config: { queues: ["default"] } } })
@@ -83,6 +83,130 @@ RSpec.describe Pgbus::Process::Supervisor do
 
       forks = supervisor.instance_variable_get(:@forks)
       expect(forks).not_to have_key(3001)
+    end
+  end
+
+  # A child that dies right after forking (bad config, unreachable DB,
+  # crashing initializer) must not be re-forked in a tight loop — that
+  # burns CPU and floods logs. Crashes within the stable-uptime window
+  # get an exponentially backed-off restart; stable children and clean
+  # exits (worker recycling) restart immediately.
+  describe "restart backoff for crash-looping children" do
+    let(:supervisor) { described_class.new }
+    let(:crash_status) { instance_double(Process::Status, exitstatus: 1, success?: false) }
+    let(:clean_status) { instance_double(Process::Status, exitstatus: 0, success?: true) }
+    let(:worker_config) { { queues: ["default"], threads: 5 } }
+
+    def now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    before do
+      allow(supervisor).to receive(:fork).and_return(6001)
+      allow(Pgbus.logger).to receive(:warn)
+    end
+
+    it "restarts immediately when the crashed child had a stable uptime" do
+      supervisor.instance_variable_set(
+        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: now - 120 } }
+      )
+      allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
+
+      supervisor.send(:reap_children)
+
+      expect(supervisor).to have_received(:fork)
+    end
+
+    it "restarts immediately on a clean exit even with short uptime (worker recycling)" do
+      supervisor.instance_variable_set(
+        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: now - 5 } }
+      )
+      allow(Process).to receive(:waitpid2).and_return([3001, clean_status], nil)
+
+      supervisor.send(:reap_children)
+
+      expect(supervisor).to have_received(:fork)
+    end
+
+    it "delays the restart when the child crashed shortly after forking" do
+      supervisor.instance_variable_set(
+        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: now - 1 } }
+      )
+      allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
+
+      supervisor.send(:reap_children)
+      supervisor.send(:process_pending_restarts)
+
+      expect(supervisor).not_to have_received(:fork)
+    end
+
+    it "runs the pending restart once its backoff has elapsed" do
+      base = now
+      allow(supervisor).to receive(:monotonic_now).and_return(base)
+      supervisor.instance_variable_set(
+        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: base } }
+      )
+      allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
+
+      supervisor.send(:reap_children)
+      expect(supervisor).not_to have_received(:fork)
+
+      allow(supervisor).to receive(:monotonic_now).and_return(base + 61)
+      supervisor.send(:process_pending_restarts)
+
+      expect(supervisor).to have_received(:fork)
+    end
+
+    it "escalates the backoff on consecutive rapid crashes" do
+      messages = []
+      allow(Pgbus.logger).to receive(:warn) { |&blk| messages << blk.call }
+
+      base = now
+      allow(supervisor).to receive(:monotonic_now).and_return(base)
+      supervisor.instance_variable_set(
+        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: base } }
+      )
+      allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
+      supervisor.send(:reap_children)
+
+      # First backoff elapses; the child is restarted, then crashes again fast.
+      allow(supervisor).to receive(:monotonic_now).and_return(base + 61)
+      supervisor.send(:process_pending_restarts)
+      allow(Process).to receive(:waitpid2).and_return([6001, crash_status], nil)
+      supervisor.send(:reap_children)
+
+      joined = messages.join("\n")
+      expect(joined).to include("restarting in 1s")
+      expect(joined).to include("restarting in 2s")
+    end
+
+    it "resets the crash streak after a stable run" do
+      messages = []
+      allow(Pgbus.logger).to receive(:warn) { |&blk| messages << blk.call }
+
+      base = now
+      allow(supervisor).to receive(:monotonic_now).and_return(base)
+      supervisor.instance_variable_set(
+        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: base } }
+      )
+      allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
+      supervisor.send(:reap_children)
+
+      # Backoff elapses, child restarts and then runs well past the stable window.
+      allow(supervisor).to receive(:monotonic_now).and_return(base + 61)
+      supervisor.send(:process_pending_restarts)
+
+      # Stable crash: restarts immediately and clears the streak...
+      allow(supervisor).to receive(:monotonic_now).and_return(base + 200)
+      allow(Process).to receive(:waitpid2).and_return([6001, crash_status], nil)
+      supervisor.send(:reap_children)
+
+      # ...so the next rapid crash starts back at the base backoff.
+      allow(supervisor).to receive(:monotonic_now).and_return(base + 201)
+      allow(Process).to receive(:waitpid2).and_return([6001, crash_status], nil)
+      supervisor.send(:reap_children)
+
+      expect(messages.join("\n").scan("restarting in 1s").size).to eq(2)
     end
   end
 

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Pgbus::Process::Supervisor do
 
       supervisor.send(:reap_children)
 
-      expect(supervisor).to have_received(:fork)
+      expect(supervisor).to have_received(:fork).once
     end
 
     it "restarts immediately on a clean exit even with short uptime (worker recycling)" do
@@ -125,17 +125,85 @@ RSpec.describe Pgbus::Process::Supervisor do
 
       supervisor.send(:reap_children)
 
-      expect(supervisor).to have_received(:fork)
+      expect(supervisor).to have_received(:fork).once
     end
 
     it "delays the restart when the child crashed shortly after forking" do
+      base = now
+      allow(supervisor).to receive(:monotonic_now).and_return(base)
       supervisor.instance_variable_set(
-        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: now - 1 } }
+        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: base - 1 } }
       )
       allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
 
       supervisor.send(:reap_children)
       supervisor.send(:process_pending_restarts)
+
+      expect(supervisor).not_to have_received(:fork)
+    end
+
+    it "keeps separate crash streaks for identically-configured sibling workers" do
+      messages = []
+      allow(Pgbus.logger).to receive(:warn) { |&blk| messages << blk.call }
+      allow(supervisor).to receive(:fork).and_return(6001, 6002, 6003)
+
+      base = now
+      allow(supervisor).to receive(:monotonic_now).and_return(base)
+      supervisor.instance_variable_set(:@forks, sibling_forks(base))
+
+      reap(3002, crash_status) # slot 1 crashes fast — crash #1, 1s backoff
+      reap(3001, clean_status) # slot 0 recycles cleanly — must NOT reset slot 1's streak
+
+      # Slot 1's restart fires, then it crashes fast again — crash #2, 2s backoff.
+      allow(supervisor).to receive(:monotonic_now).and_return(base + 61)
+      supervisor.send(:process_pending_restarts)
+      restarted_pid = supervisor.instance_variable_get(:@forks).find { |_, i| i[:slot] == 1 }.first
+      reap(restarted_pid, crash_status)
+
+      expect(messages.join("\n")).to include("restarting in 2s")
+    end
+
+    def sibling_forks(base)
+      { 3001 => { type: :worker, config: worker_config, slot: 0, spawned_at: base },
+        3002 => { type: :worker, config: worker_config, slot: 1, spawned_at: base } }
+    end
+
+    def reap(pid, status)
+      allow(Process).to receive(:waitpid2).and_return([pid, status], nil)
+      supervisor.send(:reap_children)
+    end
+
+    it "fires due pending restarts from the monitor loop" do
+      allow(supervisor).to receive(:fork).and_return(7001)
+      allow(Process).to receive(:waitpid2).and_return(nil)
+      supervisor.instance_variable_set(
+        :@pending_restarts, [{ info: { type: :dispatcher }, at: now - 1 }]
+      )
+      # Stop the loop after one pass.
+      allow(supervisor).to receive(:interruptible_sleep) do
+        supervisor.instance_variable_set(:@shutting_down, true)
+        supervisor.instance_variable_set(:@forks, {})
+      end
+      allow(supervisor).to receive(:check_stalled_workers)
+
+      supervisor.send(:monitor_loop)
+
+      expect(supervisor).to have_received(:fork).once
+    end
+
+    it "does not fire pending restarts once shutting down" do
+      allow(supervisor).to receive(:fork)
+      supervisor.instance_variable_set(:@shutting_down, true)
+      supervisor.instance_variable_set(
+        :@forks, { 8001 => { type: :worker, config: worker_config, spawned_at: now } }
+      )
+      supervisor.instance_variable_set(
+        :@pending_restarts, [{ info: { type: :dispatcher }, at: now - 1 }]
+      )
+      allow(Process).to receive(:waitpid2).and_return([8001, crash_status], nil)
+      allow(supervisor).to receive(:interruptible_sleep)
+
+      supervisor.send(:monitor_loop)
 
       expect(supervisor).not_to have_received(:fork)
     end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -132,6 +132,32 @@ RSpec.describe Pgbus::Process::Worker do
       Pgbus.stopping = false
       runner&.kill
     end
+
+    # Waiting for quiesced? must be bounded: a permanently-stuck job (e.g. a
+    # TCP read with no timeout) would otherwise hold the drain loop open
+    # forever — recycling never completes, TERM shutdown of the whole process
+    # tree hangs, and the loop keeps stamping loop_tick so the supervisor
+    # watchdog never intervenes. After DRAIN_TIMEOUT the loop must fall
+    # through to shutdown, whose wait_for_termination(30) bounds the rest.
+    it "exits the drain loop after DRAIN_TIMEOUT even if a job never finishes" do
+      stub_const("Pgbus::Process::Worker::DRAIN_TIMEOUT", 0.2)
+      allow(pool).to receive(:quiesced?).and_return(false)
+      allow(worker).to receive(:start_notify_listener)
+      allow(worker).to receive(:claim_and_execute)
+      allow(Pgbus.logger).to receive(:warn)
+
+      runner = Thread.new { worker.run }
+      deadline = Time.now + 2
+      sleep 0.01 while worker.stats[:state] != :running && Time.now < deadline
+      expect(worker.stats[:state]).to eq(:running)
+
+      worker.graceful_shutdown
+
+      expect(runner.join(3)).to eq(runner), "worker did not stop after the drain deadline"
+    ensure
+      Pgbus.stopping = false
+      runner&.kill
+    end
   end
 
   describe "#recycle_needed? (private)" do

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -101,6 +101,39 @@ RSpec.describe Pgbus::Process::Worker do
     end
   end
 
+  # The drain loop must wait for ALL in-flight jobs, not exit as soon as one
+  # pool slot frees up. pool.idle? is true with 4 of 5 slots busy — using it
+  # as the drain condition abandoned in-flight jobs to the 30s shutdown
+  # timeout, killing any job that ran longer.
+  describe "drain behavior during #run" do
+    after { Pgbus.stopping = false }
+
+    it "keeps the loop alive until the pool quiesces, then stops" do
+      quiesced = Concurrent::AtomicBoolean.new(false)
+      allow(pool).to receive(:quiesced?) { quiesced.value }
+      allow(worker).to receive(:start_notify_listener)
+      allow(worker).to receive(:claim_and_execute)
+
+      runner = Thread.new { worker.run }
+      deadline = Time.now + 2
+      sleep 0.01 while worker.stats[:state] != :running && Time.now < deadline
+      expect(worker.stats[:state]).to eq(:running)
+
+      worker.graceful_shutdown
+      sleep 0.3
+
+      # One free slot (idle? true) but work still in flight (quiesced? false):
+      # the worker must keep draining.
+      expect(runner).to be_alive
+
+      quiesced.make_true
+      expect(runner.join(2)).to eq(runner), "worker did not stop after pool quiesced"
+    ensure
+      Pgbus.stopping = false
+      runner&.kill
+    end
+  end
+
   describe "#recycle_needed? (private)" do
     it "returns false when no limits are configured" do
       expect(worker.send(:recycle_needed?)).to be false


### PR DESCRIPTION
## Summary

Stability and self-healing improvements — the P0 set from the codebase audit, plus fixes for everything a multi-agent adversarial review of this branch confirmed.

### Supervisor: exponential restart backoff for crash-looping children
A child that died on boot (bad config, unreachable DB, raising initializer) was re-forked immediately in a tight fork-crash-fork loop, burning CPU and flooding logs. Crashes within 30s of forking now restart with exponential backoff (1s base, doubling per consecutive crash, 60s cap), scheduled through the monitor loop so signal handling stays responsive.

- Clean exits (worker recycling) and crashes after a stable run restart immediately and reset the crash streak.
- Streaks are keyed per child **slot**, not per config hash — identically-configured sibling workers (`"default: 5; default: 5"`) don't share/reset each other's backoff.
- Pending restarts are dropped once shutdown begins.

### Worker: drain waits for **all** in-flight jobs, bounded by a deadline
The drain loop exited on `pool.idle?` — true as soon as *any* slot freed — so with 4 of 5 threads still busy the worker left the loop and relied on the 30s `wait_for_termination`, killing any in-flight job that ran longer. Both execution pools gain `quiesced?` (all slots free) and the drain condition uses it.

Bounded by `DRAIN_TIMEOUT` (30s): a permanently-stuck job can't wedge the loop forever (which would block recycling, hang TERM shutdown of the whole tree, and keep `loop_tick` fresh so the watchdog never intervenes).

### Executor: archive retried once on connection error after job success
A job that succeeded but failed to archive redelivered after VT expiry and executed twice. Archiving is idempotent, so a connection error there is safe to retry — unlike sends. If the retry also fails, the existing failure path applies.

### ConfigLoader: unknown keys warn instead of vanishing
A typo like `pooling_interval` was silently dropped. Unknown keys now log a warning naming the key. Env-section fallback (file has sections but not for the running env) intentionally does **not** warn, so `production:`/`staging:` aren't flagged as typos.

## Adversarial review

A 26-agent review workflow (4 dimensions × find → adversarially verify) ran against this branch before submission. It confirmed 4 real defects in the initial implementation — unbounded drain (critical), crash-streak key collision, env-section warning false positive, and spec-hardening gaps — all fixed in the last three commits.

## Test plan
- [x] `bundle exec rubocop` — clean (411 files)
- [x] `bundle exec rspec` (unit) — 2352 examples, 0 failures introduced (2 pre-existing i18n failures also fail on `main`)
- [x] TDD throughout: every change landed RED → GREEN
- [ ] Integration suite against real Postgres (`PGBUS_DATABASE_URL`) in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “quiesced/drained” state to execution pools to better coordinate shutdown.
  * Workers now wait for all in-flight work to finish, with a bounded drain timeout to prevent indefinite waits.
* **Bug Fixes**
  * Archive failures caused by transient connection errors are retried once before normal failure handling.
  * Configuration loading now supports both sectioned and flat configs, with more precise unknown-key warnings (including env-section behavior).
* **Chores**
  * Process supervision now applies exponential backoff for crash-loops and improves restart scheduling, including suppression during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->