### PR TITLE
feat(connections): reject replica connections when building listener connections

### DIFF
--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -20,6 +20,23 @@ module Pgbus
   class SchemaNotReady < Error; end
   class ReadTimeoutError < Error; end
 
+  module Process
+    # A LISTEN connection landed on a read-only replica (pg_is_in_recovery() =>
+    # t). After a failover, stale DNS can point a fresh connection at the
+    # demoted master; NOTIFY fires only on the primary, so such a connection
+    # connects "successfully" but never wakes. Raised by
+    # Process::PrimaryValidator so the listener rejects it and retries with
+    # backoff (re-resolving DNS each attempt).
+    #
+    # Defined here rather than in process/primary_validator.rb because Zeitwerk
+    # requires each managed file to define exactly the constant matching its
+    # path — a second class in that file would break eager_load. lib/pgbus.rb
+    # is the (require-loaded) gem entry point, so it can define the error and
+    # explicitly namespace Process without conflicting with Zeitwerk's
+    # management of the lib/pgbus/process/ directory.
+    class ReplicaConnectionError < Error; end
+  end
+
   class << self
     # Process-global flag set by Worker#graceful_shutdown so the adapter
     # can report stopping? to ActiveJob::Continuation (Rails 8.1+).

--- a/lib/pgbus/process/notify_listener.rb
+++ b/lib/pgbus/process/notify_listener.rb
@@ -103,6 +103,13 @@ module Pgbus
 
       def run_loop
         conn = build_connection
+        # Reject a connection that landed on a read-only replica before doing
+        # anything else. After a failover, stale DNS can point this fresh
+        # connection at the demoted master; NOTIFY fires only on the primary,
+        # so we'd sit deaf forever. A replica here raises ReplicaConnectionError
+        # and the rescue below runs the fatal/ensure path (worker-level startup
+        # retry is a separate concern); a reconnect converges on the primary.
+        PrimaryValidator.validate_primary!(conn)
         # One-shot delivery self-probe on the initial connection only. A pooler
         # or replica that silently breaks LISTEN/NOTIFY is surfaced here with an
         # actionable error; the listener still runs and degrades to polling.
@@ -205,12 +212,16 @@ module Pgbus
           new_conn = nil
           begin
             new_conn = build_connection
+            # Reject a replica before re-LISTENing. A fresh PG.connect re-resolves
+            # DNS, so backing off and retrying converges on the promoted master
+            # once DNS catches up after a failover.
+            PrimaryValidator.validate_primary!(new_conn)
             channels.each { |channel| new_conn.exec(%(LISTEN "#{channel}")) }
-          rescue PG::Error => e
-            # build_connection may have succeeded before a later LISTEN raised.
-            # Without this close, the partially-built conn is orphaned and the
-            # next retry just allocates another one — leaking PG connections on
-            # repeated failures.
+          rescue PG::Error, ReplicaConnectionError => e
+            # build_connection may have succeeded before a later LISTEN raised,
+            # or validate_primary! rejected a replica. Without this close, the
+            # partially-built conn is orphaned and the next retry just allocates
+            # another one — leaking PG connections on repeated failures.
             close_quietly(new_conn)
             @logger.error { "[Pgbus::NotifyListener] reconnect failed: #{e.class}: #{e.message}" }
             sleep RECONNECT_BACKOFF_SECONDS

