### PR TITLE
feat(process): DB-independent pipe liveness for supervisor watchdog

### DIFF
--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -97,7 +97,21 @@ module Pgbus
         exec_mode = config.execution_mode_for(worker_config)
         grp_mode = worker_config[:group_mode] || worker_config["group_mode"] || config.group_mode
 
+        # OS-level liveness channel: the child writes a byte each loop
+        # iteration, the parent drains the reader in monitor_loop. This lets
+        # the watchdog detect a wedged worker without the database.
+        liveness_reader, liveness_writer = IO.pipe
+
         pid = fork do
+          # Child owns the writer end. A fork copies the whole parent FD
+          # table, so this child also inherits every earlier sibling's
+          # liveness reader (they live in @forks). Close them — otherwise each
+          # new worker accumulates N-1 stale reader FDs. (Sibling *writers*
+          # are never inherited: the parent closes each writer below before
+          # forking the next worker, so a dead sibling's pipe still reaches
+          # EOF correctly.) Finally close this fork's own reader copy.
+          close_inherited_liveness_readers
+          liveness_reader.close
           restore_signals
           setup_child_process
           load_rails_app
@@ -105,19 +119,30 @@ module Pgbus
           worker = Worker.new(
             queues: queues, threads: threads, config: config,
             single_active_consumer: single_active, consumer_priority: priority,
-            execution_mode: exec_mode, group_mode: grp_mode
+            execution_mode: exec_mode, group_mode: grp_mode,
+            liveness_pipe: liveness_writer
           )
           worker.run
         end
 
         unless pid
+          close_pipe(liveness_reader)
+          close_pipe(liveness_writer)
           Pgbus.logger.error { "[Pgbus] Failed to fork worker for queues=#{queues.join(",")}" }
           return
         end
 
-        @forks[pid] = { type: :worker, config: worker_config, slot: slot, spawned_at: monotonic_now }
+        # Parent keeps the reader, discards its writer copy so the pipe reaches
+        # EOF once the (sole remaining) child writer closes.
+        close_pipe(liveness_writer)
+        @forks[pid] = {
+          type: :worker, config: worker_config, slot: slot, spawned_at: monotonic_now,
+          liveness_reader: liveness_reader, last_pipe_tick_at: monotonic_now, pipe_seen: false
+        }
         Pgbus.logger.info { "[Pgbus] Forked worker pid=#{pid} queues=#{queues.join(",")} mode=#{exec_mode}" }
       rescue Errno::EAGAIN, Errno::ENOMEM => e
+        close_pipe(liveness_reader)
+        close_pipe(liveness_writer)
         ErrorReporter.report(e, { action: "fork_worker", queues: queues })
       end
 
@@ -266,6 +291,7 @@ module Pgbus
 
           process_signals
           reap_children
+          drain_liveness_pipes
           unless @shutting_down
             process_pending_restarts
             check_stalled_workers
@@ -281,6 +307,11 @@ module Pgbus
 
           info = @forks.delete(pid)
           next unless info
+
+          # Close the liveness reader as the fork leaves @forks so a crash-loop
+          # (restart deferred up to RESTART_BACKOFF_MAX) can't leak an FD per
+          # crash. Scrub the key so the closed IO never rides into a restart.
+          close_pipe(info.delete(:liveness_reader))
 
           if @shutting_down
             Pgbus.logger.info { "[Pgbus] Child #{info[:type]} pid=#{pid} exited (status=#{status.exitstatus})" }
@@ -356,30 +387,91 @@ module Pgbus
         worker_pids = @forks.select { |_, info| info[:type] == :worker }.keys
         return if worker_pids.empty?
 
