### PR TITLE
test(engine): add initializer specs via dummy-app harness

### DIFF
--- a/spec/pgbus/engine_spec.rb
+++ b/spec/pgbus/engine_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "tmpdir"
+
+# Two-layer coverage for lib/pgbus/engine.rb:
+#
+#   1. Post-boot assertions against the already-booted spec/dummy app
+#      (mounted by rails_helper). These verify the initializers ran with
+#      their real effects: middleware installed, i18n paths appended, web
+#      constants required, logger defaulted.
+#
+#   2. Isolated initializer-block tests: each `initializer "name" do |app|`
+#      block is fetched from Pgbus::Engine.initializers and invoked directly
+#      with a stub app rooted at a tmpdir. This exercises the branchy blocks
+#      (pgbus.recurring fallbacks, pgbus.configure, pgbus.db, AppSignal guard)
+#      without rebooting Rails or touching the dummy app's real config dir.
+RSpec.describe Pgbus::Engine do
+  # Fetch a named initializer's block so it can be invoked in isolation.
+  def initializer_block(name)
+    described_class.initializers.find { |i| i.name == name.to_sym || i.name == name }.instance_variable_get(:@block)
+  end
+
+  # Restore the suite baseline config after any example that mutates or
+  # resets it, so random-order runs don't leak state into later specs.
+  def restore_baseline_config
+    Pgbus.reset!
+    Pgbus.configure do |c|
+      c.logger = Logger.new(IO::NULL)
+      c.queue_prefix = "pgbus_test"
+      c.default_queue = "default"
+    end
+  end
+
+  describe "post-boot state" do
+    it "installs the watermark cache middleware when streams are enabled" do
+      expect(Pgbus.configuration.streams_enabled).to be(true)
+      names = Rails.application.middleware.map(&:name)
+      expect(names).to include("Pgbus::Streams::WatermarkCacheMiddleware")
+    end
+
+    it "appends the engine's locale files to the i18n load path" do
+      pgbus_locales = I18n.load_path.select do |path|
+        path.include?("pgbus") && path.include?("locales") && path.end_with?(".yml")
+      end
+      expect(pgbus_locales).not_to be_empty
+    end
+
+    it "requires the web authentication and data source constants" do
+      expect(defined?(Pgbus::Web::Authentication)).to eq("constant")
+      expect(defined?(Pgbus::Web::DataSource)).to eq("constant")
+    end
+
+    it "defaults the configuration logger" do
+      expect(Pgbus.configuration.logger).not_to be_nil
+    end
+  end
+
+  describe "pgbus.active_job initializer" do
+    # The dummy app does not require active_job/railtie, so the on_load(:active_job)
+    # hook has not fired against ActiveJob::Base at boot. Load ActiveJob here and
+    # run the hooks to prove the initializer includes both concerns.
+    it "includes Concurrency and Uniqueness on ActiveJob::Base" do
+      require "active_job"
+
+      # Ensure the engine's on_load block is registered, then flush the hooks.
+      initializer_block("pgbus.active_job").call
+      ActiveSupport.run_load_hooks(:active_job, ActiveJob::Base)
+
+      expect(ActiveJob::Base.include?(Pgbus::Concurrency)).to be(true)
+      expect(ActiveJob::Base.include?(Pgbus::Uniqueness)).to be(true)
+    end
+  end
+
+  describe "pgbus.configure initializer" do
+    subject(:block) { initializer_block("pgbus.configure") }
+
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:app) { instance_double(Rails::Application, root: Pathname.new(tmpdir)) }
+
+    before { FileUtils.mkdir_p(File.join(tmpdir, "config")) }
+
+    after do
+      FileUtils.remove_entry(tmpdir)
+      restore_baseline_config
+    end
+
+    it "loads config/pgbus.yml when present" do
+      File.write(File.join(tmpdir, "config", "pgbus.yml"), "default_queue: from_yaml\n")
+
+      block.call(app)
+
+      expect(Pgbus.configuration.default_queue).to eq("from_yaml")
+    end
+
+    it "is a no-op when config/pgbus.yml is absent" do
+      expect { block.call(app) }.not_to raise_error
+    end
+  end
+
+  describe "pgbus.recurring initializer" do
+    subject(:block) { initializer_block("pgbus.recurring") }
+
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:app) { instance_double(Rails::Application, root: Pathname.new(tmpdir)) }
+    let(:default_path) { File.join(tmpdir, "config", "recurring.yml") }
+    let(:task_yaml) do
+      <<~YAML
+        cleanup:
+          class: CleanupJob
+          schedule: "every hour"
+      YAML
+    end
+
+    before do
+      FileUtils.mkdir_p(File.join(tmpdir, "config"))
+      restore_baseline_config
+    end
+
+    after do
+      FileUtils.remove_entry(tmpdir)
+      restore_baseline_config
+    end
+
+    it "skips when recurring_tasks is already set" do
+      Pgbus.configuration.recurring_tasks = { "existing" => { "class" => "X" } }
+
+      block.call(app)
+
+      expect(Pgbus.configuration.recurring_tasks).to eq("existing" => { "class" => "X" })
+    end
+
+    it "loads explicit recurring_tasks_files when they contain tasks" do
+      explicit = File.join(tmpdir, "config", "explicit.yml")
+      File.write(explicit, task_yaml)
+      Pgbus.configuration.recurring_tasks_files = [explicit]
+
+      block.call(app)
+
+      expect(Pgbus.configuration.recurring_tasks).to include("cleanup")
+    end
+
+    it "falls back to default recurring.yml when explicit files are empty" do
+      empty = File.join(tmpdir, "config", "empty.yml")
+      File.write(empty, "{}\n")
+      File.write(default_path, task_yaml)
+      Pgbus.configuration.recurring_tasks_files = [empty]
+
+      block.call(app)
+
+      expect(Pgbus.configuration.recurring_tasks).to include("cleanup")
+      expect(Pgbus.configuration.recurring_tasks_file).to eq(default_path)
+    end
+
+    it "loads the default recurring.yml when no explicit files are configured" do
+      File.write(default_path, task_yaml)
+
+      block.call(app)
+
+      expect(Pgbus.configuration.recurring_tasks).to include("cleanup")
+      expect(Pgbus.configuration.recurring_tasks_file).to eq(default_path)
+    end
+
+    it "is a no-op when neither explicit files nor a default exist" do
+      block.call(app)
+
+      expect(Pgbus.configuration.recurring_tasks).to be_nil
+    end
+  end
+
+  describe "pgbus.db initializer" do
+    after { restore_baseline_config }
+
+    let(:block) { initializer_block("pgbus.db") }
+
+    it "wires BusRecord.connects_to when configuration.connects_to is set" do
+      connects = { database: { writing: :pgbus } }
+      Pgbus.configuration.connects_to = connects
+      allow(Pgbus::BusRecord).to receive(:connects_to)
+
+      block.call
+      ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+
+      # on_load(:active_record) fires the block once per already-loaded model
+      # plus the explicit run above, so assert the contract (called with the
+      # configured args) rather than a brittle exact call count.
+      expect(Pgbus::BusRecord).to have_received(:connects_to).with(**connects).at_least(:once)
+    end
+
+    it "does not call connects_to when configuration.connects_to is nil" do
+      Pgbus.configuration.connects_to = nil
+      allow(Pgbus::BusRecord).to receive(:connects_to)
+
+      block.call
+      ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+
+      expect(Pgbus::BusRecord).not_to have_received(:connects_to)
+    end
+  end
+
+  describe "pgbus.integrations.appsignal initializer" do
+    subject(:block) { initializer_block("pgbus.integrations.appsignal") }
+
+    after { restore_baseline_config }
+
+    it "is a no-op when Appsignal is undefined" do
+      skip "Appsignal is loaded in this environment" if defined?(Appsignal)
+
+      block.call
+      expect { ActiveSupport.run_load_hooks(:after_initialize, Rails.application) }.not_to raise_error
+    end
+
+    it "is a no-op when appsignal_enabled is false" do
+      Pgbus.configuration.appsignal_enabled = false
+      allow(Pgbus::Integrations::Appsignal).to receive(:install!) if defined?(Pgbus::Integrations::Appsignal)
+
+      block.call
+      ActiveSupport.run_load_hooks(:after_initialize, Rails.application)
+
+      expect(Pgbus::Integrations::Appsignal).not_to have_received(:install!) if defined?(Pgbus::Integrations::Appsignal)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,5 +8,18 @@ require "rspec/rails"
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
-  config.use_transactional_fixtures = true
+
+  # Transactional fixtures open a process-wide ActiveRecord transaction around
+  # EVERY example once rspec-rails is loaded — including pure unit specs that
+  # only `require "spec_helper"`. That ambient open transaction makes
+  # Pgbus::Streams::Stream#broadcast defer to `after_commit` (returning nil
+  # instead of the msg_id), so streams unit specs fail whenever a rails_helper
+  # spec happens to load first in a random-ordered run. No spec here relies on
+  # DB fixtures (integration/system specs use their own helpers), so leave it
+  # off by default and let a DB-backed example opt in with the
+  # `:use_transactional_tests` metadata tag if one is ever added.
+  config.use_transactional_fixtures = false
+  config.before(:each, :use_transactional_tests) do
+    self.use_transactional_tests = true
+  end
 end


