### PR TITLE
test(integration): add end-to-end specs for outbox, event bus, and batches

### DIFF
--- a/spec/integration/batch_flow_spec.rb
+++ b/spec/integration/batch_flow_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+require "active_job"
+require "active_job/queue_adapters/pgbus_adapter"
+
+# End-to-end coverage of batches: real jobs enqueued inside a batch, real
+# per-job completion signals, and a real callback job landing on a PGMQ queue
+# only after the final job completes. Previously batch_spec.rb stubbed
+# BatchEntry entirely (receive_message_chain), so the finish-detection and
+# callback-enqueue paths never ran against a database.
+RSpec.describe "Batch flow (integration)", :integration do
+  let(:client) { Pgbus.client }
+  let(:callback_queue) { "batch_callbacks" }
+  let(:work_queue) { "batch_work" }
+
+  # Worker jobs go to their own queue so reads of the callback queue only ever
+  # see callback jobs — never the batch's member jobs.
+  let(:worker_job) do
+    queue = work_queue
+    Class.new(ActiveJob::Base) do
+      self.queue_adapter = :pgbus
+      queue_as(queue)
+      def perform(*); end
+    end
+  end
+
+  let(:on_finish_job) do
+    queue = callback_queue
+    Class.new(ActiveJob::Base) do
+      self.queue_adapter = :pgbus
+      queue_as(queue)
+      def self.name = "BatchFlowSpec::OnFinishJob"
+      def perform(*); end
+    end
+  end
+
+  let(:on_success_job) do
+    queue = callback_queue
+    Class.new(ActiveJob::Base) do
+      self.queue_adapter = :pgbus
+      queue_as(queue)
+      def self.name = "BatchFlowSpec::OnSuccessJob"
+      def perform(*); end
+    end
+  end
+
+  let(:on_discard_job) do
+    queue = callback_queue
+    Class.new(ActiveJob::Base) do
+      self.queue_adapter = :pgbus
+      queue_as(queue)
+      def self.name = "BatchFlowSpec::OnDiscardJob"
+      def perform(*); end
+    end
+  end
+
+  before do
+    ActiveJob::Base.logger = Logger.new(IO::NULL)
+    stub_const("BatchFlowSpec", Module.new)
+    stub_const("BatchFlowSpec::OnFinishJob", on_finish_job)
+    stub_const("BatchFlowSpec::OnSuccessJob", on_success_job)
+    stub_const("BatchFlowSpec::OnDiscardJob", on_discard_job)
+    client.ensure_queue(callback_queue)
+    client.ensure_queue(work_queue)
+  end
+
+  # Drain the callback queue and return the ActiveJob class names of every
+  # message on it, deleting each as it is read so a re-read never sees it again.
+  def drain_callback_job_classes
+    classes = []
+    while (message = client.read_message(callback_queue, vt: 30))
+      classes << JSON.parse(message.message).fetch("job_class")
+      client.delete_message(callback_queue, message.msg_id.to_i)
+    end
+    classes
+  end
+
+  # The class name of the single callback job currently on the queue, or nil.
+  def next_callback_job_class
+    drain_callback_job_classes.first
+  end
+
+  def enqueue_batch(**callbacks)
+    batch = Pgbus::Batch.new(**callbacks)
+    batch.enqueue do
+      worker_job.perform_later
+      worker_job.perform_later
+    end
+    batch
+  end
+
+  describe "on_success path" do
+    it "fires the callback exactly once, only on the final completion" do
+      batch = enqueue_batch(on_finish: on_finish_job, on_success: on_success_job)
+
+      # Two jobs enqueued means total_jobs == 2 and status == processing.
+      record = Pgbus::BatchEntry.find_by(batch_id: batch.batch_id)
+      expect(record.total_jobs).to eq(2)
+      expect(record.status).to eq("processing")
+
+      # First completion: not finished yet, no callback enqueued.
+      Pgbus::Batch.job_completed(batch.batch_id)
+      expect(Pgbus::BatchEntry.find_by(batch_id: batch.batch_id).status).to eq("processing")
+
+      # Final completion: batch finishes and callbacks enqueue.
+      Pgbus::Batch.job_completed(batch.batch_id)
+      finished = Pgbus::BatchEntry.find_by(batch_id: batch.batch_id)
+      expect(finished.status).to eq("finished")
+      expect(finished.finished_at).not_to be_nil
+
+      # on_finish + on_success both land on the callback queue (all succeeded).
+      expect(drain_callback_job_classes).to contain_exactly(
+        "BatchFlowSpec::OnFinishJob",
+        "BatchFlowSpec::OnSuccessJob"
+      )
+    end
+
+    it "is idempotent — an extra completion signal fires no second callback" do
+      batch = enqueue_batch(on_finish: on_finish_job)
+
+      2.times { Pgbus::Batch.job_completed(batch.batch_id) }
+      # Drain the single expected on_finish callback.
+      expect(next_callback_job_class).to eq("BatchFlowSpec::OnFinishJob")
+
+      # A stray extra completion after finish must not enqueue anything more.
+      Pgbus::Batch.job_completed(batch.batch_id)
+      expect(next_callback_job_class).to be_nil
+    end
+  end
+
+  describe "on_discard path" do
+    it "fires on_discard instead of on_success when a job is discarded" do
+      batch = enqueue_batch(on_success: on_success_job, on_discard: on_discard_job)
+
+      # One completes, one is discarded (dead-lettered) — batch still finishes.
+      Pgbus::Batch.job_completed(batch.batch_id)
+      Pgbus::Batch.job_discarded(batch.batch_id)
+
+      finished = Pgbus::BatchEntry.find_by(batch_id: batch.batch_id)
+      expect(finished.status).to eq("finished")
+      expect(finished.discarded_jobs).to eq(1)
+
+      expect(drain_callback_job_classes).to contain_exactly("BatchFlowSpec::OnDiscardJob")
+    end
+  end
+end

