### PR TITLE
feat(connections): validate database connectivity at supervisor boot

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -62,6 +62,25 @@ module Pgbus
       @schema_ensured = false
     end
 
+    # Actively open a database connection and run `SELECT 1` so a bad
+    # database_url / connection_params surfaces at boot instead of on the
+    # first operation. PGMQ::Client's pool is lazy — nothing touches the
+    # database at init — so without this the supervisor forks children that
+    # crash-loop against an unreachable DB. Called from Supervisor#run before
+    # any queue bootstrap or forking.
+    #
+    # Raises Pgbus::ConfigurationError (not a transient PGMQ error) because a
+    # failure here means the operator's connection config is wrong: the message
+    # carries the underlying error plus which config source was in use.
+    def verify_connection!
+      synchronized do
+        @pgmq.with_connection { |conn| conn.exec("SELECT 1") }
+      end
+      true
+    rescue PGMQ::Errors::ConnectionError, PG::Error => e
+      raise ConfigurationError, "Database connection failed via #{connection_source}: #{e.message}"
+    end
+
     def ensure_queue(name)
       ensure_pgmq_schema
       @queue_strategy.physical_queue_names(name).each { |pq| ensure_single_queue(pq) }
@@ -462,6 +481,19 @@ module Pgbus
     end
 
     private
+
+    # Human-readable label for which config knob supplied the connection
+    # options, mirroring Configuration#connection_options' precedence. Used in
+    # verify_connection!'s error so the operator knows which setting to fix.
+    def connection_source
+      if config.database_url
+        "database_url"
+      elsif config.connection_params
+        "connection_params"
+      else
+        "ActiveRecord-derived connection"
+      end
+    end
 
     # Accept either a logical name ("default") or an already-prefixed
     # physical name ("pgbus_default") and return the physical name.

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -35,6 +35,13 @@ module Pgbus
 
         Pgbus.logger.info { "[Pgbus] Supervisor starting pid=#{::Process.pid}" }
 
+        # Fail fast on a bad database_url / connection_params. PGMQ's pool is
+        # lazy, so an unreachable DB would otherwise only surface once forked
+        # children crash-loop against it. verify_connection! raises
+        # Pgbus::ConfigurationError with an actionable message; we let it
+        # propagate so the supervisor exits instead of forking anything.
+        Pgbus.client.verify_connection!
+
         # Bootstrap queues once in the parent process before forking children.
         # This avoids the deadlock that occurs when multiple forked children
         # race to call enable_notify_insert (DROP TRIGGER + CREATE TRIGGER)

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -456,6 +456,85 @@ RSpec.describe Pgbus::Client do
     end
   end
 
+  describe "#verify_connection!" do
+    let(:raw_conn) { double("PG::Connection") }
+
+    before do
+      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
+    end
+
+    context "when the connection is healthy" do
+      before do
+        allow(mock_pgmq).to receive(:with_connection).and_yield(raw_conn)
+        allow(raw_conn).to receive(:exec).with("SELECT 1").and_return(double("PG::Result"))
+      end
+
+      it "runs SELECT 1 through a pooled connection" do
+        client.verify_connection!
+
+        expect(raw_conn).to have_received(:exec).with("SELECT 1")
+      end
+
+      it "returns a truthy value" do
+        expect(client.verify_connection!).to be_truthy
+      end
+    end
+
+    context "when pgmq raises a ConnectionError" do
+      before do
+        allow(mock_pgmq).to receive(:with_connection)
+          .and_raise(PGMQ::Errors::ConnectionError, "could not connect to server")
+      end
+
+      it "raises Pgbus::ConfigurationError" do
+        expect { client.verify_connection! }.to raise_error(Pgbus::ConfigurationError)
+      end
+
+      it "includes the underlying error message" do
+        expect { client.verify_connection! }
+          .to raise_error(Pgbus::ConfigurationError, /could not connect to server/)
+      end
+
+      it "names the database_url config source" do
+        expect { client.verify_connection! }
+          .to raise_error(Pgbus::ConfigurationError, /database_url/)
+      end
+    end
+
+    context "when a raw PG::Error surfaces" do
+      before do
+        allow(mock_pgmq).to receive(:with_connection).and_yield(raw_conn)
+        allow(raw_conn).to receive(:exec).with("SELECT 1")
+                                         .and_raise(PG::Error, "server closed the connection unexpectedly")
+      end
+
+      it "raises Pgbus::ConfigurationError carrying the PG message" do
+        expect { client.verify_connection! }
+          .to raise_error(Pgbus::ConfigurationError, /server closed the connection unexpectedly/)
+      end
+    end
+
+    context "when configured with connection_params" do
+      let(:config) do
+        Pgbus::Configuration.new.tap do |c|
+          c.connection_params = { host: "localhost", dbname: "pgbus_test" }
+          c.queue_prefix = "pgbus_test"
+        end
+      end
+
+      before do
+        allow(mock_pgmq).to receive(:with_connection)
+          .and_raise(PGMQ::Errors::ConnectionError, "boom")
+      end
+
+      it "names the connection_params config source" do
+        expect { client.verify_connection! }
+          .to raise_error(Pgbus::ConfigurationError, /connection_params/)
+      end
+    end
+  end
+
   describe "#list_queues" do
     it "delegates to pgmq.list_queues" do
       client.list_queues

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -349,6 +349,7 @@ RSpec.describe Pgbus::Process::Supervisor do
     before do
       allow(Pgbus).to receive(:client).and_return(mock_client)
       allow(mock_client).to receive(:ensure_all_queues)