### PR DESCRIPTION
## Summary

`lib/pgbus/engine.rb` defined 13 initializers with zero spec coverage — boot-order regressions there shipped silently. This adds `spec/pgbus/engine_spec.rb` using the dummy-app harness, in two layers:

1. **Post-boot assertions** against the already-booted `spec/dummy` app (mounted by `rails_helper`):
   - `Pgbus::Streams::WatermarkCacheMiddleware` is installed when streams are enabled
   - the engine's `config/locales/*.yml` are on `I18n.load_path`
   - `Pgbus::Web::Authentication` and `Pgbus::Web::DataSource` are required
   - `Pgbus.configuration.logger` is defaulted
   - ActiveJob concern inclusion (`Pgbus::Concurrency`, `Pgbus::Uniqueness`) is verified by invoking the `pgbus.active_job` initializer's `on_load(:active_job)` hook — the dummy app does not `require "active_job/railtie"`, so the hook has not fired at boot.

2. **Isolated initializer-block tests** — each block is fetched from `Pgbus::Engine.initializers` and invoked directly with a stub app (`instance_double(Rails::Application, root: Pathname.new(tmpdir))`):
   - `pgbus.recurring`: all fallback branches — already-set skip, explicit files with tasks, explicit-empty + default `recurring.yml` fallback, no files + default, and neither (no-op)
   - `pgbus.configure`: with and without `config/pgbus.yml`
   - `pgbus.db`: `BusRecord.connects_to` wiring when `configuration.connects_to` is set, and no call when nil
   - `pgbus.integrations.appsignal`: no-op when `Appsignal` is undefined or `appsignal_enabled` is false

