### PR TITLE
fix(dispatcher): back off maintenance during systemic outages

### DIFF
--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -43,6 +43,33 @@ module Pgbus
         def skipped? = status == :skipped
       end
 
+      # Accumulates the per-item outcomes of a task that loops over queues.
+      # A task should only be considered failed when it attempted work and
+      # *every* attempt failed — a partial failure (some items succeed) must
+      # not trip maintenance backoff. #result returns the first error in the
+      # total-failure case and nil otherwise, matching the "return e on
+      # failure" contract run_if_due expects.
+      class LoopOutcome
+        def initialize
+          @successes = 0
+          @failures = 0
+          @first_error = nil
+        end
+
+        def record_success
+          @successes += 1
+        end
+
+        def record_failure(error)
+          @failures += 1
+          @first_error = error if @first_error.nil?
+        end
+
+        def result
+          @first_error if @failures.positive? && @successes.zero?
+        end
+      end
+
       attr_reader :config
 
       def initialize(config: Pgbus.configuration)
@@ -371,15 +398,19 @@ module Pgbus
         conn = config.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection
         queue_names = conn.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
 
+        outcome = LoopOutcome.new
         queue_names.each do |full_name|
           next unless full_name.start_with?("#{prefix}_")
 
           stripped = full_name.delete_prefix("#{prefix}_")
           deleted = Pgbus.client.purge_archive(stripped, older_than: cutoff, batch_size: batch_size)
           Pgbus.logger.debug { "[Pgbus] Compacted #{deleted} archive entries from #{full_name}" } if deleted.positive?
+          outcome.record_success
         rescue StandardError => e
           Pgbus.logger.warn { "[Pgbus] Archive compaction failed for #{full_name}: #{e.message}" }
+          outcome.record_failure(e)
         end
+        outcome.result
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Archive compaction failed: #{e.message}" }
         e
@@ -399,6 +430,7 @@ module Pgbus
         conn = config.connects_to ? Pgbus::BusRecord.connection : ActiveRecord::Base.connection
         queue_names = conn.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
 
+        outcome = LoopOutcome.new
         queue_names.each do |full_name|
           next unless full_name.start_with?("#{prefix}_")
 
@@ -413,9 +445,12 @@ module Pgbus
               "[Pgbus] Compacted #{deleted} stream archive entries from #{full_name}"
             end
           end
+          outcome.record_success
         rescue StandardError => e
           Pgbus.logger.warn { "[Pgbus] Stream archive compaction failed for #{full_name}: #{e.message}" }
+          outcome.record_failure(e)
         end
+        outcome.result
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Stream archive compaction failed: #{e.message}" }
         e
@@ -446,6 +481,7 @@ module Pgbus
         queue_names = conn.select_values("SELECT queue_name FROM pgmq.meta ORDER BY queue_name")
 
         dropped = 0
+        outcome = LoopOutcome.new
         queue_names.each do |full_name|
           next unless full_name.start_with?("#{prefix}_")
 
@@ -460,11 +496,14 @@ module Pgbus
           Pgbus.client.drop_queue(full_name, prefixed: false)
           dropped += 1
           Pgbus.logger.info { "[Pgbus] Dropped orphan stream queue: #{full_name}" }
+          outcome.record_success
         rescue StandardError => e
           Pgbus.logger.warn { "[Pgbus] Orphan stream sweep failed for #{full_name}: #{e.message}" }
+          outcome.record_failure(e)
         end
 
         Pgbus.logger.debug { "[Pgbus] Orphan stream sweep complete: dropped #{dropped} queue(s)" } if dropped.positive?
+        outcome.result
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Orphan stream sweep failed: #{e.message}" }
         e

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -24,6 +24,25 @@ module Pgbus
       # too-small value just delays cleanup, never breaks anything.
       ARCHIVE_COMPACTION_BATCH_SIZE = 1000
 
+      # Maintenance backoff during systemic outages. When every attempted
+      # maintenance task fails for two consecutive cycles (e.g. the database
+      # is down), skip maintenance entirely for an exponentially growing
+      # window instead of retrying ~12 tasks every dispatch interval and
+      # flooding logs and error trackers. The window doubles per consecutive
+      # failed cycle and is capped. Constants (not config) per the precedent
+      # above: the values rarely need tuning and only affect noise, never
+      # correctness. Backoff exits the moment any task succeeds again.
+      MAINTENANCE_BACKOFF_BASE = 30    # seconds; first backoff window
+      MAINTENANCE_BACKOFF_MAX = 600    # seconds; window ceiling (10 minutes)
+
+      # Outcome of a single maintenance task in a cycle. Lets run_maintenance
+      # distinguish success/failed/skipped and, on failure, carry the error
+      # and task name for reporting or summarizing.
+      MaintenanceResult = ::Struct.new(:status, :task, :error) do
+        def success? = status == :success
+        def skipped? = status == :skipped
+      end
+
       attr_reader :config
 
       def initialize(config: Pgbus.configuration)