--- a/lib/pgbus/process/primary_validator.rb
+++ b/lib/pgbus/process/primary_validator.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Pgbus
+  module Process
+    # Rejects a freshly built LISTEN connection that landed on a read-only
+    # replica. After a PostgreSQL failover, stale DNS can point a fresh
+    # `PG.connect` at the demoted master — now a replica. NOTIFY fires only on
+    # the primary, so the listener would connect "successfully" and then sit
+    # deaf forever, waking on nothing and degrading to slow fallback polling
+    # with no explanation.
+    #
+    # `SELECT pg_is_in_recovery()` returns `t` on a replica (a standby in
+    # recovery) and `f` on the primary. On a replica we raise
+    # ReplicaConnectionError so the caller's existing reconnect loop closes the
+    # connection, backs off, and retries. Each retry calls `PG.connect` fresh,
+    # which re-resolves DNS, so the loop converges on the promoted master once
+    # DNS catches up.
+    #
+    # These listeners own raw PG::Connections by design — the documented
+    # exception to the "all PGMQ access through Pgbus::Client" rule — so the
+    # validator operates directly on a PG::Connection. It is a sibling of
+    # NotifyProbe (delivery self-probe); PrimaryValidator is the cheap
+    # every-connection recovery check, NotifyProbe the one-shot start-only
+    # delivery check.
+    module PrimaryValidator
+      RECOVERY_QUERY = "SELECT pg_is_in_recovery()"
+
+      class << self
+        # Runs the recovery check. Returns the connection unchanged on a primary
+        # so callers can write `validate_primary!(build_connection)`. Raises
+        # ReplicaConnectionError on a replica. A PG::Error from exec (dead
+        # connection, etc.) propagates unchanged — callers already rescue
+        # PG::Error and treat it as a reconnect trigger.
+        def validate_primary!(conn)
+          return conn unless in_recovery?(conn)
+
+          raise ReplicaConnectionError,
+                "LISTEN connection landed on a read-only replica " \
+                "(pg_is_in_recovery() => t). After a failover, stale DNS can " \
+                "point a fresh connection at the demoted master. NOTIFY fires " \
+                "only on the primary, so this connection would never wake. " \
+                "Rejecting it; the reconnect loop will re-resolve DNS and retry."
+        end
+
+        private
+
+        def in_recovery?(conn)
+          conn.exec(RECOVERY_QUERY).getvalue(0, 0) == "t"
+        end
+      end
+    end
+  end
+end

--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -147,8 +147,8 @@ module Pgbus
           require "pg" unless defined?(::PG::Connection)
           opts = @config.streams_connection_options
           case opts
-          when String then probe(::PG.connect(opts))
-          when Hash   then probe(::PG.connect(**opts))
+          when String then probe(validate_primary(::PG.connect(opts)))
+          when Hash   then probe(validate_primary(::PG.connect(**opts)))
           when Proc
             # The Proc branch in connection_options typically returns
             # ActiveRecord::Base.connection.raw_connection — a pooled
@@ -166,6 +166,31 @@ module Pgbus
             raise Pgbus::ConfigurationError,
                   "Cannot build streamer PG connection from #{opts.class}"
           end
+        end
+
+        # Reject a connection that landed on a read-only replica before the
+        # streamer wires it into a Listener. After a failover, stale DNS can
+        # point this fresh PG.connect at the demoted master; NOTIFY fires only
+        # on the primary, so the streamer would sit deaf. Unlike the reconnect
+        # loop (which retries), this runs once at Instance construction (Puma
+        # worker boot), so a replica here is a fatal misconfiguration: re-raise
+        # as a ConfigurationError naming the direct-connection overrides.
+        def validate_primary(pg_connection)
+          Pgbus::Process::PrimaryValidator.validate_primary!(pg_connection)
+        rescue Pgbus::Process::ReplicaConnectionError => e
+          close_quietly(pg_connection)
+          raise Pgbus::ConfigurationError,
+                "Streamer LISTEN connection landed on a read-only replica " \
+                "(#{e.message}). NOTIFY fires only on the primary, so the " \
+                "streamer would never wake. Point the streamer at a DIRECT " \
+                "primary via streams_database_url (or streams_host / " \
+                "streams_port)."
+        end
+
+        def close_quietly(pg_connection)
+          pg_connection.close if pg_connection.respond_to?(:close)
+        rescue StandardError
+          nil
         end
 
         # One-shot LISTEN/NOTIFY delivery self-probe on the freshly built