--- a/spec/integration/event_bus_flow_spec.rb
+++ b/spec/integration/event_bus_flow_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+# End-to-end coverage of the event bus: publish -> PGMQ topic queue ->
+# consumer reads a real message -> idempotent handler runs -> a
+# pgbus_processed_events row is claimed -> redelivery is skipped. Previously
+# only the unit specs under spec/pgbus/event_bus/ exercised these pieces, all
+# with mocks and never against a real database.
+RSpec.describe "Event bus flow (integration)", :integration do
+  # A real handler that records every event it handles, so the spec can assert
+  # the handler actually ran (not merely that a row was written).
+  let(:handler_class) do
+    Class.new(Pgbus::EventBus::Handler) do
+      idempotent!
+
+      def self.handled
+        @handled ||= []
+      end
+
+      def self.name
+        "EventBusFlowSpec::RecordingHandler"
+      end
+
+      def handle(event)
+        self.class.handled << event.event_id
+      end
+    end
+  end
+
+  let(:registry) { Pgbus::EventBus::Registry.instance }
+  let(:consumer) { Pgbus::Process::Consumer.new(topics: ["orders.#"], threads: 1) }
+  let(:client) { Pgbus.client }
+  let(:queue_name) { "event_bus_flow" }
+
+  before do
+    stub_const("EventBusFlowSpec", Module.new)
+    stub_const("EventBusFlowSpec::RecordingHandler", handler_class)
+
+    registry.clear!
+    registry.subscribe("orders.created", handler_class, queue_name: queue_name)
+    registry.setup_all! # ensure_queue + bind_topic for the pattern
+
+    # Drop any dedup cache carried over from a prior example so the DB is the
+    # sole source of idempotency truth for each run.
+    handler_class.dedup_cache.clear!
+
+    consumer.send(:setup_subscriptions)
+  end
+
+  after do
+    registry.clear!
+  end
+
+  def publish_and_read
+    Pgbus::EventBus::Publisher.publish("orders.created", { "order_id" => 99 })
+    message = client.read_message(queue_name)
+    expect(message).not_to be_nil
+    message
+  end
+
+  describe "happy path" do
+    it "runs the handler and records a processed_events row" do
+      message = publish_and_read
+
+      consumer.send(:handle_message, message, queue_name)
+
+      expect(handler_class.handled.size).to eq(1)
+      expect(Pgbus::ProcessedEvent.count).to eq(1)
+
+      row = Pgbus::ProcessedEvent.first
+      expect(row.handler_class).to eq("EventBusFlowSpec::RecordingHandler")
+      expect(row.event_id).to eq(handler_class.handled.first)
+    end
+
+    it "archives the message off the queue after handling" do
+      message = publish_and_read
+      consumer.send(:handle_message, message, queue_name)
+
+      expect(client.read_message(queue_name)).to be_nil
+    end
+  end
+
+  describe "idempotency" do
+    it "skips a redelivered event and never writes a second row" do
+      Pgbus::EventBus::Publisher.publish("orders.created", { "order_id" => 99 })
+
+      # First delivery: claims idempotency, handler runs, message archived.
+      first = client.read_message(queue_name, vt: 0)
+      consumer.send(:handle_message, first, queue_name)
+
+      # The in-memory dedup cache would short-circuit the second claim before
+      # the DB. Clear it so the redelivery genuinely exercises the
+      # INSERT ... ON CONFLICT DO NOTHING path and proves DB-level dedup.
+      handler_class.dedup_cache.clear!
+
+      # Re-publish the SAME event_id by handing the handler the same message
+      # body again through a fresh handler instance.
+      handler = handler_class.new
+      result = handler.process(first)
+
+      expect(result).to eq(:skipped)
+      expect(handler_class.handled.size).to eq(1)
+      expect(Pgbus::ProcessedEvent.count).to eq(1)
+    end
+  end
+end

