### PR TITLE
test(generators): cover the 13 untested generators + MigrationPath

### DIFF
--- a/spec/generators/pgbus/add_failed_events_index_generator_spec.rb
+++ b/spec/generators/pgbus/add_failed_events_index_generator_spec.rb
@@ -21,36 +21,43 @@ RSpec.describe Pgbus::Generators::AddFailedEventsIndexGenerator do
     end
 
     it "has a description mentioning the failed events index" do
-      expect(described_class.desc).to match(/pgbus_failed_events/)
+      expect(described_class.desc).to include("pgbus_failed_events")
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path(
-        "../../../lib/generators/pgbus/templates/add_failed_events_unique_index.rb.erb", __dir__
-      )
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_failed_events_unique_index.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
+    end
+
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
     it "defines a versioned migration class" do
-      expect(content).to include(
-        "class AddPgbusFailedEventsUniqueIndex < ActiveRecord::Migration<%= migration_version %>"
-      )
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusFailedEventsUniqueIndex < ActiveRecord::Migration\[\d+\.\d+\]/)
+      end
     end
 
-    it "adds a unique index on (queue_name, msg_id)" do
-      expect(content).to include("add_index :pgbus_failed_events, [:queue_name, :msg_id]")
-      expect(content).to include("unique: true")
-      expect(content).to include('name: "idx_pgbus_failed_events_queue_msg"')
-    end
-
-    it "is idempotent via if_not_exists" do
-      expect(content).to include("if_not_exists: true")
+    it "adds a unique idempotent index on (queue_name, msg_id)" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("add_index :pgbus_failed_events, [:queue_name, :msg_id]")
+        expect(content).to include("unique: true")
+        expect(content).to include('name: "idx_pgbus_failed_events_queue_msg"')
+        expect(content).to include("if_not_exists: true")
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_failed_events_index_generator_spec.rb
+++ b/spec/generators/pgbus/add_failed_events_index_generator_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_failed_events_index_generator"
+
+RSpec.describe Pgbus::Generators::AddFailedEventsIndexGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning the failed events index" do
+      expect(described_class.desc).to match(/pgbus_failed_events/)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path(
+        "../../../lib/generators/pgbus/templates/add_failed_events_unique_index.rb.erb", __dir__
+      )
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include(
+        "class AddPgbusFailedEventsUniqueIndex < ActiveRecord::Migration<%= migration_version %>"
+      )
+    end
+
+    it "adds a unique index on (queue_name, msg_id)" do
+      expect(content).to include("add_index :pgbus_failed_events, [:queue_name, :msg_id]")
+      expect(content).to include("unique: true")
+      expect(content).to include('name: "idx_pgbus_failed_events_queue_msg"')
+    end
+
+    it "is idempotent via if_not_exists" do
+      expect(content).to include("if_not_exists: true")
+    end
+  end
+end

--- a/spec/generators/pgbus/add_failed_events_index_generator_spec.rb
+++ b/spec/generators/pgbus/add_failed_events_index_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_failed_events_index_generator"
 
 RSpec.describe Pgbus::Generators::AddFailedEventsIndexGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning the failed events index" do
-      expect(described_class.desc).to include("pgbus_failed_events")
-    end
-  end
+  it_behaves_like "a pgbus generator", /pgbus_failed_events/
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_failed_events_unique_index.rb" }

--- a/spec/generators/pgbus/add_job_locks_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_locks_generator_spec.rb
@@ -25,46 +25,52 @@ RSpec.describe Pgbus::Generators::AddJobLocksGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_job_locks.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_job_locks.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
-    end
-
-    it "defines a versioned migration class" do
-      expect(content).to include("class AddPgbusJobLocks < ActiveRecord::Migration<%= migration_version %>")
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "creates the pgbus_job_locks table" do
-      expect(content).to include("create_table :pgbus_job_locks")
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
+    end
+
+    it "defines a versioned migration class creating pgbus_job_locks" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusJobLocks < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("create_table :pgbus_job_locks")
+      end
     end
 
     it "declares the lock ownership columns" do
-      expect(content).to include("t.string :lock_key, null: false")
-      expect(content).to include("t.string :job_class, null: false")
-      expect(content).to include('t.string :state, null: false, default: "queued"')
-      expect(content).to include("t.integer :owner_pid")
-      expect(content).to include("t.datetime :expires_at, null: false")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("t.string :lock_key, null: false")
+        expect(content).to include("t.string :job_class, null: false")
+        expect(content).to include('t.string :state, null: false, default: "queued"')
+        expect(content).to include("t.integer :owner_pid")
+        expect(content).to include("t.datetime :expires_at, null: false")
+      end
     end
 
