### PR TITLE
feat(process): fail fast in children when the PGMQ schema is missing

### DIFF
--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -46,7 +46,7 @@ module Pgbus
         # This avoids the deadlock that occurs when multiple forked children
         # race to call enable_notify_insert (DROP TRIGGER + CREATE TRIGGER)
         # concurrently on the same queue tables. Children still call
-        # bootstrap_queues post-fork but the idempotent check in
+        # bootstrap_queues! post-fork but the idempotent check in
         # notify_trigger_current? makes those calls cheap no-ops.
         bootstrap_queues
 
@@ -115,7 +115,7 @@ module Pgbus
           restore_signals
           setup_child_process
           load_rails_app
-          bootstrap_queues
+          bootstrap_queues!
           worker = Worker.new(
             queues: queues, threads: threads, config: config,
             single_active_consumer: single_active, consumer_priority: priority,
@@ -179,7 +179,7 @@ module Pgbus
           setup_child_process
           load_rails_app
           load_recurring_config
-          bootstrap_queues
+          bootstrap_queues!
           scheduler = Recurring::Scheduler.new(config: config)
           scheduler.run
         end
@@ -492,8 +492,29 @@ module Pgbus
         end
       end
 
+      # Lenient bootstrap for the parent (supervisor.rb#run). A transiently
+      # unavailable DB at boot must not kill the supervisor — children
+      # crash-and-backoff until it recovers — so every StandardError (including
+      # SchemaNotReady) is reported and swallowed.
       def bootstrap_queues
         Pgbus.client.ensure_all_queues
+      rescue StandardError => e
+        ErrorReporter.report(e, { action: "bootstrap_queues" })
+      end
+
+      # Strict bootstrap for forked children (fork_worker, fork_scheduler). A
+      # genuinely missing schema (database absent, migrations not run) surfaces
+      # as Pgbus::SchemaNotReady — log its already-actionable message once and
+      # re-raise so the child exits non-zero. schedule_restart then paces the
+      # crash loop with exponential backoff (up to RESTART_BACKOFF_MAX) instead
+      # of letting children boot and drown in downstream "relation does not
+      # exist" errors. Other StandardErrors stay reported-and-swallowed, exactly
+      # as the lenient variant handles them.
+      def bootstrap_queues!
+        Pgbus.client.ensure_all_queues
+      rescue Pgbus::SchemaNotReady => e
+        Pgbus.logger.error { "[Pgbus] #{e.message}" }
+        raise
       rescue StandardError => e
         ErrorReporter.report(e, { action: "bootstrap_queues" })
       end

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -436,6 +436,46 @@ RSpec.describe Pgbus::Process::Supervisor do
       expect { supervisor.send(:bootstrap_queues) }.not_to raise_error
       expect(Pgbus.logger).to have_received(:error).at_least(:once)
     end
+
+    it "swallows SchemaNotReady so the parent survives a missing schema at boot" do
+      allow(mock_client).to receive(:ensure_all_queues)
+        .and_raise(Pgbus::SchemaNotReady, "PGMQ schema installation failed. Ensure migrations have been run.")
+      allow(Pgbus.logger).to receive(:error)
+
+      expect { supervisor.send(:bootstrap_queues) }.not_to raise_error
+    end
+  end
+
+  describe "bootstrap_queues! (private)" do
+    let(:supervisor) { described_class.new }
+    let(:mock_client) { build_mock_client }
+
+    before do
+      allow(Pgbus).to receive(:client).and_return(mock_client)
+      allow(mock_client).to receive(:ensure_all_queues)
+    end
+
+    it "calls ensure_all_queues on the client" do
+      supervisor.send(:bootstrap_queues!)
+
+      expect(mock_client).to have_received(:ensure_all_queues).once
+    end
+
+    it "logs one actionable error and re-raises on SchemaNotReady" do
+      message = "PGMQ schema installation failed. Ensure the pgbus database exists and migrations have been run."
+      allow(mock_client).to receive(:ensure_all_queues).and_raise(Pgbus::SchemaNotReady, message)
+      allow(Pgbus.logger).to receive(:error)
+
+      expect { supervisor.send(:bootstrap_queues!) }.to raise_error(Pgbus::SchemaNotReady, message)
+      expect(Pgbus.logger).to have_received(:error).once
+    end
+
+    it "reports and swallows a non-schema StandardError, as the lenient variant does" do
+      allow(mock_client).to receive(:ensure_all_queues).and_raise(StandardError, "connection failed")
+      allow(Pgbus.logger).to receive(:error)
+
+      expect { supervisor.send(:bootstrap_queues!) }.not_to raise_error
+    end
   end
 
   describe "pre-fork bootstrap" do


### PR DESCRIPTION
## Summary
`Supervisor#bootstrap_queues` swallowed every `StandardError`, so when the PGMQ schema was genuinely missing (database absent, migrations not run) the forked children in `fork_worker` (`supervisor.rb:97`) and `fork_scheduler` (`supervisor.rb:150`) booted anyway and drowned every fetch in the confusing downstream `relation "pgmq.q_..." does not exist` error — tripping the queue-eviction machinery (`worker.rb:347-358`) instead of telling the operator what is actually wrong.

This adds a strict `bootstrap_queues!` for the child fork blocks:
- On `Pgbus::SchemaNotReady`, log its already-actionable message once (`Pgbus.logger.error`) and re-raise so the child exits non-zero.
- The PR #189 restart policy (`schedule_restart`, `supervisor.rb:298-317`) classifies the fast crash as a crash loop and paces restarts exponentially up to `RESTART_BACKOFF_MAX` (60s) — no fork storm.
- Other `StandardError`s stay reported-and-swallowed, exactly as the lenient variant handles them.

The parent call at `supervisor.rb:44` keeps the lenient `bootstrap_queues`: a transiently unavailable DB at boot must not kill the supervisor — children crash-and-backoff until it recovers.

No config or public API changes; the ActiveJob adapter path is unaffected.

## Acceptance criteria
- [x] `bootstrap_queues!` logs one actionable error and re-raises on `Pgbus::SchemaNotReady`.
- [x] Other `StandardError`s are still reported-and-swallowed in both strict and lenient variants.
- [x] The parent supervisor survives `SchemaNotReady` during its own bootstrap.
- [x] A child crashing on `SchemaNotReady` is restarted with backoff, not immediately (existing `schedule_restart` policy, now reached because the child exits non-zero).

## Test plan
- [x] `bootstrap_queues!` calls `ensure_all_queues`
- [x] `bootstrap_queues!` logs one error and re-raises on `SchemaNotReady`
- [x] `bootstrap_queues!` reports-and-swallows a non-schema `StandardError`
- [x] lenient `bootstrap_queues` swallows `SchemaNotReady` so the parent survives
- [x] existing restart-backoff specs prove a fast child crash is paced with exponential backoff

Closes #210

https://claude.ai/code/session_019UyWsPP7veHzzB8Z1zGr6W