--- a/spec/integration/outbox_flow_spec.rb
+++ b/spec/integration/outbox_flow_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+
+# End-to-end coverage of the transactional outbox: an OutboxEntry written
+# inside an AR transaction is picked up by the Poller and published to PGMQ,
+# where it becomes readable through Pgbus::Client. Previously the poller was
+# only exercised with a stubbed client (spec/pgbus/outbox/poller_spec.rb).
+RSpec.describe "Outbox flow (integration)", :integration do
+  let(:client) { Pgbus.client }
+  let(:poller) { Pgbus::Outbox::Poller.new }
+
+  before do
+    client.ensure_queue("outbox_target")
+  end
+
+  describe "direct-queue publishing" do
+    it "publishes a queued entry to PGMQ and marks it published" do
+      entry = nil
+      Pgbus::OutboxEntry.transaction do
+        entry = Pgbus::Outbox.publish("outbox_target", { "order_id" => 42 })
+      end
+
+      expect(entry.published_at).to be_nil
+
+      published = poller.poll_and_publish
+      expect(published).to eq(1)
+
+      message = client.read_message("outbox_target")
+      expect(message).not_to be_nil
+      expect(JSON.parse(message.message)).to include("order_id" => 42)
+
+      expect(entry.reload.published_at).not_to be_nil
+    end
+
+    it "batches multiple entries for the same queue into one send" do
+      Pgbus::OutboxEntry.transaction do
+        Pgbus::Outbox.publish("outbox_target", { "n" => 1 })
+        Pgbus::Outbox.publish("outbox_target", { "n" => 2 })
+        Pgbus::Outbox.publish("outbox_target", { "n" => 3 })
+      end
+
+      expect(poller.poll_and_publish).to eq(3)
+
+      messages = client.read_batch("outbox_target", qty: 10)
+      values = messages.map { |m| JSON.parse(m.message)["n"] }
+      expect(values).to contain_exactly(1, 2, 3)
+
+      expect(Pgbus::OutboxEntry.unpublished.count).to eq(0)
+    end
+  end
+
+  describe "topic-routed publishing" do
+    let(:consumer_queue) { "outbox_events" }
+
+    before do
+      client.ensure_queue(consumer_queue)
+      client.bind_topic("orders.created", consumer_queue)
+    end
+
+    it "publishes an event entry to the bound topic queue" do
+      Pgbus::OutboxEntry.transaction do
+        Pgbus::Outbox.publish_event("orders.created", { "order_id" => 7 })
+      end
+
+      expect(poller.poll_and_publish).to eq(1)
+
+      message = client.read_message(consumer_queue)
+      expect(message).not_to be_nil
+
+      parsed = JSON.parse(message.message)
+      expect(parsed.dig("payload", "order_id")).to eq(7)
+      expect(parsed["event_id"]).to be_present
+    end
+  end
+
+  describe "failure path" do
+    it "leaves the entry unpublished when publishing raises" do
+      Pgbus::OutboxEntry.transaction do
+        Pgbus::Outbox.publish("outbox_target", { "will" => "retry" })
+      end
+
+      allow(client).to receive(:send_batch).and_raise(StandardError, "pgmq down")
+      allow(client).to receive(:send_message).and_raise(StandardError, "pgmq down")
+      allow(Pgbus).to receive(:client).and_return(client)
+
+      expect(poller.poll_and_publish).to eq(0)
+      expect(Pgbus::OutboxEntry.unpublished.count).to eq(1)
+    end
+  end
+end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -66,6 +66,71 @@ def bootstrap_integration_tables(conn)
     CREATE UNIQUE INDEX IF NOT EXISTS idx_pgbus_failed_events_queue_msg
       ON pgbus_failed_events (queue_name, msg_id);
   SQL