--- a/lib/pgbus/web/streamer/listener.rb
+++ b/lib/pgbus/web/streamer/listener.rb
@@ -199,6 +199,14 @@ module Pgbus
 
         def reconnect!
           @conn.reset
+          # Reject a connection that came back on a read-only replica before
+          # re-LISTENing. After a failover, conn.reset can re-resolve stale DNS
+          # to the demoted master; NOTIFY fires only on the primary, so
+          # re-LISTENing there would register channels that never wake. A
+          # replica raises ReplicaConnectionError into the rescue below, which
+          # sleeps 0.5s; the next cycle resets again and converges on the
+          # promoted primary once DNS catches up.
+          Pgbus::Process::PrimaryValidator.validate_primary!(@conn)
           # Don't clear @listening_to until the new set is built. If a
           # mid-loop LISTEN raises, we keep the original set so the
           # next reconnect cycle still knows which channels need to
@@ -211,7 +219,7 @@ module Pgbus
             new_listening.add(channel)
           end
           @listening_to = new_listening
-        rescue PG::Error => e
+        rescue PG::Error, Pgbus::Process::ReplicaConnectionError => e
           @logger.error { "[Pgbus::Streamer::Listener] reconnect failed: #{e.class}: #{e.message}" }
           sleep 0.5
         end

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Pgbus::Process::NotifyListener do
     # notify_probe_spec. Neutralize it by default so it doesn't consume events
     # from the fake connection's queue; the probe-specific describe re-stubs it.
     allow(Pgbus::Process::NotifyProbe).to receive(:probe_notify_delivery!).and_return(true)
+    # PrimaryValidator runs SELECT pg_is_in_recovery() on every built connection.
+    # The default fake_pg's #exec returns nil, so neutralize the validator by
+    # default (it passes the connection through). The replica-rejection describe
+    # re-stubs it to raise ReplicaConnectionError.
+    allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!) { |conn| conn }
   end
 
   let(:fake_pg) do
@@ -234,6 +239,72 @@ RSpec.describe Pgbus::Process::NotifyListener do
           "pgmq.q_pgbus_low.INSERT"
         )
       end
+    end
+  end
+
+  describe "replica rejection (failover self-healing)" do
+    context "when a reconnect lands on a replica then converges on the primary" do
+      let(:replica_pg) { fake_pg.class.new }
+      let(:primary_pg) { fake_pg.class.new }
+
+      before do
+        # Initial conn (fake_pg) is a primary; the first reconnect attempt lands
+        # on a replica; the second reconnect attempt lands on the primary.
+        call_sequence = [fake_pg, replica_pg, primary_pg]
+        allow_any_instance_of(described_class).to receive(:build_connection) { call_sequence.shift }
+        # validate_primary! passes fake_pg and primary_pg through, but raises
+        # for replica_pg — mirroring pg_is_in_recovery() => t on the demoted host.
+        allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!) do |conn|
+          raise Pgbus::Process::ReplicaConnectionError, "on a replica" if conn.equal?(replica_pg)
+
+          conn
+        end
+        stub_const("Pgbus::Process::NotifyListener::RECONNECT_BACKOFF_SECONDS", 0.01)
+
+        listener.start
+        fake_pg.push_timeout
+        wait_until { listener.listening_to.size == 2 }
+
+        fake_pg.push_error(PG::Error.new("connection reset"))
+        primary_pg.push_timeout
+        wait_until { primary_pg.executed.count { |s| s.start_with?("LISTEN") } >= 2 }
+      end
+
+      it "closes the replica connection before retrying" do
+        expect(replica_pg).to be_closed
+      end
+
+      it "re-LISTENs every channel on the promoted primary" do
+        expect(listener.listening_to).to contain_exactly(
+          "pgmq.q_pgbus_default.INSERT",
+          "pgmq.q_pgbus_low.INSERT"
+        )
+        expect(primary_pg.executed).to include(
+          %(LISTEN "pgmq.q_pgbus_default.INSERT"),
+          %(LISTEN "pgmq.q_pgbus_low.INSERT")
+        )
+      end
+    end
+
+    it "validates the initial connection is a primary at start" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      expect(Pgbus::Process::PrimaryValidator).to have_received(:validate_primary!).with(fake_pg)
+    end
+
+    it "does not run the delivery probe when the initial connection is a replica" do
+      allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!)
+        .and_raise(Pgbus::Process::ReplicaConnectionError.new("on a replica"))
+
+      listener.start
+      wait_until { !listener.instance_variable_get(:@thread)&.alive? }
+
+      # The replica is rejected before the delivery probe runs (probe is only
+      # meaningful on a primary), and the thread exits via the fatal/ensure path.
+      expect(Pgbus::Process::NotifyProbe).not_to have_received(:probe_notify_delivery!)
+      expect(listener.instance_variable_get(:@running)).to be(false)
     end
   end
 

