### PR TITLE
perf(process): cache ConsumerPriority.max_active_priority behind a 5s TTL

### DIFF
--- a/lib/pgbus/process/consumer_priority.rb
+++ b/lib/pgbus/process/consumer_priority.rb
@@ -11,6 +11,15 @@ module Pgbus
     # consumers are served first and lower-priority consumers wait
     # until all higher-priority consumers are at their prefetch limit.
     module ConsumerPriority
+      # Time-to-live (seconds) for cached max_active_priority lookups.
+      # The underlying data only changes on heartbeat cadence, so a short
+      # TTL avoids ~10 queries/second per prioritized worker at the default
+      # 0.1s polling interval.
+      CACHE_TTL = 5
+
+      @cache = {}
+      @cache_mutex = Mutex.new
+
       # Check if this worker should yield to a higher-priority worker.
       # Returns true if a higher-priority healthy worker exists for
       # any of the given queues.
@@ -26,7 +35,31 @@ module Pgbus
       # Returns the highest consumer_priority among healthy workers
       # that share at least one queue with the given queue list,
       # excluding the current worker (by PID).
+      #
+      # Results are cached per (sorted queues, pid) for CACHE_TTL seconds.
+      # On a miss the query runs outside the lock (a duplicate query on a
+      # race is harmless), then the value is stored under the mutex.
       def self.max_active_priority(queues, my_pid)
+        key = [queues.sort, my_pid]
+        now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+
+        cached = @cache_mutex.synchronize { @cache[key] }
+        return cached[:value] if cached && (now - cached[:at]) < CACHE_TTL
+
+        value = compute_max_active_priority(queues, my_pid)
+        @cache_mutex.synchronize { @cache[key] = { value: value, at: now } }
+        value
+      end
+
+      # Clears all cached max_active_priority entries. Intended for spec
+      # isolation; also safe to call at runtime.
+      def self.reset_cache!
+        @cache_mutex.synchronize { @cache.clear }
+      end
+
+      # Runs the actual query and reduces worker rows to the highest
+      # consumer_priority sharing a queue with the given list.
+      def self.compute_max_active_priority(queues, my_pid)
         conn = Pgbus.configuration.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection
         rows = conn.select_all(
           "SELECT metadata FROM pgbus_processes WHERE kind = 'worker' AND pid != $1 AND last_heartbeat_at > $2",
@@ -49,6 +82,7 @@ module Pgbus
 
         max_priority
       end
+      private_class_method :compute_max_active_priority
 
       # Calculate the effective polling interval for this worker.
       # Higher-priority workers use the base interval.

--- a/spec/pgbus/process/consumer_priority_spec.rb
+++ b/spec/pgbus/process/consumer_priority_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Pgbus::Process::ConsumerPriority do
   let(:connection) { double("connection") }
 
   before do
+    described_class.reset_cache!
     allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
   end
+
+  after { described_class.reset_cache! }
 
   describe ".should_yield?" do
     it "returns false when no other workers exist" do
@@ -69,6 +72,76 @@ RSpec.describe Pgbus::Process::ConsumerPriority do
         base_interval: 0.1, my_priority: 5, max_priority: 5
       )
       expect(result).to eq(0.1)
