### PR TITLE
feat(connections): adopt NotifyListener's reconnect loop in the Streamer Listener

### DIFF
--- a/lib/pgbus/web/streamer/instance.rb
+++ b/lib/pgbus/web/streamer/instance.rb
@@ -42,7 +42,13 @@ module Pgbus
             pg_connection: @pg_connection,
             dispatch_queue: @dispatch_queue,
             health_check_ms: @config.streams_listen_health_check_ms,
-            logger: @logger
+            logger: @logger,
+            # On reconnect the Listener rebuilds its OWN connection via this
+            # factory (fresh connect re-resolves DNS, converges on the promoted
+            # primary after a failover) instead of resetting a possibly-dead
+            # socket. Skipped for an injected pg_connection: (unit tests) — a
+            # nil factory falls back to conn.reset.
+            connection_factory: pg_connection ? nil : -> { build_raw_pg_connection }
           )
           @dispatcher = StreamEventDispatcher.new(
             client: @client,
@@ -143,12 +149,25 @@ module Pgbus
           end
         end
 
+        # Build the INITIAL LISTEN connection: raw connect, reject a replica
+        # fatally (a misconfiguration at boot), then run the one-shot delivery
+        # self-probe. The reconnect path uses build_raw_pg_connection directly
+        # (validation retries there, probe is skipped) — see the factory wired
+        # into Listener.new above.
         def build_pg_connection
+          probe(validate_primary(build_raw_pg_connection))
+        end
+
+        # Raw PG.connect with no validation or probe. This is what the Listener's
+        # connection_factory calls on every reconnect attempt: the reconnect loop
+        # runs its own PrimaryValidator (retrying on a replica) and skips the
+        # probe to stay cheap, mirroring Pgbus::Process::NotifyListener.
+        def build_raw_pg_connection
           require "pg" unless defined?(::PG::Connection)
           opts = @config.streams_connection_options
           case opts
-          when String then probe(validate_primary(::PG.connect(opts)))
-          when Hash   then probe(validate_primary(::PG.connect(**opts)))
+          when String then ::PG.connect(opts)
+          when Hash   then ::PG.connect(**opts)
           when Proc
             # The Proc branch in connection_options typically returns
             # ActiveRecord::Base.connection.raw_connection — a pooled

--- a/lib/pgbus/web/streamer/listener.rb
+++ b/lib/pgbus/web/streamer/listener.rb
@@ -38,13 +38,21 @@ module Pgbus
         CHANNEL_PREFIX = "pgmq.q_"
         CHANNEL_SUFFIX = ".INSERT"
 
+        RECONNECT_BACKOFF_SECONDS = 0.5
+
         attr_reader :listening_to
 
-        def initialize(pg_connection:, dispatch_queue:, health_check_ms:, logger: Pgbus.logger)
+        # @param connection_factory [#call, nil] builds a FRESH PG connection on
+        #   each reconnect attempt (the Instance passes -> { build_pg_connection }).
+        #   When nil (tests injecting only pg_connection:), reconnect falls back to
+        #   the legacy single-shot @conn.reset.
+        def initialize(pg_connection:, dispatch_queue:, health_check_ms:,
+                       logger: Pgbus.logger, connection_factory: nil)
           @conn = pg_connection
           @dispatch_queue = dispatch_queue
           @health_check_ms = health_check_ms
           @logger = logger
+          @connection_factory = connection_factory
           @listening_to = Set.new
           @commands = Queue.new
           @running = false
@@ -197,21 +205,58 @@ module Pgbus
           @conn.exec("SELECT 1")
         end
 
+        # Retry reconnect until we succeed (fresh conn + every channel
+        # re-LISTENed) or #stop flips @running to false. Mirrors
+        # NotifyListener#reconnect!: a single failed attempt never returns with
+        # a dead connection while running, so ensure_listening acks can't
+        # succeed vacuously against a broken LISTEN socket and strand SSE
+        # clients. When no connection_factory was injected (tests passing only
+        # pg_connection:), fall back to the legacy single-shot conn.reset.
         def reconnect!
+          return reconnect_via_reset unless @connection_factory
+
+          # Snapshot the canonical subscription set BEFORE tearing down the old
+          # connection. We rebuild @listening_to from this and only publish it
+          # once every channel has been re-LISTENed on the new conn, so a
+          # mid-loop LISTEN failure never loses channels.
+          channels = @listening_to.to_a
+          loop do
+            return unless @running
+
+            close_quietly(@conn)
+            @conn = nil
+            new_conn = nil
+            begin
+              new_conn = @connection_factory.call
+              # Reject a replica before re-LISTENing. A fresh connect re-resolves
+              # DNS, so backing off and retrying converges on the promoted primary
+              # once DNS catches up after a failover. NOTIFY fires only on the
+              # primary; re-LISTENing on a replica registers channels that never wake.
+              Pgbus::Process::PrimaryValidator.validate_primary!(new_conn)
+              channels.each { |channel| new_conn.exec(%(LISTEN "#{channel}")) }
+            rescue PG::Error, Pgbus::Process::ReplicaConnectionError => e
+              # The factory may have returned a live conn before a later LISTEN
+              # raised (or validate_primary! rejected a replica). Close the
+              # partial conn so repeated failures don't leak PG connections.
+              close_quietly(new_conn)
+              @logger.error { "[Pgbus::Streamer::Listener] reconnect failed: #{e.class}: #{e.message}" }
+              sleep RECONNECT_BACKOFF_SECONDS
+              next
+            end
+
+            @conn = new_conn
+            @listening_to = Set.new(channels)
+            return
+          end
+        end
+
+        # Legacy fallback for tests that inject only pg_connection: (no factory).
+        # A single conn.reset attempt; on failure it logs and backs off, leaving
+        # recovery to the next run_loop cycle. Kept for backwards compatibility
+        # with test wiring; production always injects a connection_factory.
+        def reconnect_via_reset
           @conn.reset
-          # Reject a connection that came back on a read-only replica before
-          # re-LISTENing. After a failover, conn.reset can re-resolve stale DNS
-          # to the demoted master; NOTIFY fires only on the primary, so
-          # re-LISTENing there would register channels that never wake. A
-          # replica raises ReplicaConnectionError into the rescue below, which
-          # sleeps 0.5s; the next cycle resets again and converges on the
-          # promoted primary once DNS catches up.
           Pgbus::Process::PrimaryValidator.validate_primary!(@conn)
-          # Don't clear @listening_to until the new set is built. If a
-          # mid-loop LISTEN raises, we keep the original set so the
-          # next reconnect cycle still knows which channels need to
-          # come back. The previous version cleared first and lost
-          # any channels not yet retried on a transient error.
           to_relisten = @listening_to.to_a
           new_listening = Set.new
           to_relisten.each do |channel|
@@ -221,12 +266,22 @@ module Pgbus
           @listening_to = new_listening
         rescue PG::Error, Pgbus::Process::ReplicaConnectionError => e
           @logger.error { "[Pgbus::Streamer::Listener] reconnect failed: #{e.class}: #{e.message}" }
-          sleep 0.5
+          sleep RECONNECT_BACKOFF_SECONDS
+        end
+
+        # Close a PG connection we're discarding (the old conn at the top of a
+        # reconnect cycle, or a half-built one whose LISTEN raised). Best-effort.
+        def close_quietly(conn)
+          conn&.close if conn.respond_to?(:close)
+        rescue StandardError
+          nil
         end
 
         def safe_unlisten_all
           @listening_to.each do |channel|
-            @conn.exec(%(UNLISTEN "#{channel}"))
+            # @conn may be nil if #stop interrupted the reconnect loop between
+            # closing the old connection and publishing a new one.
+            @conn&.exec(%(UNLISTEN "#{channel}"))
           rescue PG::Error
             # connection may be dead; nothing we can do
           end

--- a/spec/pgbus/web/streamer/instance_spec.rb
+++ b/spec/pgbus/web/streamer/instance_spec.rb
@@ -155,6 +155,35 @@ RSpec.describe Pgbus::Web::Streamer::Instance do
       expect(Pgbus::Process::NotifyProbe).not_to have_received(:probe_notify_delivery!)
     end
 
+    it "wires a connection_factory into the Listener that builds a fresh raw connection" do
+      require "pg"
+      connects = 0
+      allow(PG).to receive(:connect) do |**_kwargs|
+        connects += 1
+        fake_pg_module_conn
+      end
+
+      instance = described_class.new(client: client, config: streamer_config, logger: Logger.new(IO::NULL))
+
+      factory = instance.listener.instance_variable_get(:@connection_factory)
+      expect(factory).to respond_to(:call)
+
+      # Calling the factory builds another raw connection (no probe/validate:
+      # the reconnect loop owns those). One connect for the initial build, one
+      # for the factory invocation here.
+      connects_before = connects
+      factory.call
+      expect(connects).to eq(connects_before + 1)
+    end
+
+    it "passes no factory when a pg_connection is injected (reset fallback)" do
+      allow(Pgbus::Process::NotifyProbe).to receive(:probe_notify_delivery!).and_return(true)
+
+      instance = described_class.new(client: client, config: config, pg_connection: fake_pg, logger: Logger.new(IO::NULL))
+
+      expect(instance.listener.instance_variable_get(:@connection_factory)).to be_nil
+    end
+
     context "when the freshly built connection lands on a read-only replica" do
       before do
         require "pg"

--- a/spec/pgbus/web/streamer/listener_spec.rb
+++ b/spec/pgbus/web/streamer/listener_spec.rb
@@ -32,17 +32,23 @@ RSpec.describe Pgbus::Web::Streamer::Listener do
   # blocking semantics without needing a real Postgres.
   let(:fake_pg) do
     Class.new do
-      attr_reader :executed, :reset_count
+      attr_reader :executed, :reset_count, :close_count
 
       def initialize
         @executed = []
         @events = Queue.new
         @reset_count = 0
+        @close_count = 0
         @closed = false
+        @raise_on_next_listen = false
       end
 
       def exec(sql)
         @executed << sql
+        if sql.start_with?("LISTEN") && @raise_on_next_listen
+          @raise_on_next_listen = false
+          raise PG::Error, "listen failed mid-rebuild"
+        end
         nil
       end
 
@@ -69,10 +75,12 @@ RSpec.describe Pgbus::Web::Streamer::Listener do
         @reset_count += 1
       end
 
-      # Called by Listener#stop. Pushes a :close event to unblock any
-      # thread currently sitting inside wait_for_notify.
+      # Called by Listener#stop and by the factory reconnect loop when it
+      # discards the old/partial connection. Pushes a :close event to
+      # unblock any thread currently sitting inside wait_for_notify.
       def close
         @closed = true
+        @close_count += 1
         @events << [:close]
       end
 
@@ -86,6 +94,12 @@ RSpec.describe Pgbus::Web::Streamer::Listener do
 
       def push_error(error)
         @events << [:raise, error]
+      end
+
+      # Arm the connection so its next LISTEN raises PG::Error once — used to
+      # simulate a partially-built reconnect connection.
+      def fail_next_listen!
+        @raise_on_next_listen = true
       end
     end.new
   end
@@ -284,6 +298,149 @@ RSpec.describe Pgbus::Web::Streamer::Listener do
         "pgmq.q_chat.INSERT", "pgmq.q_presence.INSERT"
       )
       raising_listener.stop