--- a/spec/pgbus/process/primary_validator_spec.rb
+++ b/spec/pgbus/process/primary_validator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgbus::Process::PrimaryValidator do
+  before do
+    stub_const("PG", Module.new) unless defined?(PG)
+    stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
+  end
+
+  # A minimal PG::Connection double: exec("SELECT pg_is_in_recovery()") returns a
+  # PG::Result-like object whose getvalue(0, 0) is the scripted "t"/"f" string.
+  def build_conn(in_recovery:)
+    result = Object.new
+    value = in_recovery ? "t" : "f"
+    result.define_singleton_method(:getvalue) { |_row, _col| value }
+
+    conn = Object.new
+    executed = []
+    conn.define_singleton_method(:exec) do |sql|
+      executed << sql
+      result
+    end
+    conn.define_singleton_method(:executed) { executed }
+    conn
+  end
+
+  describe ".validate_primary!" do
+    context "when the connection is a primary (pg_is_in_recovery() => f)" do
+      let(:conn) { build_conn(in_recovery: false) }
+
+      it "returns the connection" do
+        expect(described_class.validate_primary!(conn)).to be(conn)
+      end
+
+      it "runs SELECT pg_is_in_recovery()" do
+        described_class.validate_primary!(conn)
+        expect(conn.executed).to include("SELECT pg_is_in_recovery()")
+      end
+
+      it "does not raise" do
+        expect { described_class.validate_primary!(conn) }.not_to raise_error
+      end
+    end
+
+    context "when the connection is a read-only replica (pg_is_in_recovery() => t)" do
+      let(:conn) { build_conn(in_recovery: true) }
+
+      it "raises ReplicaConnectionError" do
+        expect { described_class.validate_primary!(conn) }
+          .to raise_error(Pgbus::Process::ReplicaConnectionError)
+      end
+
+      it "raises a subclass of Pgbus::Error" do
+        expect(Pgbus::Process::ReplicaConnectionError.ancestors).to include(Pgbus::Error)
+      end
+
+      it "names the replica/recovery condition in the message" do
+        expect { described_class.validate_primary!(conn) }
+          .to raise_error(Pgbus::Process::ReplicaConnectionError, /replica|recovery/i)
+      end
+    end
+  end
+end

--- a/spec/pgbus/web/streamer/instance_spec.rb
+++ b/spec/pgbus/web/streamer/instance_spec.rb
@@ -105,7 +105,13 @@ RSpec.describe Pgbus::Web::Streamer::Instance do
 
     # Neutralize the self-probe by default (it owns a real LISTEN/NOTIFY dance
     # covered by notify_probe_spec); probe-specific examples below re-stub it.
-    before { allow(Pgbus::Process::NotifyProbe).to receive(:probe_notify_delivery!).and_return(true) }
+    before do
+      allow(Pgbus::Process::NotifyProbe).to receive(:probe_notify_delivery!).and_return(true)
+      # build_pg_connection validates the freshly built connection is a primary.
+      # Neutralize the validator by default (fake connections aren't real);
+      # the replica-rejection examples below re-stub it to raise.
+      allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!) { |conn| conn }
+    end
 
     it "uses streams_connection_options so the listener can be pointed at a different port" do
       require "pg"