-        rows = ProcessEntry.where(kind: "worker", pid: worker_pids).to_a
-        rows.each do |entry|
+        db_ages = db_loop_tick_ages(worker_pids)
+
+        worker_pids.each do |pid|
+          info = @forks[pid]
+          next unless info
+
+          kill_stalled_worker(pid, threshold) if worker_stalled?(info, db_ages[pid], now, threshold)
+        end
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Supervisor watchdog check failed: #{e.message}" }
+      end
+
+      # Read each worker's loop_tick_at from the process table and return a
+      # {pid => wall-clock age in seconds} map. Isolated in its own rescue so a
+      # database outage degrades to the OS-pipe fallback instead of skipping
+      # the whole watchdog — the exact failure this pipe channel exists to fix.
+      def db_loop_tick_ages(worker_pids)
+        ages = {}
+        ProcessEntry.where(kind: "worker", pid: worker_pids).to_a.each do |entry|
           meta = entry.metadata
           next unless meta.is_a?(Hash)
 
           loop_tick = meta["loop_tick_at"]
-          next unless loop_tick
+          ages[entry.pid] = Time.current.to_f - loop_tick.to_f if loop_tick
+        end
+        ages
+      rescue StandardError => e
+        Pgbus.logger.warn { "[Pgbus] Supervisor watchdog DB read failed, using pipe fallback: #{e.message}" }
+        ages
+      end
 
-          age = Time.current.to_f - loop_tick.to_f
-          next unless age > threshold
+      # A worker is stalled only when EVERY liveness channel that has spoken
+      # agrees it is stale (min-age / fresh-wins): a fresh DB row OR a fresh
+      # pipe tick proves the loop is advancing. If no channel has any signal
+      # (a slow-booting worker with no DB row and an unarmed pipe), we do not
+      # kill — mirroring the pre-existing "no loop_tick_at → skip" tolerance.
+      def worker_stalled?(info, db_age, now, threshold)
+        pipe_age = (now - info[:last_pipe_tick_at] if info[:pipe_seen] && info[:last_pipe_tick_at])
+        ages = [db_age, pipe_age].compact
+        return false if ages.empty?
 
-          pid = entry.pid
-          Pgbus.logger.error do
-            "[Pgbus] Supervisor watchdog: worker pid=#{pid} claim loop stalled " \
-              "(loop_tick_at age=#{age.round(1)}s > threshold=#{threshold}s), sending SIGKILL"
-          end
+        ages.min > threshold
+      end
+
+      def kill_stalled_worker(pid, threshold)
+        Pgbus.logger.error do
+          "[Pgbus] Supervisor watchdog: worker pid=#{pid} claim loop stalled " \
+            "(no liveness within threshold=#{threshold}s), sending SIGKILL"
+        end
+        ::Process.kill("KILL", pid)
+      rescue Errno::ESRCH
+        # already gone
+      end
+
+      # Drain each worker's liveness pipe. Any readable byte means the worker's
+      # loop advanced since the last drain, so we stamp arrival on the parent's
+      # own monotonic clock (never a worker timestamp — that would cross the
+      # fork's incomparable CLOCK_MONOTONIC) and arm pipe_seen. Bounded to a
+      # few reads per reader so a fast-writing worker can't wedge the 1s loop;
+      # "any bytes ⇒ alive" needs no full drain. Per-reader rescue so one
+      # closed reader (racing reap/shutdown) can't skip the rest.
+      def drain_liveness_pipes
+        now = monotonic_now
+        @forks.each_value do |info|
+          reader = info[:liveness_reader]
+          next unless reader
+
+          read_any = false
           begin
-            ::Process.kill("KILL", pid)
-          rescue Errno::ESRCH
-            # already gone
+            2.times do
+              reader.read_nonblock(4096)
+              read_any = true
+            end
+          rescue IO::WaitReadable, EOFError
+            # empty / drained, or writer closed (worker exiting — reap handles it)
+          rescue IOError, Errno::EBADF
+            # reader closed by a racing reap/shutdown this tick
+            next
+          end
+
+          if read_any
+            info[:last_pipe_tick_at] = now
+            info[:pipe_seen] = true
           end
         end
-      rescue StandardError => e
-        Pgbus.logger.warn { "[Pgbus] Supervisor watchdog check failed: #{e.message}" }
       end
 
       def signal_children(sig)