@@ -41,6 +60,8 @@ module Pgbus
         @last_stats_cleanup_at = monotonic_now
         @last_orphan_stream_sweep_at = monotonic_now
         @last_table_maintenance_at = monotonic_now
+        @maintenance_failure_streak = 0
+        @maintenance_backoff_until = nil
       end
 
       def run
@@ -75,33 +96,120 @@ module Pgbus
 
       private
 
-      def run_maintenance
-        now = monotonic_now
+      def run_maintenance(now = monotonic_now)
+        return if in_backoff?(now)
 
-        run_if_due(now, :@last_cleanup_at, CLEANUP_INTERVAL) { cleanup_processed_events }
-        run_if_due(now, :@last_reap_at, REAP_INTERVAL) { reap_stale_processes }
-        run_if_due(now, :@last_concurrency_at, CONCURRENCY_INTERVAL) { cleanup_concurrency }
-        run_if_due(now, :@last_batch_cleanup_at, BATCH_CLEANUP_INTERVAL) { cleanup_batches }
-        run_if_due(now, :@last_recurring_cleanup_at, RECURRING_CLEANUP_INTERVAL) { cleanup_recurring_executions }
-        run_if_due(now, :@last_archive_compaction_at, ARCHIVE_COMPACTION_INTERVAL) { compact_archives }
-        run_if_due(now, :@last_stream_archive_compaction_at, ARCHIVE_COMPACTION_INTERVAL) { prune_stream_archives }
-        run_if_due(now, :@last_outbox_cleanup_at, OUTBOX_CLEANUP_INTERVAL) { cleanup_outbox }
-        run_if_due(now, :@last_job_lock_cleanup_at, JOB_LOCK_CLEANUP_INTERVAL) { cleanup_job_locks }
-        run_if_due(now, :@last_stats_cleanup_at, STATS_CLEANUP_INTERVAL) { cleanup_stats }
-        sweep_interval = config.streams_orphan_sweep_interval
-        run_if_due(now, :@last_orphan_stream_sweep_at, sweep_interval) { sweep_orphan_streams } if sweep_interval
-        run_if_due(now, :@last_table_maintenance_at, TABLE_MAINTENANCE_INTERVAL) { run_table_maintenance }
+        results = run_maintenance_tasks(now)
+        update_maintenance_backoff(now, results)
       end
 
-      # Only update the timestamp when the block succeeds.
-      # On failure, the next tick retries instead of waiting the full interval.
-      def run_if_due(now, ivar, interval)
-        return unless now - instance_variable_get(ivar) >= interval
+      # Runs every due maintenance task and returns their results. Each entry
+      # is a MaintenanceResult carrying the outcome (:success/:failed/:skipped)
+      # and, on failure, the exception and task name so run_maintenance can
+      # decide whether to report per-task or summarize.
+      def run_maintenance_tasks(now)
+        results = []
+        results << run_if_due(now, :@last_cleanup_at, CLEANUP_INTERVAL) { cleanup_processed_events }
+        results << run_if_due(now, :@last_reap_at, REAP_INTERVAL) { reap_stale_processes }
+        results << run_if_due(now, :@last_concurrency_at, CONCURRENCY_INTERVAL) { cleanup_concurrency }
+        results << run_if_due(now, :@last_batch_cleanup_at, BATCH_CLEANUP_INTERVAL) { cleanup_batches }
+        results << run_if_due(now, :@last_recurring_cleanup_at, RECURRING_CLEANUP_INTERVAL) { cleanup_recurring_executions }
+        results << run_if_due(now, :@last_archive_compaction_at, ARCHIVE_COMPACTION_INTERVAL) { compact_archives }
+        results << run_if_due(now, :@last_stream_archive_compaction_at, ARCHIVE_COMPACTION_INTERVAL) { prune_stream_archives }
+        results << run_if_due(now, :@last_outbox_cleanup_at, OUTBOX_CLEANUP_INTERVAL) { cleanup_outbox }
+        results << run_if_due(now, :@last_job_lock_cleanup_at, JOB_LOCK_CLEANUP_INTERVAL) { cleanup_job_locks }
+        results << run_if_due(now, :@last_stats_cleanup_at, STATS_CLEANUP_INTERVAL) { cleanup_stats }
+        sweep_interval = config.streams_orphan_sweep_interval
+        results << run_if_due(now, :@last_orphan_stream_sweep_at, sweep_interval) { sweep_orphan_streams } if sweep_interval
+        results << run_if_due(now, :@last_table_maintenance_at, TABLE_MAINTENANCE_INTERVAL) { run_table_maintenance }
+        results
+      end
 