+    end
+  end
+
+  describe ".max_active_priority caching" do
+    let(:rows) { [{ "metadata" => '{"queues":["default"],"consumer_priority":10}' }] }
+
+    before { allow(connection).to receive(:select_all).and_return(rows) }
+
+    it "executes exactly one query for repeated calls within the TTL" do
+      described_class.max_active_priority(%w[default], 1)
+      described_class.max_active_priority(%w[default], 1)
+
+      expect(connection).to have_received(:select_all).once
+    end
+
+    it "returns the same cached value on repeated calls within the TTL" do
+      first = described_class.max_active_priority(%w[default], 1)
+      second = described_class.max_active_priority(%w[default], 1)
+
+      expect(first).to eq(10)
+      expect(second).to eq(10)
+    end
+
+    it "re-queries after the TTL expires" do
+      described_class.max_active_priority(%w[default], 1)
+
+      allow(Process).to receive(:clock_gettime)
+        .with(Process::CLOCK_MONOTONIC)
+        .and_return(Process.clock_gettime(Process::CLOCK_MONOTONIC) + described_class::CACHE_TTL + 1)
+
+      described_class.max_active_priority(%w[default], 1)
+
+      expect(connection).to have_received(:select_all).twice
+    end
+
+    it "caches different queue lists independently" do
+      described_class.max_active_priority(%w[default], 1)
+      described_class.max_active_priority(%w[events], 1)
+
+      expect(connection).to have_received(:select_all).twice
+    end
+
+    it "caches different pids independently" do
+      described_class.max_active_priority(%w[default], 1)
+      described_class.max_active_priority(%w[default], 2)
+
+      expect(connection).to have_received(:select_all).twice
+    end
+
+    it "treats queue lists as order-independent" do
+      described_class.max_active_priority(%w[default events], 1)
+      described_class.max_active_priority(%w[events default], 1)
+
+      expect(connection).to have_received(:select_all).once
+    end
+
+    it "clears all cached entries with reset_cache!" do
+      described_class.max_active_priority(%w[default], 1)
+      described_class.reset_cache!
+      described_class.max_active_priority(%w[default], 1)
+
+      expect(connection).to have_received(:select_all).twice
+    end
+
+    it "consults the cached value from should_yield?" do
+      described_class.max_active_priority(%w[default], 1)
+      result = described_class.should_yield?(queues: %w[default], my_priority: 0, my_pid: 1)
+
+      expect(result).to be true
+      expect(connection).to have_received(:select_all).once
     end
   end
 end


### PR DESCRIPTION
## Summary

`ConsumerPriority.max_active_priority` runs a SELECT over `pgbus_processes` and JSON-parses every worker row. Any worker with `consumer_priority > 0` calls it through `effective_polling_interval` → `wake_timeout` → `claim_and_execute` on **every loop iteration**. At the default `polling_interval` of 0.1s that is ~10 queries/second per prioritized worker — reading data that only changes on the 60s heartbeat cadence.

This adds a mutex-guarded TTL cache (`CACHE_TTL = 5`s) keyed by `[queues.sort, my_pid]`:

- On a hit within the TTL, returns the cached value with **no query**.
- On a miss/expiry, the query runs **outside the lock** (a duplicate query on a race is harmless), then the value is stored under `@cache_mutex` (project rule: no unsynchronized shared state).
- Query/reduce logic moves to a private `compute_max_active_priority`; `should_yield?` benefits automatically since it delegates.
- Adds `reset_cache!` for spec isolation.

Mirrors the pattern established in #231 (worker memory readings behind a 5s TTL). PGMQ rules untouched (no PGMQ calls here); this is process-model code, so the `Web::DataSource` rule does not apply — existing ActiveRecord connection access is preserved.

## Acceptance criteria

- [x] Two calls with the same (queues, pid) inside the TTL execute exactly one SQL query.
- [x] After the TTL expires the value is recomputed.
- [x] Different queue lists / pids are cached independently.
- [x] `reset_cache!` clears all cached entries.
- [x] Priority semantics unchanged: `effective_polling_interval` specs stay green.

## Test plan

- [x] `bundle exec rspec spec/pgbus/process/consumer_priority_spec.rb` — 16 examples, 0 failures
- [x] `bundle exec rspec spec/pgbus/process` — 261 examples, 0 failures
- [x] `bundle exec rubocop lib/pgbus/process/consumer_priority.rb spec/...` — clean
- [x] Worker `effective_polling_interval` / priority specs green

Note: pre-existing failures on `main` in `spec/i18n_spec.rb` (missing/unused locale keys) and `spec/system/**` (browser specs) are unrelated to this change and confirmed present without it.

Closes #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved priority lookups to reuse recent results for a short period, reducing repeated work and helping keep polling behavior responsive.
  * Ensured priority checks stay consistent across repeated requests, regardless of queue ordering.

* **Performance**
  * Added short-lived result caching so the app can avoid unnecessary recalculations during frequent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->