@@ -424,6 +516,23 @@ module Pgbus
         ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       end
 
+      # Close a pipe IO idempotently. nil (non-worker forks, already-scrubbed
+      # entries) and already-closed IOs are no-ops; a rare EBADF/IOError from a
+      # racing close is swallowed. FD management is single-threaded (main loop
+      # only), so the closed? check-then-close needs no lock.
+      def close_pipe(io)
+        io.close if io && !io.closed?
+      rescue IOError, Errno::EBADF
+        nil
+      end
+
+      # Close every sibling liveness reader this fork inherited from the
+      # parent's FD table. Called only inside a just-forked child, before it
+      # becomes a Worker, so the worker never holds its siblings' pipe ends.
+      def close_inherited_liveness_readers
+        @forks.each_value { |info| close_pipe(info[:liveness_reader]) }
+      end
+
       def shutdown
         # Wait for all children with timeout
         deadline = Time.now + 30
@@ -435,6 +544,10 @@ module Pgbus
 
         # Force kill any remaining
         signal_children("KILL") unless @forks.empty?
+
+        # Close any liveness readers still open on un-reaped children so the
+        # supervisor never leaks FDs across a restart of itself.
+        @forks.each_value { |info| close_pipe(info[:liveness_reader]) }
 
         @heartbeat&.stop
         restore_signals

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -11,7 +11,7 @@ module Pgbus
 
       def initialize(queues:, threads: 5, config: Pgbus.configuration,
                      single_active_consumer: false, consumer_priority: 0,
-                     execution_mode: :threads, group_mode: nil)
+                     execution_mode: :threads, group_mode: nil, liveness_pipe: nil)
         @queues = Array(queues)
         @initial_queues = @queues.dup.freeze
         @wildcard = @queues.include?("*")
@@ -55,6 +55,11 @@ module Pgbus
         @notify_listener = nil
         @notify_retry_at = 0.0
         @notify_retry_backoff = NOTIFY_RETRY_BASE_SECONDS
+        # OS-level liveness channel to the supervisor watchdog. Optional: nil
+        # unless the supervisor forked us with one. Written from stamp_loop_tick
+        # so the watchdog can detect a wedged worker even when the database (and
+        # thus the Heartbeat's loop_tick_at) is unavailable.
+        @liveness_pipe = liveness_pipe
       end
 
       def stats
@@ -624,8 +629,23 @@ module Pgbus
       # Wall clock is required because the supervisor watchdog reads
       # this value from a different process (cross-fork) and the
       # dashboard reads it from a different host.
+      #
+      # Also pokes the OS-level liveness pipe (when the supervisor forked us
+      # with one) so the watchdog has a database-independent signal. The write
+      # is non-blocking and never raises in the hot path: exception: false
+      # returns :wait_writable on a full pipe (which itself proves recent,
+      # undrained ticks — liveness — so a dropped write is fine), and the
+      # rescue covers the reader-gone / fd-closed cases so a dead pipe can
+      # never crash the worker loop. The payload is a content-free byte: the
+      # supervisor treats "any bytes readable" as liveness and stamps arrival
+      # time on its own monotonic clock, so no timestamp crosses the fork.
       def stamp_loop_tick
         @loop_tick_at.set(Time.now.to_f)
+        return unless @liveness_pipe
+
+        @liveness_pipe.write_nonblock("\0", exception: false)
+      rescue Errno::EPIPE, IOError, Errno::EBADF
+        nil
       end
     end
   end

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -318,6 +318,102 @@ RSpec.describe Pgbus::Process::Supervisor do
     end
   end
 
