### PR TITLE
fix(dedup): remove evicted keys from @insertion_order

### DIFF
--- a/lib/pgbus/dedup_cache.rb
+++ b/lib/pgbus/dedup_cache.rb
@@ -60,11 +60,19 @@ module Pgbus
 
     def evict(key)
       @cache.delete(key)
+      # Concurrent::Array#delete is O(n), but this only runs on expiry and n is
+      # bounded by @max_size, so it stays cheap. Without it, @insertion_order
+      # leaks and stale duplicates can evict live keys in evict_oldest.
+      @insertion_order.delete(key)
     end
 
     def evict_oldest
       while @cache.size >= @max_size && !@insertion_order.empty?
         oldest_key = @insertion_order.shift
+        # Skip residual order entries for keys already gone from @cache so a
+        # stale duplicate never evicts a freshly re-marked (live) key.
+        next unless @cache.key?(oldest_key)
+
         @cache.delete(oldest_key)
       end
     end

--- a/spec/pgbus/dedup_cache_spec.rb
+++ b/spec/pgbus/dedup_cache_spec.rb
@@ -43,6 +43,58 @@ RSpec.describe Pgbus::DedupCache do
     end
   end
 
+  describe "insertion-order bookkeeping" do
+    def insertion_order(dedup)
+      dedup.instance_variable_get(:@insertion_order)
+    end
+
+    def expire!(dedup, key)
+      dedup.instance_variable_get(:@cache)[key] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 20
+    end
+
+    it "removes an expired-and-evicted key from @insertion_order" do
+      cache.mark!("event-1:Handler")
+      expire!(cache, "event-1:Handler")
+
+      expect(cache.seen?("event-1:Handler")).to be false
+      expect(insertion_order(cache)).not_to include("event-1:Handler")
+    end
+
+    it "keeps a re-marked key alive when older keys are evicted" do
+      # victim goes in first, so its stale order entry sits at the front.
+      cache.mark!("event-victim:Handler")
+      cache.mark!("event-old-0:Handler")
+      cache.mark!("event-old-1:Handler")
+
+      # Expire victim, then re-mark it so it is now the NEWEST live entry —
+      # but with the leak bug a stale duplicate lingers at the front of
+      # @insertion_order and would be shifted first by evict_oldest.
+      expire!(cache, "event-victim:Handler")
+      cache.seen?("event-victim:Handler") # expiry eviction
+      cache.mark!("event-victim:Handler") # re-mark (now newest)
+
+      # Fill to max_size and push past it to trigger evict_oldest.
+      cache.mark!("event-old-2:Handler")
+      cache.mark!("event-old-3:Handler")
+      cache.mark!("event-trigger:Handler")
+
+      # old-0 (genuinely oldest) should be gone; the re-marked victim must survive.
+      expect(cache.seen?("event-old-0:Handler")).to be false
+      expect(cache.seen?("event-victim:Handler")).to be true
+    end
+
+    it "keeps @insertion_order bounded by @cache size across expire/re-mark cycles" do
+      20.times do
+        cache.mark!("event-recycle:Handler")
+        expire!(cache, "event-recycle:Handler")
+        cache.seen?("event-recycle:Handler")
+      end
+
+      expect(insertion_order(cache).size).to be <= cache.size + 1
+    end
+  end
+
   describe "#clear!" do
     it "removes all entries" do
       3.times { |i| cache.mark!("event-#{i}:Handler") }


### PR DESCRIPTION
## Summary

`DedupCache#evict` (`lib/pgbus/dedup_cache.rb`) deleted an expired key from `@cache` but never from `@insertion_order`. On long-running workers this produced two bugs:

1. **Leak** — when entries expire before `max_size` is reached, `@insertion_order` grows without bound.
2. **Wrong eviction** — an expired-and-evicted key that is re-marked gets appended again (`already_present` is false in `mark!`), leaving a stale duplicate at the front of the order list. `evict_oldest` later shifts that stale entry and deletes the freshly re-marked *live* key from `@cache`, defeating dedup — the exact guarantee `pgbus_processed_events` exists to protect.

### Fix (entirely inside `dedup_cache.rb`)

- `evict(key)` now also `@insertion_order.delete(key)`. `Concurrent::Array#delete` is O(n), but only runs on expiry and n is bounded by `max_size`, so it stays cheap.
- `evict_oldest` skips shifted keys no longer in `@cache` (`next unless @cache.key?(oldest_key)`) so a residual stale/duplicate order entry never evicts a live key. The existing `while @cache.size >= @max_size && !@insertion_order.empty?` loop keeps working.

Public `seen?` / `mark!` / `size` / `clear!` contract is unchanged. No new config.

Closes #207

## Test plan

Extended `spec/pgbus/dedup_cache_spec.rb` with three regression tests, each verified to **fail without the fix** and **pass with it**:

- [x] Leak regression — after expire + `seen?` eviction, the key is gone from `@insertion_order`
- [x] Premature-eviction regression — expire → re-mark → fill to `max_size`; the re-marked key survives while the genuinely-oldest key is evicted
- [x] Bounded growth — repeated expire/re-mark cycles keep `@insertion_order` bounded by `@cache` size
- [x] All 7 existing `dedup_cache_spec` examples stay green (10 total)

## Verification

- [x] `bundle exec rspec spec/pgbus/dedup_cache_spec.rb` — 10 passed
- [x] `bundle exec rubocop lib/pgbus/dedup_cache.rb spec/pgbus/dedup_cache_spec.rb` — no offenses