-    it "adds a unique index on lock_key" do
-      expect(content).to include("add_index :pgbus_job_locks, :lock_key")
-      expect(content).to include('name: "idx_pgbus_job_locks_key"')
-      expect(content).to include("unique: true")
-    end
-
-    it "adds a reaper index on (state, owner_pid)" do
-      expect(content).to include("add_index :pgbus_job_locks, [:state, :owner_pid]")
-      expect(content).to include('name: "idx_pgbus_job_locks_reaper"')
-    end
-
-    it "adds an expiry index" do
-      expect(content).to include("add_index :pgbus_job_locks, :expires_at")
-      expect(content).to include('name: "idx_pgbus_job_locks_expires"')
+    it "adds the key, expiry, and reaper indexes" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("add_index :pgbus_job_locks, :lock_key")
+        expect(content).to include('name: "idx_pgbus_job_locks_key"')
+        expect(content).to include("add_index :pgbus_job_locks, :expires_at")
+        expect(content).to include('name: "idx_pgbus_job_locks_expires"')
+        expect(content).to include("add_index :pgbus_job_locks, [:state, :owner_pid]")
+        expect(content).to include('name: "idx_pgbus_job_locks_reaper"')
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_job_locks_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_locks_generator_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_job_locks_generator"
+
+RSpec.describe Pgbus::Generators::AddJobLocksGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning job locks" do
+      expect(described_class.desc).to match(/job locks/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_job_locks.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include("class AddPgbusJobLocks < ActiveRecord::Migration<%= migration_version %>")
+    end
+
+    it "creates the pgbus_job_locks table" do
+      expect(content).to include("create_table :pgbus_job_locks")
+    end
+
+    it "declares the lock ownership columns" do
+      expect(content).to include("t.string :lock_key, null: false")
+      expect(content).to include("t.string :job_class, null: false")
+      expect(content).to include('t.string :state, null: false, default: "queued"')
+      expect(content).to include("t.integer :owner_pid")
+      expect(content).to include("t.datetime :expires_at, null: false")
+    end
+
+    it "adds a unique index on lock_key" do
+      expect(content).to include("add_index :pgbus_job_locks, :lock_key")
+      expect(content).to include('name: "idx_pgbus_job_locks_key"')
+      expect(content).to include("unique: true")
+    end
+
+    it "adds a reaper index on (state, owner_pid)" do
+      expect(content).to include("add_index :pgbus_job_locks, [:state, :owner_pid]")
+      expect(content).to include('name: "idx_pgbus_job_locks_reaper"')
+    end
+
+    it "adds an expiry index" do
+      expect(content).to include("add_index :pgbus_job_locks, :expires_at")
+      expect(content).to include('name: "idx_pgbus_job_locks_expires"')
+    end
+  end
+end

--- a/spec/generators/pgbus/add_job_locks_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_locks_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_job_locks_generator"
 
 RSpec.describe Pgbus::Generators::AddJobLocksGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning job locks" do
-      expect(described_class.desc).to match(/job locks/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /job locks/i
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_job_locks.rb" }

--- a/spec/generators/pgbus/add_job_stats_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_job_stats_generator"
 
 RSpec.describe Pgbus::Generators::AddJobStatsGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning job stats" do
-      expect(described_class.desc).to match(/job stats/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /job stats/i
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_job_stats.rb" }

--- a/spec/generators/pgbus/add_job_stats_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_generator_spec.rb
@@ -25,44 +25,51 @@ RSpec.describe Pgbus::Generators::AddJobStatsGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_job_stats.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_job_stats.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
-    end
-
-    it "defines a versioned migration class" do
-      expect(content).to include("class AddPgbusJobStats < ActiveRecord::Migration<%= migration_version %>")
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "creates the pgbus_job_stats table" do
-      expect(content).to include("create_table :pgbus_job_stats")
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
+    end
+
+    it "defines a versioned migration class creating pgbus_job_stats" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusJobStats < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("create_table :pgbus_job_stats")
+      end
     end
 
     it "declares the stats columns" do
-      expect(content).to include("t.string :job_class, null: false")
-      expect(content).to include("t.string :queue_name, null: false")
-      expect(content).to include("t.string :status, null: false")
-      expect(content).to include("t.integer :duration_ms, null: false, default: 0")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("t.string :job_class, null: false")
+        expect(content).to include("t.string :queue_name, null: false")
+        expect(content).to include("t.string :status, null: false")
+        expect(content).to include("t.integer :duration_ms, null: false, default: 0")
+      end
     end
 
-    it "indexes created_at for time-window queries" do
-      expect(content).to include("add_index :pgbus_job_stats, :created_at")
-      expect(content).to include('name: "idx_pgbus_job_stats_time"')
-    end
-
-    it "indexes (job_class, created_at)" do
-      expect(content).to include("add_index :pgbus_job_stats, [:job_class, :created_at]")
-      expect(content).to include('name: "idx_pgbus_job_stats_class_time"')
-    end
-
-    it "indexes (status, created_at)" do
-      expect(content).to include("add_index :pgbus_job_stats, [:status, :created_at]")
-      expect(content).to include('name: "idx_pgbus_job_stats_status_time"')
+    it "indexes created_at, (job_class, created_at), and (status, created_at)" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("add_index :pgbus_job_stats, :created_at")
+        expect(content).to include('name: "idx_pgbus_job_stats_time"')
+        expect(content).to include("add_index :pgbus_job_stats, [:job_class, :created_at]")
+        expect(content).to include('name: "idx_pgbus_job_stats_class_time"')
+        expect(content).to include("add_index :pgbus_job_stats, [:status, :created_at]")
+        expect(content).to include('name: "idx_pgbus_job_stats_status_time"')
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_job_stats_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_generator_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_job_stats_generator"
+
+RSpec.describe Pgbus::Generators::AddJobStatsGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning job stats" do
+      expect(described_class.desc).to match(/job stats/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_job_stats.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include("class AddPgbusJobStats < ActiveRecord::Migration<%= migration_version %>")
+    end
+
+    it "creates the pgbus_job_stats table" do
+      expect(content).to include("create_table :pgbus_job_stats")
+    end
+
+    it "declares the stats columns" do
+      expect(content).to include("t.string :job_class, null: false")
+      expect(content).to include("t.string :queue_name, null: false")
+      expect(content).to include("t.string :status, null: false")
+      expect(content).to include("t.integer :duration_ms, null: false, default: 0")
+    end
+
+    it "indexes created_at for time-window queries" do
+      expect(content).to include("add_index :pgbus_job_stats, :created_at")
+      expect(content).to include('name: "idx_pgbus_job_stats_time"')
+    end
+
+    it "indexes (job_class, created_at)" do
+      expect(content).to include("add_index :pgbus_job_stats, [:job_class, :created_at]")
+      expect(content).to include('name: "idx_pgbus_job_stats_class_time"')
+    end
+
+    it "indexes (status, created_at)" do
+      expect(content).to include("add_index :pgbus_job_stats, [:status, :created_at]")
+      expect(content).to include('name: "idx_pgbus_job_stats_status_time"')
+    end
+  end
+end

--- a/spec/generators/pgbus/add_job_stats_latency_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_latency_generator_spec.rb
@@ -25,34 +25,45 @@ RSpec.describe Pgbus::Generators::AddJobStatsLatencyGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_job_stats_latency.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_job_stats_latency.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
+    end
+
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
     it "defines a versioned migration class" do
-      expect(content).to include(
-        "class AddPgbusJobStatsLatency < ActiveRecord::Migration<%= migration_version %>"
-      )
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusJobStatsLatency < ActiveRecord::Migration\[\d+\.\d+\]/)
+      end
     end
 
-    it "adds the enqueue_latency_ms column as bigint" do
-      expect(content).to include("add_column :pgbus_job_stats, :enqueue_latency_ms, :bigint")
-    end
-
-    it "adds the retry_count column defaulting to 0" do
-      expect(content).to include("add_column :pgbus_job_stats, :retry_count, :integer, default: 0")
+    it "adds the enqueue_latency_ms and retry_count columns" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("add_column :pgbus_job_stats, :enqueue_latency_ms, :bigint")
+        expect(content).to include("add_column :pgbus_job_stats, :retry_count, :integer, default: 0")
+      end
     end
 
     it "adds the queue latency index idempotently" do
-      expect(content).to include("add_index :pgbus_job_stats, [:queue_name, :created_at]")
-      expect(content).to include('name: "idx_pgbus_job_stats_queue_time"')
-      expect(content).to include("if_not_exists: true")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("add_index :pgbus_job_stats, [:queue_name, :created_at]")
+        expect(content).to include('name: "idx_pgbus_job_stats_queue_time"')
+        expect(content).to include("if_not_exists: true")
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_job_stats_latency_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_latency_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_job_stats_latency_generator"
 
 RSpec.describe Pgbus::Generators::AddJobStatsLatencyGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning latency" do
-      expect(described_class.desc).to match(/latency/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /latency/i
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_job_stats_latency.rb" }

--- a/spec/generators/pgbus/add_job_stats_latency_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_latency_generator_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_job_stats_latency_generator"
+
+RSpec.describe Pgbus::Generators::AddJobStatsLatencyGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning latency" do
+      expect(described_class.desc).to match(/latency/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_job_stats_latency.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include(
+        "class AddPgbusJobStatsLatency < ActiveRecord::Migration<%= migration_version %>"
+      )
+    end
+
+    it "adds the enqueue_latency_ms column as bigint" do
+      expect(content).to include("add_column :pgbus_job_stats, :enqueue_latency_ms, :bigint")
+    end
+
+    it "adds the retry_count column defaulting to 0" do
+      expect(content).to include("add_column :pgbus_job_stats, :retry_count, :integer, default: 0")
+    end
+
+    it "adds the queue latency index idempotently" do
+      expect(content).to include("add_index :pgbus_job_stats, [:queue_name, :created_at]")
+      expect(content).to include('name: "idx_pgbus_job_stats_queue_time"')
+      expect(content).to include("if_not_exists: true")
+    end
+  end
+end

--- a/spec/generators/pgbus/add_job_stats_queue_index_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_queue_index_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_job_stats_queue_index_generator"
 
 RSpec.describe Pgbus::Generators::AddJobStatsQueueIndexGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning the composite index" do
-      expect(described_class.desc).to include("pgbus_job_stats")
-    end
-  end
+  it_behaves_like "a pgbus generator", /pgbus_job_stats/
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_job_stats_queue_index.rb" }

--- a/spec/generators/pgbus/add_job_stats_queue_index_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_queue_index_generator_spec.rb
@@ -21,33 +21,42 @@ RSpec.describe Pgbus::Generators::AddJobStatsQueueIndexGenerator do
     end
 
     it "has a description mentioning the composite index" do
-      expect(described_class.desc).to match(/pgbus_job_stats/)
+      expect(described_class.desc).to include("pgbus_job_stats")
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_job_stats_queue_index.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_job_stats_queue_index.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
+    end
+
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
     it "defines a versioned migration class" do
-      expect(content).to include(
-        "class AddPgbusJobStatsQueueIndex < ActiveRecord::Migration<%= migration_version %>"
-      )
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusJobStatsQueueIndex < ActiveRecord::Migration\[\d+\.\d+\]/)
+      end
     end
 
-    it "adds a composite index on (queue_name, created_at)" do
-      expect(content).to include("add_index :pgbus_job_stats, %i[queue_name created_at]")
-      expect(content).to include('name: "idx_pgbus_job_stats_queue_time"')
-    end
-
-    it "is idempotent via if_not_exists" do
-      expect(content).to include("if_not_exists: true")
+    it "adds an idempotent composite index on (queue_name, created_at)" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("add_index :pgbus_job_stats, %i[queue_name created_at]")
+        expect(content).to include('name: "idx_pgbus_job_stats_queue_time"')
+        expect(content).to include("if_not_exists: true")
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_job_stats_queue_index_generator_spec.rb
+++ b/spec/generators/pgbus/add_job_stats_queue_index_generator_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_job_stats_queue_index_generator"
+
+RSpec.describe Pgbus::Generators::AddJobStatsQueueIndexGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning the composite index" do
+      expect(described_class.desc).to match(/pgbus_job_stats/)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_job_stats_queue_index.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include(
+        "class AddPgbusJobStatsQueueIndex < ActiveRecord::Migration<%= migration_version %>"
+      )
+    end
+
+    it "adds a composite index on (queue_name, created_at)" do
+      expect(content).to include("add_index :pgbus_job_stats, %i[queue_name created_at]")
+      expect(content).to include('name: "idx_pgbus_job_stats_queue_time"')
+    end
+
+    it "is idempotent via if_not_exists" do
+      expect(content).to include("if_not_exists: true")
+    end
+  end
+end

--- a/spec/generators/pgbus/add_outbox_generator_spec.rb
+++ b/spec/generators/pgbus/add_outbox_generator_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_outbox_generator"
+
+RSpec.describe Pgbus::Generators::AddOutboxGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning the outbox" do
+      expect(described_class.desc).to match(/outbox/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_outbox.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include("class AddPgbusOutbox < ActiveRecord::Migration<%= migration_version %>")
+    end
+
+    it "creates the pgbus_outbox_entries table" do
+      expect(content).to include("create_table :pgbus_outbox_entries")
+    end
+
+    it "stores the jsonb payload as non-null" do
+      expect(content).to include("t.jsonb :payload, null: false")
+    end
+
+    it "enforces exactly one of queue_name or routing_key via a check constraint" do
+      expect(content).to include("add_check_constraint :pgbus_outbox_entries")
+      expect(content).to include("(queue_name IS NOT NULL) <> (routing_key IS NOT NULL)")
+      expect(content).to include('name: "chk_pgbus_outbox_destination"')
+    end
+
+    it "indexes unpublished rows partially" do
+      expect(content).to include('where: "published_at IS NULL"')
+      expect(content).to include('name: "idx_pgbus_outbox_unpublished"')
+    end
+
+    it "indexes published rows for cleanup" do
+      expect(content).to include('where: "published_at IS NOT NULL"')
+      expect(content).to include('name: "idx_pgbus_outbox_cleanup"')
+    end
+  end
+end

--- a/spec/generators/pgbus/add_outbox_generator_spec.rb
+++ b/spec/generators/pgbus/add_outbox_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_outbox_generator"
 
 RSpec.describe Pgbus::Generators::AddOutboxGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning the outbox" do
-      expect(described_class.desc).to match(/outbox/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /outbox/i
 
   describe "generated migration" do
     it "writes the migration into db/migrate by default" do

--- a/spec/generators/pgbus/add_outbox_generator_spec.rb
+++ b/spec/generators/pgbus/add_outbox_generator_spec.rb
@@ -25,42 +25,52 @@ RSpec.describe Pgbus::Generators::AddOutboxGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_outbox.rb.erb", __dir__)
+  describe "generated migration" do
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: "_add_pgbus_outbox.rb") do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
-    let(:content) { File.read(template_path) }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: "_add_pgbus_outbox.rb"
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
     it "defines a versioned migration class" do
-      expect(content).to include("class AddPgbusOutbox < ActiveRecord::Migration<%= migration_version %>")
+      generate_migration(described_class, basename: "_add_pgbus_outbox.rb") do |_path, content|
+        expect(content).to match(/class AddPgbusOutbox < ActiveRecord::Migration\[\d+\.\d+\]/)
+      end
     end
 
-    it "creates the pgbus_outbox_entries table" do
-      expect(content).to include("create_table :pgbus_outbox_entries")
-    end
-
-    it "stores the jsonb payload as non-null" do
-      expect(content).to include("t.jsonb :payload, null: false")
+    it "creates the pgbus_outbox_entries table with a non-null jsonb payload" do
+      generate_migration(described_class, basename: "_add_pgbus_outbox.rb") do |_path, content|
+        expect(content).to include("create_table :pgbus_outbox_entries")
+        expect(content).to include("t.jsonb :payload, null: false")
+      end
     end
 
     it "enforces exactly one of queue_name or routing_key via a check constraint" do
-      expect(content).to include("add_check_constraint :pgbus_outbox_entries")
-      expect(content).to include("(queue_name IS NOT NULL) <> (routing_key IS NOT NULL)")
-      expect(content).to include('name: "chk_pgbus_outbox_destination"')
+      generate_migration(described_class, basename: "_add_pgbus_outbox.rb") do |_path, content|
+        expect(content).to include("add_check_constraint :pgbus_outbox_entries")
+        expect(content).to include("(queue_name IS NOT NULL) <> (routing_key IS NOT NULL)")
+        expect(content).to include('name: "chk_pgbus_outbox_destination"')
+      end
     end
 
-    it "indexes unpublished rows partially" do
-      expect(content).to include('where: "published_at IS NULL"')
-      expect(content).to include('name: "idx_pgbus_outbox_unpublished"')
-    end
-
-    it "indexes published rows for cleanup" do
-      expect(content).to include('where: "published_at IS NOT NULL"')
-      expect(content).to include('name: "idx_pgbus_outbox_cleanup"')
+    it "adds partial indexes for unpublished and published rows" do
+      generate_migration(described_class, basename: "_add_pgbus_outbox.rb") do |_path, content|
+        expect(content).to include('where: "published_at IS NULL"')
+        expect(content).to include('name: "idx_pgbus_outbox_unpublished"')
+        expect(content).to include('where: "published_at IS NOT NULL"')
+        expect(content).to include('name: "idx_pgbus_outbox_cleanup"')
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_presence_generator_spec.rb
+++ b/spec/generators/pgbus/add_presence_generator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_presence_generator"
+
+RSpec.describe Pgbus::Generators::AddPresenceGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning presence" do
+      expect(described_class.desc).to match(/presence/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_presence.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include("class AddPgbusPresence < ActiveRecord::Migration<%= migration_version %>")
+    end
+
+    it "creates the pgbus_presence_members table without a default id" do
+      expect(content).to include("create_table :pgbus_presence_members, id: false")
+    end
+
+    it "declares the membership columns" do
+      expect(content).to include("t.string :stream_name, null: false")
+      expect(content).to include("t.string :member_id, null: false")
+      expect(content).to include("t.jsonb :metadata, null: false, default: {}")
+      expect(content).to include("t.datetime :last_seen_at, null: false")
+    end
+
+    it "adds a unique composite primary-key index on (stream_name, member_id)" do
+      expect(content).to include("%i[stream_name member_id]")
+      expect(content).to include("unique: true")
+      expect(content).to include('name: "idx_pgbus_presence_members_pk"')
+    end
+
+    it "adds a sweep index on (stream_name, last_seen_at)" do
+      expect(content).to include("%i[stream_name last_seen_at]")
+      expect(content).to include('name: "idx_pgbus_presence_members_sweep"')
+    end
+  end
+end

--- a/spec/generators/pgbus/add_presence_generator_spec.rb
+++ b/spec/generators/pgbus/add_presence_generator_spec.rb
@@ -25,40 +25,50 @@ RSpec.describe Pgbus::Generators::AddPresenceGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_presence.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_presence.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "defines a versioned migration class" do
-      expect(content).to include("class AddPgbusPresence < ActiveRecord::Migration<%= migration_version %>")
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
     it "creates the pgbus_presence_members table without a default id" do
-      expect(content).to include("create_table :pgbus_presence_members, id: false")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusPresence < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("create_table :pgbus_presence_members, id: false")
+      end
     end
 
     it "declares the membership columns" do
-      expect(content).to include("t.string :stream_name, null: false")
-      expect(content).to include("t.string :member_id, null: false")
-      expect(content).to include("t.jsonb :metadata, null: false, default: {}")
-      expect(content).to include("t.datetime :last_seen_at, null: false")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("t.string :stream_name, null: false")
+        expect(content).to include("t.string :member_id, null: false")
+        expect(content).to include("t.jsonb :metadata, null: false, default: {}")
+        expect(content).to include("t.datetime :last_seen_at, null: false")
+      end
     end
 
-    it "adds a unique composite primary-key index on (stream_name, member_id)" do
-      expect(content).to include("%i[stream_name member_id]")
-      expect(content).to include("unique: true")
-      expect(content).to include('name: "idx_pgbus_presence_members_pk"')
-    end
-
-    it "adds a sweep index on (stream_name, last_seen_at)" do
-      expect(content).to include("%i[stream_name last_seen_at]")
-      expect(content).to include('name: "idx_pgbus_presence_members_sweep"')
+    it "adds the unique composite primary-key index and the sweep index" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("%i[stream_name member_id]")
+        expect(content).to include("unique: true")
+        expect(content).to include('name: "idx_pgbus_presence_members_pk"')
+        expect(content).to include("%i[stream_name last_seen_at]")
+        expect(content).to include('name: "idx_pgbus_presence_members_sweep"')
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_presence_generator_spec.rb
+++ b/spec/generators/pgbus/add_presence_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_presence_generator"
 
 RSpec.describe Pgbus::Generators::AddPresenceGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning presence" do
-      expect(described_class.desc).to match(/presence/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /presence/i
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_presence.rb" }

--- a/spec/generators/pgbus/add_queue_states_generator_spec.rb
+++ b/spec/generators/pgbus/add_queue_states_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_queue_states_generator"
 
 RSpec.describe Pgbus::Generators::AddQueueStatesGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning pause/resume or circuit breaker" do
-      expect(described_class.desc).to match(/pause|circuit breaker/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /pause|circuit breaker/i
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_queue_states.rb" }

--- a/spec/generators/pgbus/add_queue_states_generator_spec.rb
+++ b/spec/generators/pgbus/add_queue_states_generator_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_queue_states_generator"
+
+RSpec.describe Pgbus::Generators::AddQueueStatesGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning pause/resume or circuit breaker" do
+      expect(described_class.desc).to match(/pause|circuit breaker/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_queue_states.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include("class AddPgbusQueueStates < ActiveRecord::Migration<%= migration_version %>")
+    end
+
+    it "creates the pgbus_queue_states table" do
+      expect(content).to include("create_table :pgbus_queue_states")
+    end
+
+    it "declares the pause and circuit breaker columns" do
+      expect(content).to include("t.string :queue_name, null: false")
+      expect(content).to include("t.boolean :paused, null: false, default: false")
+      expect(content).to include("t.integer :circuit_breaker_trip_count, default: 0")
+      expect(content).to include("t.datetime :circuit_breaker_resume_at")
+    end
+
+    it "adds a unique index on queue_name" do
+      expect(content).to include("add_index :pgbus_queue_states, :queue_name")
+      expect(content).to include("unique: true")
+      expect(content).to include('name: "idx_pgbus_queue_states_queue_name"')
+    end
+  end
+end

--- a/spec/generators/pgbus/add_queue_states_generator_spec.rb
+++ b/spec/generators/pgbus/add_queue_states_generator_spec.rb
@@ -25,35 +25,48 @@ RSpec.describe Pgbus::Generators::AddQueueStatesGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_queue_states.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_queue_states.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "defines a versioned migration class" do
-      expect(content).to include("class AddPgbusQueueStates < ActiveRecord::Migration<%= migration_version %>")
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
     it "creates the pgbus_queue_states table" do
-      expect(content).to include("create_table :pgbus_queue_states")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusQueueStates < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("create_table :pgbus_queue_states")
+      end
     end
 
     it "declares the pause and circuit breaker columns" do
-      expect(content).to include("t.string :queue_name, null: false")
-      expect(content).to include("t.boolean :paused, null: false, default: false")
-      expect(content).to include("t.integer :circuit_breaker_trip_count, default: 0")
-      expect(content).to include("t.datetime :circuit_breaker_resume_at")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("t.string :queue_name, null: false")
+        expect(content).to include("t.boolean :paused, null: false, default: false")
+        expect(content).to include("t.integer :circuit_breaker_trip_count, default: 0")
+        expect(content).to include("t.datetime :circuit_breaker_resume_at")
+      end
     end
 
     it "adds a unique index on queue_name" do
-      expect(content).to include("add_index :pgbus_queue_states, :queue_name")
-      expect(content).to include("unique: true")
-      expect(content).to include('name: "idx_pgbus_queue_states_queue_name"')
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("add_index :pgbus_queue_states, :queue_name")
+        expect(content).to include("unique: true")
+        expect(content).to include('name: "idx_pgbus_queue_states_queue_name"')
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_recurring_generator_spec.rb
+++ b/spec/generators/pgbus/add_recurring_generator_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_recurring_generator"
+
+RSpec.describe Pgbus::Generators::AddRecurringGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning recurring jobs" do
+      expect(described_class.desc).to match(/recurring/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_recurring_tables.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include(
+        "class AddPgbusRecurringTables < ActiveRecord::Migration<%= migration_version %>"
+      )
+    end
+
+    it "creates the pgbus_recurring_tasks table" do
+      expect(content).to include("create_table :pgbus_recurring_tasks")
+      expect(content).to include("t.string :key, null: false")
+      expect(content).to include("t.string :schedule, null: false")
+      expect(content).to include("t.boolean :enabled, null: false, default: true")
+    end
+
+    it "adds a unique index on the task key" do
+      expect(content).to include("add_index :pgbus_recurring_tasks, :key")
+      expect(content).to include("unique: true")
+      expect(content).to include('name: "idx_pgbus_recurring_tasks_key"')
+    end
+
+    it "creates the pgbus_recurring_executions table" do
+      expect(content).to include("create_table :pgbus_recurring_executions")
+      expect(content).to include("t.string :task_key, null: false")
+      expect(content).to include("t.datetime :run_at, null: false")
+    end
+
+    it "adds a unique dedup index on (task_key, run_at)" do
+      expect(content).to include("add_index :pgbus_recurring_executions, [:task_key, :run_at]")
+      expect(content).to include("unique: true")
+      expect(content).to include('name: "idx_pgbus_recurring_executions_dedup"')
+    end
+
+    it "adds a cleanup index on run_at" do
+      expect(content).to include("add_index :pgbus_recurring_executions, :run_at")
+      expect(content).to include('name: "idx_pgbus_recurring_executions_cleanup"')
+    end
+  end
+
+  describe "recurring config template" do
+    let(:config_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/recurring.yml.erb", __dir__)
+    end
+
+    it "renders a config/recurring.yml template alongside the migration" do
+      expect(File.exist?(config_path)).to be(true)
+    end
+  end
+end

--- a/spec/generators/pgbus/add_recurring_generator_spec.rb
+++ b/spec/generators/pgbus/add_recurring_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_recurring_generator"
 
 RSpec.describe Pgbus::Generators::AddRecurringGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning recurring jobs" do
-      expect(described_class.desc).to match(/recurring/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /recurring/i
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_recurring_tables.rb" }

--- a/spec/generators/pgbus/add_recurring_generator_spec.rb
+++ b/spec/generators/pgbus/add_recurring_generator_spec.rb
@@ -25,60 +25,58 @@ RSpec.describe Pgbus::Generators::AddRecurringGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_recurring_tables.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_recurring_tables.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
-    end
-
-    it "defines a versioned migration class" do
-      expect(content).to include(
-        "class AddPgbusRecurringTables < ActiveRecord::Migration<%= migration_version %>"
-      )
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "creates the pgbus_recurring_tasks table" do
-      expect(content).to include("create_table :pgbus_recurring_tasks")
-      expect(content).to include("t.string :key, null: false")
-      expect(content).to include("t.string :schedule, null: false")
-      expect(content).to include("t.boolean :enabled, null: false, default: true")
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "adds a unique index on the task key" do
-      expect(content).to include("add_index :pgbus_recurring_tasks, :key")
-      expect(content).to include("unique: true")
-      expect(content).to include('name: "idx_pgbus_recurring_tasks_key"')
+    it "creates the pgbus_recurring_tasks table with a unique key index" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusRecurringTables < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("create_table :pgbus_recurring_tasks")
+        expect(content).to include("t.string :key, null: false")
+        expect(content).to include("t.string :schedule, null: false")
+        expect(content).to include("t.boolean :enabled, null: false, default: true")
+        expect(content).to include("add_index :pgbus_recurring_tasks, :key")
+        expect(content).to include('name: "idx_pgbus_recurring_tasks_key"')
+      end
     end
 
-    it "creates the pgbus_recurring_executions table" do
-      expect(content).to include("create_table :pgbus_recurring_executions")
-      expect(content).to include("t.string :task_key, null: false")
-      expect(content).to include("t.datetime :run_at, null: false")
-    end
-
-    it "adds a unique dedup index on (task_key, run_at)" do
-      expect(content).to include("add_index :pgbus_recurring_executions, [:task_key, :run_at]")
-      expect(content).to include("unique: true")
-      expect(content).to include('name: "idx_pgbus_recurring_executions_dedup"')
-    end
-
-    it "adds a cleanup index on run_at" do
-      expect(content).to include("add_index :pgbus_recurring_executions, :run_at")
-      expect(content).to include('name: "idx_pgbus_recurring_executions_cleanup"')
+    it "creates the pgbus_recurring_executions table with dedup and cleanup indexes" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("create_table :pgbus_recurring_executions")
+        expect(content).to include("t.string :task_key, null: false")
+        expect(content).to include("t.datetime :run_at, null: false")
+        expect(content).to include("add_index :pgbus_recurring_executions, [:task_key, :run_at]")
+        expect(content).to include('name: "idx_pgbus_recurring_executions_dedup"')
+        expect(content).to include("add_index :pgbus_recurring_executions, :run_at")
+        expect(content).to include('name: "idx_pgbus_recurring_executions_cleanup"')
+      end
     end
   end
 
-  describe "recurring config template" do
-    let(:config_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/recurring.yml.erb", __dir__)
-    end
+  describe "recurring config" do
+    let(:basename) { "_add_pgbus_recurring_tables.rb" }
 
-    it "renders a config/recurring.yml template alongside the migration" do
-      expect(File.exist?(config_path)).to be(true)
+    it "also renders config/recurring.yml alongside the migration" do
+      generate_migration(described_class, basename: basename) do |_path, _content, root|
+        expect(File.exist?(File.join(root, "config", "recurring.yml"))).to be(true)
+      end
     end
   end
 end

--- a/spec/generators/pgbus/add_stream_stats_generator_spec.rb
+++ b/spec/generators/pgbus/add_stream_stats_generator_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/add_stream_stats_generator"
+
+RSpec.describe Pgbus::Generators::AddStreamStatsGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning stream stats" do
+      expect(described_class.desc).to match(/stream stats/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/add_stream_stats.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include("class AddPgbusStreamStats < ActiveRecord::Migration<%= migration_version %>")
+    end
+
+    it "creates the pgbus_stream_stats table" do
+      expect(content).to include("create_table :pgbus_stream_stats")
+    end
+
+    it "declares the stream stat columns" do
+      expect(content).to include("t.string :stream_name, null: false")
+      expect(content).to include("t.string :event_type, null: false")
+      expect(content).to include("t.integer :duration_ms, null: false, default: 0")
+      expect(content).to include("t.integer :fanout")
+    end
+
+    it "indexes created_at for time-window queries" do
+      expect(content).to include("add_index :pgbus_stream_stats, :created_at")
+      expect(content).to include('name: "idx_pgbus_stream_stats_time"')
+    end
+
+    it "indexes (stream_name, created_at)" do
+      expect(content).to include("add_index :pgbus_stream_stats, %i[stream_name created_at]")
+      expect(content).to include('name: "idx_pgbus_stream_stats_stream_time"')
+    end
+
+    it "indexes (event_type, created_at)" do
+      expect(content).to include("add_index :pgbus_stream_stats, %i[event_type created_at]")
+      expect(content).to include('name: "idx_pgbus_stream_stats_type_time"')
+    end
+  end
+end

--- a/spec/generators/pgbus/add_stream_stats_generator_spec.rb
+++ b/spec/generators/pgbus/add_stream_stats_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/add_stream_stats_generator"
 
 RSpec.describe Pgbus::Generators::AddStreamStatsGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning stream stats" do
-      expect(described_class.desc).to match(/stream stats/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /stream stats/i
 
   describe "generated migration" do
     let(:basename) { "_add_pgbus_stream_stats.rb" }

--- a/spec/generators/pgbus/add_stream_stats_generator_spec.rb
+++ b/spec/generators/pgbus/add_stream_stats_generator_spec.rb
@@ -25,44 +25,51 @@ RSpec.describe Pgbus::Generators::AddStreamStatsGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/add_stream_stats.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_add_pgbus_stream_stats.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "defines a versioned migration class" do
-      expect(content).to include("class AddPgbusStreamStats < ActiveRecord::Migration<%= migration_version %>")
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
     it "creates the pgbus_stream_stats table" do
-      expect(content).to include("create_table :pgbus_stream_stats")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class AddPgbusStreamStats < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("create_table :pgbus_stream_stats")
+      end
     end
 
     it "declares the stream stat columns" do
-      expect(content).to include("t.string :stream_name, null: false")
-      expect(content).to include("t.string :event_type, null: false")
-      expect(content).to include("t.integer :duration_ms, null: false, default: 0")
-      expect(content).to include("t.integer :fanout")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("t.string :stream_name, null: false")
+        expect(content).to include("t.string :event_type, null: false")
+        expect(content).to include("t.integer :duration_ms, null: false, default: 0")
+        expect(content).to include("t.integer :fanout")
+      end
     end
 
-    it "indexes created_at for time-window queries" do
-      expect(content).to include("add_index :pgbus_stream_stats, :created_at")
-      expect(content).to include('name: "idx_pgbus_stream_stats_time"')
-    end
-
-    it "indexes (stream_name, created_at)" do
-      expect(content).to include("add_index :pgbus_stream_stats, %i[stream_name created_at]")
-      expect(content).to include('name: "idx_pgbus_stream_stats_stream_time"')
-    end
-
-    it "indexes (event_type, created_at)" do
-      expect(content).to include("add_index :pgbus_stream_stats, %i[event_type created_at]")
-      expect(content).to include('name: "idx_pgbus_stream_stats_type_time"')
+    it "adds the time, stream, and event-type indexes" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("add_index :pgbus_stream_stats, :created_at")
+        expect(content).to include('name: "idx_pgbus_stream_stats_time"')
+        expect(content).to include("add_index :pgbus_stream_stats, %i[stream_name created_at]")
+        expect(content).to include('name: "idx_pgbus_stream_stats_stream_time"')
+        expect(content).to include("add_index :pgbus_stream_stats, %i[event_type created_at]")
+        expect(content).to include('name: "idx_pgbus_stream_stats_type_time"')
+      end
     end
   end
 end

--- a/spec/generators/pgbus/migrate_job_locks_generator_spec.rb
+++ b/spec/generators/pgbus/migrate_job_locks_generator_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/migrate_job_locks_generator"
+
+RSpec.describe Pgbus::Generators::MigrateJobLocksGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning the uniqueness keys migration" do
+      expect(described_class.desc).to match(/uniqueness/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path(
+        "../../../lib/generators/pgbus/templates/migrate_job_locks_to_uniqueness_keys.rb.erb", __dir__
+      )
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include(
+        "class MigratePgbusJobLocksToUniquenessKeys < ActiveRecord::Migration<%= migration_version %>"
+      )
+    end
+
+    it "creates the new lightweight pgbus_uniqueness_keys table only if absent" do
+      expect(content).to include("unless table_exists?(:pgbus_uniqueness_keys)")
+      expect(content).to include("create_table :pgbus_uniqueness_keys, id: false")
+      expect(content).to include("t.string :lock_key, null: false")
+      expect(content).to include("t.bigint :msg_id, null: false")
+    end
+
+    it "adds a unique index on the uniqueness key" do
+      expect(content).to include("add_index :pgbus_uniqueness_keys, :lock_key")
+      expect(content).to include("unique: true")
+      expect(content).to include('name: "idx_pgbus_uniqueness_keys_key"')
+    end
+
+    it "refuses to migrate while active locks remain in pgbus_job_locks" do
+      expect(content).to include("if table_exists?(:pgbus_job_locks)")
+      expect(content).to include("SELECT COUNT(*) FROM pgbus_job_locks")
+      expect(content).to include("raise")
+    end
+
+    it "drops the old pgbus_job_locks table once drained" do
+      expect(content).to include("drop_table :pgbus_job_locks")
+    end
+
+    it "is irreversible on down" do
+      expect(content).to include("raise ActiveRecord::IrreversibleMigration")
+    end
+  end
+end

--- a/spec/generators/pgbus/migrate_job_locks_generator_spec.rb
+++ b/spec/generators/pgbus/migrate_job_locks_generator_spec.rb
@@ -25,49 +25,51 @@ RSpec.describe Pgbus::Generators::MigrateJobLocksGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path(
-        "../../../lib/generators/pgbus/templates/migrate_job_locks_to_uniqueness_keys.rb.erb", __dir__
-      )
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_migrate_pgbus_job_locks_to_uniqueness_keys.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "defines a versioned migration class" do
-      expect(content).to include(
-        "class MigratePgbusJobLocksToUniquenessKeys < ActiveRecord::Migration<%= migration_version %>"
-      )
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "creates the new lightweight pgbus_uniqueness_keys table only if absent" do
-      expect(content).to include("unless table_exists?(:pgbus_uniqueness_keys)")
-      expect(content).to include("create_table :pgbus_uniqueness_keys, id: false")
-      expect(content).to include("t.string :lock_key, null: false")
-      expect(content).to include("t.bigint :msg_id, null: false")
+    it "creates the lightweight pgbus_uniqueness_keys table only if absent" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class MigratePgbusJobLocksToUniquenessKeys < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("unless table_exists?(:pgbus_uniqueness_keys)")
+        expect(content).to include("create_table :pgbus_uniqueness_keys, id: false")
+        expect(content).to include("t.string :lock_key, null: false")
+        expect(content).to include("t.bigint :msg_id, null: false")
+        expect(content).to include("add_index :pgbus_uniqueness_keys, :lock_key")
+        expect(content).to include('name: "idx_pgbus_uniqueness_keys_key"')
+      end
     end
 
-    it "adds a unique index on the uniqueness key" do
-      expect(content).to include("add_index :pgbus_uniqueness_keys, :lock_key")
-      expect(content).to include("unique: true")
-      expect(content).to include('name: "idx_pgbus_uniqueness_keys_key"')
-    end
-
-    it "refuses to migrate while active locks remain in pgbus_job_locks" do
-      expect(content).to include("if table_exists?(:pgbus_job_locks)")
-      expect(content).to include("SELECT COUNT(*) FROM pgbus_job_locks")
-      expect(content).to include("raise")
-    end
-
-    it "drops the old pgbus_job_locks table once drained" do
-      expect(content).to include("drop_table :pgbus_job_locks")
+    it "refuses to migrate while active locks remain, then drops the old table" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("if table_exists?(:pgbus_job_locks)")
+        expect(content).to include("SELECT COUNT(*) FROM pgbus_job_locks")
+        expect(content).to include("raise")
+        expect(content).to include("drop_table :pgbus_job_locks")
+      end
     end
 
     it "is irreversible on down" do
-      expect(content).to include("raise ActiveRecord::IrreversibleMigration")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("raise ActiveRecord::IrreversibleMigration")
+      end
     end
   end
 end

--- a/spec/generators/pgbus/migrate_job_locks_generator_spec.rb
+++ b/spec/generators/pgbus/migrate_job_locks_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/migrate_job_locks_generator"
 
 RSpec.describe Pgbus::Generators::MigrateJobLocksGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning the uniqueness keys migration" do
-      expect(described_class.desc).to match(/uniqueness/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /uniqueness/i
 
   describe "generated migration" do
     let(:basename) { "_migrate_pgbus_job_locks_to_uniqueness_keys.rb" }

--- a/spec/generators/pgbus/migration_path_spec.rb
+++ b/spec/generators/pgbus/migration_path_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "generators/pgbus/migration_path"
+
+RSpec.describe Pgbus::Generators::MigrationPath do
+  # pgbus_migrate_path / separate_database? are private in the mixin.
+  subject(:migrate_path) { host.send(:pgbus_migrate_path) }
+
+  let(:host) { host_class.new(options) }
+
+  # A minimal host that mixes in the module the way every generator does.
+  # `options` and `db_migrate_path` normally come from Thor/Rails; here they
+  # are stubbed so the branching logic can be tested in isolation without a
+  # real Rails generator or database.yml.
+  let(:host_class) do
+    Class.new do
+      include Pgbus::Generators::MigrationPath
+
+      attr_reader :options
+
+      def initialize(options)
+        @options = options
+      end
+
+      # Stands in for ActiveRecord::Generators::Migration#db_migrate_path,
+      # which reads migrations_paths from database.yml at runtime.
+      def db_migrate_path
+        "db/pgbus_migrate"
+      end
+    end
+  end
+
+  context "when no --database option is set" do
+    let(:options) { {} }
+
+    it "returns the single-database default path" do
+      expect(migrate_path).to eq("db/migrate")
+    end
+
+    it "reports separate_database? as false" do
+      expect(host.send(:separate_database?)).to be(false)
+    end
+
+    it "does not delegate to db_migrate_path" do
+      allow(host).to receive(:db_migrate_path)
+      migrate_path
+      expect(host).not_to have_received(:db_migrate_path)
+    end
+  end
+
+  context "when --database is nil" do
+    let(:options) { { database: nil } }
+
+    it "treats a nil database as single-database mode" do
+      expect(migrate_path).to eq("db/migrate")
+    end
+
+    it "reports separate_database? as false" do
+      expect(host.send(:separate_database?)).to be(false)
+    end
+  end
+
+  context "when --database is a blank string" do
+    let(:options) { { database: "" } }
+
+    it "treats a blank database as single-database mode" do
+      expect(migrate_path).to eq("db/migrate")
+    end
+  end
+
+  context "when --database=pgbus is set" do
+    let(:options) { { database: "pgbus" } }
+
+    it "delegates to Rails' db_migrate_path" do
+      expect(migrate_path).to eq("db/pgbus_migrate")
+    end
+
+    it "reports separate_database? as true" do
+      expect(host.send(:separate_database?)).to be(true)
+    end
+
+    it "calls db_migrate_path exactly once" do
+      allow(host).to receive(:db_migrate_path).and_return("db/pgbus_migrate")
+      migrate_path
+      expect(host).to have_received(:db_migrate_path).once
+    end
+  end
+end

--- a/spec/generators/pgbus/tune_autovacuum_generator_spec.rb
+++ b/spec/generators/pgbus/tune_autovacuum_generator_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/tune_autovacuum_generator"
+
+RSpec.describe Pgbus::Generators::TuneAutovacuumGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning autovacuum tuning" do
+      expect(described_class.desc).to match(/autovacuum/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/tune_autovacuum.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include("class TunePgbusAutovacuum < ActiveRecord::Migration<%= migration_version %>")
+    end
+
+    it "applies queue-wide autovacuum settings via AutovacuumTuning" do
+      expect(content).to include("execute Pgbus::AutovacuumTuning.sql_for_all_queues")
+    end
+
+    it "tunes high-churn pgbus tables too" do
+      expect(content).to include("execute Pgbus::AutovacuumTuning.sql_for_high_churn_tables")
+    end
+
+    it "resets autovacuum settings on down" do
+      expect(content).to include("def down")
+      expect(content).to include("RESET (autovacuum_vacuum_scale_factor")
+      expect(content).to include("Pgbus::AutovacuumTuning::HIGH_CHURN_TABLES")
+    end
+  end
+end

--- a/spec/generators/pgbus/tune_autovacuum_generator_spec.rb
+++ b/spec/generators/pgbus/tune_autovacuum_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/tune_autovacuum_generator"
 
 RSpec.describe Pgbus::Generators::TuneAutovacuumGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning autovacuum tuning" do
-      expect(described_class.desc).to match(/autovacuum/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /autovacuum/i
 
   describe "generated migration" do
     let(:basename) { "_tune_pgbus_autovacuum.rb" }

--- a/spec/generators/pgbus/tune_autovacuum_generator_spec.rb
+++ b/spec/generators/pgbus/tune_autovacuum_generator_spec.rb
@@ -25,32 +25,40 @@ RSpec.describe Pgbus::Generators::TuneAutovacuumGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/tune_autovacuum.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_tune_pgbus_autovacuum.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
-    end
-
-    it "defines a versioned migration class" do
-      expect(content).to include("class TunePgbusAutovacuum < ActiveRecord::Migration<%= migration_version %>")
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "applies queue-wide autovacuum settings via AutovacuumTuning" do
-      expect(content).to include("execute Pgbus::AutovacuumTuning.sql_for_all_queues")
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "tunes high-churn pgbus tables too" do
-      expect(content).to include("execute Pgbus::AutovacuumTuning.sql_for_high_churn_tables")
+    it "applies queue and high-churn autovacuum settings via AutovacuumTuning" do
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class TunePgbusAutovacuum < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("execute Pgbus::AutovacuumTuning.sql_for_all_queues")
+        expect(content).to include("execute Pgbus::AutovacuumTuning.sql_for_high_churn_tables")
+      end
     end
 
     it "resets autovacuum settings on down" do
-      expect(content).to include("def down")
-      expect(content).to include("RESET (autovacuum_vacuum_scale_factor")
-      expect(content).to include("Pgbus::AutovacuumTuning::HIGH_CHURN_TABLES")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("def down")
+        expect(content).to include("RESET (autovacuum_vacuum_scale_factor")
+        expect(content).to include("Pgbus::AutovacuumTuning::HIGH_CHURN_TABLES")
+      end
     end
   end
 end

--- a/spec/generators/pgbus/tune_fillfactor_generator_spec.rb
+++ b/spec/generators/pgbus/tune_fillfactor_generator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/pgbus/tune_fillfactor_generator"
+
+RSpec.describe Pgbus::Generators::TuneFillfactorGenerator do
+  describe "generator class wiring" do
+    it "is a Rails::Generators::Base subclass" do
+      expect(described_class.ancestors).to include(Rails::Generators::Base)
+    end
+
+    it "mixes in the shared MigrationPath path logic" do
+      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+    end
+
+    it "exposes a --database option defaulting to nil" do
+      option = described_class.class_options[:database]
+      expect(option).not_to be_nil
+      expect(option.default).to be_nil
+    end
+
+    it "has a description mentioning fillfactor" do
+      expect(described_class.desc).to match(/fillfactor/i)
+    end
+  end
+
+  describe "migration template" do
+    let(:template_path) do
+      File.expand_path("../../../lib/generators/pgbus/templates/tune_fillfactor.rb.erb", __dir__)
+    end
+    let(:content) { File.read(template_path) }
+
+    it "exists" do
+      expect(File.exist?(template_path)).to be(true)
+    end
+
+    it "defines a versioned migration class" do
+      expect(content).to include("class TunePgbusFillfactor < ActiveRecord::Migration<%= migration_version %>")
+    end
+
+    it "sets fillfactor across all queue tables via TableMaintenance" do
+      expect(content).to include("execute Pgbus::TableMaintenance.fillfactor_sql_for_all_queues")
+    end
+
+    it "resets fillfactor on down" do
+      expect(content).to include("def down")
+      expect(content).to include("RESET (fillfactor)")
+    end
+  end
+end

--- a/spec/generators/pgbus/tune_fillfactor_generator_spec.rb
+++ b/spec/generators/pgbus/tune_fillfactor_generator_spec.rb
@@ -5,25 +5,7 @@ require "rails/generators"
 require "generators/pgbus/tune_fillfactor_generator"
 
 RSpec.describe Pgbus::Generators::TuneFillfactorGenerator do
-  describe "generator class wiring" do
-    it "is a Rails::Generators::Base subclass" do
-      expect(described_class.ancestors).to include(Rails::Generators::Base)
-    end
-
-    it "mixes in the shared MigrationPath path logic" do
-      expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
-    end
-
-    it "exposes a --database option defaulting to nil" do
-      option = described_class.class_options[:database]
-      expect(option).not_to be_nil
-      expect(option.default).to be_nil
-    end
-
-    it "has a description mentioning fillfactor" do
-      expect(described_class.desc).to match(/fillfactor/i)
-    end
-  end
+  it_behaves_like "a pgbus generator", /fillfactor/i
 
   describe "generated migration" do
     let(:basename) { "_tune_pgbus_fillfactor.rb" }

--- a/spec/generators/pgbus/tune_fillfactor_generator_spec.rb
+++ b/spec/generators/pgbus/tune_fillfactor_generator_spec.rb
@@ -25,27 +25,38 @@ RSpec.describe Pgbus::Generators::TuneFillfactorGenerator do
     end
   end
 
-  describe "migration template" do
-    let(:template_path) do
-      File.expand_path("../../../lib/generators/pgbus/templates/tune_fillfactor.rb.erb", __dir__)
-    end
-    let(:content) { File.read(template_path) }
+  describe "generated migration" do
+    let(:basename) { "_tune_pgbus_fillfactor.rb" }
 
-    it "exists" do
-      expect(File.exist?(template_path)).to be(true)
+    it "writes the migration into db/migrate by default" do
+      generate_migration(described_class, basename: basename) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
-    it "defines a versioned migration class" do
-      expect(content).to include("class TunePgbusFillfactor < ActiveRecord::Migration<%= migration_version %>")
+    it "routes into db/pgbus_migrate when --database is set" do
+      generate_migration(
+        described_class,
+        options: { database: "pgbus" },
+        migrate_dir: "db/pgbus_migrate",
+        basename: basename
+      ) do |path, _content|
+        expect(path).not_to be_nil
+      end
     end
 
     it "sets fillfactor across all queue tables via TableMaintenance" do
-      expect(content).to include("execute Pgbus::TableMaintenance.fillfactor_sql_for_all_queues")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to match(/class TunePgbusFillfactor < ActiveRecord::Migration\[\d+\.\d+\]/)
+        expect(content).to include("execute Pgbus::TableMaintenance.fillfactor_sql_for_all_queues")
+      end
     end
 
     it "resets fillfactor on down" do
-      expect(content).to include("def down")
-      expect(content).to include("RESET (fillfactor)")
+      generate_migration(described_class, basename: basename) do |_path, content|
+        expect(content).to include("def down")
+        expect(content).to include("RESET (fillfactor)")
+      end
     end
   end
 end

--- a/spec/support/generator_invocation.rb
+++ b/spec/support/generator_invocation.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+require "stringio"
+
+# Shared helpers for exercising Pgbus migration generators end-to-end.
+#
+# Content-only assertions (reading the .erb) prove a template exists but never
+# run the generator body — create_migration_file, migration_version, and
+# display_post_install stay uncovered. These helpers invoke the generator
+# against a throwaway destination so those methods actually execute and the
+# generated migration can be asserted against.
+module GeneratorInvocation
+  # Runs the generator in a temporary destination root and yields the path of
+  # the migration it wrote (matched by the destination basename, minus the
+  # timestamp prefix Rails adds), its content, and the destination root.
+  # Silences the generator's stdout chatter.
+  def generate_migration(generator_class, basename:, options: {}, migrate_dir: "db/migrate")
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.mkdir_p(File.join(tmpdir, migrate_dir))
+
+      generator = generator_class.new([], options)
+      generator.destination_root = tmpdir
+      # Separate-database routing delegates to Rails' db_migrate_path, which
+      # needs a real database.yml. Stub it so --database specs don't require one.
+      allow(generator).to receive(:db_migrate_path).and_return(migrate_dir) if options[:database].present?
+
+      silence_generator { generator.invoke_all }
+
+      path = Dir[File.join(tmpdir, migrate_dir, "*#{basename}")].first
+      yield path, path && File.read(path), tmpdir
+    end
+  end
+
+  def silence_generator
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+end
+
+RSpec.configure do |config|
+  config.include GeneratorInvocation, type: :generator
+  # Auto-tag specs living under spec/generators/ so the helper is available
+  # without every file repeating `type: :generator`.
+  config.define_derived_metadata(file_path: %r{/spec/generators/}) do |metadata|
+    metadata[:type] ||= :generator
+  end
+end

--- a/spec/support/shared_examples/pgbus_generator.rb
+++ b/spec/support/shared_examples/pgbus_generator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Shared wiring contract for every pgbus migration generator: it must be a
+# Rails generator, mix in the shared MigrationPath routing, expose an opt-in
+# --database flag, and carry a meaningful description. Pass the description
+# matcher (a Regexp) the generator under test should satisfy.
+RSpec.shared_examples "a pgbus generator" do |desc_matcher|
+  it "is a Rails::Generators::Base subclass" do
+    expect(described_class.ancestors).to include(Rails::Generators::Base)
+  end
+
+  it "mixes in the shared MigrationPath path logic" do
+    expect(described_class.ancestors).to include(Pgbus::Generators::MigrationPath)
+  end
+
+  it "exposes a --database option defaulting to nil" do
+    option = described_class.class_options[:database]
+    expect(option).not_to be_nil
+    expect(option.default).to be_nil
+  end
+
+  it "has a matching description" do
+    expect(described_class.desc).to match(desc_matcher)
+  end
+end


### PR DESCRIPTION
## Summary

`lib/generators/pgbus/` shipped 15 generators, but only `install`, `update`, and `upgrade_pgmq` had specs. The other 13 emit migration templates into `pgbus_migrate_path` with no test coverage — a typo in a `.erb` (broken SQL, wrong index name, dropped `null: false`) or a broken `--database` route would reach users with nothing to catch it.

This adds **14 spec files / 137 examples**: one per untested generator plus a spec for the shared `MigrationPath` routing mixin.

## What each generator spec asserts

- **Class wiring** — is a `Rails::Generators::Base` subclass, includes `Pgbus::Generators::MigrationPath`, declares `class_option :database` defaulting to `nil`, and has the expected `desc`.
- **Template DDL** — the referenced `.erb` exists and contains the exact `create_table` / `add_column` / `add_index` / `add_check_constraint` statements, table names, key columns, and index names (derived by reading each template, not guessed).

## MigrationPath routing

`spec/generators/pgbus/migration_path_spec.rb` mixes the module into a minimal host class with stubbed `options` and `db_migrate_path`, then verifies:

- no `--database` (also `nil` / blank string) → `"db/migrate"` and does **not** call `db_migrate_path`
- `--database=pgbus` → delegates to Rails' `db_migrate_path` (which reads `migrations_paths` from `database.yml`)

## Generators now covered (13)

`add_failed_events_index`, `add_job_locks`, `add_job_stats`, `add_job_stats_latency`, `add_job_stats_queue_index`, `add_outbox`, `add_presence`, `add_queue_states`, `add_recurring`, `add_stream_stats`, `migrate_job_locks`, `tune_autovacuum`, `tune_fillfactor`

Closes #225

## Test plan

- [x] `bundle exec rspec spec/generators/` — 160 passed
- [x] `bundle exec rubocop spec/generators/` — clean

https://claude.ai/code/session_019UyWsPP7veHzzB8Z1zGr6W


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broad coverage for multiple database migration generators, including outbox, presence, recurring tasks, job stats, stream stats, queue states, job locks, autovacuum, fillfactor, and more.
  * Verified generator setup, database selection behavior, and migration templates now include the expected tables, columns, indexes, and safeguards.
  * Added coverage for migration path handling to ensure generators use the correct migration location by default and with a separate database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->