-        yield
+      # Runs the block when the interval has elapsed and reports the outcome.
+      # Only updates the timestamp when the block succeeds — on failure the
+      # next tick retries instead of waiting the full interval. Errors are NOT
+      # reported here; run_maintenance decides whether to report per-task or
+      # summarize into a single backoff warning.
+      #
+      # A task fails one of two ways: it raises (a few tasks let errors
+      # propagate), or its own rescue returns the exception (most tasks catch
+      # StandardError to log a descriptive warning, then hand the error back
+      # here via `return e` so the cycle can still see the failure). Both are
+      # normalized to a :failed result carrying the exception.
+      def run_if_due(now, ivar, interval)
+        return MaintenanceResult.new(:skipped, task_name(ivar), nil) unless now - instance_variable_get(ivar) >= interval
+
+        outcome = yield
+        return MaintenanceResult.new(:failed, task_name(ivar), outcome) if outcome.is_a?(StandardError)
+
         instance_variable_set(ivar, now)
+        MaintenanceResult.new(:success, task_name(ivar), nil)
       rescue StandardError => e
-        ErrorReporter.report(e, { action: "dispatcher_maintenance", task: ivar.to_s.delete_prefix("@last_").delete_suffix("_at") })
+        MaintenanceResult.new(:failed, task_name(ivar), e)
+      end
+
+      def task_name(ivar)
+        ivar.to_s.delete_prefix("@last_").delete_suffix("_at")
+      end
+
+      def in_backoff?(now)
+        @maintenance_backoff_until && now < @maintenance_backoff_until
+      end
+
+      # Given this cycle's results, advance or reset the failure streak and
+      # the backoff window. Any success restores normal cadence. An all-failed
+      # cycle (at least one task attempted, none succeeded) advances the
+      # streak; the first such cycle reports every error individually, and the
+      # cycle that reaches the streak threshold enters backoff with a single
+      # summary warning instead.
+      def update_maintenance_backoff(now, results)
+        attempted = results.reject(&:skipped?)
+        return if attempted.empty?
+
+        if attempted.any?(&:success?)
+          reset_maintenance_backoff
+          return
+        end
+
+        enter_or_advance_backoff(now, attempted)
+      end
+
+      def reset_maintenance_backoff
+        @maintenance_failure_streak = 0
+        @maintenance_backoff_until = nil
+      end
+
+      def enter_or_advance_backoff(now, failures)
+        first_failing_cycle = @maintenance_failure_streak.zero?
+        @maintenance_failure_streak += 1
+
+        if first_failing_cycle
+          report_maintenance_failures(failures)
+        elsif @maintenance_failure_streak >= 2
+          begin_backoff(now, failures)
+        end
+      end
+
+      def report_maintenance_failures(failures)
+        failures.each do |result|
+          ErrorReporter.report(result.error, { action: "dispatcher_maintenance", task: result.task })
+        end
+      end
+
+      def begin_backoff(now, failures)
+        delay = backoff_delay(@maintenance_failure_streak)
+        @maintenance_backoff_until = now + delay
+        first = failures.first
+        Pgbus.logger.warn do
+          "[Pgbus] Dispatcher maintenance backoff: #{failures.size} task(s) failing " \
+            "(#{first.error.class}: #{first.error.message}); skipping maintenance for #{delay}s"
+        end
+      end
+
+      # Exponential window: BASE * 2**(streak - 2), capped at MAX. Streak 2 is
+      # the first backoff (2**0 == 1 == BASE), streak 3 doubles it, and so on.
+      def backoff_delay(streak)
+        [MAINTENANCE_BACKOFF_BASE * (2**(streak - 2)), MAINTENANCE_BACKOFF_MAX].min
       end
 
       def cleanup_processed_events
@@ -112,6 +220,7 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} expired processed events" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Idempotency cleanup failed: #{e.message}" }
+        e
       end
 
       def reap_stale_processes