+    end
+  end
+
+  describe "reconnect via connection_factory (NotifyListener loop)" do
+    subject(:listener) do
+      described_class.new(
+        pg_connection: fake_pg,
+        dispatch_queue: dispatch_queue,
+        health_check_ms: 50,
+        logger: logger,
+        connection_factory: -> { factory_conns.shift }
+      )
+    end
+
+    let(:factory_conns) { [] }
+
+    # A connection whose LISTEN always raises — used to prove the reconnect
+    # loop spins on failure and only exits when stop() flips @running.
+    let(:always_failing_conn) do
+      Class.new do
+        attr_reader :close_count
+
+        def initialize = (@close_count = 0)
+
+        def exec(sql)
+          raise PG::Error, "always fails" if sql.start_with?("LISTEN")
+
+          nil
+        end
+
+        def reset = nil
+        def close = (@close_count += 1)
+      end
+    end
+
+    before { stub_const("#{described_class}::RECONNECT_BACKOFF_SECONDS", 0.01) }
+
+    it "rebuilds via the factory and re-LISTENs every channel on the fresh connection" do
+      new_pg = fake_pg.class.new
+      factory_conns << new_pg
+
+      listener.start
+      listener.ensure_listening("chat")
+      listener.ensure_listening("presence")
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 2 }
+
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      new_pg.push_timeout
+
+      wait_until do
+        new_pg.executed.count { |s| s.start_with?("LISTEN") } >= 2
+      end
+
+      expect(new_pg.executed).to include(
+        %(LISTEN "pgmq.q_chat.INSERT"),
+        %(LISTEN "pgmq.q_presence.INSERT")
+      )
+      # The original connection must NOT have been reset — a fresh connect
+      # was used instead (the whole point of the factory path).
+      expect(fake_pg.reset_count).to eq(0)
+      expect(listener.listening_to).to contain_exactly(
+        "pgmq.q_chat.INSERT", "pgmq.q_presence.INSERT"
+      )
+    end
+
+    it "retries with a fresh factory connection until one succeeds" do
+      # The first factory connection fails its first LISTEN (partially built);
+      # the loop closes it, backs off, and rebuilds from the successor.
+      first = fake_pg.class.new
+      second = fake_pg.class.new
+      first.fail_next_listen! if first.respond_to?(:fail_next_listen!)
+      factory_conns.push(first, second)
+
+      listener.start
+      listener.ensure_listening("chat")
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 1 }
+
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      second.push_timeout
+
+      wait_until do
+        second.executed.count { |s| s == %(LISTEN "pgmq.q_chat.INSERT") } >= 1
+      end
+
+      expect(listener.listening_to).to contain_exactly("pgmq.q_chat.INSERT")
+    end
+
+    it "closes the partially-built connection before retrying (no leak)" do
+      half_built = fake_pg.class.new
+      good = fake_pg.class.new
+      half_built.fail_next_listen!
+      factory_conns.push(half_built, good)
+
+      listener.start
+      listener.ensure_listening("chat")
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 1 }
+
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      good.push_timeout
+
+      wait_until { half_built.close_count >= 1 }
+      expect(half_built.close_count).to be >= 1
+    end
+
+    it "exits the reconnect loop promptly when stop is called mid-retry" do
+      # The factory returns a brand-new failing connection on every call, so the
+      # reconnect loop never runs dry and would spin forever unless stop() breaks
+      # it. We prove stop returns and the thread joins within the timeout.
+      infinite_listener = described_class.new(
+        pg_connection: fake_pg, dispatch_queue: dispatch_queue, health_check_ms: 50,
+        logger: logger, connection_factory: -> { always_failing_conn.new }
+      )
+      infinite_listener.start
+      infinite_listener.ensure_listening("chat")
+      fake_pg.push_timeout
+      wait_until { infinite_listener.listening_to.size == 1 }
+
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      sleep 0.05 # let the loop spin through several failing attempts
+      thread = infinite_listener.instance_variable_get(:@thread)
+      infinite_listener.stop
+      expect(thread.alive?).to be false
+    end
+  end
+
+  describe "reconnect fallback without a factory (uses conn.reset)" do
+    it "still resets the original connection when no factory is provided" do
+      listener.start
+      listener.ensure_listening("chat")
+      fake_pg.push_timeout
+      wait_until { listener.listening_to.size == 1 }
+
+      fake_pg.push_error(PG::Error.new("connection reset"))
+      wait_until { fake_pg.reset_count >= 1 }
+      fake_pg.push_timeout
+
+      wait_until do
+        fake_pg.executed.count { |s| s == %(LISTEN "pgmq.q_chat.INSERT") } >= 2
+      end
+      expect(listener.listening_to).to contain_exactly("pgmq.q_chat.INSERT")
     end
   end
 