+  describe "worker liveness pipe (private)" do
+    let(:supervisor) { described_class.new }
+    let(:worker_config) { { queues: ["default"], threads: 5 } }
+
+    # With fork stubbed to return a pid, the child block never runs, so the
+    # parent path (create pipe, close writer, store reader) is exercised.
+    before do
+      allow(supervisor).to receive(:fork).and_return(7001)
+    end
+
+    describe "fork_worker" do
+      it "stores a liveness_reader IO for the forked worker" do
+        supervisor.send(:fork_worker, worker_config, slot: 0)
+
+        info = supervisor.instance_variable_get(:@forks)[7001]
+        expect(info[:liveness_reader]).to be_a(IO)
+        expect(info[:liveness_reader]).not_to be_closed
+      end
+
+      it "seeds last_pipe_tick_at (monotonic) and leaves pipe_seen unarmed" do
+        supervisor.send(:fork_worker, worker_config, slot: 0)
+
+        info = supervisor.instance_variable_get(:@forks)[7001]
+        expect(info[:last_pipe_tick_at]).to be_a(Float)
+        expect(info[:pipe_seen]).to be(false)
+      end
+
+      it "closes both pipe ends and stores no reader when the fork fails (nil pid)" do
+        allow(supervisor).to receive(:fork).and_return(nil)
+        created = []
+        allow(IO).to receive(:pipe).and_wrap_original do |orig|
+          pair = orig.call
+          created.concat(pair)
+          pair
+        end
+
+        supervisor.send(:fork_worker, worker_config, slot: 0)
+
+        expect(supervisor.instance_variable_get(:@forks)).not_to have_key(7001)
+        expect(created).to all(be_closed)
+      end
+
+      it "closes both pipe ends when the fork raises Errno::EAGAIN" do
+        allow(supervisor).to receive(:fork).and_raise(Errno::EAGAIN)
+        created = []
+        allow(IO).to receive(:pipe).and_wrap_original do |orig|
+          pair = orig.call
+          created.concat(pair)
+          pair
+        end
+
+        expect { supervisor.send(:fork_worker, worker_config, slot: 0) }.not_to raise_error
+        expect(created).to all(be_closed)
+      end
+    end
+
+    describe "reap_children closes the liveness reader" do
+      let(:status_double) { instance_double(Process::Status, exitstatus: 0, success?: true) }
+
+      it "closes the reader and drops the fork on reap" do
+        reader, writer = IO.pipe
+        writer.close
+        supervisor.instance_variable_set(:@forks, {
+                                           3001 => { type: :worker, config: worker_config,
+                                                     spawned_at: 0.0, liveness_reader: reader,
+                                                     last_pipe_tick_at: 0.0, pipe_seen: true }
+                                         })
+        supervisor.instance_variable_set(:@shutting_down, true)
+        allow(Process).to receive(:waitpid2).with(-1, Process::WNOHANG).and_return([3001, status_double], nil)
+
+        supervisor.send(:reap_children)
+
+        expect(reader).to be_closed
+        expect(supervisor.instance_variable_get(:@forks)).not_to have_key(3001)
+      end
+    end
+
+    describe "shutdown closes remaining liveness readers" do
+      it "closes any un-reaped worker readers" do
+        reader, writer = IO.pipe
+        writer.close
+        supervisor.instance_variable_set(:@forks, {
+                                           3001 => { type: :worker, config: worker_config,
+                                                     liveness_reader: reader }
+                                         })
+        allow(supervisor).to receive(:reap_children)
+        allow(supervisor).to receive(:interruptible_sleep)
+        allow(Process).to receive(:kill)
+
+        supervisor.send(:shutdown)
+
+        expect(reader).to be_closed
+      end
+    end
+  end
+
   describe "bootstrap_queues (private)" do
     let(:supervisor) { described_class.new }
     let(:mock_client) { build_mock_client }

--- a/spec/pgbus/process/supervisor_watchdog_spec.rb
+++ b/spec/pgbus/process/supervisor_watchdog_spec.rb
@@ -126,5 +126,129 @@ RSpec.describe Pgbus::Process::Supervisor do
         expect { supervisor.send(:check_stalled_workers) }.not_to raise_error
       end
     end