@@ -120,6 +229,7 @@ module Pgbus
         Pgbus.logger.info { "[Pgbus] Reaped #{deleted} stale processes" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Stale process reaping failed: #{e.message}" }
+        e
       end
 
       def cleanup_concurrency
@@ -132,6 +242,7 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Expired #{orphaned} orphaned blocked executions" } if orphaned.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Concurrency cleanup failed: #{e.message}" }
+        e
       end
 
       def release_blocked_for_key(key)
@@ -146,6 +257,7 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} finished batches" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Batch cleanup failed: #{e.message}" }
+        e
       end
 
       def cleanup_stats
@@ -176,6 +288,7 @@ module Pgbus
         Pgbus.logger.info { "[Pgbus] Table maintenance completed: #{maintained} table(s) vacuumed" } if maintained.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Table maintenance failed: #{e.message}" }
+        e
       end
 
       def cleanup_job_locks
@@ -186,6 +299,9 @@ module Pgbus
         # that fail and retry can hold locks for hours.
         reaped = reap_orphaned_uniqueness_keys
         Pgbus.logger.info { "[Pgbus] Reaped #{reaped} orphaned uniqueness keys" } if reaped.positive?
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Job lock cleanup failed: #{e.message}" }
+        e
       end
 
       def reap_orphaned_uniqueness_keys
@@ -208,9 +324,6 @@ module Pgbus
         return 0 if orphaned.empty?
 
         UniquenessKey.where(lock_key: orphaned.map(&:lock_key)).delete_all
-      rescue StandardError => e
-        Pgbus.logger.warn { "[Pgbus] Uniqueness key cleanup failed: #{e.message}" }
-        0
       end
 
       # Returns true if the message referenced by this lock is definitely gone
@@ -244,6 +357,7 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} published outbox entries" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Outbox cleanup failed: #{e.message}" }
+        e
       end
 
       def compact_archives
@@ -268,6 +382,7 @@ module Pgbus
         end
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Archive compaction failed: #{e.message}" }
+        e
       end
 
       # Prunes per-stream archive tables. Unlike compact_archives (which
@@ -303,6 +418,7 @@ module Pgbus
         end
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Stream archive compaction failed: #{e.message}" }
+        e
       end
 
       def retention_for_stream_queue(full_name)
@@ -351,6 +467,7 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Orphan stream sweep complete: dropped #{dropped} queue(s)" } if dropped.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Orphan stream sweep failed: #{e.message}" }
+        e
       end
 
       def cleanup_recurring_executions
@@ -361,6 +478,7 @@ module Pgbus
         Pgbus.logger.debug { "[Pgbus] Cleaned up #{deleted} old recurring executions" } if deleted.positive?
       rescue StandardError => e
         Pgbus.logger.warn { "[Pgbus] Recurring execution cleanup failed: #{e.message}" }
+        e
       end
 
       def monotonic_now

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -12,6 +12,33 @@ RSpec.describe Pgbus::Process::Dispatcher do
     allow(Pgbus).to receive(:client).and_return(mock_client)
   end
 
+  describe described_class::LoopOutcome do
+    subject(:outcome) { described_class.new }
+
+    it "returns nil when nothing was attempted" do
+      expect(outcome.result).to be_nil
+    end
+
+    it "returns nil when every item succeeded" do
+      outcome.record_success
+      outcome.record_success
+      expect(outcome.result).to be_nil
+    end
+
+    it "returns nil on a partial failure (at least one success)" do
+      outcome.record_success
+      outcome.record_failure(StandardError.new("boom"))
+      expect(outcome.result).to be_nil
+    end
+
+    it "returns the first error when every attempt failed" do
+      first = StandardError.new("first")
+      outcome.record_failure(first)
+      outcome.record_failure(StandardError.new("second"))
+      expect(outcome.result).to be(first)
+    end
+  end
+
   describe "constants" do
     it "has a cleanup interval of 1 hour" do
       expect(described_class::CLEANUP_INTERVAL).to eq(3600)
@@ -242,6 +269,26 @@ RSpec.describe Pgbus::Process::Dispatcher do
 
       expect(call_count).to eq(2)
     end
+
+    it "returns the first error when every queue fails (surfaces total outage)" do
+      allow(mock_client).to receive(:purge_archive).and_raise(StandardError, "db down")
+
+      result = dispatcher.send(:compact_archives)
+
+      expect(result).to be_a(StandardError)
+    end
+
+    it "does not surface a failure when at least one queue succeeds (partial)" do
+      allow(mock_client).to receive(:purge_archive) do |queue_name, **_opts|
+        raise StandardError, "fail" if queue_name == "default"
+
+        3
+      end
+
+      result = dispatcher.send(:compact_archives)
+
+      expect(result).not_to be_a(StandardError)
+    end
   end
 
   describe "#run_maintenance includes archive compaction" do