`engine.rb` line coverage went from ~0% to **79.7%** (the remaining lines are the turbo-rails / importmap streams initializers whose gems aren't loaded in the dummy app — out of scope per the issue).

## Fix: transactional-fixtures cross-spec pollution

While verifying "full suite green in random order," a latent bug surfaced. `spec/rails_helper.rb` set `use_transactional_fixtures = true`, which opens a **process-wide** ActiveRecord transaction around every example once rspec-rails loads — including pure unit specs that only `require "spec_helper"`.

That ambient open transaction makes `Pgbus::Streams::Stream#broadcast` take its `current_open_transaction` path and defer to `after_commit` (returning `nil` instead of the msg_id), so streams unit specs fail whenever a `rails_helper` spec happens to sort first in a random-ordered run.

This predates this PR — the existing `spec/pgbus/web/locale_spec.rb` triggers the same 2 streams failures when it loads before the streams specs. The new (larger) engine spec just exposed it across more orderings.

Root-cause fix: no spec here relies on DB fixtures (integration/system specs use their own helpers), so `use_transactional_fixtures` is now `false` by default, with a `:use_transactional_tests` metadata opt-in for any future DB-backed example.

## Test plan

- [x] `bundle exec rspec spec/pgbus/engine_spec.rb` -> 16 examples, 0 failures
- [x] full `spec/pgbus/` green across seeds 12345 / 1 / 999 / 42 -> 2830 examples, 0 failures, 1 pending (identical every seed)
- [x] `bundle exec rspec spec/pgbus/ spec/generators/` -> 2853 examples, 0 failures; line 89.88%, branch 75.82% (both above the SimpleCov floor)
- [x] `bundle exec rubocop spec/pgbus/engine_spec.rb spec/rails_helper.rb` passes

Closes #226