+
+    # Pipe-based liveness fallback: when the database is unreachable the
+    # Heartbeat can't write loop_tick_at and the watchdog DB read raises.
+    # The OS pipe channel keeps stall detection working during the outage.
+    describe "pipe-liveness fallback (DB-independent)" do
+      let(:now) { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+
+      before do
+        supervisor.instance_variable_set(:@last_watchdog_at, 0.0)
+        allow(Process).to receive(:kill)
+      end
+
+      def set_forks(pid, last_pipe_tick_at:, pipe_seen:)
+        supervisor.instance_variable_set(:@forks, {
+                                           pid => { type: :worker, config: { queues: ["default"] },
+                                                    liveness_reader: nil,
+                                                    last_pipe_tick_at: last_pipe_tick_at,
+                                                    pipe_seen: pipe_seen }
+                                         })
+      end
+
+      it "SIGKILLs a worker with a stale pipe tick when the DB read raises" do
+        allow(Pgbus::ProcessEntry).to receive(:where).and_raise(StandardError, "connection lost")
+        set_forks(1001, last_pipe_tick_at: now - 120, pipe_seen: true)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Process).to have_received(:kill).with("KILL", 1001)
+      end
+
+      it "does NOT kill a worker with a fresh pipe tick when the DB read raises" do
+        allow(Pgbus::ProcessEntry).to receive(:where).and_raise(StandardError, "connection lost")
+        set_forks(1001, last_pipe_tick_at: now - 1, pipe_seen: true)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Process).not_to have_received(:kill)
+      end
+
+      it "does NOT kill a worker whose pipe is unarmed (booting, no byte seen yet)" do
+        allow(Pgbus::ProcessEntry).to receive(:where).and_raise(StandardError, "connection lost")
+        # Seeded far in the past but never armed — a slow-booting worker.
+        set_forks(1001, last_pipe_tick_at: now - 999, pipe_seen: false)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Process).not_to have_received(:kill)
+      end
+
+      it "keeps a worker alive on a stale DB row when the pipe tick is fresh (fresh-wins)" do
+        stale_db = double("ProcessEntry", kind: "worker", pid: 1001,
+                                          metadata: { "loop_tick_at" => (Time.now.to_f - 300) })
+        allow(Pgbus::ProcessEntry).to receive(:where)
+          .with(kind: "worker", pid: [1001])
+          .and_return(double(to_a: [stale_db]))
+        set_forks(1001, last_pipe_tick_at: now - 1, pipe_seen: true)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Process).not_to have_received(:kill)
+      end
+
+      it "kills a worker when BOTH the DB row and the pipe tick are stale" do
+        stale_db = double("ProcessEntry", kind: "worker", pid: 1001,
+                                          metadata: { "loop_tick_at" => (Time.now.to_f - 300) })
+        allow(Pgbus::ProcessEntry).to receive(:where)
+          .with(kind: "worker", pid: [1001])
+          .and_return(double(to_a: [stale_db]))
+        set_forks(1001, last_pipe_tick_at: now - 120, pipe_seen: true)
+
+        supervisor.send(:check_stalled_workers)
+
+        expect(Process).to have_received(:kill).with("KILL", 1001)
+      end
+    end
+
+    # The watchdog draining side: monitor_loop advances last_pipe_tick_at and
+    # arms pipe_seen when a worker's pipe has readable bytes.
+    describe "drain_liveness_pipes (private)" do
+      it "advances last_pipe_tick_at and arms pipe_seen when bytes are readable" do
+        reader, writer = IO.pipe
+        writer.write("\0\0")
+        supervisor.instance_variable_set(:@forks, {
+                                           1001 => { type: :worker, liveness_reader: reader,
+                                                     last_pipe_tick_at: 0.0, pipe_seen: false }
+                                         })
+
+        supervisor.send(:drain_liveness_pipes)
+
+        info = supervisor.instance_variable_get(:@forks)[1001]
+        expect(info[:pipe_seen]).to be(true)
+        expect(info[:last_pipe_tick_at]).to be > 0.0
+      ensure
+        reader.close unless reader.closed?
+        writer.close unless writer.closed?
+      end
+
+      it "does not arm pipe_seen when the pipe is empty" do
+        reader, writer = IO.pipe
+        supervisor.instance_variable_set(:@forks, {
+                                           1001 => { type: :worker, liveness_reader: reader,
+                                                     last_pipe_tick_at: 0.0, pipe_seen: false }
+                                         })
+
+        supervisor.send(:drain_liveness_pipes)
+
+        expect(supervisor.instance_variable_get(:@forks)[1001][:pipe_seen]).to be(false)
+      ensure
+        reader.close unless reader.closed?
+        writer.close unless writer.closed?
+      end
+
+      it "does not raise when a reader was closed by a racing reap" do
+        reader, writer = IO.pipe
+        reader.close
+        writer.close
+        supervisor.instance_variable_set(:@forks, {
+                                           1001 => { type: :worker, liveness_reader: reader,
+                                                     last_pipe_tick_at: 0.0, pipe_seen: false }
+                                         })
+
+        expect { supervisor.send(:drain_liveness_pipes) }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -1059,4 +1059,58 @@ RSpec.describe Pgbus::Process::Worker do
       end
     end
   end