@@ -400,6 +447,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
       allow(Pgbus).to receive(:logger).and_return(logger)
       allow(dispatcher).to receive(:monotonic_now) { clock }
       allow(dispatcher.config).to receive(:streams_orphan_sweep_interval).and_return(3600)
+      allow(Pgbus::ErrorReporter).to receive(:report)
     end
 
     # Make every task due as of the current stubbed clock.
@@ -437,7 +485,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "reports every task error individually on the first failing cycle" do
       force_all_due
       stub_tasks
-      allow(Pgbus::ErrorReporter).to receive(:report)
 
       run_cycle
 
@@ -446,8 +493,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
 
     it "enters backoff after two consecutive all-failed cycles with a single summary warn" do
-      allow(Pgbus::ErrorReporter).to receive(:report)
-
       force_all_due
       stub_tasks
       run_cycle # streak -> 1, per-task reports
@@ -462,8 +507,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
 
     it "suppresses per-task ErrorReporter calls once in backoff" do
-      allow(Pgbus::ErrorReporter).to receive(:report)
-
       force_all_due
       stub_tasks
       run_cycle # first failing cycle: tasks.size reports
@@ -475,8 +518,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
 
     it "skips all maintenance while inside the backoff window" do
-      allow(Pgbus::ErrorReporter).to receive(:report)
-
       force_all_due
       stub_tasks
       run_cycle
@@ -494,7 +535,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
 
     it "does not enter backoff on a partial failure (some tasks succeed)" do
-      allow(Pgbus::ErrorReporter).to receive(:report)
       succeeding = :reap_stale_processes
 
       force_all_due
@@ -508,8 +548,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
 
     it "resets the streak and restores cadence when a task succeeds" do
-      allow(Pgbus::ErrorReporter).to receive(:report)
-
       force_all_due
       stub_tasks
       run_cycle # streak -> 1
@@ -524,8 +562,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
 
     it "exits backoff as soon as a maintenance task succeeds again" do
-      allow(Pgbus::ErrorReporter).to receive(:report)
-
       force_all_due
       stub_tasks
       run_cycle
@@ -542,7 +578,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
 
     it "doubles the backoff window per consecutive failed cycle" do
-      allow(Pgbus::ErrorReporter).to receive(:report)
       stub_tasks
       base = described_class::MAINTENANCE_BACKOFF_BASE
 
@@ -561,7 +596,6 @@ RSpec.describe Pgbus::Process::Dispatcher do
     end
 
     it "caps the backoff window at MAINTENANCE_BACKOFF_MAX" do
-      allow(Pgbus::ErrorReporter).to receive(:report)
       stub_tasks
       max = described_class::MAINTENANCE_BACKOFF_MAX
 
@@ -599,13 +633,11 @@ RSpec.describe Pgbus::Process::Dispatcher do
       end
 
       it "enters backoff during a real outage where the task rescues fire" do
-        allow(Pgbus::ErrorReporter).to receive(:report)
         # Drive genuine task bodies (task methods are NOT stubbed). Make their
         # underlying dependencies raise so each task's own rescue returns the
-        # exception to run_if_due. Only the three tasks below are due; the
-        # rest stay skipped, so this proves the swallow-and-return-e path
+        # exception to run_if_due. Only the three tasks below are forced due;
+        # the rest stay skipped, so this proves the swallow-and-return-e path
         # surfaces failure without depending on every task's guard clauses.
-        allow(dispatcher.config).to receive(:streams_orphan_sweep_interval).and_return(nil)
         allow(Pgbus::ProcessedEvent).to receive(:expired).and_raise(StandardError, "db down")
         allow(Pgbus::ProcessEntry).to receive(:stale).and_raise(StandardError, "db down")
         allow(Pgbus::Batch).to receive(:cleanup).and_raise(StandardError, "db down")

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -364,4 +364,264 @@ RSpec.describe Pgbus::Process::Dispatcher do
       expect(heartbeat).to have_received(:start)
     end
   end
