### PR TITLE
perf(client): reuse pooled connection for bootstrap trigger checks

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -668,8 +668,17 @@ module Pgbus
     # expected throttle interval. When it does, we can skip the destructive
     # DROP TRIGGER + CREATE TRIGGER cycle that causes deadlocks when multiple
     # forked processes race during bootstrap.
+    #
+    # Routes through the pooled @pgmq.with_connection (health-checked, reused)
+    # rather than opening a fresh PG.connect per queue: on the String/Hash path
+    # with_raw_connection did a full TCP/TLS/auth setup for every queue at every
+    # supervisor boot — and again in each forked child — churning short-lived
+    # connections through the pooler. The checkout here is a sequential sibling
+    # of the @pgmq.create call above it (create's own checkout has already been
+    # returned), so there is no nested checkout: safe even on the shared-Proc
+    # pool_size=1 path.
     def notify_trigger_current?(full_name, throttle_ms)
-      with_raw_connection do |conn|
+      @pgmq.with_connection do |conn|
         result = conn.exec_params(<<~SQL, [full_name, throttle_ms])
           SELECT 1
           FROM pg_trigger t

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -535,6 +535,96 @@ RSpec.describe Pgbus::Client do
     end
   end
 
+  describe "#notify_trigger_current? (via ensure_queue)" do
+    # The class-level subject stubs notify_trigger_current? so most specs skip
+    # its raw SQL. Here we exercise the real method to prove it routes through
+    # the pooled PGMQ connection instead of opening a fresh PG.connect.
+    let(:conn) { double("PG::Connection") }
+    let(:result) { double("PG::Result", ntuples: 0) }
+
+    before do
+      config.listen_notify = true
+      allow(client).to receive(:notify_trigger_current?).and_call_original
+      allow(conn).to receive(:exec_params).and_return(result)
+    end
+
+    it "checks the trigger through the pooled @pgmq.with_connection, not a fresh PG.connect" do
+      allow(mock_pgmq).to receive(:with_connection).and_yield(conn)
+
+      client.ensure_queue("jobs")
+
+      expect(mock_pgmq).to have_received(:with_connection)
+    end
+
+    it "never opens a raw PG.connect connection during an N-queue bootstrap" do
+      stub_const("PG", Module.new) unless defined?(PG)
+      allow(PG).to receive(:connect)
+      allow(mock_pgmq).to receive(:with_connection).and_yield(conn)
+      allow(client).to receive(:with_raw_connection).and_call_original
+
+      client.ensure_all_queues
+
+      expect(PG).not_to have_received(:connect)
+      expect(client).not_to have_received(:with_raw_connection)
+    end
+
+    it "passes the physical queue name and throttle interval to exec_params" do
+      allow(mock_pgmq).to receive(:with_connection).and_yield(conn)
+
+      client.ensure_queue("jobs")
+
+      expect(conn).to have_received(:exec_params).with(
+        a_string_matching(/pg_trigger/),
+        ["pgbus_test_jobs", Pgbus::Client::NOTIFY_THROTTLE_MS]
+      )
+    end
+
+    it "skips enable_notify_insert when the pooled check finds a current trigger" do
+      allow(mock_pgmq).to receive(:with_connection).and_yield(conn)
+      allow(conn).to receive(:exec_params).and_return(double("PG::Result", ntuples: 1))
+
+      client.ensure_queue("jobs")
+
+      expect(mock_pgmq).not_to have_received(:enable_notify_insert)
+    end
+
+    it "falls back to false (and enables notify) when the pooled connection raises" do
+      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      allow(mock_pgmq).to receive(:with_connection)
+        .and_raise(PGMQ::Errors::ConnectionError, "schema not ready")
+
+      expect { client.ensure_queue("jobs") }.not_to raise_error
+      expect(mock_pgmq).to have_received(:enable_notify_insert)
+    end
+
+    context "with the shared-connection Proc path (pool_size=1)" do
+      # Force the Proc branch of Client#initialize (@shared_connection = true,
+      # @pgmq_mutex = Mutex.new, pgmq pool_size=1) so we prove the trigger check
+      # does not deadlock on a nested checkout against a single-slot pool.
+      subject(:shared_client) do
+        allow(config).to receive(:connection_options).and_return(-> { conn })
+        allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+        c = described_class.new(config)
+        c.instance_variable_set(:@schema_ensured, true)
+        allow(c).to receive(:tune_autovacuum)
+        c
+      end
+
+      before { allow(mock_pgmq).to receive(:with_connection).and_yield(conn) }
+
+      it "uses a Mutex to serialize the single-slot pool" do
+        expect(shared_client.instance_variable_get(:@pgmq_mutex)).to be_a(Mutex)
+      end
+
+      it "completes the trigger check without a nested pool checkout / deadlock" do
+        # create() and the trigger check are sequential checkouts, not nested:
+        # @pgmq.create returns before notify_trigger_current? checks out again.
+        expect { shared_client.ensure_queue("jobs") }.not_to raise_error
+        expect(mock_pgmq).to have_received(:with_connection)
+      end
+    end
+  end
+
   describe "#list_queues" do
     it "delegates to pgmq.list_queues" do
       client.list_queues