+
+  describe "#stamp_loop_tick liveness pipe" do
+    let(:reader_writer) { IO.pipe }
+    let(:reader) { reader_writer[0] }
+    let(:writer) { reader_writer[1] }
+
+    after do
+      reader.close unless reader.closed?
+      writer.close unless writer.closed?
+    end
+
+    it "writes a liveness byte to the pipe when a liveness_pipe is given" do
+      w = described_class.new(queues: %w[default], threads: 5, liveness_pipe: writer)
+
+      w.send(:stamp_loop_tick)
+
+      expect(reader.read_nonblock(16)).to eq("\0")
+    end
+
+    it "still advances the DB loop-tick timestamp when a pipe is present" do
+      w = described_class.new(queues: %w[default], threads: 5, liveness_pipe: writer)
+
+      w.send(:stamp_loop_tick)
+
+      expect(w.instance_variable_get(:@loop_tick_at).get).to be_a(Float)
+    end
+
+    it "does not write to a pipe and behaves as today when no liveness_pipe is given" do
+      w = described_class.new(queues: %w[default], threads: 5)
+
+      expect { w.send(:stamp_loop_tick) }.not_to raise_error
+      expect(w.instance_variable_get(:@loop_tick_at).get).to be_a(Float)
+    end
+
+    it "does not raise when the pipe is full (write dropped, worker still alive)" do
+      w = described_class.new(queues: %w[default], threads: 5, liveness_pipe: writer)
+      # Fill the OS pipe buffer so the next write_nonblock cannot proceed.
+      filler = "x" * 65_536
+      begin
+        writer.write_nonblock(filler)
+      rescue IO::WaitWritable
+        # already full
+      end
+
+      expect { w.send(:stamp_loop_tick) }.not_to raise_error
+    end
+
+    it "does not raise when the reader end is already closed" do
+      w = described_class.new(queues: %w[default], threads: 5, liveness_pipe: writer)
+      reader.close
+
+      expect { w.send(:stamp_loop_tick) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The supervisor watchdog (`check_stalled_workers`) detected wedged workers **only** by reading `loop_tick_at` from the `pgbus_processes` table, written by the worker `Heartbeat`. During a database outage the heartbeat write fails (dropped) and the watchdog read raises (swallowed) — so stall detection **failed open exactly when workers are most likely wedged** on dead DB connections.

This adds an OS-level liveness channel that needs no database.

## How it works

- **Write side** (`Worker#stamp_loop_tick`, `lib/pgbus/process/worker.rb`): when the supervisor forked us with a `liveness_pipe:`, each loop iteration also writes one non-blocking byte. `write_nonblock("\0", exception: false)` never raises on a full pipe (a full pipe *is* proof of recent, undrained ticks), and a small rescue covers the reader-gone cases so a dead pipe can never crash the worker loop.
- **Read side** (`Supervisor#drain_liveness_pipes`, `monitor_loop`): each 1s tick drains every worker's reader (bounded, per-reader rescue) and stamps arrival on the **parent's own monotonic clock**, arming `pipe_seen`.
- **Decision** (`check_stalled_workers`): kills a worker only when `min(db_age, pipe_age) > stall_threshold` — every liveness channel that has spoken must agree it is stale. The DB read is isolated in its own rescue (`db_loop_tick_ages`) so an outage degrades to the pipe fallback instead of skipping the whole watchdog.

### Decision table

| DB row | DB age | pipe armed | pipe age | Outcome |
|---|---|---|---|---|
| fresh | ≤thr | — | — | alive (DB proves it) |
| stale | >thr | yes | ≤thr | **alive** — pipe rescues a worker whose heartbeat thread died |
| stale | >thr | yes | >thr | **KILL** (both agree) |
| stale | >thr | no (booting) | — | alive — matches today's "no row → skip" tolerance |
| missing (DB outage) | nil | yes | >thr | **KILL** — the core win |
| missing (DB outage) | nil | yes | ≤thr | alive — pipe proves liveness during the outage |
| missing | nil | no | — | alive (booting, no signal) |

## Design review

The implementation was hardened against a three-lens adversarial design review (process/FD safety, watchdog decision logic, Ruby IO edge cases). Fixes it surfaced, all applied:

- **Child closes every inherited sibling liveness reader** post-fork (a `fork` copies the whole FD table) — no per-worker FD accumulation.
- **Reader close bound to `reap_children`'s `@forks.delete`** (not the deferred restart) and scrubbed from `info`, so a crash-loop can't leak an FD per crash. Both pipe ends closed on every fork-failure path; `shutdown` closes any remaining readers.
- **`pipe_seen` arms pipe-based killing only after the first observed byte** — a slow-booting worker (>`stall_threshold` in Rails boot, no DB row, unarmed pipe) is never false-killed.
- **`min`-age / fresh-wins** decision — fixes a stale-DB-row false-kill: a healthy worker whose heartbeat thread died but whose loop is fine is now rescued by its fresh pipe.
- Rescue lists and non-blocking idioms mirror the existing `async_pool.rb` / `signal_handler.rb` self-pipe precedent.

Clock domains stay separate: wall-clock (DB) and monotonic (pipe) are never cross-compared, and the pipe payload carries no timestamp so nothing crosses the fork's incomparable `CLOCK_MONOTONIC`.

## Test plan

- [x] `worker_spec`: stamp writes a byte; still advances `loop_tick_at`; no-pipe path unchanged; full pipe and closed reader don't raise.
- [x] `supervisor_watchdog_spec`: DB raise + stale/armed pipe → KILL; DB raise + fresh pipe → no kill; unarmed pipe (booting) → no kill; stale DB row + fresh pipe → no kill (fresh-wins); both stale → KILL; `drain_liveness_pipes` arms on readable bytes, ignores empty, survives a closed reader.
- [x] `supervisor_spec`: `fork_worker` stores a `liveness_reader` + seeds `last_pipe_tick_at`/`pipe_seen`; fork failure (nil pid / `EAGAIN`) closes both ends and stores nothing; `reap_children` and `shutdown` close the reader.
- [x] **End-to-end with real forks + real OS pipes**: healthy child ticks are drained; a silent (wedged) child's age grows past threshold; no FD leak across 20 fork/close cycles.

## Verification

- `bundle exec rspec spec/pgbus/process/{worker,supervisor,supervisor_watchdog}_spec.rb` → **142 examples, 0 failures**
- `bundle exec rubocop` on all 5 changed files → clean
- Non-system suite (`--order defined`): **97 failures on both `main` and this branch** (+19 new examples, all passing) → **zero new failures**. The 97 are pre-existing test-ordering pollution in `web/streamer/*`, `event_bus/registry`, `consumer_spec` (all pass in isolation) — unrelated to this change.

Closes #202