+
+  describe "maintenance backoff during systemic outages" do
+    # Drive run_maintenance with every task due and force each task to either
+    # raise (outage) or succeed. monotonic_now is stubbed so backoff windows
+    # are deterministic. All task methods are stubbed; the real run_if_due
+    # runs, so its :success/:failed/:skipped result and the streak/backoff
+    # logic in run_maintenance are exercised end to end.
+    let(:logger) { instance_double(Logger, info: nil, debug: nil, warn: nil, error: nil) }
+
+    # Maps each maintenance timestamp ivar to its task method, matching
+    # run_maintenance. Keeping this in the spec lets us force every task due
+    # and control which succeed or fail.
+    let(:tasks) do
+      {
+        "@last_cleanup_at": :cleanup_processed_events,
+        "@last_reap_at": :reap_stale_processes,
+        "@last_concurrency_at": :cleanup_concurrency,
+        "@last_batch_cleanup_at": :cleanup_batches,
+        "@last_recurring_cleanup_at": :cleanup_recurring_executions,
+        "@last_archive_compaction_at": :compact_archives,
+        "@last_stream_archive_compaction_at": :prune_stream_archives,
+        "@last_outbox_cleanup_at": :cleanup_outbox,
+        "@last_job_lock_cleanup_at": :cleanup_job_locks,
+        "@last_stats_cleanup_at": :cleanup_stats,
+        "@last_orphan_stream_sweep_at": :sweep_orphan_streams,
+        "@last_table_maintenance_at": :run_table_maintenance
+      }
+    end
+
+    let(:task_methods) { tasks.values }
+    let(:clock) { 1_000_000.0 }
+
+    before do
+      allow(Pgbus).to receive(:logger).and_return(logger)
+      allow(dispatcher).to receive(:monotonic_now) { clock }
+      allow(dispatcher.config).to receive(:streams_orphan_sweep_interval).and_return(3600)
+    end
+
+    # Make every task due as of the current stubbed clock.
+    def force_all_due
+      force_due(tasks.keys)
+    end
+
+    # Make only the listed timestamp ivars due as of the current stubbed clock.
+    def force_due(ivars)
+      ivars.each { |ivar| dispatcher.instance_variable_set(ivar, clock - 1_000_000) }
+    end
+
+    # Reset every timestamp ivar to now, so no task is due until forced.
+    # (initialize runs before monotonic_now is stubbed, so the ivars start at
+    # the real monotonic clock — normalize them here.)
+    def reset_all_not_due
+      tasks.each_key { |ivar| dispatcher.instance_variable_set(ivar, clock) }
+    end
+
+    # Stub every task method: fail the named tasks (default: all), succeed the rest.
+    def stub_tasks(failing: task_methods)
+      task_methods.each do |method|
+        if failing.include?(method)
+          allow(dispatcher).to receive(method).and_raise(StandardError, "db down: #{method}")
+        else
+          allow(dispatcher).to receive(method)
+        end
+      end
+    end
+
+    def run_cycle(now: clock)
+      dispatcher.send(:run_maintenance, now)
+    end
+
+    it "reports every task error individually on the first failing cycle" do
+      force_all_due
+      stub_tasks
+      allow(Pgbus::ErrorReporter).to receive(:report)
+
+      run_cycle
+
+      expect(Pgbus::ErrorReporter).to have_received(:report).exactly(tasks.size).times
+      expect(logger).not_to have_received(:warn).with(a_string_matching(/backoff/i))
+    end
+
+    it "enters backoff after two consecutive all-failed cycles with a single summary warn" do
+      allow(Pgbus::ErrorReporter).to receive(:report)
+
+      force_all_due
+      stub_tasks
+      run_cycle # streak -> 1, per-task reports
+
+      # Second all-failed cycle: streak -> 2, enter backoff, one summary warn,
+      # per-task reports suppressed.
+      force_all_due
+      run_cycle
+
+      expect(logger).to have_received(:warn).once
+      expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(2)
+    end
+
+    it "suppresses per-task ErrorReporter calls once in backoff" do
+      allow(Pgbus::ErrorReporter).to receive(:report)
+
+      force_all_due
+      stub_tasks
+      run_cycle # first failing cycle: tasks.size reports
+
+      force_all_due
+      run_cycle # enters backoff: no per-task reports, summary warn only
+
+      expect(Pgbus::ErrorReporter).to have_received(:report).exactly(tasks.size).times
+    end
+
+    it "skips all maintenance while inside the backoff window" do
+      allow(Pgbus::ErrorReporter).to receive(:report)
+
+      force_all_due
+      stub_tasks
+      run_cycle
+      force_all_due
+      run_cycle # now in backoff until clock + BACKOFF_BASE
+
+      force_all_due
+      run_cycle(now: clock + 1) # still inside backoff window
+
+      # The third cycle is inside the backoff window, so no task runs again:
+      # each task was invoked exactly twice (the two pre-backoff cycles).
+      task_methods.each do |method|
+        expect(dispatcher).to have_received(method).exactly(2).times
+      end
+    end
+
+    it "does not enter backoff on a partial failure (some tasks succeed)" do
+      allow(Pgbus::ErrorReporter).to receive(:report)
+      succeeding = :reap_stale_processes
+
+      force_all_due
+      stub_tasks(failing: task_methods - [succeeding])
+      run_cycle
+      force_all_due
+      run_cycle
+
+      expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(0)
+      expect(logger).not_to have_received(:warn)
+    end
+
+    it "resets the streak and restores cadence when a task succeeds" do
+      allow(Pgbus::ErrorReporter).to receive(:report)
+
+      force_all_due
+      stub_tasks
+      run_cycle # streak -> 1
+
+      # Recovery cycle: all tasks succeed.
+      task_methods.each { |method| allow(dispatcher).to receive(method) }
+      force_all_due
+      run_cycle
+
+      expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(0)
+      expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to be_nil
+    end
+
+    it "exits backoff as soon as a maintenance task succeeds again" do
+      allow(Pgbus::ErrorReporter).to receive(:report)
+
+      force_all_due
+      stub_tasks
+      run_cycle
+      force_all_due
+      run_cycle # in backoff
+
+      backoff_end = dispatcher.instance_variable_get(:@maintenance_backoff_until)
+      task_methods.each { |method| allow(dispatcher).to receive(method) } # all succeed
+      force_all_due
+      run_cycle(now: backoff_end + 1)
+
+      expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(0)
+      expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to be_nil
+    end
+
+    it "doubles the backoff window per consecutive failed cycle" do
+      allow(Pgbus::ErrorReporter).to receive(:report)
+      stub_tasks
+      base = described_class::MAINTENANCE_BACKOFF_BASE
+
+      # Cycle 1: streak 1 (no backoff). Cycle 2: streak 2 -> base * 2**0.
+      force_all_due
+      run_cycle(now: clock)
+      force_all_due
+      run_cycle(now: clock)
+      expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to eq(clock + base)
+
+      # Next failing cycle after window: streak 3 -> base * 2**1.
+      later = clock + base + 1
+      force_all_due
+      run_cycle(now: later)
+      expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to eq(later + (base * 2))
+    end
+
+    it "caps the backoff window at MAINTENANCE_BACKOFF_MAX" do
+      allow(Pgbus::ErrorReporter).to receive(:report)
+      stub_tasks
+      max = described_class::MAINTENANCE_BACKOFF_MAX
+
+      now = clock
+      window = nil
+      # Drive many consecutive failing cycles, each starting just after the
+      # previous window ends. Capture the last window (deadline - cycle start).
+      20.times do
+        force_all_due
+        run_cycle(now: now)
+        deadline = dispatcher.instance_variable_get(:@maintenance_backoff_until)
+        window = deadline - now if deadline
+        now = (deadline || now) + 1
+      end
+
+      expect(window).to eq(max)
+    end
+
+    context "when a task swallows its own error and returns the exception" do
+      # Most task methods rescue StandardError internally (to log a
+      # descriptive warning) and hand the exception back to run_if_due via
+      # `return e`. run_if_due must treat that as a failure just like a raise,
+      # otherwise a real outage (where those rescues fire) would never trip
+      # backoff.
+      it "normalizes a returned StandardError to a :failed result" do
+        dispatcher.instance_variable_set(:@last_cleanup_at, clock - 1_000_000)
+        result = dispatcher.send(:run_if_due, clock, :@last_cleanup_at, described_class::CLEANUP_INTERVAL) do
+          StandardError.new("db down")
+        end
+
+        expect(result.status).to eq(:failed)
+        expect(result.error).to be_a(StandardError)
+        # Timestamp must NOT advance on failure, so the next tick retries.
+        expect(dispatcher.instance_variable_get(:@last_cleanup_at)).to eq(clock - 1_000_000)
+      end
+
+      it "enters backoff during a real outage where the task rescues fire" do
+        allow(Pgbus::ErrorReporter).to receive(:report)
+        # Drive genuine task bodies (task methods are NOT stubbed). Make their
+        # underlying dependencies raise so each task's own rescue returns the
+        # exception to run_if_due. Only the three tasks below are due; the
+        # rest stay skipped, so this proves the swallow-and-return-e path
+        # surfaces failure without depending on every task's guard clauses.
+        allow(dispatcher.config).to receive(:streams_orphan_sweep_interval).and_return(nil)
+        allow(Pgbus::ProcessedEvent).to receive(:expired).and_raise(StandardError, "db down")
+        allow(Pgbus::ProcessEntry).to receive(:stale).and_raise(StandardError, "db down")
+        allow(Pgbus::Batch).to receive(:cleanup).and_raise(StandardError, "db down")
+
+        due = %i[@last_cleanup_at @last_reap_at @last_batch_cleanup_at]
+        reset_all_not_due
+
+        force_due(due)
+        run_cycle # first failing cycle: per-task reports, streak -> 1
+        reset_all_not_due
+        force_due(due)
+        run_cycle # second failing cycle: streak -> 2, enter backoff
+
+        expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(2)
+        expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to eq(clock + described_class::MAINTENANCE_BACKOFF_BASE)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

