### PR TITLE
feat(process): cache worker memory readings behind a 5s TTL

### DIFF
--- a/lib/pgbus/process/memory_usage.rb
+++ b/lib/pgbus/process/memory_usage.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Process
+    module MemoryUsage
+      MEMORY_CHECK_TTL = 5
+
+      @mutex = Mutex.new
+      @cached_value = nil
+      @cached_at = nil
+
+      class << self
+        def current_mb
+          @mutex.synchronize do
+            now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+
+            return @cached_value if @cached_value && @cached_at && (now - @cached_at) < MEMORY_CHECK_TTL
+
+            @cached_value = read_memory
+            @cached_at = now
+            @cached_value
+          end
+        end
+
+        def reset!
+          @mutex.synchronize do
+            @cached_value = nil
+            @cached_at = nil
+          end
+        end
+
+        private
+
+        def read_memory
+          if RUBY_PLATFORM.include?("darwin")
+            `ps -o rss= -p #{::Process.pid}`.to_i / 1024
+          else
+            begin
+              File.read("/proc/#{::Process.pid}/statm").split[1].to_i * 4096 / (1024 * 1024)
+            rescue Errno::ENOENT
+              0
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -445,16 +445,9 @@ module Pgbus
         true
       end
 
+      # Instrumentation payload may report a value up to MEMORY_CHECK_TTL seconds old.
       def current_memory_mb
-        if RUBY_PLATFORM.include?("darwin")
-          `ps -o rss= -p #{::Process.pid}`.to_i / 1024
-        else
-          begin
-            File.read("/proc/#{::Process.pid}/statm").split[1].to_i * 4096 / (1024 * 1024)
-          rescue Errno::ENOENT
-            0
-          end
-        end
+        MemoryUsage.current_mb
       end
 
       def notify_wakeup?

--- a/spec/pgbus/process/memory_usage_spec.rb
+++ b/spec/pgbus/process/memory_usage_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Process::MemoryUsage do
+  before { described_class.reset! }
+
+  after { described_class.reset! }
+
+  describe ".current_mb" do
+    context "when on darwin" do
+      before do
+        stub_const("RUBY_PLATFORM", "x86_64-darwin23")
+        allow(described_class).to receive(:`).with(/ps -o rss=/).and_return("131072\n")
+      end
+
+      it "returns RSS in megabytes" do
+        expect(described_class.current_mb).to eq(128)
+      end
+
+      it "caches the value within the TTL window" do
+        described_class.current_mb
+        described_class.current_mb
+
+        expect(described_class).to have_received(:`).once
+      end
+
+      it "re-reads after TTL expires" do
+        described_class.current_mb
+
+        allow(Process).to receive(:clock_gettime)
+          .with(Process::CLOCK_MONOTONIC)
+          .and_return(Process.clock_gettime(Process::CLOCK_MONOTONIC) + described_class::MEMORY_CHECK_TTL + 1)
+
+        described_class.current_mb
+
+        expect(described_class).to have_received(:`).twice
+      end
+    end
+
+    context "when on linux" do
+      before do
+        stub_const("RUBY_PLATFORM", "x86_64-linux")
+      end
+
+      it "reads /proc/PID/statm and converts pages to MB" do
+        # statm second field = pages; 4096 bytes/page
+        pages = 65_536
+        allow(File).to receive(:read)
+          .with("/proc/#{Process.pid}/statm")
+          .and_return("100000 #{pages} 50000 1000 0 40000 0")
+
+        expect(described_class.current_mb).to eq(256)
+      end
+
+      it "returns 0 when /proc file is missing" do
+        allow(File).to receive(:read)
+          .with("/proc/#{Process.pid}/statm")
+          .and_raise(Errno::ENOENT)
+
+        expect(described_class.current_mb).to eq(0)
+      end
+    end
+
+    describe "thread safety" do
+      before do
+        stub_const("RUBY_PLATFORM", "x86_64-darwin23")
+        allow(described_class).to receive(:`).with(/ps -o rss=/).and_return("131072\n")
+      end
+
+      it "handles concurrent access without errors" do
+        threads = Array.new(10) do
+          Thread.new { described_class.current_mb }
+        end
+
+        results = threads.map(&:value)
+        expect(results).to all(eq(128))
+      end
+    end
+  end
+
+  describe ".reset!" do
+    before do
+      stub_const("RUBY_PLATFORM", "x86_64-darwin23")
+      allow(described_class).to receive(:`).with(/ps -o rss=/).and_return("131072\n")
+    end
+
+    it "clears the cached value so the next call re-reads" do
+      described_class.current_mb
+      described_class.reset!
+      described_class.current_mb
+
+      expect(described_class).to have_received(:`).twice
+    end
+  end
+end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -187,6 +187,25 @@ RSpec.describe Pgbus::Process::Worker do
         expect(worker.send(:recycle_needed?)).to be true
       end
     end
+
+    context "when max_memory_mb is exceeded" do
+      before do
+        worker.config.max_memory_mb = 256
+        Pgbus::Process::MemoryUsage.reset!
+      end
+
+      after { Pgbus::Process::MemoryUsage.reset! }
+
+      it "returns true when memory exceeds the limit" do
+        allow(Pgbus::Process::MemoryUsage).to receive(:current_mb).and_return(512)
+        expect(worker.send(:recycle_needed?)).to be true
+      end
+
+      it "returns false when memory is within the limit" do
+        allow(Pgbus::Process::MemoryUsage).to receive(:current_mb).and_return(128)
+        expect(worker.send(:recycle_needed?)).to be false
+      end
+    end
   end
 
   describe "#fetch_messages (private)" do


### PR DESCRIPTION
## Summary

- Extract `Worker#current_memory_mb` into `Pgbus::Process::MemoryUsage` module with a 5-second TTL cache
- Workers were forking `ps` ~10x/sec (every poll tick) — now at most once per 5 seconds
- Mutex-guarded cache; darwin/linux branches and `Errno::ENOENT` fallback preserved unchanged
- `.reset!` method for test isolation; module is the reuse point for Consumer recycling parity

Closes #206

## Test plan

- [ ] `spec/pgbus/process/memory_usage_spec.rb` — caching within TTL, re-read after TTL, darwin/linux paths, thread safety, `.reset!`
- [ ] `spec/pgbus/process/worker_spec.rb` — `exceeded_max_memory?` delegates through MemoryUsage, existing recycle tests green
- [ ] Full suite passes (`bundle exec rspec` — 0 failures)
- [ ] `bundle exec rubocop` clean on all changed files
