### PR TITLE
test(coverage): add SimpleCov measurement with measured baseline and CI artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,14 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run unit tests
-        run: bundle exec rspec spec/pgbus/
+        run: bundle exec rspec spec/pgbus/ spec/generators/
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-ruby-${{ matrix.ruby }}
+          path: coverage/
+          if-no-files-found: warn
 
   integration:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -44,4 +44,9 @@ group :development, :test do
   gem "globalid", ">= 1.0"
   gem "mcp", "~> 0.22"
   gem "pg", "~> 1.5"
+
+  # Coverage measurement — a dev tool, not a gemspec runtime dep.
+  # Loaded at the top of spec/spec_helper.rb before "pgbus" so lib files
+  # are instrumented before they load.
+  gem "simplecov", require: false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,29 @@
 # frozen_string_literal: true
 
+# SimpleCov must start before "pgbus" is required (below) so lib files are
+# instrumented as they load. rails_helper.rb requires this file, so unit,
+# generator, and request specs are all measured. NOTE: integration_helper.rb
+# and system_helper.rb do NOT require spec_helper, so those runs are unmeasured.
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+
+  add_filter "/spec/"
+
+  add_group "Client", "lib/pgbus/client"
+  add_group "ActiveJob", "lib/pgbus/active_job"
+  add_group "Event Bus", "lib/pgbus/event_bus"
+  add_group "Process", "lib/pgbus/process"
+  add_group "Web", %w[lib/pgbus/web app/controllers app/views app/helpers]
+  add_group "Generators", "lib/generators"
+
+  # Baseline measured from `bundle exec rspec spec/pgbus/ spec/generators/`:
+  # line 89.75% (7920/8825), branch 75.41% (2183/2895). Floors set below the
+  # measured values so CI is green day one; ratchet toward the 80%/100% targets
+  # in .claude/rules/testing.md in follow-ups.
+  minimum_coverage line: 89, branch: 75
+end
+
 require "active_record"
 require "pgbus"
 require "globalid"


### PR DESCRIPTION
## Summary

Coverage was never measured — `simplecov` appeared nowhere in the Gemfile, `spec/spec_helper.rb`, or `.github/workflows/`, so the 80%/100% targets in `.claude/rules/testing.md` were unverifiable. This wires up SimpleCov with a **measured** baseline floor and uploads the report from CI.

- **Gemfile**: add `gem "simplecov", require: false` to the existing `:development, :test` group (a dev tool, not a gemspec runtime dep).
- **`spec/spec_helper.rb`**: start SimpleCov at the very top, before `require "pgbus"`, so lib files are instrumented as they load. Branch coverage enabled, `/spec/` filtered, `add_group` entries mirror the architecture layers (Client, ActiveJob, Event Bus, Process, Web, Generators). `rails_helper.rb` requires this file, so unit, generator, and request specs are all measured.
- **`minimum_coverage line: 89, branch: 75`** — floors of the measured baseline so CI is green day one. Ratcheting toward the 80%/100% targets is follow-up work.
- **CI (`.github/workflows/main.yml`)**: the unit test job now runs `spec/pgbus/ spec/generators/` and uploads `coverage/` as an artifact with `if: always()`, named per Ruby version (`coverage-ruby-${{ matrix.ruby }}`) since the test job runs a 3.3/3.4/4.0 matrix and `upload-artifact@v4` rejects duplicate artifact names.

`integration_helper.rb` and `system_helper.rb` do not require `spec_helper`, so those runs are unmeasured — noted in a comment, out of scope per the issue.

## Measured baseline

`bundle exec rspec spec/pgbus/ spec/generators/` (2837 examples, 0 failures, 1 pending):

| Metric | Coverage | Counts | `minimum_coverage` floor |
|--------|----------|--------|--------------------------|
| Line   | 89.75%   | 7920 / 8825 | 89 |
| Branch | 75.41%   | 2183 / 2895 | 75 |

## Acceptance criteria

- [x] `bundle exec rspec spec/pgbus/ spec/generators/` prints a coverage summary and writes `coverage/`
- [x] `minimum_coverage` set to the measured baseline (documented above), suite passes
- [x] `spec/` excluded; branch coverage enabled; groups match architecture layers (verified in `coverage/index.html`)
- [x] CI uploads `coverage/` as an artifact on the unit test job
- [x] `bundle exec rubocop` passes (443 files, 0 offenses)

## Test plan

Per the issue, no new specs — the suite was run twice:

- [x] Passing run at the baseline floor → exit 0
- [x] `minimum_coverage` temporarily set to 100 → non-zero exit (`SimpleCov failed with exit 2 due to a coverage related error`)
- [x] `coverage/index.html` renders all six architecture groups plus Ungrouped

Closes #224


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage to include additional test suites.
  * Added coverage reporting in CI, with artifacts now available for review.
  * Improved coverage tracking to include branch-level checks and minimum thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->