@@ -147,6 +153,33 @@ RSpec.describe Pgbus::Web::Streamer::Instance do
       described_class.new(client: client, config: config, pg_connection: fake_pg, logger: Logger.new(IO::NULL))
 
       expect(Pgbus::Process::NotifyProbe).not_to have_received(:probe_notify_delivery!)
+    end
+
+    context "when the freshly built connection lands on a read-only replica" do
+      before do
+        require "pg"
+        allow(PG).to receive(:connect).and_return(fake_pg_module_conn)
+        allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!)
+          .and_raise(Pgbus::Process::ReplicaConnectionError.new("on a replica"))
+      end
+
+      it "raises a ConfigurationError naming the streams_* override keys" do
+        error = nil
+        begin
+          described_class.new(client: client, config: streamer_config, logger: Logger.new(IO::NULL))
+        rescue Pgbus::ConfigurationError => e
+          error = e
+        end
+
+        expect(error).to be_a(Pgbus::ConfigurationError)
+        expect(error.message).to include("streams_database_url", "streams_host", "streams_port")
+      end
+
+      it "names the read-only replica condition in the message" do
+        expect do
+          described_class.new(client: client, config: streamer_config, logger: Logger.new(IO::NULL))
+        end.to raise_error(Pgbus::ConfigurationError, /replica/i)
+      end
     end
   end
 

--- a/spec/pgbus/web/streamer/listener_spec.rb
+++ b/spec/pgbus/web/streamer/listener_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Pgbus::Web::Streamer::Listener do
   before do
     stub_const("PG", Module.new) unless defined?(PG)
     stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
+    # reconnect! validates the connection is a primary via pg_is_in_recovery().
+    # The fake_pg's #exec returns nil, so neutralize the validator by default
+    # (it passes the connection through). The replica-rejection describe re-stubs
+    # it to raise ReplicaConnectionError.
+    allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!) { |conn| conn }
   end
 
   # A scripted stand-in for PG::Connection. The real PG::Connection blocks on
@@ -279,6 +284,61 @@ RSpec.describe Pgbus::Web::Streamer::Listener do
         "pgmq.q_chat.INSERT", "pgmq.q_presence.INSERT"
       )
       raising_listener.stop
+    end
+  end
+
+  describe "replica rejection on reconnect (failover self-healing)" do
+    it "keeps retrying while conn.reset lands on a replica, then re-LISTENs on the primary" do
+      listener.start
+      listener.ensure_listening("chat")
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 1 }
+
+      # First validation after reset sees a replica (pg_is_in_recovery => t) and
+      # raises; the second sees the promoted primary and passes. reconnect! sleeps
+      # 0.5s between cycles, so drive one PG::Error, wait for the retry, then feed
+      # the loop a timeout so the successful relisten can be observed.
+      calls = 0
+      allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!) do |conn|
+        calls += 1
+        raise Pgbus::Process::ReplicaConnectionError, "on a replica" if calls == 1
+
+        conn
+      end
+
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      # First reconnect: reset succeeds, validate raises replica → logs, sleeps 0.5s.
+      wait_until { fake_pg.reset_count >= 1 }
+      # Second reconnect cycle: another PG::Error drives the loop back in; this
+      # time validate passes and every channel is re-LISTENed.
+      fake_pg.push_error(PG::Error.new("still settling"))
+      fake_pg.push_timeout
+
+      wait_until(timeout: 3) do
+        fake_pg.executed.count { |s| s == %(LISTEN "pgmq.q_chat.INSERT") } >= 2
+      end
+
+      expect(listener.listening_to).to contain_exactly("pgmq.q_chat.INSERT")
+    end
+
+    it "does not re-LISTEN channels while still on a replica" do
+      listener.start
+      listener.ensure_listening("chat")
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 1 }
+
+      allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!)
+        .and_raise(Pgbus::Process::ReplicaConnectionError.new("on a replica"))
+
+      listen_count_before = fake_pg.executed.count { |s| s == %(LISTEN "pgmq.q_chat.INSERT") }
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      wait_until { fake_pg.reset_count >= 1 }
+      sleep 0.1
+
+      # A replica reset must not re-LISTEN — the channel would register on a host
+      # that never NOTIFYs. The subscription set is preserved for the next cycle.
+      expect(fake_pg.executed.count { |s| s == %(LISTEN "pgmq.q_chat.INSERT") }).to eq(listen_count_before)
+      expect(listener.listening_to).to contain_exactly("pgmq.q_chat.INSERT")
     end
   end
 