+
+  # Transactional outbox — mirrors lib/generators/pgbus/templates/add_outbox.rb.erb.
+  # The Poller reads OutboxEntry.unpublished (published_at IS NULL), so the
+  # nullable published_at column is load-bearing for the outbox_flow_spec.
+  unless conn.table_exists?("pgbus_outbox_entries")
+    conn.execute(<<~SQL)
+      CREATE TABLE pgbus_outbox_entries (
+        id BIGSERIAL PRIMARY KEY,
+        queue_name VARCHAR,
+        routing_key VARCHAR,
+        payload JSONB NOT NULL,
+        headers JSONB,
+        priority INTEGER DEFAULT 0,
+        delay INTEGER DEFAULT 0,
+        published_at TIMESTAMP,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT chk_pgbus_outbox_destination
+          CHECK ((queue_name IS NOT NULL) <> (routing_key IS NOT NULL))
+      );
+      CREATE INDEX idx_pgbus_outbox_unpublished
+        ON pgbus_outbox_entries (published_at) WHERE published_at IS NULL;
+    SQL
+  end
+
+  # Idempotency ledger — mirrors the processed_events DDL in
+  # lib/generators/pgbus/templates/migration.rb.erb. Handler#claim_idempotency?
+  # does INSERT ... ON CONFLICT (event_id, handler_class) DO NOTHING, so the
+  # unique index is what makes the second delivery return :skipped.
+  unless conn.table_exists?("pgbus_processed_events")
+    conn.execute(<<~SQL)
+      CREATE TABLE pgbus_processed_events (
+        id BIGSERIAL PRIMARY KEY,
+        event_id VARCHAR NOT NULL,
+        handler_class VARCHAR NOT NULL,
+        processed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+      CREATE UNIQUE INDEX idx_pgbus_processed_events_unique
+        ON pgbus_processed_events (event_id, handler_class);
+    SQL
+  end
+
+  # Batch tracking — mirrors the pgbus_batches DDL in
+  # lib/generators/pgbus/templates/migration.rb.erb. BatchEntry.increment_counter!
+  # locks the row and fires callbacks when completed + discarded == total.
+  unless conn.table_exists?("pgbus_batches")
+    conn.execute(<<~SQL)
+      CREATE TABLE pgbus_batches (
+        id BIGSERIAL PRIMARY KEY,
+        batch_id VARCHAR NOT NULL,
+        description VARCHAR,
+        on_finish_class VARCHAR,
+        on_success_class VARCHAR,
+        on_discard_class VARCHAR,
+        properties JSONB DEFAULT '{}',
+        total_jobs INTEGER NOT NULL DEFAULT 0,
+        completed_jobs INTEGER NOT NULL DEFAULT 0,
+        failed_jobs INTEGER NOT NULL DEFAULT 0,
+        discarded_jobs INTEGER NOT NULL DEFAULT 0,
+        status VARCHAR NOT NULL DEFAULT 'pending',
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        finished_at TIMESTAMP
+      );
+      CREATE UNIQUE INDEX idx_pgbus_batches_batch_id ON pgbus_batches (batch_id);
+    SQL
+  end
 rescue StandardError => e
   warn "[pgbus integration] Bootstrap warning: #{e.message}"
 end
@@ -160,7 +225,8 @@ def cleanup_tables
   tables = %w[
     pgbus_semaphores pgbus_blocked_executions pgbus_uniqueness_keys
     pgbus_processes pgbus_recurring_executions pgbus_failed_events
-    pgbus_presence_members
+    pgbus_presence_members pgbus_outbox_entries pgbus_processed_events
+    pgbus_batches
   ]
   tables.each do |table|
     conn.execute("DELETE FROM #{table}")


### PR DESCRIPTION
## Summary
Three core subsystems were tested only with mocks — the outbox poller stubbed the client, batches stubbed `BatchEntry` with a message chain, and the event bus was unit-level. The real transactional flows (write → poll → PGMQ publish → consume → idempotency claim → callback) had never run against a real database. This adds end-to-end coverage for all three.

- Extends `bootstrap_integration_tables` (`spec/integration_helper.rb`) to create `pgbus_outbox_entries`, `pgbus_processed_events`, and `pgbus_batches`, with DDL mirrored from the generator templates, and adds them to `cleanup_tables`.
- `spec/integration/outbox_flow_spec.rb` — transactional `Outbox.publish` / `Outbox.publish_event` → `Poller#poll_and_publish` → message readable via `Pgbus::Client`, `published_at` set. Covers direct-queue batching, topic routing, and the failure path (publisher raises → entry left unpublished for retry).
- `spec/integration/event_bus_flow_spec.rb` — registers an idempotent handler, publishes via `Publisher`, drives `Consumer#handle_message` with a real read message. Asserts the handler ran, exactly one `ProcessedEvent` row, the message archived, and that a redelivery (after clearing the in-memory dedup cache) returns `:skipped` with no second row — proving DB-level idempotency, not just the cache.
- `spec/integration/batch_flow_spec.rb` — real jobs enqueued inside a batch through the pgbus adapter, `Batch.job_completed` / `job_discarded` per job, and the callback job landing on its own queue only after the final completion. Covers on_success, on_discard, and idempotent extra-completion.

All queue access goes through `Pgbus::Client` — no raw PGMQ.

Closes #228

## Test plan
- [x] `PGBUS_DATABASE_URL=... bundle exec rspec spec/integration/{outbox,event_bus,batch}_flow_spec.rb` → 10 examples, 0 failures
- [x] Without `PGBUS_DATABASE_URL` → 10 pending (auto-skip), 0 failures
- [x] Full integration suite → 151 examples, 0 failures (no cross-spec pollution)
- [x] `bundle exec rubocop` passes on the new files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for batch processing, event delivery, and transactional outbox workflows.
  * Verified successful, discarded, and idempotent processing paths, plus message publishing and retry-failure behavior.
  * Expanded test setup to include the data structures needed to support these integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->