### PR TITLE
feat(connections): retry failed NotifyListener startup from the worker loop

### DIFF
--- a/lib/pgbus/process/notify_listener.rb
+++ b/lib/pgbus/process/notify_listener.rb
@@ -95,11 +95,14 @@ module Pgbus
         @commands << [:unlisten, physical_queue]
       end
 
-      private
-
+      # Public so the owning worker can detect a listener whose thread died
+      # (run_loop hit a fatal error and cleared @running in its ensure) and
+      # restart it. Guarded by @state_mutex like every other @running access.
       def running?
         @state_mutex.synchronize { @running }
       end
+
+      private
 
       def run_loop
         conn = build_connection

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -53,6 +53,8 @@ module Pgbus
         @drain_started_at = nil
         @queue_lock = QueueLock.new if @single_active_consumer
         @notify_listener = nil
+        @notify_retry_at = 0.0
+        @notify_retry_backoff = NOTIFY_RETRY_BASE_SECONDS
       end
 
       def stats
@@ -71,6 +73,15 @@ module Pgbus
       end
 
       NOTIFY_FALLBACK_POLL_SECONDS = 15
+
+      # NotifyListener startup can fail on a transient boot-time condition (DB
+      # restarting, failover, DNS blip) or its thread can die mid-run. Rather
+      # than downgrade to blind polling until process restart, the loop retries
+      # from ensure_notify_listener on an exponential backoff: NOTIFY_RETRY_BASE
+      # doubling up to NOTIFY_RETRY_MAX. Constant-tuned, matching DRAIN_TIMEOUT
+      # and CircuitBreaker/Dispatcher precedent.
+      NOTIFY_RETRY_BASE_SECONDS = 5
+      NOTIFY_RETRY_MAX_SECONDS = 300
 
       # Upper bound on the drain phase. Waiting for quiesced? must be
       # bounded: a permanently-stuck job would otherwise hold the loop open
@@ -98,6 +109,7 @@ module Pgbus
           process_signals
           check_recycle
           refresh_wildcard_queues
+          ensure_notify_listener
 
           break if @lifecycle.stopped?
           # quiesced? (all slots free), not idle? (any slot free) — exiting
@@ -455,7 +467,11 @@ module Pgbus
       end
 
       def wake_timeout
-        return effective_polling_interval unless notify_wakeup? && @notify_listener
+        # A dead listener (running? false) will never wake the loop, so treat
+        # it as absent and keep polling at the short interval until
+        # ensure_notify_listener restarts it. Only a live listener earns the
+        # long NOTIFY-mode ceiling.
+        return effective_polling_interval unless notify_wakeup? && @notify_listener&.running?
 
         [effective_polling_interval, config.polling_interval, NOTIFY_FALLBACK_POLL_SECONDS].max
       end
@@ -487,6 +503,42 @@ module Pgbus
         Pgbus.logger.error do
           "[Pgbus] NotifyListener failed to start, falling back to polling: #{e.class}: #{e.message}"
         end
+      end
+
+      # Self-heal a NotifyListener that never started or whose thread died.
+      # Called each loop iteration but gated by a monotonic backoff timestamp
+      # so a persistent outage retries on 5s→…→300s intervals, not every tick
+      # (mirrors refresh_wildcard_queues' throttle). A restarted listener has
+      # its queue subscription reconciled (wildcard workers) and the backoff
+      # reset; a still-failing restart doubles the backoff up to the cap.
+      def ensure_notify_listener
+        return unless notify_wakeup?
+        return if @notify_listener&.running?
+        return if monotonic_now < @notify_retry_at
+
+        stop_dead_notify_listener
+        start_notify_listener
+
+        if @notify_listener&.running?
+          sync_notify_listener_queues
+          @notify_retry_backoff = NOTIFY_RETRY_BASE_SECONDS
+        else
+          @notify_retry_backoff = [@notify_retry_backoff * 2, NOTIFY_RETRY_MAX_SECONDS].min
+        end
+        @notify_retry_at = monotonic_now + @notify_retry_backoff
+      end
+
+      # Stop a listener whose thread died so its dedicated PG connection is
+      # released before start_notify_listener allocates a fresh one. A nil or
+      # still-running listener is left alone (the caller already gated on it).
+      def stop_dead_notify_listener
+        return if @notify_listener.nil?
+
+        @notify_listener.stop
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Failed to stop dead NotifyListener: #{e.class}: #{e.message}" }
+      ensure
+        @notify_listener = nil
       end
 
       def sync_notify_listener_queues

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -356,6 +356,33 @@ RSpec.describe Pgbus::Process::NotifyListener do
     end
   end
 