### PR DESCRIPTION
## Summary

After a PostgreSQL failover, stale DNS can point a fresh LISTEN connection at the old master — now a read-only replica. NOTIFY fires only on the primary, so the listener connects "successfully" but never wakes, staying pinned to the demoted host until process restart.

This adds `Pgbus::Process::PrimaryValidator.validate_primary!(conn)` (runs `SELECT pg_is_in_recovery()`, raises `Pgbus::Process::ReplicaConnectionError` on a replica) and wires it into every listener connection-build path.

## Changes

- **`NotifyListener#run_loop`** (`lib/pgbus/process/notify_listener.rb`) — validates the initial connection; a replica takes the existing fatal/ensure path (worker-level startup retry is a separate concern).
- **`NotifyListener#reconnect!`** — validates the rebuilt connection inside the begin block and rescues `ReplicaConnectionError` alongside `PG::Error`: the connection is `close_quietly`'d, logged, backed off (`RECONNECT_BACKOFF_SECONDS`), and retried. Each retry calls `PG.connect` fresh (re-resolving DNS), so the loop converges on the promoted primary.
- **`Streamer::Listener#reconnect!`** (`lib/pgbus/web/streamer/listener.rb`) — validates after `@conn.reset`; a replica raises into the existing `rescue`, which sleeps 0.5s and retries next cycle.
- **`Streamer::Instance#build_pg_connection`** (`lib/pgbus/web/streamer/instance.rb`) — validates the freshly built connection and re-raises a replica as `Pgbus::ConfigurationError` naming the `streams_database_url` / `streams_host` / `streams_port` overrides. This runs once at Puma worker boot, so a replica here is a fatal misconfiguration, not a retry loop.
- **`ReplicaConnectionError`** is defined in `lib/pgbus.rb` under an explicit `Process` module rather than in `primary_validator.rb`, because Zeitwerk requires each managed file to define exactly the constant matching its path — a second class in that file would break `eager_load`.

Raw PG usage in these listeners is the established exception to the "all PGMQ access through `Pgbus::Client`" rule.

## Acceptance criteria

- [x] A connection where `pg_is_in_recovery()` returns `t` is closed and retried with backoff in `NotifyListener#reconnect!`
- [x] Streamer reconnect re-validates and keeps retrying while on a replica
- [x] Log/error messages name the replica condition and the relevant override keys
- [x] Once a connection reports `f`, the listener proceeds and re-LISTENs all channels

## Test plan

- [x] `spec/pgbus/process/primary_validator_spec.rb` — raises on `t`, passes on `f`, subclass of `Pgbus::Error`, actionable message
- [x] `spec/pgbus/process/notify_listener_spec.rb` — reconnect converges (replica → primary), replica conn closed, channels re-LISTENed on the primary; replica at start skips the delivery probe and exits via the fatal path
- [x] `spec/pgbus/web/streamer/listener_spec.rb` — reconnect keeps retrying while on a replica and does not re-LISTEN there
- [x] `spec/pgbus/web/streamer/instance_spec.rb` — build-time replica raises `ConfigurationError` naming the `streams_*` override keys and the replica condition
- [x] `bundle exec rubocop` clean (9 files); `bundle exec rspec` green (55 examples across the 4 affected specs, 0 failures)

Closes #192