### PR DESCRIPTION
## Summary

`Client#notify_trigger_current?` opened a brand-new `PG.connect` (full TCP/TLS/auth setup) **per queue** on the String/Hash config path via `with_raw_connection`. `ensure_all_queues` therefore did N connection setups for N queues at every supervisor boot — and again in each forked child — churning short-lived connections through the pooler.

This routes the check through the existing pooled `@pgmq.with_connection` (health-checked, reused) — the exact pattern `verify_connection!` already uses. The `exec_params` body is unchanged.

### Why it's safe on the shared-Proc (`pool_size=1`) path
`notify_trigger_current?` runs inside `ensure_single_queue`'s `synchronized` block, *after* `@pgmq.create` has fully returned. Each `@pgmq.*` call wraps its work in its own `with_connection do … end` that exits before the next call — so the trigger check is a **sequential sibling** checkout, never nested inside `create`'s. No nested checkout ⇒ no deadlock on the single-slot pool. A spec exercises this path explicitly.

`with_raw_connection` is retained for its other callers (PGMQ schema install/check, `purge_archive`, `message_exists?`) — out of scope.

### Error behavior preserved
Any `StandardError` falls back to `false` (pgmq wraps `PG::Error` into `PGMQ::Errors::ConnectionError`, a `StandardError`), identical to before.

## Measured (real DB, 21-queue `ensure_all_queues`)

| | raw `PG.connect` calls | wall time |
|---|---|---|
| **Before** (`with_raw_connection`) | **22** (1 pool + 21 per-queue trigger checks) | ~371 ms |
| **After** (`@pgmq.with_connection`) | **1** (pool only, reused for all 21) | ~250 ms |

The connection count is **deterministic** (verified stable at 1 across repeated runs). Wall time trended lower but is noisy single-run (schema check + queue create/drop round-trips dominate), so the connection-count reduction is the reported result — not the timing.

Bootstrap is not a per-job hot path; this reduces per-boot gem overhead and pooler churn, not steady-state job throughput.

## Test plan

New specs under `#notify_trigger_current? (via ensure_queue)` in `spec/pgbus/client_spec.rb`:

- [x] routes the check through `@pgmq.with_connection`, not a fresh `PG.connect`
- [x] N-queue bootstrap opens **zero** raw connections (asserts `PG.connect` never invoked, `with_raw_connection` never called)
- [x] passes physical queue name + throttle interval to `exec_params`
- [x] skips `enable_notify_insert` when a current trigger is found
- [x] falls back to `false` (and enables notify) when the pooled connection raises
- [x] shared-Proc `pool_size=1` path completes without a nested-checkout deadlock

## Verification

- `bundle exec rspec spec/pgbus/client_spec.rb` → 237 examples, 0 failures
- `bundle exec rubocop lib/pgbus/client.rb spec/pgbus/client_spec.rb` → clean
- Full non-system suite: no new failures vs. `main` (pre-existing i18n / flaky worker-timing failures unchanged; `spec/system/*` needs a browser harness not available locally)

Closes #199