+      allow(mock_client).to receive(:verify_connection!).and_return(true)
     end
 
     it "calls bootstrap_queues before boot_processes" do
@@ -363,6 +364,38 @@ RSpec.describe Pgbus::Process::Supervisor do
       supervisor.run
 
       expect(call_order).to eq(%i[bootstrap boot])
+    end
+
+    it "verifies the database connection once before bootstrapping queues" do
+      call_order = []
+      allow(mock_client).to receive(:verify_connection!) { call_order << :verify }
+      allow(supervisor).to receive(:bootstrap_queues) { call_order << :bootstrap }
+      allow(supervisor).to receive(:boot_processes) { call_order << :boot }
+      allow(supervisor).to receive(:setup_signals)
+      allow(supervisor).to receive(:start_heartbeat)
+      allow(supervisor).to receive(:monitor_loop)
+      allow(supervisor).to receive(:shutdown)
+
+      supervisor.run
+
+      expect(call_order).to eq(%i[verify bootstrap boot])
+      expect(mock_client).to have_received(:verify_connection!).once
+    end
+
+    it "propagates a ConfigurationError from verification without booting children" do
+      allow(mock_client).to receive(:verify_connection!)
+        .and_raise(Pgbus::ConfigurationError, "Database connection failed via database_url: nope")
+      allow(supervisor).to receive(:bootstrap_queues)
+      allow(supervisor).to receive(:boot_processes)
+      allow(supervisor).to receive(:setup_signals)
+      allow(supervisor).to receive(:start_heartbeat)
+      allow(supervisor).to receive(:monitor_loop)
+      allow(supervisor).to receive(:shutdown)
+
+      expect { supervisor.run }.to raise_error(Pgbus::ConfigurationError, /database_url/)
+
+      expect(supervisor).not_to have_received(:bootstrap_queues)
+      expect(supervisor).not_to have_received(:boot_processes)
     end
 
     it "rescues bootstrap errors in the parent without aborting" do


### PR DESCRIPTION
## Summary
`Pgbus::Client#initialize` constructs `PGMQ::Client`, whose connection pool creates connections lazily — nothing touches the database at init, so a bad `database_url` / `connection_params` only surfaces on the first operation. `Supervisor#run` then calls `bootstrap_queues` (which rescues `StandardError` and merely reports) and forks children anyway — each child crash-loops against the unreachable DB. The operator sees worker crash storms instead of "your database_url is wrong".

This adds a fail-fast connectivity check at supervisor boot:

- **`Client#verify_connection!`** (`lib/pgbus/client.rb`) runs `SELECT 1` via `@pgmq.with_connection` (public pgmq-ruby 0.7 API) inside `synchronized`. It rescues `PGMQ::Errors::ConnectionError` and `PG::Error` and raises `Pgbus::ConfigurationError` carrying the underlying message plus which config source was in use — `database_url`, `connection_params`, or AR-derived. No log-and-continue.
- **`Supervisor#run`** (`lib/pgbus/process/supervisor.rb`) calls `Pgbus.client.verify_connection!` before `bootstrap_queues` and lets the `ConfigurationError` propagate, so the supervisor exits with the actionable message instead of forking children.
- **`bootstrap_queues`' existing rescue is kept** — post-verification failures there are transient and recoverable.
- All DB access stays inside `Pgbus::Client` (project rule: no direct PGMQ calls elsewhere).

Closes #195

## Acceptance criteria
- [x] `verify_connection!` returns truthy on a healthy connection
- [x] On failure it raises `Pgbus::ConfigurationError` whose message includes the underlying error and names the config source
- [x] `Supervisor#run` raises before forking any child when verification fails
- [x] Healthy boots are unchanged apart from one `SELECT 1`
- [x] `bundle exec rspec` (changed specs: 150 examples, 0 failures) and `bundle exec rubocop` (417 files, no offenses) green

## Test plan
- `spec/pgbus/client_spec.rb`: mocks `@pgmq.with_connection` to yield a conn double (success — asserts `SELECT 1` runs, returns truthy) and to raise `PGMQ::Errors::ConnectionError` / `PG::Error` (failure — asserts `ConfigurationError` class, underlying message, and that the message names `database_url` vs `connection_params` per configuration).
- `spec/pgbus/process/supervisor_spec.rb`: healthy path calls `verify_connection!` exactly once before `bootstrap_queues`; failure path stubs it to raise and asserts the error propagates and neither `bootstrap_queues` nor `boot_processes` runs.

Note: the 61 pre-existing failures in `spec/system/*` and `spec/i18n_spec.rb` are environment-dependent (Capybara/browser) and also fail on `main`; they are unrelated to this change.

https://claude.ai/code/session_019UyWsPP7veHzzB8Z1zGr6W