+  describe "#running? (public)" do
+    it "is false before start" do
+      expect(listener.running?).to be(false)
+    end
+
+    it "is true while the listener thread is alive" do
+      listener.start
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      expect(listener.running?).to be(true)
+    end
+
+    it "reflects thread death after a fatal run_loop error" do
+      # A connection built at start that dies mid-loop drives run_loop through
+      # its rescue/ensure path, which clears @running. The worker relies on
+      # running? flipping to false to detect a dead listener and restart it.
+      allow_any_instance_of(described_class).to receive(:build_connection)
+        .and_raise(PG::Error.new("boot failed"))
+
+      listener.start
+      wait_until { !listener.instance_variable_get(:@thread)&.alive? }
+
+      expect(listener.running?).to be(false)
+    end
+  end
+
   describe "#stop" do
     it "interrupts the blocking wait and clears the LISTEN set" do
       listener.start

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -373,11 +373,11 @@ RSpec.describe Pgbus::Process::NotifyListener do
       # A connection built at start that dies mid-loop drives run_loop through
       # its rescue/ensure path, which clears @running. The worker relies on
       # running? flipping to false to detect a dead listener and restart it.
-      allow_any_instance_of(described_class).to receive(:build_connection)
+      allow(listener).to receive(:build_connection)
         .and_raise(PG::Error.new("boot failed"))
 
       listener.start
-      wait_until { !listener.instance_variable_get(:@thread)&.alive? }
+      wait_until { !listener.running? }
 
       expect(listener.running?).to be(false)
     end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -679,7 +679,7 @@ RSpec.describe Pgbus::Process::Worker do
       instance_double(
         Pgbus::Process::NotifyListener,
         start: nil, stop: nil, add_queue: nil, remove_queue: nil,
-        listening_to: []
+        listening_to: [], running?: true
       ).tap { |l| allow(l).to receive(:start).and_return(l) }
     end
 
@@ -746,6 +746,17 @@ RSpec.describe Pgbus::Process::Worker do
         worker.instance_variable_set(:@notify_listener, fake_listener)
         expect(worker.send(:wake_timeout))
           .to eq(described_class::NOTIFY_FALLBACK_POLL_SECONDS)
+      end
+
+      it "returns effective_polling_interval when the listener thread has died" do
+        # A listener whose thread crashed (running? false) will never wake the
+        # loop. Treating it as active would keep the wait at the long NOTIFY
+        # ceiling — the loop would sleep 15s between retries while jobs pile
+        # up. Fall back to the polling interval until it's restarted.
+        allow(worker).to receive(:notify_wakeup?).and_return(true)
+        allow(fake_listener).to receive(:running?).and_return(false)
+        worker.instance_variable_set(:@notify_listener, fake_listener)
+        expect(worker.send(:wake_timeout)).to eq(worker.config.polling_interval)
       end
     end
 
@@ -833,6 +844,111 @@ RSpec.describe Pgbus::Process::Worker do
         expect { worker.send(:start_notify_listener) }.not_to raise_error
         expect(worker.instance_variable_get(:@notify_listener)).to be_nil
         expect(Pgbus.logger).to have_received(:error)
+      end
+    end
+
+    describe "#ensure_notify_listener" do
+      # The self-healing loop: a listener that never started (nil) or whose
+      # thread died (running? false) must be retried from the worker loop,
+      # throttled by exponential backoff so a persistent outage doesn't spin
+      # start attempts every tick.
+      let(:base) { described_class::NOTIFY_RETRY_BASE_SECONDS }
+
+      before { allow(worker).to receive(:notify_wakeup?).and_return(true) }
+
+      it "is a no-op when notify_wakeup? is off" do
+        allow(worker).to receive(:notify_wakeup?).and_return(false)
+        allow(worker).to receive(:start_notify_listener)
+        worker.send(:ensure_notify_listener)
+        expect(worker).not_to have_received(:start_notify_listener)
+      end
+
+      it "is a no-op while a healthy listener is running" do
+        worker.instance_variable_set(:@notify_listener, fake_listener)
+        allow(worker).to receive(:start_notify_listener)
+        worker.send(:ensure_notify_listener)
+        expect(worker).not_to have_received(:start_notify_listener)
+      end
+
+      it "does not retry before the backoff window elapses" do
+        # Listener is absent and a retry was just scheduled into the future.
+        worker.instance_variable_set(:@notify_listener, nil)
+        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) + base)
+        allow(worker).to receive(:start_notify_listener)
+        worker.send(:ensure_notify_listener)
+        expect(worker).not_to have_received(:start_notify_listener)
+      end
+
+      it "retries start once the backoff window has elapsed" do
+        worker.instance_variable_set(:@notify_listener, nil)
+        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        allow(worker).to receive(:start_notify_listener) do
+          worker.instance_variable_set(:@notify_listener, fake_listener)
+        end
+
+        worker.send(:ensure_notify_listener)
+        expect(worker).to have_received(:start_notify_listener)
+      end
+
+      it "doubles the backoff each time the restart fails" do
+        worker.instance_variable_set(:@notify_listener, nil)
+        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        # start leaves @notify_listener nil (failed to start).
+        allow(worker).to receive(:start_notify_listener)
+
+        worker.send(:ensure_notify_listener)
+        expect(worker.instance_variable_get(:@notify_retry_backoff)).to eq(base * 2)
+
+        # Second failed attempt (advance clock past the new window) doubles again.
+        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        worker.send(:ensure_notify_listener)
+        expect(worker.instance_variable_get(:@notify_retry_backoff)).to eq(base * 4)
+      end
+
+      it "caps the backoff at NOTIFY_RETRY_MAX_SECONDS" do
+        worker.instance_variable_set(:@notify_listener, nil)
+        worker.instance_variable_set(:@notify_retry_backoff, described_class::NOTIFY_RETRY_MAX_SECONDS)
+        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        allow(worker).to receive(:start_notify_listener)
+
+        worker.send(:ensure_notify_listener)
+        expect(worker.instance_variable_get(:@notify_retry_backoff))
+          .to eq(described_class::NOTIFY_RETRY_MAX_SECONDS)
+      end
+
+      it "resets the backoff after a successful restart" do
+        worker.instance_variable_set(:@notify_listener, nil)
+        worker.instance_variable_set(:@notify_retry_backoff, base * 8)
+        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        allow(worker).to receive(:start_notify_listener) do
+          worker.instance_variable_set(:@notify_listener, fake_listener)
+        end
+
+        worker.send(:ensure_notify_listener)
+        expect(worker.instance_variable_get(:@notify_retry_backoff)).to eq(base)
+      end
+
+      it "stops a dead listener before restarting it" do
+        dead = fake_listener
+        allow(dead).to receive(:running?).and_return(false)
+        worker.instance_variable_set(:@notify_listener, dead)
+        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        allow(worker).to receive(:start_notify_listener)
+
+        worker.send(:ensure_notify_listener)
+        expect(dead).to have_received(:stop)
+      end
+
+      it "reconciles queues after a successful restart (wildcard workers)" do
+        worker.instance_variable_set(:@notify_listener, nil)
+        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        allow(worker).to receive(:start_notify_listener) do
+          worker.instance_variable_set(:@notify_listener, fake_listener)
+        end
+        allow(worker).to receive(:sync_notify_listener_queues)
+
+        worker.send(:ensure_notify_listener)
+        expect(worker).to have_received(:sync_notify_listener_queues)
       end
     end
 