### PR DESCRIPTION
## Summary

The Streamer `Listener#reconnect!` made a single `@conn.reset` attempt and could return with a **dead LISTEN connection** during an extended outage. Recovery then depended on the next `wait_for_notify` raising again in `run_loop`, and `reset` reused the original connection object (re-resolving stale DNS to a demoted master after a failover) instead of a fresh connect. During the gap, `ensure_listening` acks succeeded **vacuously** on the dead connection — stranding SSE clients.

This adopts the proven `Pgbus::Process::NotifyListener#reconnect!` loop.

## Key changes

- **`Listener` gains a `connection_factory:` keyword** (`lib/pgbus/web/streamer/listener.rb`). `Instance` injects `-> { build_raw_pg_connection }` so the Listener rebuilds its **own fresh connection** each reconnect attempt — a fresh connect re-resolves DNS and converges on the promoted primary after a failover.
- **`reconnect!` now loops while `@running`**: close the old conn → build fresh via the factory → `PrimaryValidator.validate_primary!` → re-LISTEN every channel from a pre-teardown snapshot → publish the new conn + rebuilt `@listening_to` **only on full success**. On `PG::Error`/`ReplicaConnectionError` it closes the partial conn, logs, sleeps `RECONNECT_BACKOFF_SECONDS`, and retries — no leaked connections.
- **`@listening_to` preserved across a mid-loop failure**: snapshotted before teardown, republished only once every channel is re-LISTENed.
- **`stop()` stays responsive**: each loop iteration checks `@running`.
- **`Instance#build_pg_connection` split** (`lib/pgbus/web/streamer/instance.rb`): `build_raw_pg_connection` (raw connect, used by the factory — validation retries in the loop, probe skipped to stay cheap) vs. the initial-connection path `probe(validate_primary(...))`.
- **Legacy fallback kept**: `reconnect_via_reset` (single-shot `conn.reset`) runs when no factory is injected (unit tests passing only `pg_connection:`).
- **`safe_unlisten_all` guarded** for a nil `@conn` — `stop` can interrupt the loop between closing the old conn and publishing a new one.

Closes #194

## Test plan

- [x] `listener_spec`: factory rebuild re-LISTENs every channel on the fresh conn and does **not** reset the original; retries with a fresh conn until one succeeds; closes the partially-built conn before retrying (no leak); stop mid-retry exits the loop promptly; no-factory fallback still resets.
- [x] `instance_spec`: Instance wires a callable `connection_factory` that builds a fresh raw connection; passes no factory when a `pg_connection` is injected.
- [x] `bundle exec rspec spec/pgbus/web/streamer/ spec/pgbus/process/notify_listener_spec.rb` — 223 pass.
- [x] `bundle exec rubocop` — clean (417 files).

Note: the 49 failures in a full `bundle exec rspec` run are pre-existing and unrelated — system/Capybara specs (no browser driver in CI sandbox) and an i18n scan error on vendored `apexcharts.js`, all reproduce on clean `main`.