During a sustained database outage, the dispatcher's ~12 maintenance tasks each became due every `dispatch_interval` and failed, emitting up to **12 error reports per tick** for the whole outage — log spam and error-tracker noise.

This adds a full-cycle failure streak with exponential backoff:

- `run_if_due` now returns a `MaintenanceResult` (`:success` / `:failed` / `:skipped`); `run_maintenance` collects them.
- A cycle that attempts ≥1 task and fails **all** of them increments `@maintenance_failure_streak`; **any** success resets it to 0.
- At streak 2 the dispatcher enters **backoff** — skipping all maintenance for `MAINTENANCE_BACKOFF_BASE * 2**(streak - 2)` seconds, capped at `MAINTENANCE_BACKOFF_MAX` (30s → 600s). New constants, per the constants-not-config precedent already in the file.
- Per backoff decision: exactly **one** summarized `Pgbus.logger.warn` (failed task count, first error class/message, delay).
- The **first** failing cycle still reports every task error individually via `ErrorReporter.report`; while in backoff, per-task reports are suppressed.
- Backoff **exits the moment any task succeeds** again.
- The main loop's `interruptible_sleep` is untouched, so graceful shutdown stays responsive mid-backoff.

### Why the task methods changed too

Most maintenance task methods rescue their own errors to log a descriptive warning, so they **never re-raised** to `run_if_due`. Keyed off `run_if_due` alone, backoff would have seen those swallowed failures as `:success` and **never engaged during a real outage** — defeating the whole point.