### PR DESCRIPTION
## Summary

A transient boot-time condition (DB restarting, failover, DNS blip) or a listener thread that dies mid-run permanently downgraded a worker to blind polling until process restart. Two gaps:

1. `Worker#start_notify_listener` rescued any startup failure, set `@notify_listener = nil`, logged "falling back to polling", and **never retried**.
2. `NotifyListener#run_loop` failing mid-run cleared `@running` but left the worker's `@notify_listener` non-nil, so `wake_timeout` kept using the long 15s NOTIFY-mode ceiling (`NOTIFY_FALLBACK_POLL_SECONDS`) even though nothing would ever wake the loop — job latency ballooned to ~15s with no self-healing.

## Changes

- **`NotifyListener#running?` promoted to public** (`lib/pgbus/process/notify_listener.rb`) so the worker can detect a dead listener thread.
- **`Worker#ensure_notify_listener`** (`lib/pgbus/process/worker.rb`), called each loop iteration alongside `refresh_wildcard_queues`. When notify wakeup is on and the listener is absent or dead (`running?` false), it stops any dead listener (releasing its dedicated PG connection) and restarts it, throttled by a monotonic backoff: `NOTIFY_RETRY_BASE_SECONDS = 5` doubling to `NOTIFY_RETRY_MAX_SECONDS = 300`. A successful restart reconciles queues via `sync_notify_listener_queues` (wildcard workers) and resets the backoff; a still-failing restart doubles it up to the cap.
- **`wake_timeout` gated on `@notify_listener&.running?`** — a dead listener is treated as absent, so polling stays at `effective_polling_interval` between retries instead of the 15s ceiling.

## Acceptance criteria

- [x] Startup failure retried with exponential backoff (5s base, 300s cap), not once per loop tick
- [x] A listener whose thread died (`running?` false) is detected and restarted
- [x] `wake_timeout` returns `effective_polling_interval` while the listener is down
- [x] Successful restart resets the backoff
- [x] `bundle exec rspec` and `bundle exec rubocop` green

## Test plan

- `spec/pgbus/process/notify_listener_spec.rb`: `running?` is public, true while alive, false after a fatal `run_loop` error clears `@running`.
- `spec/pgbus/process/worker_spec.rb` `#ensure_notify_listener`: no-op when wakeup off / listener healthy / before the backoff window; retries after the window; backoff doubles on failure and caps at 300s; resets on success; stops a dead listener before restart; reconciles queues after a successful restart.
- `spec/pgbus/process/worker_spec.rb` `#wake_timeout`: returns `effective_polling_interval` when the listener thread has died.

## Verification

- `bundle exec rubocop` — clean (417 files)
- `bundle exec rspec` — full-suite failure count unchanged from `main` (76 pre-existing `spec/system/*` browser specs + one cross-file config-leak ordering flake, none touched by this change); +13 new passing examples. `spec/pgbus` in isolation: 2416 examples, 0 failures.

Closes #193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for notification listeners when they stop running, helping workers resume event-driven behavior without manual intervention.
  * Improved wake-up timing so workers use the shorter polling interval when a listener is unavailable.

* **Bug Fixes**
  * Better handles listener failures and restarts with retry backoff, reducing repeated restart attempts.
  * Ensures listener subscriptions are refreshed after a successful restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->