Each swallowing task now hands the caught exception back via `return e`; `run_if_due` normalizes a returned `StandardError` (or a raise) to a `:failed` result. The redundant inner rescue in `reap_orphaned_uniqueness_keys` moved up into `cleanup_job_locks` so job-lock failures surface too. Descriptive per-task warn logging is preserved.

## Acceptance criteria

- [x] Sustained all-task outage → one summary warn per backoff period instead of ~12 error reports per tick
- [x] Backoff doubles per consecutive failed cycle, capped at `MAINTENANCE_BACKOFF_MAX`
- [x] First failing cycle still reports every task error individually
- [x] Partial failure (some tasks succeed) never triggers backoff
- [x] One task succeeding resets the streak and restores normal cadence
- [x] Graceful shutdown during backoff exits promptly (`interruptible_sleep` untouched)

## Test plan

`spec/pgbus/process/dispatcher_spec.rb` (stubbed monotonic clock):

- [x] all-tasks-fail streak triggers backoff + a single summary log
- [x] partial failure does not trigger backoff
- [x] recovery resets streak and exits backoff
- [x] `ErrorReporter` receives per-task calls only on the first failing cycle
- [x] backoff doubles per cycle and respects the cap
- [x] `run_if_due` normalizes a returned `StandardError` to `:failed`
- [x] real-outage path: a task's own rescue returning the exception trips backoff (task methods not stubbed)

## Verification

- `bundle exec rubocop` (changed files) — clean
- `bundle exec rspec spec/pgbus/process/` — 272 examples, 0 failures
- `dispatcher_spec` — 50 examples, 0 failures

Pre-existing, unrelated failures on `main` (confirmed by stashing this branch): `spec/i18n_spec.rb` (i18n-tasks scanner bug) and `spec/system/queues_spec.rb` (needs a browser). Neither touches the dispatcher.

Closes #203


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maintenance now uses backoff during repeated outages to reduce noisy logs and repeated retries.
  * Maintenance tasks are tracked with clearer per-task outcomes, including success, failure, and skipped states.

* **Bug Fixes**
  * Improved handling when maintenance tasks fail or return errors, so failures are reported more consistently.
  * Maintenance timestamps now advance only after successful runs, helping retry behavior stay accurate.
  * Recovery after an outage resets backoff state and resumes normal maintenance timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->