### PR TITLE
test: de-brittle process & client specs (ivar poking, allow_any, fake errors)

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -27,7 +27,10 @@ module Pgbus
     # re-running the trigger DDL on every queue.
     NOTIFY_THROTTLE_MS = 250
 
-    def initialize(config = Pgbus.configuration)
+    # `schema_ensured:` lets a caller (in practice, tests) skip the one-time
+    # PGMQ schema install probe by asserting the schema already exists. Defaults
+    # to false so production always runs the check on first queue access.
+    def initialize(config = Pgbus.configuration, schema_ensured: false)
       # Define the PGMQ module before requiring the gem so that Zeitwerk's
       # eager_load (called inside pgmq.rb) can resolve the constant.
       # Without this, Ruby 4.0 + Zeitwerk 2.7.5 raises NameError because
@@ -69,7 +72,7 @@ module Pgbus
       @queues_created = Concurrent::Map.new
       @stream_indexes_created = Concurrent::Map.new
       @queue_strategy = QueueFactory.for(config)
-      @schema_ensured = false
+      @schema_ensured = schema_ensured
       @connection_health = ConnectionHealth.new(
         on_open: method(:log_circuit_open),
         on_close: method(:log_circuit_close)
@@ -81,6 +84,22 @@ module Pgbus
       # linked libpq version are all fixed for a Client's lifetime.
       @libpq_read_bounds_effective = libpq_read_bounds_effective?
       warn_shared_connection_read_bounds
+    end
+
+    # True when this client shares ActiveRecord's connection (the Proc
+    # connection_options path): pool_size is forced to 1 and every operation is
+    # serialized through @pgmq_mutex. False on the dedicated-connection path,
+    # where pgmq-ruby owns its own pool and no mutex is needed.
+    def shared_connection?
+      @shared_connection
+    end
+
+    # Whether the shared-connection serialization mutex is currently held. False
+    # on the dedicated-connection path (no mutex). Lets callers assert that a
+    # code path (e.g. a retry backoff sleep) runs OUTSIDE the mutex without
+    # reaching into the mutex object itself.
+    def synchronizing?
+      @pgmq_mutex ? @pgmq_mutex.locked? : false
     end
 
     # Actively open a database connection and run `SELECT 1` so a bad

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -27,18 +27,26 @@ module Pgbus
     # re-running the trigger DDL on every queue.
     NOTIFY_THROTTLE_MS = 250
 
-    # `schema_ensured:` lets a caller (in practice, tests) skip the one-time
-    # PGMQ schema install probe by asserting the schema already exists. Defaults
-    # to false so production always runs the check on first queue access.
-    def initialize(config = Pgbus.configuration, schema_ensured: false)
-      # Define the PGMQ module before requiring the gem so that Zeitwerk's
-      # eager_load (called inside pgmq.rb) can resolve the constant.
-      # Without this, Ruby 4.0 + Zeitwerk 2.7.5 raises NameError because
-      # eager_load runs const_get(:Client) on PGMQ before the module is defined.
+    # Load the pgmq-ruby gem, defining the PGMQ module before requiring it so
+    # Zeitwerk's eager_load (called inside pgmq.rb) can resolve the constant.
+    # Without the pre-definition, Ruby 4.0 + Zeitwerk 2.7.5 raises NameError
+    # because eager_load runs const_get(:Client) on PGMQ before the module is
+    # defined. Extracted as a class method so unit specs that fake PGMQ::Client
+    # can stub *this* (a per-example class-method stub, torn down cleanly)
+    # instead of the global Kernel#require, which — if stubbed before pgmq is
+    # genuinely loaded — permanently prevents the real gem from ever loading.
+    def self.load_pgmq_gem!
       PGMQ_REQUIRE_MUTEX.synchronize do
         Object.const_set(:PGMQ, Module.new) unless defined?(::PGMQ)
         require "pgmq"
       end
+    end
+
+    # `schema_ensured:` lets a caller (in practice, tests) skip the one-time
+    # PGMQ schema install probe by asserting the schema already exists. Defaults
+    # to false so production always runs the check on first queue access.
+    def initialize(config = Pgbus.configuration, schema_ensured: false)
+      self.class.load_pgmq_gem!
       @config = config
       conn_opts = config.connection_options
       @shared_connection = conn_opts.is_a?(Proc)

--- a/lib/pgbus/process/consumer.rb
+++ b/lib/pgbus/process/consumer.rb
@@ -7,7 +7,28 @@ module Pgbus
     class Consumer
       include SignalHandler
 
-      attr_reader :topics, :threads, :config, :execution_mode
+      attr_reader :topics, :threads, :config, :execution_mode,
+                  :queue_names, :wake_signal, :notify_retry_backoff
+      # notify_listener is writable so tests can simulate a start_notify_listener
+      # success from inside a stub (production sets it in start_notify_listener).
+      # notify_retry_at is writable so a test can re-arm the backoff window
+      # between successive ensure_notify_listener calls.
+      attr_accessor :notify_listener, :notify_retry_at
+
+      def shutting_down?
+        @shutting_down
+      end
+
+      def jobs_processed
+        @jobs_processed.value
+      end
+
+      # Seed the processed-job counter. Used by tests to drive the recycle
+      # thresholds without running thousands of real jobs; production only ever
+      # increments it via the AtomicFixnum during message handling.
+      def jobs_processed=(count)
+        @jobs_processed.value = count
+      end
 
       # Mirrors Worker::NOTIFY_FALLBACK_POLL_SECONDS. When a live NotifyListener
       # drives wake-up latency, the empty-read wait is a safety net rather than
@@ -22,7 +43,16 @@ module Pgbus
       NOTIFY_RETRY_BASE_SECONDS = 5
       NOTIFY_RETRY_MAX_SECONDS = 300
 
-      def initialize(topics:, threads: 3, config: Pgbus.configuration, execution_mode: :threads)
+      # The notify-listener lifecycle state (`notify_listener`, `notify_retry_at`,
+      # `notify_retry_backoff`), the recycle clock (`started_at_monotonic`), and
+      # the resolved subscription set (`queue_names`) accept injected seeds so
+      # tests can drive the run loop from a known state without poking private
+      # ivars. All default to the values production initializes to; `queue_names`
+      # defaults to nil, meaning "derive from the registry in setup_subscriptions".
+      def initialize(topics:, threads: 3, config: Pgbus.configuration, execution_mode: :threads,
+                     queue_names: nil, notify_listener: nil, notify_retry_at: 0.0,
+                     notify_retry_backoff: NOTIFY_RETRY_BASE_SECONDS,
+                     started_at_monotonic: nil)
         @topics = Array(topics)
         @threads = threads
         @config = config
@@ -30,7 +60,7 @@ module Pgbus
         @shutting_down = false
         @recycling = false
         @jobs_processed = Concurrent::AtomicFixnum.new(0)
-        @started_at_monotonic = monotonic_now
+        @started_at_monotonic = started_at_monotonic || monotonic_now
         @wake_signal = WakeSignal.new
         @pool = ExecutionPools.build(
           mode: @execution_mode,
@@ -38,9 +68,10 @@ module Pgbus
           on_state_change: -> { @wake_signal.notify! }
         )
         @registry = EventBus::Registry.instance
-        @notify_listener = nil
-        @notify_retry_at = 0.0
-        @notify_retry_backoff = NOTIFY_RETRY_BASE_SECONDS
+        @queue_names = queue_names
+        @notify_listener = notify_listener
+        @notify_retry_at = notify_retry_at
+        @notify_retry_backoff = notify_retry_backoff
       end
 
       def run

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -87,8 +87,10 @@ module Pgbus
         @shutting_down
       end
 
-      # The last monotonic timestamp stamped by the run loop (via the heartbeat's
-      # loop_tick_supplier). nil until the first stamp_loop_tick.
+      # The last wall-clock timestamp (Time.now.to_f) stamped by the run loop
+      # via the heartbeat's loop_tick_supplier. Wall-clock — NOT monotonic — so
+      # it stays comparable across the parent/child process boundary the
+      # supervisor watchdog reads it over. nil until the first stamp_loop_tick.
       def last_loop_tick
         @loop_tick_at.get
       end
@@ -117,18 +119,10 @@ module Pgbus
       def initialize(config: Pgbus.configuration)
         @config = config
         @shutting_down = false
-        @last_cleanup_at = monotonic_now
-        @last_reap_at = monotonic_now
-        @last_concurrency_at = monotonic_now
-        @last_batch_cleanup_at = monotonic_now
-        @last_recurring_cleanup_at = monotonic_now
-        @last_archive_compaction_at = monotonic_now
-        @last_stream_archive_compaction_at = monotonic_now
-        @last_outbox_cleanup_at = monotonic_now
-        @last_job_lock_cleanup_at = monotonic_now
-        @last_stats_cleanup_at = monotonic_now
-        @last_orphan_stream_sweep_at = monotonic_now
-        @last_table_maintenance_at = monotonic_now
+        # Seed every per-task timestamp from the single source of truth so the
+        # list can never drift from set_maintenance_timestamp's allow-list.
+        now = monotonic_now
+        MAINTENANCE_TIMESTAMPS.each { |ivar| instance_variable_set(ivar, now) }
         @maintenance_failure_streak = 0
         @maintenance_backoff_until = nil
         @loop_tick_at = Concurrent::AtomicReference.new(nil)

--- a/lib/pgbus/process/dispatcher.rb
+++ b/lib/pgbus/process/dispatcher.rb
@@ -37,6 +37,15 @@ module Pgbus
       MAINTENANCE_BACKOFF_BASE = 30    # seconds; first backoff window
       MAINTENANCE_BACKOFF_MAX = 600    # seconds; window ceiling (10 minutes)
 
+      # The per-task monotonic timestamps run_maintenance consults via run_if_due.
+      # Enumerated so set_maintenance_timestamp can validate its argument.
+      MAINTENANCE_TIMESTAMPS = %i[
+        @last_cleanup_at @last_reap_at @last_concurrency_at @last_batch_cleanup_at
+        @last_recurring_cleanup_at @last_archive_compaction_at @last_stream_archive_compaction_at
+        @last_outbox_cleanup_at @last_job_lock_cleanup_at @last_stats_cleanup_at
+        @last_orphan_stream_sweep_at @last_table_maintenance_at
+      ].freeze
+
       # Outcome of a single maintenance task in a cycle. Lets run_maintenance
       # distinguish success/failed/skipped and, on failure, carry the error
       # and task name for reporting or summarizing.
@@ -72,7 +81,38 @@ module Pgbus
         end
       end
 
-      attr_reader :config
+      attr_reader :config, :maintenance_failure_streak, :maintenance_backoff_until
+
+      def shutting_down?
+        @shutting_down
+      end
+
+      # The last monotonic timestamp stamped by the run loop (via the heartbeat's
+      # loop_tick_supplier). nil until the first stamp_loop_tick.
+      def last_loop_tick
+        @loop_tick_at.get
+      end
+
+      # Test seam: set one of the @last_*_at maintenance timestamps so a task
+      # becomes (or stops being) due on the next run_maintenance. The timestamps
+      # are per-task monotonic clocks with no constructor injection point (all 12
+      # default to monotonic_now at construction), so a post-construction setter
+      # is the minimal way to drive the due/not-due logic deterministically.
+      # ivar must be one of the recognized @last_*_at names.
+      def set_maintenance_timestamp(ivar, monotonic_value)
+        raise ArgumentError, "unknown maintenance timestamp #{ivar}" unless MAINTENANCE_TIMESTAMPS.include?(ivar.to_sym)
+
+        instance_variable_set(ivar, monotonic_value)
+      end
+
+      # Read one of the @last_*_at maintenance timestamps (companion to
+      # set_maintenance_timestamp) so a test can assert a timestamp did or did
+      # not advance without reaching into the ivar directly.
+      def maintenance_timestamp(ivar)
+        raise ArgumentError, "unknown maintenance timestamp #{ivar}" unless MAINTENANCE_TIMESTAMPS.include?(ivar.to_sym)
+
+        instance_variable_get(ivar)
+      end
 
       def initialize(config: Pgbus.configuration)
         @config = config

--- a/lib/pgbus/process/signal_handler.rb
+++ b/lib/pgbus/process/signal_handler.rb
@@ -7,6 +7,12 @@ module Pgbus
         base.attr_reader :signal_queue
       end
 
+      # The signals setup_signals has installed handlers for (and will restore on
+      # restore_signals). Empty until setup_signals runs.
+      def handled_signals
+        (@previous_handlers || {}).keys
+      end
+
       def setup_signals
         @signal_queue = Queue.new
         @previous_handlers = {}

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -20,15 +20,24 @@ module Pgbus
       RESTART_BACKOFF_BASE = 1
       RESTART_BACKOFF_MAX = 60
 
-      attr_reader :config
+      attr_reader :config, :forks
 
-      def initialize(config: Pgbus.configuration)
+      # The child-fork bookkeeping (`forks`, `pending_restarts`) and the
+      # `shutting_down` flag accept injected seeds so tests can drive the
+      # monitor/reap loops from a known state without poking private ivars. All
+      # default to the empty/false values production always starts from.
+      def initialize(config: Pgbus.configuration, forks: {}, shutting_down: false,
+                     pending_restarts: [])
         @config = config
-        @forks = {}
-        @shutting_down = false
+        @forks = forks
+        @shutting_down = shutting_down
         @last_watchdog_at = monotonic_now
-        @pending_restarts = []
+        @pending_restarts = pending_restarts
         @crash_counts = Hash.new(0)
+      end
+
+      def shutting_down?
+        @shutting_down
       end
 
       def run

--- a/lib/pgbus/process/supervisor.rb
+++ b/lib/pgbus/process/supervisor.rb
@@ -20,18 +20,22 @@ module Pgbus
       RESTART_BACKOFF_BASE = 1
       RESTART_BACKOFF_MAX = 60
 
-      attr_reader :config, :forks
+      attr_reader :config
+      # forks is readable everywhere; the writer exists only so tests can seed a
+      # known set of children before exercising the reap/watchdog paths (in
+      # production forks is populated by fork_* as children spawn).
+      attr_accessor :forks
 
       # The child-fork bookkeeping (`forks`, `pending_restarts`) and the
       # `shutting_down` flag accept injected seeds so tests can drive the
       # monitor/reap loops from a known state without poking private ivars. All
       # default to the empty/false values production always starts from.
       def initialize(config: Pgbus.configuration, forks: {}, shutting_down: false,
-                     pending_restarts: [])
+                     pending_restarts: [], last_watchdog_at: nil)
         @config = config
         @forks = forks
         @shutting_down = shutting_down
-        @last_watchdog_at = monotonic_now
+        @last_watchdog_at = last_watchdog_at || monotonic_now
         @pending_restarts = pending_restarts
         @crash_counts = Hash.new(0)
       end
@@ -39,6 +43,11 @@ module Pgbus
       def shutting_down?
         @shutting_down
       end
+
+      # Test seam: reset the watchdog clock so check_stalled_workers runs on the
+      # next call instead of waiting out WATCHDOG_INTERVAL. Production advances
+      # this internally after each watchdog pass.
+      attr_writer :last_watchdog_at
 
       def run
         setup_signals

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -127,8 +127,10 @@ module Pgbus
         @in_flight.value = count
       end
 
-      # The last monotonic loop-tick stamp fed to the heartbeat's
-      # loop_tick_supplier. nil until the first stamp_loop_tick.
+      # The last wall-clock loop-tick stamp (Time.now.to_f) fed to the
+      # heartbeat's loop_tick_supplier. Wall-clock — NOT monotonic — so it stays
+      # comparable across the process boundary the supervisor watchdog reads it
+      # over. nil until the first stamp_loop_tick.
       def last_loop_tick
         @loop_tick_at.get
       end

--- a/lib/pgbus/process/worker.rb
+++ b/lib/pgbus/process/worker.rb
@@ -7,11 +7,30 @@ module Pgbus
     class Worker
       include SignalHandler
 
-      attr_reader :queues, :threads, :config, :execution_mode
+      attr_reader :queues, :threads, :config, :execution_mode,
+                  :rate_counter, :wake_signal, :restore_streak, :lifecycle
+      # stat_buffer is writable so a test can swap in a buffer double after
+      # construction to assert graceful_shutdown / check_recycle flush it. The
+      # executor captured the original buffer at construction, but these paths
+      # flush @stat_buffer directly, so the swap is observable.
+      attr_accessor :stat_buffer
+      # notify_listener / notify_retry_at / notify_retry_backoff are writable so
+      # tests can seed the self-healing listener state, re-arm the backoff window
+      # between calls, and simulate start_notify_listener assigning the listener
+      # from inside a stub (production mutates all three in the run loop).
+      attr_accessor :notify_listener, :notify_retry_at, :notify_retry_backoff
 
+      # The collaborators below (rate_counter, wake_signal, stat_buffer) and the
+      # recycle clock (started_at_monotonic) accept injected seeds so tests can
+      # observe or stub them without poking private ivars. All default to the
+      # exact values production constructs, so behavior is unchanged.
       def initialize(queues:, threads: 5, config: Pgbus.configuration,
                      single_active_consumer: false, consumer_priority: 0,
-                     execution_mode: :threads, group_mode: nil, liveness_pipe: nil)
+                     execution_mode: :threads, group_mode: nil, liveness_pipe: nil,
+                     rate_counter: nil, wake_signal: nil, stat_buffer: :default,
+                     notify_listener: nil, notify_retry_at: 0.0,
+                     notify_retry_backoff: NOTIFY_RETRY_BASE_SECONDS,
+                     started_at_monotonic: nil)
         @queues = Array(queues)
         @initial_queues = @queues.dup.freeze
         @wildcard = @queues.include?("*")
@@ -38,18 +57,24 @@ module Pgbus
         @jobs_failed = Concurrent::AtomicFixnum.new(0)
         @in_flight = Concurrent::AtomicFixnum.new(0)
         @loop_tick_at = Concurrent::AtomicReference.new(nil)
-        @rate_counter = RateCounter.new(:processed, :failed, :dequeued)
+        @rate_counter = rate_counter || RateCounter.new(:processed, :failed, :dequeued)
         @started_at = Time.current
-        @started_at_monotonic = monotonic_now
+        @started_at_monotonic = started_at_monotonic || monotonic_now
+        # stat_buffer: :default means "build one iff config.stats_enabled";
+        # passing an explicit value (including nil) overrides that for tests.
         @stat_buffer =
-          if config.stats_enabled
-            Pgbus::StatBuffer.new(
-              flush_size: config.stats_flush_size,
-              flush_interval: config.stats_flush_interval
-            )
+          if stat_buffer == :default
+            if config.stats_enabled
+              Pgbus::StatBuffer.new(
+                flush_size: config.stats_flush_size,
+                flush_interval: config.stats_flush_interval
+              )
+            end
+          else
+            stat_buffer
           end
         @executor = Pgbus::ActiveJob::Executor.new(stat_buffer: @stat_buffer)
-        @wake_signal = WakeSignal.new
+        @wake_signal = wake_signal || WakeSignal.new
         @pool = ExecutionPools.build(
           mode: @execution_mode,
           capacity: threads,
@@ -65,9 +90,9 @@ module Pgbus
         @last_evicted_at = nil
         @deferral_warned = false
         @queue_lock = QueueLock.new if @single_active_consumer
-        @notify_listener = nil
-        @notify_retry_at = 0.0
-        @notify_retry_backoff = NOTIFY_RETRY_BASE_SECONDS
+        @notify_listener = notify_listener
+        @notify_retry_at = notify_retry_at
+        @notify_retry_backoff = notify_retry_backoff
         # OS-level liveness channel to the supervisor watchdog. Optional: nil
         # unless the supervisor forked us with one. Written from stamp_loop_tick
         # so the watchdog can detect a wedged worker even when the database (and
@@ -88,6 +113,24 @@ module Pgbus
           rates: @rate_counter.rates,
           started_at: @started_at
         }.merge(@pool.metadata)
+      end
+
+      # Test seams for the atomic counters recycle logic and prefetch
+      # flow-control consult. Production only increments these during message
+      # handling; seeding them lets a test cross a threshold without running
+      # thousands of real jobs.
+      def jobs_processed=(count)
+        @jobs_processed.value = count
+      end
+
+      def in_flight=(count)
+        @in_flight.value = count
+      end
+
+      # The last monotonic loop-tick stamp fed to the heartbeat's
+      # loop_tick_supplier. nil until the first stamp_loop_tick.
+      def last_loop_tick
+        @loop_tick_at.get
       end
 
       NOTIFY_FALLBACK_POLL_SECONDS = 15

--- a/spec/generators/pgbus/update_generator_spec.rb
+++ b/spec/generators/pgbus/update_generator_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     end
 
     it "prints the fresh-install redirect when the detector reports FRESH_INSTALL" do
-      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
-        .and_return([Pgbus::Generators::MigrationDetector::FRESH_INSTALL])
+      allow(Pgbus::Generators::MigrationDetector).to receive(:new)
+        .and_return(instance_double(Pgbus::Generators::MigrationDetector, missing_migrations: [Pgbus::Generators::MigrationDetector::FRESH_INSTALL]))
 
       generator = build_generator(quiet: false)
       allow(generator).to receive(:invoke)
@@ -125,8 +125,8 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     end
 
     it "logs 'up to date' and does nothing when the detector returns an empty list" do
-      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
-        .and_return([])
+      allow(Pgbus::Generators::MigrationDetector).to receive(:new)
+        .and_return(instance_double(Pgbus::Generators::MigrationDetector, missing_migrations: []))
 
       generator = build_generator(quiet: false)
       allow(generator).to receive(:invoke)
@@ -136,8 +136,8 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     end
 
     it "invokes each missing migration's generator in order" do
-      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
-        .and_return(%i[add_presence add_stream_stats])
+      allow(Pgbus::Generators::MigrationDetector).to receive(:new)
+        .and_return(instance_double(Pgbus::Generators::MigrationDetector, missing_migrations: %i[add_presence add_stream_stats]))
 
       generator = build_generator(dry_run: false)
       allow(generator).to receive(:invoke)
@@ -149,8 +149,8 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     end
 
     it "skips invocation on dry_run and prints 'would invoke'" do
-      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
-        .and_return(%i[add_presence])
+      allow(Pgbus::Generators::MigrationDetector).to receive(:new)
+        .and_return(instance_double(Pgbus::Generators::MigrationDetector, missing_migrations: %i[add_presence]))
 
       generator = build_generator(dry_run: true, quiet: false)
       allow(generator).to receive(:invoke)
@@ -162,8 +162,8 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     end
 
     it "passes --database through when explicitly set via options" do
-      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
-        .and_return(%i[add_presence])
+      allow(Pgbus::Generators::MigrationDetector).to receive(:new)
+        .and_return(instance_double(Pgbus::Generators::MigrationDetector, missing_migrations: %i[add_presence]))
 
       generator = build_generator(dry_run: false, database: "queue_db")
       allow(generator).to receive(:invoke)
@@ -176,8 +176,8 @@ RSpec.describe Pgbus::Generators::UpdateGenerator do
     it "auto-detects --database from Pgbus.configuration.connects_to" do
       allow(Pgbus.configuration).to receive(:connects_to).and_return(database: { writing: :pgbus })
       allow(Pgbus::BusRecord).to receive(:connection).and_return(mock_connection)
-      allow_any_instance_of(Pgbus::Generators::MigrationDetector).to receive(:missing_migrations)
-        .and_return(%i[add_presence])
+      allow(Pgbus::Generators::MigrationDetector).to receive(:new)
+        .and_return(instance_double(Pgbus::Generators::MigrationDetector, missing_migrations: %i[add_presence]))
 
       generator = build_generator(dry_run: false)
       allow(generator).to receive(:invoke)

--- a/spec/pgbus/active_job/executor_spec.rb
+++ b/spec/pgbus/active_job/executor_spec.rb
@@ -112,9 +112,10 @@ RSpec.describe Pgbus::ActiveJob::Executor do
     context "when archive fails with a connection error after the job succeeded" do
       let(:message) { build_message_double(msg_id: 9, message: message_json, read_ct: 1) }
 
-      before do
-        stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
-      end
+      # Load the genuine PGMQ::Errors::ConnectionError so this proves the
+      # executor's archive-retry rescue (archive_from → connection_error?) matches
+      # the real pgmq-ruby hierarchy — not a fake StandardError subclass.
+      before { real_pgmq_connection_error }
 
       it "retries the archive once and returns :success" do
         calls = 0

--- a/spec/pgbus/client/connection_health_spec.rb
+++ b/spec/pgbus/client/connection_health_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Pgbus::Client::ConnectionHealth do
   let(:clock_at) { [1000.0] }
 
   before do
-    stub_const("PGMQ::Errors", Module.new)
-    stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError))
+    real_pgmq_connection_error
   end
 
   # Advance the injected monotonic clock by `seconds`.

--- a/spec/pgbus/client/ensure_stream_queue_spec.rb
+++ b/spec/pgbus/client/ensure_stream_queue_spec.rb
@@ -11,10 +11,9 @@ RSpec.describe Pgbus::Client::EnsureStreamQueue do
   end
 
   before do
-    # require "pgmq" fires inside Client#initialize before the instance exists,
-    # so stub it at the module boundary rather than on any instance.
-    allow(Kernel).to receive(:require).and_call_original
-    allow(Kernel).to receive(:require).with("pgmq").and_return(true)
+    # Stub the class method that loads pgmq so the faked PGMQ::Client stands;
+    # a clean per-example stub, unlike stubbing global Kernel#require.
+    allow(Pgbus::Client).to receive(:load_pgmq_gem!)
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)

--- a/spec/pgbus/client/ensure_stream_queue_spec.rb
+++ b/spec/pgbus/client/ensure_stream_queue_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe Pgbus::Client::EnsureStreamQueue do
   end
 
   before do
-    allow_any_instance_of(Pgbus::Client).to receive(:require).with("pgmq").and_return(true)
+    # require "pgmq" fires inside Client#initialize before the instance exists,
+    # so stub it at the module boundary rather than on any instance.
+    allow(Kernel).to receive(:require).and_call_original
+    allow(Kernel).to receive(:require).with("pgmq").and_return(true)
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)

--- a/spec/pgbus/client/new_features_spec.rb
+++ b/spec/pgbus/client/new_features_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe Pgbus::Client do
     end
 
     before do
-      allow_any_instance_of(described_class).to receive(:require).with("pgmq").and_return(true)
+      # require "pgmq" fires inside Client#initialize before the instance exists,
+      # so stub it at the module boundary rather than on any instance.
+      allow(Kernel).to receive(:require).and_call_original
+      allow(Kernel).to receive(:require).with("pgmq").and_return(true)
       stub_const("PGMQ::Client", Class.new do
         def initialize(*args, **kwargs); end
       end)
@@ -267,7 +270,10 @@ RSpec.describe Pgbus::Client do
     end
 
     before do
-      allow_any_instance_of(described_class).to receive(:require).with("pgmq").and_return(true)
+      # require "pgmq" fires inside Client#initialize before the instance exists,
+      # so stub it at the module boundary rather than on any instance.
+      allow(Kernel).to receive(:require).and_call_original
+      allow(Kernel).to receive(:require).with("pgmq").and_return(true)
       stub_const("PGMQ::Client", Class.new do
         def initialize(*args, **kwargs); end
       end)

--- a/spec/pgbus/client/new_features_spec.rb
+++ b/spec/pgbus/client/new_features_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe Pgbus::Client do
     end
 
     before do
-      # require "pgmq" fires inside Client#initialize before the instance exists,
-      # so stub it at the module boundary rather than on any instance.
-      allow(Kernel).to receive(:require).and_call_original
-      allow(Kernel).to receive(:require).with("pgmq").and_return(true)
+      # Stub the class method that loads pgmq so the faked PGMQ::Client stands;
+      # a clean per-example stub, unlike stubbing global Kernel#require.
+      allow(described_class).to receive(:load_pgmq_gem!)
       stub_const("PGMQ::Client", Class.new do
         def initialize(*args, **kwargs); end
       end)
@@ -270,10 +269,9 @@ RSpec.describe Pgbus::Client do
     end
 
     before do
-      # require "pgmq" fires inside Client#initialize before the instance exists,
-      # so stub it at the module boundary rather than on any instance.
-      allow(Kernel).to receive(:require).and_call_original
-      allow(Kernel).to receive(:require).with("pgmq").and_return(true)
+      # Stub the class method that loads pgmq so the faked PGMQ::Client stands;
+      # a clean per-example stub, unlike stubbing global Kernel#require.
+      allow(described_class).to receive(:load_pgmq_gem!)
       stub_const("PGMQ::Client", Class.new do
         def initialize(*args, **kwargs); end
       end)

--- a/spec/pgbus/client/notify_stream_spec.rb
+++ b/spec/pgbus/client/notify_stream_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe Pgbus::Client::NotifyStream do
   end
 
   before do
-    allow_any_instance_of(Pgbus::Client).to receive(:require).with("pgmq").and_return(true)
+    # require "pgmq" fires inside Client#initialize before the instance exists,
+    # so stub it at the module boundary rather than on any instance.
+    allow(Kernel).to receive(:require).and_call_original
+    allow(Kernel).to receive(:require).with("pgmq").and_return(true)
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)

--- a/spec/pgbus/client/notify_stream_spec.rb
+++ b/spec/pgbus/client/notify_stream_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Pgbus::Client::NotifyStream do
 
     context "with stale pgmq connection recovery" do
       before do
-        stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+        real_pgmq_connection_error
         # Stale retries now back off between attempts; stub the delay so the
         # suite doesn't actually sleep.
         allow(client).to receive(:sleep)

--- a/spec/pgbus/client/notify_stream_spec.rb
+++ b/spec/pgbus/client/notify_stream_spec.rb
@@ -11,10 +11,9 @@ RSpec.describe Pgbus::Client::NotifyStream do
   end
 
   before do
-    # require "pgmq" fires inside Client#initialize before the instance exists,
-    # so stub it at the module boundary rather than on any instance.
-    allow(Kernel).to receive(:require).and_call_original
-    allow(Kernel).to receive(:require).with("pgmq").and_return(true)
+    # Stub the class method that loads pgmq so the faked PGMQ::Client stands;
+    # a clean per-example stub, unlike stubbing global Kernel#require.
+    allow(Pgbus::Client).to receive(:load_pgmq_gem!)
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)

--- a/spec/pgbus/client/read_after_spec.rb
+++ b/spec/pgbus/client/read_after_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe Pgbus::Client::ReadAfter do
   end
 
   before do
-    allow_any_instance_of(Pgbus::Client).to receive(:require).with("pgmq").and_return(true)
+    # require "pgmq" fires inside Client#initialize before the instance exists,
+    # so stub it at the module boundary rather than on any instance.
+    allow(Kernel).to receive(:require).and_call_original
+    allow(Kernel).to receive(:require).with("pgmq").and_return(true)
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)

--- a/spec/pgbus/client/read_after_spec.rb
+++ b/spec/pgbus/client/read_after_spec.rb
@@ -11,10 +11,9 @@ RSpec.describe Pgbus::Client::ReadAfter do
   end
 
   before do
-    # require "pgmq" fires inside Client#initialize before the instance exists,
-    # so stub it at the module boundary rather than on any instance.
-    allow(Kernel).to receive(:require).and_call_original
-    allow(Kernel).to receive(:require).with("pgmq").and_return(true)
+    # Stub the class method that loads pgmq so the faked PGMQ::Client stands;
+    # a clean per-example stub, unlike stubbing global Kernel#require.
+    allow(Pgbus::Client).to receive(:load_pgmq_gem!)
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)

--- a/spec/pgbus/client/read_timeout_spec.rb
+++ b/spec/pgbus/client/read_timeout_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe Pgbus::Client do
     end
 
     before do
-      allow_any_instance_of(described_class).to receive(:require).with("pgmq").and_return(true)
+      # require "pgmq" fires inside Client#initialize before the instance exists,
+      # so stub it at the module boundary rather than on any instance.
+      allow(Kernel).to receive(:require).and_call_original
+      allow(Kernel).to receive(:require).with("pgmq").and_return(true)
       stub_const("PGMQ::Client", Class.new { def initialize(*args, **kwargs); end })
       # Real PGMQ::Errors::ConnectionError coexists with the faked PGMQ::Client.
       real_pgmq_connection_error

--- a/spec/pgbus/client/read_timeout_spec.rb
+++ b/spec/pgbus/client/read_timeout_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Pgbus::Client do
   describe "read_timeout" do
     subject(:client) do
       allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
-      c = described_class.new(config)
-      c.instance_variable_set(:@schema_ensured, true)
+      c = described_class.new(config, schema_ensured: true)
       allow(c).to receive(:tune_autovacuum)
       allow(c).to receive(:notify_trigger_current?).and_return(false)
       c
@@ -21,10 +20,9 @@ RSpec.describe Pgbus::Client do
     end
 
     before do
-      # require "pgmq" fires inside Client#initialize before the instance exists,
-      # so stub it at the module boundary rather than on any instance.
-      allow(Kernel).to receive(:require).and_call_original
-      allow(Kernel).to receive(:require).with("pgmq").and_return(true)
+      # Stub the class method that loads pgmq so the faked PGMQ::Client stands;
+      # a clean per-example stub, unlike stubbing global Kernel#require.
+      allow(described_class).to receive(:load_pgmq_gem!)
       stub_const("PGMQ::Client", Class.new { def initialize(*args, **kwargs); end })
       # Real PGMQ::Errors::ConnectionError coexists with the faked PGMQ::Client.
       real_pgmq_connection_error
@@ -117,8 +115,7 @@ RSpec.describe Pgbus::Client do
       context "when on the shared-connection (Proc) path" do
         subject(:shared_client) do
           allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
-          c = described_class.new(shared_config)
-          c.instance_variable_set(:@schema_ensured, true)
+          c = described_class.new(shared_config, schema_ensured: true)
           allow(c).to receive(:tune_autovacuum)
           allow(c).to receive(:notify_trigger_current?).and_return(false)
           c

--- a/spec/pgbus/client/read_timeout_spec.rb
+++ b/spec/pgbus/client/read_timeout_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Pgbus::Client do
     before do
       allow_any_instance_of(described_class).to receive(:require).with("pgmq").and_return(true)
       stub_const("PGMQ::Client", Class.new { def initialize(*args, **kwargs); end })
-      stub_const("PGMQ::Errors", Module.new)
-      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError))
+      # Real PGMQ::Errors::ConnectionError coexists with the faked PGMQ::Client.
+      real_pgmq_connection_error
       # pg is loaded via pgmq-ruby in production; stub the one method the
       # read-bounds gate consults so client construction works with mocked PGMQ.
       stub_pg_library_version

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Pgbus::Client do
     end
 
     it "propagates PGMQ connection errors when queue creation fails" do
-      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      real_pgmq_connection_error
 
       allow(mock_pgmq).to receive(:create).and_raise(
         PGMQ::Errors::ConnectionError.new("Database connection error: connection refused")
@@ -483,7 +483,7 @@ RSpec.describe Pgbus::Client do
     let(:raw_conn) { double("PG::Connection") }
 
     before do
-      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      real_pgmq_connection_error
       stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
     end
 
@@ -738,7 +738,7 @@ RSpec.describe Pgbus::Client do
     end
 
     it "falls back to false (and enables notify) when the pooled connection raises" do
-      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      real_pgmq_connection_error
       allow(mock_pgmq).to receive(:with_connection)
         .and_raise(PGMQ::Errors::ConnectionError, "schema not ready")
 
@@ -1055,7 +1055,9 @@ RSpec.describe Pgbus::Client do
 
   describe "stale pgmq connection recovery" do
     before do
-      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      # Load the genuine PGMQ::Errors::ConnectionError so these prove
+      # with_stale_connection_retry rescues the real pgmq-ruby class, not a fake.
+      real_pgmq_connection_error
       # Stale retries now back off between attempts. Stub the delay so the
       # suite doesn't actually sleep; individual tests that assert the backoff
       # sequence override this with a spy.
@@ -1812,7 +1814,7 @@ RSpec.describe Pgbus::Client do
 
   describe "connection-health circuit breaker (issue #197)" do
     before do
-      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      real_pgmq_connection_error
     end
 
     # Force the client's in-memory breaker into the open state so reads fail
@@ -1888,7 +1890,7 @@ RSpec.describe Pgbus::Client do
 
   describe "libpq connection bounds (issue #198)" do
     before do
-      stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError)) unless defined?(PGMQ::Errors::ConnectionError)
+      real_pgmq_connection_error
       allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
       # PG (the pg gem) is loaded via pgmq-ruby in production; these unit specs
       # mock PGMQ, so stub the one PG method the read-bounds gate consults.

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -6,10 +6,9 @@ RSpec.describe Pgbus::Client do
   # Stub pgmq-ruby so it never loads the real gem
   subject(:client) do
     allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
-    c = described_class.new(config)
-    # Pre-mark PGMQ schema as ensured for most tests.
-    # Schema installation tests override this.
-    c.instance_variable_set(:@schema_ensured, true)
+    # Pre-mark PGMQ schema as ensured for most tests via the constructor seam.
+    # Schema installation tests build their own client with schema_ensured: false.
+    c = described_class.new(config, schema_ensured: true)
     # Stub autovacuum tuning — runs raw SQL which needs a real PG connection.
     allow(c).to receive(:tune_autovacuum)
     # Stub notify trigger check — runs raw SQL which needs a real PG connection.
@@ -19,7 +18,10 @@ RSpec.describe Pgbus::Client do
   end
 
   before do
-    allow_any_instance_of(described_class).to receive(:require).with("pgmq").and_return(true)
+    # `require "pgmq"` fires inside Client#initialize before the instance exists,
+    # so stub it at the module boundary rather than on any instance.
+    allow(Kernel).to receive(:require).and_call_original
+    allow(Kernel).to receive(:require).with("pgmq").and_return(true)
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)
@@ -34,10 +36,19 @@ RSpec.describe Pgbus::Client do
   let(:mock_pgmq) { build_mock_pgmq }
 
   describe "#ensure_pgmq_schema (via ensure_queue)" do
+    # Override the shared subject to leave the schema UN-ensured so ensure_queue
+    # actually runs the install path (the default subject pre-marks it ensured).
+    subject(:client) do
+      allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
+      c = described_class.new(config, schema_ensured: false)
+      allow(c).to receive(:tune_autovacuum)
+      allow(c).to receive(:notify_trigger_current?).and_return(false)
+      c
+    end
+
     let(:raw_conn) { double("raw_conn") }
 
     before do
-      client.instance_variable_set(:@schema_ensured, false)
       allow(client).to receive(:with_raw_connection).and_yield(raw_conn)
     end
 
@@ -580,7 +591,7 @@ RSpec.describe Pgbus::Client do
 
   describe "#configured_queues" do
     it "returns the logical queues derived from the configuration" do
-      config.instance_variable_set(:@workers, [{ queues: %w[critical mailers], threads: 2 }])
+      config.workers = [{ queues: %w[critical mailers], threads: 2 }]
 
       expect(client.configured_queues).to contain_exactly("default", "critical", "mailers")
     end
@@ -753,8 +764,7 @@ RSpec.describe Pgbus::Client do
       subject(:shared_client) do
         allow(config).to receive(:connection_options).and_return(-> { conn })
         allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
-        c = described_class.new(config)
-        c.instance_variable_set(:@schema_ensured, true)
+        c = described_class.new(config, schema_ensured: true)
         allow(c).to receive(:tune_autovacuum)
         c
       end
@@ -762,7 +772,7 @@ RSpec.describe Pgbus::Client do
       before { allow(mock_pgmq).to receive(:with_connection).and_yield(conn) }
 
       it "uses a Mutex to serialize the single-slot pool" do
-        expect(shared_client.instance_variable_get(:@pgmq_mutex)).to be_a(Mutex)
+        expect(shared_client.shared_connection?).to be(true)
       end
 
       it "completes the trigger check without a nested pool checkout / deadlock" do
@@ -812,9 +822,11 @@ RSpec.describe Pgbus::Client do
     it "removes the queue from the created cache" do
       client.ensure_queue("default")
       client.drop_queue("default")
+      # Observable proof the cache entry was evicted: the next ensure_queue must
+      # re-create the queue rather than short-circuiting on a stale cache hit.
+      client.ensure_queue("default")
 
-      # Verify the queue is no longer in the cache
-      expect(client.instance_variable_get(:@queues_created)["pgbus_test_default"]).to be_nil
+      expect(mock_pgmq).to have_received(:create).with("pgbus_test_default").twice
     end
   end
 
@@ -1215,8 +1227,7 @@ RSpec.describe Pgbus::Client do
     describe "backoff does not hold the connection mutex (shared-connection path)" do
       subject(:shared_client) do
         allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
-        c = described_class.new(shared_config)
-        c.instance_variable_set(:@schema_ensured, true)
+        c = described_class.new(shared_config, schema_ensured: true)
         allow(c).to receive(:notify_trigger_current?).and_return(false)
         c
       end
@@ -1239,13 +1250,12 @@ RSpec.describe Pgbus::Client do
       end
 
       it "runs the shared-connection path (mutex is a real Mutex)" do
-        expect(shared_client.instance_variable_get(:@pgmq_mutex)).to be_a(Mutex)
+        expect(shared_client.shared_connection?).to be(true)
       end
 
-      it "does not hold @pgmq_mutex while sleeping between retries" do
-        mutex = shared_client.instance_variable_get(:@pgmq_mutex)
+      it "does not hold the connection mutex while sleeping between retries" do
         locked_during_sleep = []
-        allow(shared_client).to receive(:sleep) { locked_during_sleep << mutex.locked? }
+        allow(shared_client).to receive(:sleep) { locked_during_sleep << shared_client.synchronizing? }
 
         call_count = 0
         allow(mock_pgmq).to receive(:produce) do
@@ -1353,8 +1363,8 @@ RSpec.describe Pgbus::Client do
 
           nil
         end
-        # Reset the queues_created memo so ensure_queue actually calls @pgmq.create
-        client.instance_variable_get(:@queues_created).clear
+        # A freshly-built client has an empty queue cache, so ensure_queue really
+        # calls @pgmq.create (proven by create_count == 2 below).
 
         expect(client.send_message("default", { "k" => "v" })).to eq(1)
         expect(create_count).to eq(2)
@@ -1368,8 +1378,6 @@ RSpec.describe Pgbus::Client do
 
           nil
         end
-        client.instance_variable_get(:@queues_created).clear
-
         expect(client.send_batch("default", [{ "k" => "v" }])).to eq([1, 2])
         expect(create_count).to eq(2)
       end
@@ -1383,8 +1391,6 @@ RSpec.describe Pgbus::Client do
 
           nil
         end
-        client.instance_variable_get(:@queues_created).clear
-
         expect(client.send_message("default", { "k" => "v" })).to eq(1)
         expect(create_count).to eq(2)
       end
@@ -1417,7 +1423,6 @@ RSpec.describe Pgbus::Client do
 
           nil
         end
-        client.instance_variable_get(:@queues_created).clear
 
         client.bind_topic("orders.*", "default")
 
@@ -1635,11 +1640,14 @@ RSpec.describe Pgbus::Client do
 
           true
         end
-        client.instance_variable_get(:@queues_created)["pgbus_test_default"] = true
+        # Populate the created-cache the public way.
+        client.ensure_queue("default")
 
         expect(client.drop_queue("default")).to be(true)
         expect(call_count).to eq(2)
-        expect(client.instance_variable_get(:@queues_created)["pgbus_test_default"]).to be_nil
+        # Memo cleared: the next ensure_queue re-creates rather than cache-hitting.
+        client.ensure_queue("default")
+        expect(mock_pgmq).to have_received(:create).with("pgbus_test_default").twice
       end
     end
   end
@@ -1786,8 +1794,7 @@ RSpec.describe Pgbus::Client do
       config.pool_size = 5
 
       # With dedicated connections, operations should not go through the mutex.
-      # We test this by verifying that the client does not have a @pgmq_mutex.
-      expect(client.instance_variable_get(:@pgmq_mutex)).to be_nil
+      expect(client.shared_connection?).to be(false)
     end
 
     it "uses mutex synchronization when falling back to shared (Proc) connections" do
@@ -1805,10 +1812,9 @@ RSpec.describe Pgbus::Client do
       stub_const("ActiveRecord::Base", ar_base)
 
       allow(PGMQ::Client).to receive(:new).and_return(mock_pgmq)
-      shared_client = described_class.new(lambda_config)
-      shared_client.instance_variable_set(:@schema_ensured, true)
+      shared_client = described_class.new(lambda_config, schema_ensured: true)
 
-      expect(shared_client.instance_variable_get(:@pgmq_mutex)).to be_a(Mutex)
+      expect(shared_client.shared_connection?).to be(true)
     end
   end
 
@@ -1898,8 +1904,7 @@ RSpec.describe Pgbus::Client do
     end
 
     def build_client(config)
-      c = described_class.new(config)
-      c.instance_variable_set(:@schema_ensured, true)
+      c = described_class.new(config, schema_ensured: true)
       allow(c).to receive(:notify_trigger_current?).and_return(false)
       c
     end

--- a/spec/pgbus/client_spec.rb
+++ b/spec/pgbus/client_spec.rb
@@ -18,10 +18,11 @@ RSpec.describe Pgbus::Client do
   end
 
   before do
-    # `require "pgmq"` fires inside Client#initialize before the instance exists,
-    # so stub it at the module boundary rather than on any instance.
-    allow(Kernel).to receive(:require).and_call_original
-    allow(Kernel).to receive(:require).with("pgmq").and_return(true)
+    # Client#initialize loads pgmq via the class method load_pgmq_gem!; stub it
+    # so the fake PGMQ::Client below is not overwritten by the real gem. A
+    # per-example class-method stub, torn down cleanly — unlike stubbing the
+    # global Kernel#require, which would permanently block the real gem load.
+    allow(described_class).to receive(:load_pgmq_gem!)
     stub_const("PGMQ::Client", Class.new do
       def initialize(*args, **kwargs); end
     end)

--- a/spec/pgbus/process/consumer_spec.rb
+++ b/spec/pgbus/process/consumer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Pgbus::Process::Consumer do
       consumer = described_class.new(topics: ["orders.#"])
       consumer.graceful_shutdown
 
-      expect(consumer.instance_variable_get(:@shutting_down)).to be true
+      expect(consumer.shutting_down?).to be true
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe Pgbus::Process::Consumer do
       consumer = described_class.new(topics: ["orders.#"])
       consumer.immediate_shutdown
 
-      expect(consumer.instance_variable_get(:@shutting_down)).to be true
+      expect(consumer.shutting_down?).to be true
       expect(mock_pool).to have_received(:kill)
     end
   end
@@ -80,14 +80,13 @@ RSpec.describe Pgbus::Process::Consumer do
       consumer = described_class.new(topics: ["payments.completed"])
       consumer.send(:setup_subscriptions)
 
-      queue_names = consumer.instance_variable_get(:@queue_names)
-      expect(queue_names).to include("q_payments")
-      expect(queue_names).not_to include("q_shipping")
+      expect(consumer.queue_names).to include("q_payments")
+      expect(consumer.queue_names).not_to include("q_shipping")
     end
   end
 
   describe "handle_message (private)" do
-    let(:consumer) { described_class.new(topics: ["orders.#"]) }
+    let(:consumer) { described_class.new(topics: ["orders.#"], queue_names: ["q_orders"]) }
     let(:handler_instance) { double("handler", process: nil) }
     let(:handler_class) { double("HandlerClass", new: handler_instance) }
     let(:matching_subscriber) { instance_double(Pgbus::EventBus::Subscriber, handler_class: handler_class) }
@@ -96,7 +95,6 @@ RSpec.describe Pgbus::Process::Consumer do
 
     before do
       allow(registry).to receive(:handlers_for).with("orders.created").and_return([matching_subscriber])
-      consumer.instance_variable_set(:@queue_names, ["q_orders"])
     end
 
     it "parses routing_key, finds handlers, processes, and archives" do
@@ -132,11 +130,7 @@ RSpec.describe Pgbus::Process::Consumer do
   end
 
   describe "fetch_multi_consumer (private)" do
-    let(:consumer) { described_class.new(topics: ["orders.#"]) }
-
-    before do
-      consumer.instance_variable_set(:@queue_names, %w[q_orders q_payments q_shipping])
-    end
+    let(:consumer) { described_class.new(topics: ["orders.#"], queue_names: %w[q_orders q_payments q_shipping]) }
 
     it "caps the total across queues at qty so the execution pool cannot overflow (issue #123)" do
       allow(mock_client).to receive(:read_multi).and_return([])
@@ -178,12 +172,12 @@ RSpec.describe Pgbus::Process::Consumer do
       after { consumer.config.max_jobs_per_worker = nil }
 
       it "returns true when jobs_processed reaches the limit" do
-        consumer.instance_variable_get(:@jobs_processed).value = 100
+        consumer.jobs_processed = 100
         expect(consumer.send(:recycle_needed?)).to be true
       end
 
       it "returns false when below the limit" do
-        consumer.instance_variable_get(:@jobs_processed).value = 50
+        consumer.jobs_processed = 50
         expect(consumer.send(:recycle_needed?)).to be false
       end
     end
@@ -193,8 +187,12 @@ RSpec.describe Pgbus::Process::Consumer do
       after { consumer.config.max_worker_lifetime = nil }
 
       it "returns true when lifetime is exceeded" do
-        consumer.instance_variable_set(:@started_at_monotonic, Process.clock_gettime(Process::CLOCK_MONOTONIC) - 120)
-        expect(consumer.send(:recycle_needed?)).to be true
+        # config.max_worker_lifetime = 60 is set by the enclosing before hook.
+        aged = described_class.new(
+          topics: ["orders.#"],
+          started_at_monotonic: Process.clock_gettime(Process::CLOCK_MONOTONIC) - 120
+        )
+        expect(aged.send(:recycle_needed?)).to be true
       end
     end
 
@@ -223,27 +221,29 @@ RSpec.describe Pgbus::Process::Consumer do
 
   describe "#check_recycle (private)" do
     let(:consumer) { described_class.new(topics: ["orders.#"]) }
-    let(:wake_signal) { consumer.instance_variable_get(:@wake_signal) }
+    let(:wake_signal) { consumer.wake_signal }
 
     before { allow(wake_signal).to receive(:notify!) }
 
     it "does nothing when no recycle is needed" do
       consumer.send(:check_recycle)
-      expect(consumer.instance_variable_get(:@shutting_down)).to be false
+      expect(consumer.shutting_down?).to be false
     end
 
     context "when a limit is exceeded" do
-      before { consumer.config.max_jobs_per_worker = 10 }
+      before do
+        consumer.config.max_jobs_per_worker = 10
+        consumer.jobs_processed = 10
+      end
+
       after { consumer.config.max_jobs_per_worker = nil }
 
-      it "sets @shutting_down so the loop exits cleanly" do
-        consumer.instance_variable_get(:@jobs_processed).value = 10
+      it "sets shutting_down so the loop exits cleanly" do
         consumer.send(:check_recycle)
-        expect(consumer.instance_variable_get(:@shutting_down)).to be true
+        expect(consumer.shutting_down?).to be true
       end
 
       it "instruments pgbus.consumer.recycle with the reason" do
-        consumer.instance_variable_get(:@jobs_processed).value = 10
         allow(Pgbus::Instrumentation).to receive(:instrument)
         consumer.send(:check_recycle)
         expect(Pgbus::Instrumentation).to have_received(:instrument)
@@ -251,13 +251,11 @@ RSpec.describe Pgbus::Process::Consumer do
       end
 
       it "wakes the idle wait so the loop notices the shutdown immediately" do
-        consumer.instance_variable_get(:@jobs_processed).value = 10
         consumer.send(:check_recycle)
         expect(wake_signal).to have_received(:notify!)
       end
 
       it "recycles only once even if called repeatedly" do
-        consumer.instance_variable_get(:@jobs_processed).value = 10
         allow(Pgbus::Instrumentation).to receive(:instrument)
         consumer.send(:check_recycle)
         consumer.send(:check_recycle)
@@ -267,7 +265,7 @@ RSpec.describe Pgbus::Process::Consumer do
   end
 
   describe "recycle counting in handle_message" do
-    let(:consumer) { described_class.new(topics: ["orders.#"]) }
+    let(:consumer) { described_class.new(topics: ["orders.#"], queue_names: ["q_orders"]) }
     let(:handler_instance) { double("handler", process: nil) }
     let(:handler_class) { double("HandlerClass", new: handler_instance) }
     let(:matching_subscriber) { instance_double(Pgbus::EventBus::Subscriber, handler_class: handler_class) }
@@ -276,27 +274,26 @@ RSpec.describe Pgbus::Process::Consumer do
 
     before do
       allow(registry).to receive(:handlers_for).with("orders.created").and_return([matching_subscriber])
-      consumer.instance_variable_set(:@queue_names, ["q_orders"])
     end
 
-    it "increments @jobs_processed after a successful handle" do
+    it "increments jobs_processed after a successful handle" do
       expect { consumer.send(:handle_message, message, "q_orders") }
-        .to change { consumer.instance_variable_get(:@jobs_processed).value }.by(1)
+        .to change(consumer, :jobs_processed).by(1)
     end
 
-    it "increments @jobs_processed when a handler raises (so recycling still counts failures)" do
+    it "increments jobs_processed when a handler raises (so recycling still counts failures)" do
       allow(registry).to receive(:handlers_for).and_raise(StandardError.new("boom"))
 
       expect { consumer.send(:handle_message, message, "q_orders") }
-        .to change { consumer.instance_variable_get(:@jobs_processed).value }.by(1)
+        .to change(consumer, :jobs_processed).by(1)
     end
 
-    it "increments @jobs_processed when a message is routed to the DLQ (poison queue still recycles)" do
+    it "increments jobs_processed when a message is routed to the DLQ (poison queue still recycles)" do
       dlq_message = build_message_double(msg_id: 9, message: message_body, read_ct: 99)
       allow(consumer.config).to receive(:max_retries).and_return(5)
 
       expect { consumer.send(:handle_message, dlq_message, "q_orders") }
-        .to change { consumer.instance_variable_get(:@jobs_processed).value }.by(1)
+        .to change(consumer, :jobs_processed).by(1)
       expect(mock_client).to have_received(:move_to_dead_letter).with("q_orders", dlq_message)
     end
   end
@@ -311,13 +308,13 @@ RSpec.describe Pgbus::Process::Consumer do
 
     it "returns polling_interval when wakeup is on but no listener attached yet" do
       allow(consumer).to receive(:notify_wakeup?).and_return(true)
-      consumer.instance_variable_set(:@notify_listener, nil)
+      consumer.notify_listener = nil
       expect(consumer.send(:wake_timeout)).to eq(consumer.config.polling_interval)
     end
 
     it "raises the wait to NOTIFY_FALLBACK_POLL_SECONDS when a listener is active" do
       allow(consumer).to receive(:notify_wakeup?).and_return(true)
-      consumer.instance_variable_set(:@notify_listener, fake_listener)
+      consumer.notify_listener = fake_listener
       expect(consumer.send(:wake_timeout))
         .to eq(described_class::NOTIFY_FALLBACK_POLL_SECONDS)
     end
@@ -325,22 +322,20 @@ RSpec.describe Pgbus::Process::Consumer do
     it "returns polling_interval when the listener thread has died" do
       allow(consumer).to receive(:notify_wakeup?).and_return(true)
       allow(fake_listener).to receive(:running?).and_return(false)
-      consumer.instance_variable_set(:@notify_listener, fake_listener)
+      consumer.notify_listener = fake_listener
       expect(consumer.send(:wake_timeout)).to eq(consumer.config.polling_interval)
     end
   end
 
   describe "#start_notify_listener (private)" do
-    let(:consumer) { described_class.new(topics: ["orders.#"]) }
-
-    before { consumer.instance_variable_set(:@queue_names, ["orders"]) }
+    let(:consumer) { described_class.new(topics: ["orders.#"], queue_names: ["orders"]) }
 
     it "does not construct a listener when notify_wakeup? is off" do
       allow(consumer).to receive(:notify_wakeup?).and_return(false)
       allow(Pgbus::Process::NotifyListener).to receive(:new)
       consumer.send(:start_notify_listener)
       expect(Pgbus::Process::NotifyListener).not_to have_received(:new)
-      expect(consumer.instance_variable_get(:@notify_listener)).to be_nil
+      expect(consumer.notify_listener).to be_nil
     end
 
     it "constructs and starts a listener over the physical queue names when wakeup is on" do
@@ -359,7 +354,7 @@ RSpec.describe Pgbus::Process::Consumer do
         logger: Pgbus.logger
       )
       expect(fake_listener).to have_received(:start)
-      expect(consumer.instance_variable_get(:@notify_listener)).to be(fake_listener)
+      expect(consumer.notify_listener).to be(fake_listener)
     end
 
     it "swallows listener startup errors and falls back to polling without crashing" do
@@ -369,7 +364,7 @@ RSpec.describe Pgbus::Process::Consumer do
       allow(Pgbus.logger).to receive(:error)
 
       expect { consumer.send(:start_notify_listener) }.not_to raise_error
-      expect(consumer.instance_variable_get(:@notify_listener)).to be_nil
+      expect(consumer.notify_listener).to be_nil
       expect(Pgbus.logger).to have_received(:error)
     end
   end
@@ -379,11 +374,12 @@ RSpec.describe Pgbus::Process::Consumer do
     # died (running? false) must be retried from the consumer loop, throttled by
     # exponential backoff so a persistent outage doesn't spin start attempts
     # every tick. Mirrors Worker#ensure_notify_listener coverage.
-    let(:consumer) { described_class.new(topics: ["orders.#"]) }
+    let(:consumer) { described_class.new(topics: ["orders.#"], queue_names: ["orders"]) }
     let(:base) { described_class::NOTIFY_RETRY_BASE_SECONDS }
+    # A retry time already in the past — the backoff window has elapsed.
+    let(:elapsed_retry_at) { consumer.send(:monotonic_now) - 1 }
 
     before do
-      consumer.instance_variable_set(:@queue_names, ["orders"])
       allow(consumer).to receive(:notify_wakeup?).and_return(true)
     end
 
@@ -395,72 +391,74 @@ RSpec.describe Pgbus::Process::Consumer do
     end
 
     it "is a no-op while a healthy listener is running" do
-      consumer.instance_variable_set(:@notify_listener, fake_listener)
+      consumer.notify_listener = fake_listener
       allow(consumer).to receive(:start_notify_listener)
       consumer.send(:ensure_notify_listener)
       expect(consumer).not_to have_received(:start_notify_listener)
     end
 
     it "does not retry before the backoff window elapses" do
-      consumer.instance_variable_set(:@notify_listener, nil)
-      consumer.instance_variable_set(:@notify_retry_at, consumer.send(:monotonic_now) + base)
-      allow(consumer).to receive(:start_notify_listener)
-      consumer.send(:ensure_notify_listener)
-      expect(consumer).not_to have_received(:start_notify_listener)
+      future = described_class.new(
+        topics: ["orders.#"], queue_names: ["orders"],
+        notify_retry_at: Process.clock_gettime(Process::CLOCK_MONOTONIC) + base
+      )
+      allow(future).to receive(:notify_wakeup?).and_return(true)
+      allow(future).to receive(:start_notify_listener)
+      future.send(:ensure_notify_listener)
+      expect(future).not_to have_received(:start_notify_listener)
     end
 
     it "retries start once the backoff window has elapsed" do
-      consumer.instance_variable_set(:@notify_listener, nil)
-      consumer.instance_variable_set(:@notify_retry_at, consumer.send(:monotonic_now) - 1)
-      allow(consumer).to receive(:start_notify_listener) do
-        consumer.instance_variable_set(:@notify_listener, fake_listener)
-      end
+      consumer.notify_retry_at = elapsed_retry_at
+      allow(consumer).to receive(:start_notify_listener) { consumer.notify_listener = fake_listener }
 
       consumer.send(:ensure_notify_listener)
       expect(consumer).to have_received(:start_notify_listener)
     end
 
     it "doubles the backoff each time the restart fails" do
-      consumer.instance_variable_set(:@notify_listener, nil)
-      consumer.instance_variable_set(:@notify_retry_at, consumer.send(:monotonic_now) - 1)
-      allow(consumer).to receive(:start_notify_listener) # leaves @notify_listener nil
+      consumer.notify_retry_at = elapsed_retry_at
+      allow(consumer).to receive(:start_notify_listener) # leaves notify_listener nil
 
       consumer.send(:ensure_notify_listener)
-      expect(consumer.instance_variable_get(:@notify_retry_backoff)).to eq(base * 2)
+      expect(consumer.notify_retry_backoff).to eq(base * 2)
 
-      consumer.instance_variable_set(:@notify_retry_at, consumer.send(:monotonic_now) - 1)
+      consumer.notify_retry_at = consumer.send(:monotonic_now) - 1
       consumer.send(:ensure_notify_listener)
-      expect(consumer.instance_variable_get(:@notify_retry_backoff)).to eq(base * 4)
+      expect(consumer.notify_retry_backoff).to eq(base * 4)
     end
 
     it "caps the backoff at NOTIFY_RETRY_MAX_SECONDS" do
-      consumer.instance_variable_set(:@notify_listener, nil)
-      consumer.instance_variable_set(:@notify_retry_backoff, described_class::NOTIFY_RETRY_MAX_SECONDS)
-      consumer.instance_variable_set(:@notify_retry_at, consumer.send(:monotonic_now) - 1)
-      allow(consumer).to receive(:start_notify_listener)
+      capped = described_class.new(
+        topics: ["orders.#"], queue_names: ["orders"],
+        notify_retry_backoff: described_class::NOTIFY_RETRY_MAX_SECONDS,
+        notify_retry_at: Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1
+      )
+      allow(capped).to receive(:notify_wakeup?).and_return(true)
+      allow(capped).to receive(:start_notify_listener)
 
-      consumer.send(:ensure_notify_listener)
-      expect(consumer.instance_variable_get(:@notify_retry_backoff))
-        .to eq(described_class::NOTIFY_RETRY_MAX_SECONDS)
+      capped.send(:ensure_notify_listener)
+      expect(capped.notify_retry_backoff).to eq(described_class::NOTIFY_RETRY_MAX_SECONDS)
     end
 
     it "resets the backoff after a successful restart" do
-      consumer.instance_variable_set(:@notify_listener, nil)
-      consumer.instance_variable_set(:@notify_retry_backoff, base * 8)
-      consumer.instance_variable_set(:@notify_retry_at, consumer.send(:monotonic_now) - 1)
-      allow(consumer).to receive(:start_notify_listener) do
-        consumer.instance_variable_set(:@notify_listener, fake_listener)
-      end
+      inflated = described_class.new(
+        topics: ["orders.#"], queue_names: ["orders"],
+        notify_retry_backoff: described_class::NOTIFY_RETRY_BASE_SECONDS * 8,
+        notify_retry_at: Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1
+      )
+      allow(inflated).to receive(:notify_wakeup?).and_return(true)
+      allow(inflated).to receive(:start_notify_listener) { inflated.notify_listener = fake_listener }
 
-      consumer.send(:ensure_notify_listener)
-      expect(consumer.instance_variable_get(:@notify_retry_backoff)).to eq(base)
+      inflated.send(:ensure_notify_listener)
+      expect(inflated.notify_retry_backoff).to eq(base)
     end
 
     it "stops a dead listener before restarting it" do
       dead = fake_listener
       allow(dead).to receive(:running?).and_return(false)
-      consumer.instance_variable_set(:@notify_listener, dead)
-      consumer.instance_variable_set(:@notify_retry_at, consumer.send(:monotonic_now) - 1)
+      consumer.notify_listener = dead
+      consumer.notify_retry_at = elapsed_retry_at
       allow(consumer).to receive(:start_notify_listener)
 
       consumer.send(:ensure_notify_listener)
@@ -471,33 +469,33 @@ RSpec.describe Pgbus::Process::Consumer do
   describe "#stop_dead_notify_listener (private)" do
     let(:consumer) { described_class.new(topics: ["orders.#"]) }
 
-    it "is a no-op and leaves @notify_listener nil when none is attached" do
-      consumer.instance_variable_set(:@notify_listener, nil)
+    it "is a no-op and leaves notify_listener nil when none is attached" do
+      consumer.notify_listener = nil
       expect { consumer.send(:stop_dead_notify_listener) }.not_to raise_error
-      expect(consumer.instance_variable_get(:@notify_listener)).to be_nil
+      expect(consumer.notify_listener).to be_nil
     end
 
     it "stops the listener and clears the reference" do
-      consumer.instance_variable_set(:@notify_listener, fake_listener)
+      consumer.notify_listener = fake_listener
       consumer.send(:stop_dead_notify_listener)
       expect(fake_listener).to have_received(:stop)
-      expect(consumer.instance_variable_get(:@notify_listener)).to be_nil
+      expect(consumer.notify_listener).to be_nil
     end
 
     it "logs, swallows a stop error, and still clears the reference so the loop can't wedge" do
       allow(fake_listener).to receive(:stop).and_raise(StandardError, "listener gone")
       allow(Pgbus.logger).to receive(:warn)
-      consumer.instance_variable_set(:@notify_listener, fake_listener)
+      consumer.notify_listener = fake_listener
 
       expect { consumer.send(:stop_dead_notify_listener) }.not_to raise_error
       expect(Pgbus.logger).to have_received(:warn)
-      expect(consumer.instance_variable_get(:@notify_listener)).to be_nil
+      expect(consumer.notify_listener).to be_nil
     end
   end
 
   describe "wake-on-notify integration" do
-    let(:consumer) { described_class.new(topics: ["orders.#"]) }
-    let(:wake_signal) { consumer.instance_variable_get(:@wake_signal) }
+    let(:consumer) { described_class.new(topics: ["orders.#"], queue_names: ["q_orders"]) }
+    let(:wake_signal) { consumer.wake_signal }
 
     it "WakeSignal#notify! interrupts the idle wait immediately" do
       # A real WakeSignal: waiting with a long timeout returns instantly once
@@ -511,7 +509,6 @@ RSpec.describe Pgbus::Process::Consumer do
     end
 
     it "consume waits on the wake_signal (not interruptible_sleep) when idle" do
-      consumer.instance_variable_set(:@queue_names, ["q_orders"])
       allow(mock_client).to receive(:read_batch).and_return([])
       allow(wake_signal).to receive(:wait)
 
@@ -525,7 +522,7 @@ RSpec.describe Pgbus::Process::Consumer do
     let(:consumer) { described_class.new(topics: ["orders.#"]) }
 
     it "stops the listener when one is attached" do
-      consumer.instance_variable_set(:@notify_listener, fake_listener)
+      consumer.notify_listener = fake_listener
       consumer.send(:shutdown)
       expect(fake_listener).to have_received(:stop)
     end

--- a/spec/pgbus/process/dispatcher_spec.rb
+++ b/spec/pgbus/process/dispatcher_spec.rb
@@ -75,14 +75,14 @@ RSpec.describe Pgbus::Process::Dispatcher do
   describe "#graceful_shutdown" do
     it "sets shutting_down flag" do
       dispatcher.graceful_shutdown
-      expect(dispatcher.instance_variable_get(:@shutting_down)).to be true
+      expect(dispatcher.shutting_down?).to be true
     end
   end
 
   describe "#immediate_shutdown" do
     it "sets shutting_down flag" do
       dispatcher.immediate_shutdown
-      expect(dispatcher.instance_variable_get(:@shutting_down)).to be true
+      expect(dispatcher.shutting_down?).to be true
     end
   end
 
@@ -151,7 +151,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
       allow(dispatcher).to receive(:cleanup_processed_events)
       allow(dispatcher).to receive(:reap_stale_processes)
 
-      dispatcher.instance_variable_set(:@last_cleanup_at, past_monotonic(described_class::CLEANUP_INTERVAL + 1))
+      dispatcher.set_maintenance_timestamp(:@last_cleanup_at, past_monotonic(described_class::CLEANUP_INTERVAL + 1))
       dispatcher.send(:run_maintenance)
 
       expect(dispatcher).to have_received(:cleanup_processed_events)
@@ -161,7 +161,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
       allow(dispatcher).to receive(:cleanup_processed_events)
       allow(dispatcher).to receive(:reap_stale_processes)
 
-      dispatcher.instance_variable_set(:@last_reap_at, past_monotonic(described_class::REAP_INTERVAL + 1))
+      dispatcher.set_maintenance_timestamp(:@last_reap_at, past_monotonic(described_class::REAP_INTERVAL + 1))
       dispatcher.send(:run_maintenance)
 
       expect(dispatcher).to have_received(:reap_stale_processes)
@@ -170,7 +170,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "runs concurrency cleanup when concurrency interval has elapsed" do
       allow(dispatcher).to receive(:cleanup_concurrency)
 
-      dispatcher.instance_variable_set(:@last_concurrency_at, past_monotonic(described_class::CONCURRENCY_INTERVAL + 1))
+      dispatcher.set_maintenance_timestamp(:@last_concurrency_at, past_monotonic(described_class::CONCURRENCY_INTERVAL + 1))
       dispatcher.send(:run_maintenance)
 
       expect(dispatcher).to have_received(:cleanup_concurrency)
@@ -179,14 +179,14 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "runs batch cleanup when batch interval has elapsed" do
       allow(dispatcher).to receive(:cleanup_batches)
 
-      dispatcher.instance_variable_set(:@last_batch_cleanup_at, past_monotonic(described_class::BATCH_CLEANUP_INTERVAL + 1))
+      dispatcher.set_maintenance_timestamp(:@last_batch_cleanup_at, past_monotonic(described_class::BATCH_CLEANUP_INTERVAL + 1))
       dispatcher.send(:run_maintenance)
 
       expect(dispatcher).to have_received(:cleanup_batches)
     end
 
     it "rescues errors from maintenance methods" do
-      dispatcher.instance_variable_set(:@last_cleanup_at, past_monotonic(described_class::CLEANUP_INTERVAL + 1))
+      dispatcher.set_maintenance_timestamp(:@last_cleanup_at, past_monotonic(described_class::CLEANUP_INTERVAL + 1))
       allow(dispatcher).to receive(:cleanup_processed_events).and_raise(StandardError, "boom")
       expect { dispatcher.send(:run_maintenance) }.not_to raise_error
     end
@@ -436,7 +436,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "runs compact_archives when interval has elapsed" do
       allow(dispatcher).to receive(:compact_archives)
 
-      dispatcher.instance_variable_set(:@last_archive_compaction_at, past_monotonic(3601))
+      dispatcher.set_maintenance_timestamp(:@last_archive_compaction_at, past_monotonic(3601))
       dispatcher.send(:run_maintenance)
 
       expect(dispatcher).to have_received(:compact_archives)
@@ -545,7 +545,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
       allow(dispatcher).to receive(:run_table_maintenance)
 
       interval = Pgbus::Process::Dispatcher::TABLE_MAINTENANCE_INTERVAL
-      dispatcher.instance_variable_set(:@last_table_maintenance_at, past_monotonic(interval + 1))
+      dispatcher.set_maintenance_timestamp(:@last_table_maintenance_at, past_monotonic(interval + 1))
       dispatcher.send(:run_maintenance)
 
       expect(dispatcher).to have_received(:run_table_maintenance)
@@ -554,7 +554,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
     it "skips table maintenance when interval has not elapsed" do
       allow(dispatcher).to receive(:run_table_maintenance)
 
-      dispatcher.instance_variable_set(:@last_table_maintenance_at, Process.clock_gettime(Process::CLOCK_MONOTONIC))
+      dispatcher.set_maintenance_timestamp(:@last_table_maintenance_at, Process.clock_gettime(Process::CLOCK_MONOTONIC))
       dispatcher.send(:run_maintenance)
 
       expect(dispatcher).not_to have_received(:run_table_maintenance)
@@ -590,7 +590,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
   describe "#stamp_loop_tick (private)" do
     it "advances the beacon on each call" do
       dispatcher.send(:stamp_loop_tick)
-      first = dispatcher.instance_variable_get(:@loop_tick_at).get
+      first = dispatcher.last_loop_tick
       expect(first).to be_within(1).of(Time.now.to_f)
     end
   end
@@ -640,14 +640,14 @@ RSpec.describe Pgbus::Process::Dispatcher do
 
     # Make only the listed timestamp ivars due as of the current stubbed clock.
     def force_due(ivars)
-      ivars.each { |ivar| dispatcher.instance_variable_set(ivar, clock - 1_000_000) }
+      ivars.each { |ivar| dispatcher.set_maintenance_timestamp(ivar, clock - 1_000_000) }
     end
 
     # Reset every timestamp ivar to now, so no task is due until forced.
     # (initialize runs before monotonic_now is stubbed, so the ivars start at
     # the real monotonic clock — normalize them here.)
     def reset_all_not_due
-      tasks.each_key { |ivar| dispatcher.instance_variable_set(ivar, clock) }
+      tasks.each_key { |ivar| dispatcher.set_maintenance_timestamp(ivar, clock) }
     end
 
     # Stub every task method: fail the named tasks (default: all), succeed the rest.
@@ -686,7 +686,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
       run_cycle
 
       expect(logger).to have_received(:warn).once
-      expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(2)
+      expect(dispatcher.maintenance_failure_streak).to eq(2)
     end
 
     it "suppresses per-task ErrorReporter calls once in backoff" do
@@ -726,7 +726,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
       force_all_due
       run_cycle
 
-      expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(0)
+      expect(dispatcher.maintenance_failure_streak).to eq(0)
       expect(logger).not_to have_received(:warn)
     end
 
@@ -740,8 +740,8 @@ RSpec.describe Pgbus::Process::Dispatcher do
       force_all_due
       run_cycle
 
-      expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(0)
-      expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to be_nil
+      expect(dispatcher.maintenance_failure_streak).to eq(0)
+      expect(dispatcher.maintenance_backoff_until).to be_nil
     end
 
     it "exits backoff as soon as a maintenance task succeeds again" do
@@ -751,13 +751,13 @@ RSpec.describe Pgbus::Process::Dispatcher do
       force_all_due
       run_cycle # in backoff
 
-      backoff_end = dispatcher.instance_variable_get(:@maintenance_backoff_until)
+      backoff_end = dispatcher.maintenance_backoff_until
       task_methods.each { |method| allow(dispatcher).to receive(method) } # all succeed
       force_all_due
       run_cycle(now: backoff_end + 1)
 
-      expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(0)
-      expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to be_nil
+      expect(dispatcher.maintenance_failure_streak).to eq(0)
+      expect(dispatcher.maintenance_backoff_until).to be_nil
     end
 
     it "doubles the backoff window per consecutive failed cycle" do
@@ -769,13 +769,13 @@ RSpec.describe Pgbus::Process::Dispatcher do
       run_cycle(now: clock)
       force_all_due
       run_cycle(now: clock)
-      expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to eq(clock + base)
+      expect(dispatcher.maintenance_backoff_until).to eq(clock + base)
 
       # Next failing cycle after window: streak 3 -> base * 2**1.
       later = clock + base + 1
       force_all_due
       run_cycle(now: later)
-      expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to eq(later + (base * 2))
+      expect(dispatcher.maintenance_backoff_until).to eq(later + (base * 2))
     end
 
     it "caps the backoff window at MAINTENANCE_BACKOFF_MAX" do
@@ -789,7 +789,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
       20.times do
         force_all_due
         run_cycle(now: now)
-        deadline = dispatcher.instance_variable_get(:@maintenance_backoff_until)
+        deadline = dispatcher.maintenance_backoff_until
         window = deadline - now if deadline
         now = (deadline || now) + 1
       end
@@ -804,7 +804,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
       # otherwise a real outage (where those rescues fire) would never trip
       # backoff.
       it "normalizes a returned StandardError to a :failed result" do
-        dispatcher.instance_variable_set(:@last_cleanup_at, clock - 1_000_000)
+        dispatcher.set_maintenance_timestamp(:@last_cleanup_at, clock - 1_000_000)
         result = dispatcher.send(:run_if_due, clock, :@last_cleanup_at, described_class::CLEANUP_INTERVAL) do
           StandardError.new("db down")
         end
@@ -812,7 +812,7 @@ RSpec.describe Pgbus::Process::Dispatcher do
         expect(result.status).to eq(:failed)
         expect(result.error).to be_a(StandardError)
         # Timestamp must NOT advance on failure, so the next tick retries.
-        expect(dispatcher.instance_variable_get(:@last_cleanup_at)).to eq(clock - 1_000_000)
+        expect(dispatcher.maintenance_timestamp(:@last_cleanup_at)).to eq(clock - 1_000_000)
       end
 
       it "enters backoff during a real outage where the task rescues fire" do
@@ -834,8 +834,8 @@ RSpec.describe Pgbus::Process::Dispatcher do
         force_due(due)
         run_cycle # second failing cycle: streak -> 2, enter backoff
 
-        expect(dispatcher.instance_variable_get(:@maintenance_failure_streak)).to eq(2)
-        expect(dispatcher.instance_variable_get(:@maintenance_backoff_until)).to eq(clock + described_class::MAINTENANCE_BACKOFF_BASE)
+        expect(dispatcher.maintenance_failure_streak).to eq(2)
+        expect(dispatcher.maintenance_backoff_until).to eq(clock + described_class::MAINTENANCE_BACKOFF_BASE)
       end
     end
   end

--- a/spec/pgbus/process/liveness_probe_spec.rb
+++ b/spec/pgbus/process/liveness_probe_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe Pgbus::Process::Worker do
     describe "loop beacon" do
       let(:worker) { described_class.new(queues: %w[default], threads: 5) }
 
-      it "initializes @loop_tick_at as an AtomicReference" do
-        tick = worker.instance_variable_get(:@loop_tick_at)
-        expect(tick).to be_a(Concurrent::AtomicReference)
-        expect(tick.get).to be_nil
+      it "starts with no stamped loop tick" do
+        expect(worker.last_loop_tick).to be_nil
       end
 
       it "passes loop_tick_supplier when starting heartbeat" do
@@ -47,15 +45,14 @@ RSpec.describe Pgbus::Process::Worker do
         expect(captured_args).to include(loop_tick_supplier: an_instance_of(Proc))
       end
 
-      it "stamp_loop_tick writes a wall-clock timestamp to @loop_tick_at" do
-        tick_ref = worker.instance_variable_get(:@loop_tick_at)
-        expect(tick_ref.get).to be_nil
+      it "stamp_loop_tick writes a wall-clock timestamp readable via last_loop_tick" do
+        expect(worker.last_loop_tick).to be_nil
 
         before = Time.now.to_f
         worker.send(:stamp_loop_tick)
         after = Time.now.to_f
 
-        stamped = tick_ref.get
+        stamped = worker.last_loop_tick
         expect(stamped).to be_a(Float)
         expect(stamped).to be >= before
         expect(stamped).to be <= after

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Pgbus::Process::NotifyListener do
   before do
     stub_const("PG", Module.new) unless defined?(PG)
     stub_const("PG::Error", Class.new(StandardError)) unless defined?(PG::Error)
-    allow_any_instance_of(described_class).to receive(:build_connection).and_return(fake_pg)
+    allow(listener).to receive(:build_connection).and_return(fake_pg)
     # The self-probe owns its own connection dance and is covered by
     # notify_probe_spec. Neutralize it by default so it doesn't consume events
     # from the fake connection's queue; the probe-specific describe re-stubs it.
@@ -187,7 +187,7 @@ RSpec.describe Pgbus::Process::NotifyListener do
       # missed reconnect could pass by reading channels from the first conn.
       second_pg = fake_pg.class.new
       call_count = 0
-      allow_any_instance_of(described_class).to receive(:build_connection) do
+      allow(listener).to receive(:build_connection) do
         call_count += 1
         call_count == 1 ? fake_pg : second_pg
       end
@@ -217,7 +217,7 @@ RSpec.describe Pgbus::Process::NotifyListener do
 
       before do
         call_sequence = [fake_pg, half_built, good_pg]
-        allow_any_instance_of(described_class).to receive(:build_connection) { call_sequence.shift }
+        allow(listener).to receive(:build_connection) { call_sequence.shift }
         stub_const("Pgbus::Process::NotifyListener::RECONNECT_BACKOFF_SECONDS", 0.01)
         listener.start
         fake_pg.push_timeout
@@ -251,7 +251,7 @@ RSpec.describe Pgbus::Process::NotifyListener do
         # Initial conn (fake_pg) is a primary; the first reconnect attempt lands
         # on a replica; the second reconnect attempt lands on the primary.
         call_sequence = [fake_pg, replica_pg, primary_pg]
-        allow_any_instance_of(described_class).to receive(:build_connection) { call_sequence.shift }
+        allow(listener).to receive(:build_connection) { call_sequence.shift }
         # validate_primary! passes fake_pg and primary_pg through, but raises
         # for replica_pg — mirroring pg_is_in_recovery() => t on the demoted host.
         allow(Pgbus::Process::PrimaryValidator).to receive(:validate_primary!) do |conn|
@@ -338,7 +338,7 @@ RSpec.describe Pgbus::Process::NotifyListener do
 
       second_pg = fake_pg.class.new
       call_count = 0
-      allow_any_instance_of(described_class).to receive(:build_connection) do
+      allow(listener).to receive(:build_connection) do
         call_count += 1
         call_count == 1 ? fake_pg : second_pg
       end
@@ -394,7 +394,7 @@ RSpec.describe Pgbus::Process::NotifyListener do
     end
 
     it "clears @running after the thread exits so start can spawn a fresh thread" do
-      allow_any_instance_of(described_class).to receive(:build_connection)
+      allow(listener).to receive(:build_connection)
         .and_raise(PG::Error.new("boot failed"))
 
       listener.start

--- a/spec/pgbus/process/notify_listener_spec.rb
+++ b/spec/pgbus/process/notify_listener_spec.rb
@@ -299,12 +299,13 @@ RSpec.describe Pgbus::Process::NotifyListener do
         .and_raise(Pgbus::Process::ReplicaConnectionError.new("on a replica"))
 
       listener.start
-      wait_until { !listener.instance_variable_get(:@thread)&.alive? }
+      # running? flips to false in the run-loop ensure once the thread exits.
+      wait_until { !listener.running? }
 
       # The replica is rejected before the delivery probe runs (probe is only
       # meaningful on a primary), and the thread exits via the fatal/ensure path.
       expect(Pgbus::Process::NotifyProbe).not_to have_received(:probe_notify_delivery!)
-      expect(listener.instance_variable_get(:@running)).to be(false)
+      expect(listener.running?).to be(false)
     end
   end
 
@@ -393,15 +394,16 @@ RSpec.describe Pgbus::Process::NotifyListener do
       expect(listener.listening_to).to be_empty
     end
 
-    it "clears @running after the thread exits so start can spawn a fresh thread" do
+    it "clears running state after the thread exits so start can spawn a fresh thread" do
       allow(listener).to receive(:build_connection)
         .and_raise(PG::Error.new("boot failed"))
 
       listener.start
-      # Thread crashes immediately on build_connection.
-      wait_until { !listener.instance_variable_get(:@thread)&.alive? }
+      # Thread crashes immediately on build_connection; running? flips back to
+      # false in the run-loop ensure.
+      wait_until { !listener.running? }
 
-      expect(listener.instance_variable_get(:@running)).to be(false)
+      expect(listener.running?).to be(false)
     end
   end
 end

--- a/spec/pgbus/process/signal_handler_spec.rb
+++ b/spec/pgbus/process/signal_handler_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe Pgbus::Process::SignalHandler do
 
     it "stores previous signal handlers for restoration" do
       handler.setup_signals
-      previous = handler.instance_variable_get(:@previous_handlers)
-      expect(previous.keys).to contain_exactly("INT", "TERM", "QUIT")
+      expect(handler.handled_signals).to contain_exactly("INT", "TERM", "QUIT")
     end
   end
 

--- a/spec/pgbus/process/supervisor_spec.rb
+++ b/spec/pgbus/process/supervisor_spec.rb
@@ -15,20 +15,19 @@ RSpec.describe Pgbus::Process::Supervisor do
       supervisor = described_class.new
 
       expect(supervisor.config).to eq(config)
-      expect(supervisor.instance_variable_get(:@forks)).to eq({})
-      expect(supervisor.instance_variable_get(:@shutting_down)).to be false
+      expect(supervisor.forks).to eq({})
+      expect(supervisor.shutting_down?).to be false
     end
   end
 
   describe "#graceful_shutdown" do
     it "sets shutting_down and signals children with TERM" do
-      supervisor = described_class.new
-      supervisor.instance_variable_set(:@forks, { 1001 => { type: :worker }, 1002 => { type: :dispatcher } })
+      supervisor = described_class.new(forks: { 1001 => { type: :worker }, 1002 => { type: :dispatcher } })
 
       allow(Process).to receive(:kill)
       supervisor.graceful_shutdown
 
-      expect(supervisor.instance_variable_get(:@shutting_down)).to be true
+      expect(supervisor.shutting_down?).to be true
       expect(Process).to have_received(:kill).with("TERM", 1001)
       expect(Process).to have_received(:kill).with("TERM", 1002)
     end
@@ -36,21 +35,19 @@ RSpec.describe Pgbus::Process::Supervisor do
 
   describe "#immediate_shutdown" do
     it "sets shutting_down and signals children with QUIT" do
-      supervisor = described_class.new
-      supervisor.instance_variable_set(:@forks, { 2001 => { type: :worker } })
+      supervisor = described_class.new(forks: { 2001 => { type: :worker } })
 
       allow(Process).to receive(:kill)
       supervisor.immediate_shutdown
 
-      expect(supervisor.instance_variable_get(:@shutting_down)).to be true
+      expect(supervisor.shutting_down?).to be true
       expect(Process).to have_received(:kill).with("QUIT", 2001)
     end
   end
 
   describe "signal_children (private)" do
     it "handles Errno::ESRCH when a child process is already gone" do
-      supervisor = described_class.new
-      supervisor.instance_variable_set(:@forks, { 9999 => { type: :worker } })
+      supervisor = described_class.new(forks: { 9999 => { type: :worker } })
 
       allow(Process).to receive(:kill).with("TERM", 9999).and_raise(Errno::ESRCH)
 
@@ -59,12 +56,10 @@ RSpec.describe Pgbus::Process::Supervisor do
   end
 
   describe "reap_children (private)" do
-    let(:supervisor) { described_class.new }
-    let(:status_double) { instance_double(Process::Status, exitstatus: 1, success?: false) }
-
-    before do
-      supervisor.instance_variable_set(:@forks, { 3001 => { type: :worker, config: { queues: ["default"] } } })
+    let(:supervisor) do
+      described_class.new(forks: { 3001 => { type: :worker, config: { queues: ["default"] } } })
     end
+    let(:status_double) { instance_double(Process::Status, exitstatus: 1, success?: false) }
 
     it "restarts a child when not shutting down" do
       allow(Process).to receive(:waitpid2).with(-1, Process::WNOHANG).and_return([3001, status_double], nil)
@@ -76,13 +71,15 @@ RSpec.describe Pgbus::Process::Supervisor do
     end
 
     it "does NOT restart a child when shutting_down is true" do
-      supervisor.instance_variable_set(:@shutting_down, true)
+      supervisor = described_class.new(
+        forks: { 3001 => { type: :worker, config: { queues: ["default"] } } },
+        shutting_down: true
+      )
       allow(Process).to receive(:waitpid2).with(-1, Process::WNOHANG).and_return([3001, status_double], nil)
 
       supervisor.send(:reap_children)
 
-      forks = supervisor.instance_variable_get(:@forks)
-      expect(forks).not_to have_key(3001)
+      expect(supervisor.forks).not_to have_key(3001)
     end
   end
 
@@ -92,24 +89,25 @@ RSpec.describe Pgbus::Process::Supervisor do
   # get an exponentially backed-off restart; stable children and clean
   # exits (worker recycling) restart immediately.
   describe "restart backoff for crash-looping children" do
-    let(:supervisor) { described_class.new }
+    # Each example seeds a distinct set of child forks; inject them via the
+    # constructor and re-apply the standard fork/log stubs via build_supervisor.
     let(:crash_status) { instance_double(Process::Status, exitstatus: 1, success?: false) }
     let(:clean_status) { instance_double(Process::Status, exitstatus: 0, success?: true) }
     let(:worker_config) { { queues: ["default"], threads: 5 } }
+
+    def build_supervisor(forks)
+      described_class.new(forks: forks).tap do |s|
+        allow(s).to receive(:fork).and_return(6001)
+        allow(Pgbus.logger).to receive(:warn)
+      end
+    end
 
     def now
       Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
-    before do
-      allow(supervisor).to receive(:fork).and_return(6001)
-      allow(Pgbus.logger).to receive(:warn)
-    end
-
     it "restarts immediately when the crashed child had a stable uptime" do
-      supervisor.instance_variable_set(
-        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: now - 120 } }
-      )
+      supervisor = build_supervisor(3001 => { type: :worker, config: worker_config, spawned_at: now - 120 })
       allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
 
       supervisor.send(:reap_children)
@@ -118,9 +116,7 @@ RSpec.describe Pgbus::Process::Supervisor do
     end
 
     it "restarts immediately on a clean exit even with short uptime (worker recycling)" do
-      supervisor.instance_variable_set(
-        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: now - 5 } }
-      )
+      supervisor = build_supervisor(3001 => { type: :worker, config: worker_config, spawned_at: now - 5 })
       allow(Process).to receive(:waitpid2).and_return([3001, clean_status], nil)
 
       supervisor.send(:reap_children)
@@ -130,10 +126,8 @@ RSpec.describe Pgbus::Process::Supervisor do
 
     it "delays the restart when the child crashed shortly after forking" do
       base = now
+      supervisor = build_supervisor(3001 => { type: :worker, config: worker_config, spawned_at: base - 1 })
       allow(supervisor).to receive(:monotonic_now).and_return(base)
-      supervisor.instance_variable_set(
-        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: base - 1 } }
-      )
       allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
 
       supervisor.send(:reap_children)
@@ -144,21 +138,20 @@ RSpec.describe Pgbus::Process::Supervisor do
 
     it "keeps separate crash streaks for identically-configured sibling workers" do
       messages = []
+      base = now
+      supervisor = build_supervisor(sibling_forks(base))
       allow(Pgbus.logger).to receive(:warn) { |&blk| messages << blk.call }
       allow(supervisor).to receive(:fork).and_return(6001, 6002, 6003)
-
-      base = now
       allow(supervisor).to receive(:monotonic_now).and_return(base)
-      supervisor.instance_variable_set(:@forks, sibling_forks(base))
 
-      reap(3002, crash_status) # slot 1 crashes fast — crash #1, 1s backoff
-      reap(3001, clean_status) # slot 0 recycles cleanly — must NOT reset slot 1's streak
+      reap(supervisor, 3002, crash_status) # slot 1 crashes fast — crash #1, 1s backoff
+      reap(supervisor, 3001, clean_status) # slot 0 recycles cleanly — must NOT reset slot 1's streak
 
       # Slot 1's restart fires, then it crashes fast again — crash #2, 2s backoff.
       allow(supervisor).to receive(:monotonic_now).and_return(base + 61)
       supervisor.send(:process_pending_restarts)
-      restarted_pid = supervisor.instance_variable_get(:@forks).find { |_, i| i[:slot] == 1 }.first
-      reap(restarted_pid, crash_status)
+      restarted_pid = supervisor.forks.find { |_, i| i[:slot] == 1 }.first
+      reap(supervisor, restarted_pid, crash_status)
 
       expect(messages.join("\n")).to include("restarting in 2s")
     end
@@ -168,21 +161,22 @@ RSpec.describe Pgbus::Process::Supervisor do
         3002 => { type: :worker, config: worker_config, slot: 1, spawned_at: base } }
     end
 
-    def reap(pid, status)
+    def reap(supervisor, pid, status)
       allow(Process).to receive(:waitpid2).and_return([pid, status], nil)
       supervisor.send(:reap_children)
     end
 
     it "fires due pending restarts from the monitor loop" do
+      supervisor = described_class.new(pending_restarts: [{ info: { type: :dispatcher }, at: now - 1 }])
       allow(supervisor).to receive(:fork).and_return(7001)
+      allow(Pgbus.logger).to receive(:warn)
       allow(Process).to receive(:waitpid2).and_return(nil)
-      supervisor.instance_variable_set(
-        :@pending_restarts, [{ info: { type: :dispatcher }, at: now - 1 }]
-      )
-      # Stop the loop after one pass.
+      # Stop the loop after one pass: flip shutdown, and let reap_children clear
+      # the just-restarted fork so the `@shutting_down && @forks.empty?` guard
+      # trips (mirrors the real path where the exited child is reaped).
       allow(supervisor).to receive(:interruptible_sleep) do
-        supervisor.instance_variable_set(:@shutting_down, true)
-        supervisor.instance_variable_set(:@forks, {})
+        supervisor.graceful_shutdown
+        allow(supervisor).to receive(:reap_children) { supervisor.forks.clear }
       end
       allow(supervisor).to receive(:check_stalled_workers)
 
@@ -192,14 +186,13 @@ RSpec.describe Pgbus::Process::Supervisor do
     end
 
     it "does not fire pending restarts once shutting down" do
+      supervisor = described_class.new(
+        forks: { 8001 => { type: :worker, config: worker_config, spawned_at: now } },
+        shutting_down: true,
+        pending_restarts: [{ info: { type: :dispatcher }, at: now - 1 }]
+      )
       allow(supervisor).to receive(:fork)
-      supervisor.instance_variable_set(:@shutting_down, true)
-      supervisor.instance_variable_set(
-        :@forks, { 8001 => { type: :worker, config: worker_config, spawned_at: now } }
-      )
-      supervisor.instance_variable_set(
-        :@pending_restarts, [{ info: { type: :dispatcher }, at: now - 1 }]
-      )
+      allow(Pgbus.logger).to receive(:warn)
       allow(Process).to receive(:waitpid2).and_return([8001, crash_status], nil)
       allow(supervisor).to receive(:interruptible_sleep)
 
@@ -210,10 +203,8 @@ RSpec.describe Pgbus::Process::Supervisor do
 
     it "runs the pending restart once its backoff has elapsed" do
       base = now
+      supervisor = build_supervisor(3001 => { type: :worker, config: worker_config, spawned_at: base })
       allow(supervisor).to receive(:monotonic_now).and_return(base)
-      supervisor.instance_variable_set(
-        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: base } }
-      )
       allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
 
       supervisor.send(:reap_children)
@@ -227,13 +218,10 @@ RSpec.describe Pgbus::Process::Supervisor do
 
     it "escalates the backoff on consecutive rapid crashes" do
       messages = []
-      allow(Pgbus.logger).to receive(:warn) { |&blk| messages << blk.call }
-
       base = now
+      supervisor = build_supervisor(3001 => { type: :worker, config: worker_config, spawned_at: base })
+      allow(Pgbus.logger).to receive(:warn) { |&blk| messages << blk.call }
       allow(supervisor).to receive(:monotonic_now).and_return(base)
-      supervisor.instance_variable_set(
-        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: base } }
-      )
       allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
       supervisor.send(:reap_children)
 
@@ -250,13 +238,10 @@ RSpec.describe Pgbus::Process::Supervisor do
 
     it "resets the crash streak after a stable run" do
       messages = []
-      allow(Pgbus.logger).to receive(:warn) { |&blk| messages << blk.call }
-
       base = now
+      supervisor = build_supervisor(3001 => { type: :worker, config: worker_config, spawned_at: base })
+      allow(Pgbus.logger).to receive(:warn) { |&blk| messages << blk.call }
       allow(supervisor).to receive(:monotonic_now).and_return(base)
-      supervisor.instance_variable_set(
-        :@forks, { 3001 => { type: :worker, config: worker_config, spawned_at: base } }
-      )
       allow(Process).to receive(:waitpid2).and_return([3001, crash_status], nil)
       supervisor.send(:reap_children)
 
@@ -289,32 +274,32 @@ RSpec.describe Pgbus::Process::Supervisor do
       info = { type: :worker, config: { queues: ["default"], threads: 5 } }
       supervisor.send(:restart_child, info)
 
-      expect(supervisor.instance_variable_get(:@forks)).to have_key(5001)
-      expect(supervisor.instance_variable_get(:@forks)[5001][:type]).to eq(:worker)
+      expect(supervisor.forks).to have_key(5001)
+      expect(supervisor.forks[5001][:type]).to eq(:worker)
     end
 
     it "routes :dispatcher to fork_dispatcher" do
       info = { type: :dispatcher }
       supervisor.send(:restart_child, info)
 
-      expect(supervisor.instance_variable_get(:@forks)).to have_key(5001)
-      expect(supervisor.instance_variable_get(:@forks)[5001][:type]).to eq(:dispatcher)
+      expect(supervisor.forks).to have_key(5001)
+      expect(supervisor.forks[5001][:type]).to eq(:dispatcher)
     end
 
     it "routes :consumer to fork_consumer" do
       info = { type: :consumer, config: { topics: ["orders.#"], threads: 3 } }
       supervisor.send(:restart_child, info)
 
-      expect(supervisor.instance_variable_get(:@forks)).to have_key(5001)
-      expect(supervisor.instance_variable_get(:@forks)[5001][:type]).to eq(:consumer)
+      expect(supervisor.forks).to have_key(5001)
+      expect(supervisor.forks[5001][:type]).to eq(:consumer)
     end
 
     it "routes :scheduler to fork_scheduler" do
       info = { type: :scheduler }
       supervisor.send(:restart_child, info)
 
-      expect(supervisor.instance_variable_get(:@forks)).to have_key(5001)
-      expect(supervisor.instance_variable_get(:@forks)[5001][:type]).to eq(:scheduler)
+      expect(supervisor.forks).to have_key(5001)
+      expect(supervisor.forks[5001][:type]).to eq(:scheduler)
     end
   end
 
@@ -332,7 +317,7 @@ RSpec.describe Pgbus::Process::Supervisor do
       it "stores a liveness_reader IO for the forked worker" do
         supervisor.send(:fork_worker, worker_config, slot: 0)
 
-        info = supervisor.instance_variable_get(:@forks)[7001]
+        info = supervisor.forks[7001]
         expect(info[:liveness_reader]).to be_a(IO)
         expect(info[:liveness_reader]).not_to be_closed
       end
@@ -340,7 +325,7 @@ RSpec.describe Pgbus::Process::Supervisor do
       it "seeds last_pipe_tick_at (monotonic) and leaves pipe_seen unarmed" do
         supervisor.send(:fork_worker, worker_config, slot: 0)
 
-        info = supervisor.instance_variable_get(:@forks)[7001]
+        info = supervisor.forks[7001]
         expect(info[:last_pipe_tick_at]).to be_a(Float)
         expect(info[:pipe_seen]).to be(false)
       end
@@ -356,7 +341,7 @@ RSpec.describe Pgbus::Process::Supervisor do
 
         supervisor.send(:fork_worker, worker_config, slot: 0)
 
-        expect(supervisor.instance_variable_get(:@forks)).not_to have_key(7001)
+        expect(supervisor.forks).not_to have_key(7001)
         expect(created).to all(be_closed)
       end
 
@@ -380,18 +365,17 @@ RSpec.describe Pgbus::Process::Supervisor do
       it "closes the reader and drops the fork on reap" do
         reader, writer = IO.pipe
         writer.close
-        supervisor.instance_variable_set(:@forks, {
-                                           3001 => { type: :worker, config: worker_config,
-                                                     spawned_at: 0.0, liveness_reader: reader,
-                                                     last_pipe_tick_at: 0.0, pipe_seen: true }
-                                         })
-        supervisor.instance_variable_set(:@shutting_down, true)
+        supervisor = described_class.new(
+          forks: { 3001 => { type: :worker, config: worker_config, spawned_at: 0.0,
+                             liveness_reader: reader, last_pipe_tick_at: 0.0, pipe_seen: true } },
+          shutting_down: true
+        )
         allow(Process).to receive(:waitpid2).with(-1, Process::WNOHANG).and_return([3001, status_double], nil)
 
         supervisor.send(:reap_children)
 
         expect(reader).to be_closed
-        expect(supervisor.instance_variable_get(:@forks)).not_to have_key(3001)
+        expect(supervisor.forks).not_to have_key(3001)
       end
     end
 
@@ -399,10 +383,9 @@ RSpec.describe Pgbus::Process::Supervisor do
       it "closes any un-reaped worker readers" do
         reader, writer = IO.pipe
         writer.close
-        supervisor.instance_variable_set(:@forks, {
-                                           3001 => { type: :worker, config: worker_config,
-                                                     liveness_reader: reader }
-                                         })
+        supervisor = described_class.new(
+          forks: { 3001 => { type: :worker, config: worker_config, liveness_reader: reader } }
+        )
         allow(supervisor).to receive(:reap_children)
         allow(supervisor).to receive(:interruptible_sleep)
         allow(Process).to receive(:kill)

--- a/spec/pgbus/process/supervisor_watchdog_spec.rb
+++ b/spec/pgbus/process/supervisor_watchdog_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe Pgbus::Process::Supervisor do
       end
 
       before do
-        supervisor.instance_variable_set(:@forks, {
-                                           1001 => { type: :worker, config: { queues: ["default"] } },
-                                           1002 => { type: :worker, config: { queues: ["priority"] } }
-                                         })
-        supervisor.instance_variable_set(:@last_watchdog_at, 0.0)
+        supervisor.forks = {
+          1001 => { type: :worker, config: { queues: ["default"] } },
+          1002 => { type: :worker, config: { queues: ["priority"] } }
+        }
+        supervisor.last_watchdog_at = 0.0
       end
 
       it "kills a worker whose loop_tick_at exceeds stall_threshold" do
@@ -98,8 +98,7 @@ RSpec.describe Pgbus::Process::Supervisor do
       end
 
       it "respects the WATCHDOG_INTERVAL rate limiter" do
-        supervisor.instance_variable_set(:@last_watchdog_at,
-                                         Process.clock_gettime(Process::CLOCK_MONOTONIC))
+        supervisor.last_watchdog_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         allow(Pgbus::ProcessEntry).to receive(:where)
 
         supervisor.send(:check_stalled_workers)
@@ -108,10 +107,10 @@ RSpec.describe Pgbus::Process::Supervisor do
       end
 
       it "does not check non-worker forks" do
-        supervisor.instance_variable_set(:@forks, {
-                                           2001 => { type: :dispatcher },
-                                           2002 => { type: :scheduler }
-                                         })
+        supervisor.forks = {
+          2001 => { type: :dispatcher },
+          2002 => { type: :scheduler }
+        }
 
         allow(Pgbus::ProcessEntry).to receive(:where)
 
@@ -134,17 +133,17 @@ RSpec.describe Pgbus::Process::Supervisor do
       let(:now) { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
 
       before do
-        supervisor.instance_variable_set(:@last_watchdog_at, 0.0)
+        supervisor.last_watchdog_at = 0.0
         allow(Process).to receive(:kill)
       end
 
       def set_forks(pid, last_pipe_tick_at:, pipe_seen:)
-        supervisor.instance_variable_set(:@forks, {
-                                           pid => { type: :worker, config: { queues: ["default"] },
-                                                    liveness_reader: nil,
-                                                    last_pipe_tick_at: last_pipe_tick_at,
-                                                    pipe_seen: pipe_seen }
-                                         })
+        supervisor.forks = {
+          pid => { type: :worker, config: { queues: ["default"] },
+                   liveness_reader: nil,
+                   last_pipe_tick_at: last_pipe_tick_at,
+                   pipe_seen: pipe_seen }
+        }
       end
 
       it "SIGKILLs a worker with a stale pipe tick when the DB read raises" do
@@ -208,14 +207,14 @@ RSpec.describe Pgbus::Process::Supervisor do
       it "advances last_pipe_tick_at and arms pipe_seen when bytes are readable" do
         reader, writer = IO.pipe
         writer.write("\0\0")
-        supervisor.instance_variable_set(:@forks, {
-                                           1001 => { type: :worker, liveness_reader: reader,
-                                                     last_pipe_tick_at: 0.0, pipe_seen: false }
-                                         })
+        supervisor.forks = {
+          1001 => { type: :worker, liveness_reader: reader,
+                    last_pipe_tick_at: 0.0, pipe_seen: false }
+        }
 
         supervisor.send(:drain_liveness_pipes)
 
-        info = supervisor.instance_variable_get(:@forks)[1001]
+        info = supervisor.forks[1001]
         expect(info[:pipe_seen]).to be(true)
         expect(info[:last_pipe_tick_at]).to be > 0.0
       ensure
@@ -225,14 +224,14 @@ RSpec.describe Pgbus::Process::Supervisor do
 
       it "does not arm pipe_seen when the pipe is empty" do
         reader, writer = IO.pipe
-        supervisor.instance_variable_set(:@forks, {
-                                           1001 => { type: :worker, liveness_reader: reader,
-                                                     last_pipe_tick_at: 0.0, pipe_seen: false }
-                                         })
+        supervisor.forks = {
+          1001 => { type: :worker, liveness_reader: reader,
+                    last_pipe_tick_at: 0.0, pipe_seen: false }
+        }
 
         supervisor.send(:drain_liveness_pipes)
 
-        expect(supervisor.instance_variable_get(:@forks)[1001][:pipe_seen]).to be(false)
+        expect(supervisor.forks[1001][:pipe_seen]).to be(false)
       ensure
         reader.close unless reader.closed?
         writer.close unless writer.closed?
@@ -242,10 +241,10 @@ RSpec.describe Pgbus::Process::Supervisor do
         reader, writer = IO.pipe
         reader.close
         writer.close
-        supervisor.instance_variable_set(:@forks, {
-                                           1001 => { type: :worker, liveness_reader: reader,
-                                                     last_pipe_tick_at: 0.0, pipe_seen: false }
-                                         })
+        supervisor.forks = {
+          1001 => { type: :worker, liveness_reader: reader,
+                    last_pipe_tick_at: 0.0, pipe_seen: false }
+        }
 
         expect { supervisor.send(:drain_liveness_pipes) }.not_to raise_error
       end

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Pgbus::Process::Worker do
 
   describe "heartbeat pool observability" do
     it "snapshots the rate counter on each beat" do
-      counter = worker.instance_variable_get(:@rate_counter)
+      counter = worker.rate_counter
       allow(counter).to receive(:snapshot!)
 
       worker.send(:on_heartbeat)
@@ -142,7 +142,7 @@ RSpec.describe Pgbus::Process::Worker do
         supplier = kwargs[:metadata_supplier]
         heartbeat
       end
-      counter = worker.instance_variable_get(:@rate_counter)
+      counter = worker.rate_counter
       counter.increment(:processed, 3)
 
       worker.send(:start_heartbeat)
@@ -176,19 +176,19 @@ RSpec.describe Pgbus::Process::Worker do
       built = described_class.new(queues: %w[default], threads: 5)
 
       expect(Pgbus::StatBuffer).not_to have_received(:new)
-      expect(built.instance_variable_get(:@stat_buffer)).to be_nil
+      expect(built.stat_buffer).to be_nil
     ensure
       Pgbus.configuration.stats_enabled = true
     end
   end
 
   describe "#graceful_shutdown" do
-    before { worker.instance_variable_get(:@lifecycle).transition_to!(:running) }
+    before { worker.lifecycle.transition_to!(:running) }
     after { Pgbus.stopping = false }
 
     it "transitions to draining state" do
       worker.graceful_shutdown
-      expect(worker.instance_variable_get(:@lifecycle).state).to eq(:draining)
+      expect(worker.lifecycle.state).to eq(:draining)
     end
 
     it "sets Pgbus.stopping for ActiveJob::Continuation support" do
@@ -197,7 +197,7 @@ RSpec.describe Pgbus::Process::Worker do
 
     it "flushes the stat buffer so entries survive a subsequent SIGKILL" do
       buffer = instance_double(Pgbus::StatBuffer, flush: nil)
-      worker.instance_variable_set(:@stat_buffer, buffer)
+      worker.stat_buffer = buffer
 
       worker.graceful_shutdown
 
@@ -205,7 +205,7 @@ RSpec.describe Pgbus::Process::Worker do
     end
 
     it "does not raise when stats are disabled (nil buffer)" do
-      worker.instance_variable_set(:@stat_buffer, nil)
+      worker.stat_buffer = nil
 
       expect { worker.graceful_shutdown }.not_to raise_error
     end
@@ -213,9 +213,9 @@ RSpec.describe Pgbus::Process::Worker do
 
   describe "#check_recycle (private) drain flush" do
     before do
-      worker.instance_variable_get(:@lifecycle).transition_to!(:running)
+      worker.lifecycle.transition_to!(:running)
       worker.config.max_jobs_per_worker = 1
-      worker.instance_variable_get(:@jobs_processed).value = 5
+      worker.jobs_processed = 5
     end
 
     after do
@@ -225,28 +225,28 @@ RSpec.describe Pgbus::Process::Worker do
 
     it "flushes the stat buffer when a recycle triggers drain" do
       buffer = instance_double(Pgbus::StatBuffer, flush: nil)
-      worker.instance_variable_set(:@stat_buffer, buffer)
+      worker.stat_buffer = buffer
 
       worker.send(:check_recycle)
 
-      expect(worker.instance_variable_get(:@lifecycle).state).to eq(:draining)
+      expect(worker.lifecycle.state).to eq(:draining)
       expect(buffer).to have_received(:flush)
     end
 
     it "does not raise when recycling with stats disabled (nil buffer)" do
-      worker.instance_variable_set(:@stat_buffer, nil)
+      worker.stat_buffer = nil
 
       expect { worker.send(:check_recycle) }.not_to raise_error
     end
   end
 
   describe "#immediate_shutdown" do
-    before { worker.instance_variable_get(:@lifecycle).transition_to!(:running) }
+    before { worker.lifecycle.transition_to!(:running) }
     after { Pgbus.stopping = false }
 
     it "transitions to stopped state and kills the pool" do
       worker.immediate_shutdown
-      expect(worker.instance_variable_get(:@lifecycle).state).to eq(:stopped)
+      expect(worker.lifecycle.state).to eq(:stopped)
       expect(pool).to have_received(:kill)
     end
 
@@ -340,12 +340,12 @@ RSpec.describe Pgbus::Process::Worker do
       before { worker.config.max_jobs_per_worker = 100 }
 
       it "returns true when jobs_processed reaches the limit" do
-        worker.instance_variable_get(:@jobs_processed).value = 100
+        worker.jobs_processed = 100
         expect(worker.send(:recycle_needed?)).to be true
       end
 
       it "returns false when below the limit" do
-        worker.instance_variable_get(:@jobs_processed).value = 50
+        worker.jobs_processed = 50
         expect(worker.send(:recycle_needed?)).to be false
       end
     end
@@ -354,8 +354,11 @@ RSpec.describe Pgbus::Process::Worker do
       before { worker.config.max_worker_lifetime = 60 }
 
       it "returns true when lifetime is exceeded" do
-        worker.instance_variable_set(:@started_at_monotonic, Process.clock_gettime(Process::CLOCK_MONOTONIC) - 120)
-        expect(worker.send(:recycle_needed?)).to be true
+        aged = described_class.new(
+          queues: %w[default], threads: 5,
+          started_at_monotonic: Process.clock_gettime(Process::CLOCK_MONOTONIC) - 120
+        )
+        expect(aged.send(:recycle_needed?)).to be true
       end
     end
 
@@ -451,13 +454,13 @@ RSpec.describe Pgbus::Process::Worker do
     end
 
     context "when a queue table is missing (deleted queue)" do
+      let(:worker) { described_class.new(queues: %w[default stale_queue], threads: 5) }
       let(:prefix) { worker.config.queue_prefix }
       let(:error_message) do
         "Database connection error: ERROR:  relation \"pgmq.q_#{prefix}_stale_queue\" does not exist"
       end
 
       before do
-        worker.instance_variable_set(:@queues, %w[default stale_queue])
         allow(mock_client).to receive(:read_multi)
           .and_raise(StandardError, error_message)
       end
@@ -473,10 +476,10 @@ RSpec.describe Pgbus::Process::Worker do
     end
 
     context "when eviction removes ALL queues (regression: issue #174)" do
+      let(:worker) { described_class.new(queues: %w[only_queue], threads: 5) }
       let(:prefix) { worker.config.queue_prefix }
 
       before do
-        worker.instance_variable_set(:@queues, %w[only_queue])
         error_message = "Database connection error: ERROR:  relation \"pgmq.q_#{prefix}_only_queue\" does not exist"
         allow(mock_client).to receive(:read_batch)
           .and_raise(StandardError, error_message)
@@ -488,14 +491,14 @@ RSpec.describe Pgbus::Process::Worker do
         stub_monotonic(0)
         worker.send(:fetch_messages, 5)
         expect(worker.queues).to be_empty
-        expect(worker.instance_variable_get(:@restore_streak)).to eq(0)
+        expect(worker.restore_streak).to eq(0)
 
         # After the cooldown the leading restore reinstates the initial queues;
         # the trailing read still fails and re-evicts, so the restore is observed
         # via the streak increment rather than the (again empty) queue list.
         stub_monotonic(Pgbus::Process::Worker::RESTORE_COOLDOWN_BASE)
         worker.send(:fetch_messages, 5)
-        expect(worker.instance_variable_get(:@restore_streak)).to eq(1)
+        expect(worker.restore_streak).to eq(1)
       end
     end
 
@@ -527,7 +530,7 @@ RSpec.describe Pgbus::Process::Worker do
       end
 
       def streak
-        worker.instance_variable_get(:@restore_streak)
+        worker.restore_streak
       end
 
       it "does not restore before the base cooldown after full eviction" do
@@ -626,7 +629,7 @@ RSpec.describe Pgbus::Process::Worker do
         worker.send(:fetch_messages, 5) # restore (streak → 1) then a clean read
 
         expect(worker.queues).to eq(%w[flaky])
-        expect(worker.instance_variable_get(:@restore_streak)).to eq(0)
+        expect(worker.restore_streak).to eq(0)
       end
     end
 
@@ -708,7 +711,7 @@ RSpec.describe Pgbus::Process::Worker do
   end
 
   describe "prefetch flow control" do
-    let(:wake_signal) { worker.instance_variable_get(:@wake_signal) }
+    let(:wake_signal) { worker.wake_signal }
 
     before { allow(wake_signal).to receive(:wait) }
 
@@ -733,7 +736,7 @@ RSpec.describe Pgbus::Process::Worker do
       end
 
       it "waits when in_flight >= prefetch_limit" do
-        worker.instance_variable_get(:@in_flight).value = 3
+        worker.in_flight = 3
         worker.send(:claim_and_execute)
         expect(mock_client).not_to have_received(:read_batch)
         expect(wake_signal).to have_received(:wait)
@@ -741,7 +744,7 @@ RSpec.describe Pgbus::Process::Worker do
 
       it "uses min of idle and available prefetch" do
         # 2 in flight, limit 3 => available = 1, idle = 5 => fetch 1
-        worker.instance_variable_get(:@in_flight).value = 2
+        worker.in_flight = 2
         allow(mock_client).to receive(:read_batch).and_return([])
         worker.send(:claim_and_execute)
         expect(mock_client).to have_received(:read_batch).with("default", qty: 1)
@@ -813,7 +816,7 @@ RSpec.describe Pgbus::Process::Worker do
   end
 
   describe "circuit breaker integration" do
-    before { allow(worker.instance_variable_get(:@wake_signal)).to receive(:wait) }
+    before { allow(worker.wake_signal).to receive(:wait) }
 
     it "skips paused queues" do
       allow(circuit_breaker).to receive(:paused?).with("default").and_return(true)
@@ -853,7 +856,7 @@ RSpec.describe Pgbus::Process::Worker do
 
     before do
       allow(Pgbus::Process::QueueLock).to receive(:new).and_return(queue_lock)
-      allow(worker.instance_variable_get(:@wake_signal)).to receive(:wait)
+      allow(worker.wake_signal).to receive(:wait)
     end
 
     it "only reads from queues where advisory lock is held" do
@@ -895,12 +898,18 @@ RSpec.describe Pgbus::Process::Worker do
     end
 
     it "re-resolves when enough time has passed" do
+      # Drive the refresh interval gate through a controllable monotonic clock
+      # instead of poking @last_wildcard_resolve: resolve at t=0, refresh at
+      # t=60 (past WILDCARD_REFRESH_INTERVAL of 30s).
+      clock = [0.0]
+      allow(worker).to receive(:monotonic_now) { clock[0] }
+
       allow(conn).to receive(:select_values).and_return(["#{prefix}_default", "#{prefix}_events"])
       worker.send(:resolve_wildcard_queues)
       expect(worker.queues).to eq(%w[default events])
 
       # Simulate time passing and queues changing
-      worker.instance_variable_set(:@last_wildcard_resolve, Process.clock_gettime(Process::CLOCK_MONOTONIC) - 60)
+      clock[0] = 60.0
       allow(conn).to receive(:select_values).and_return(["#{prefix}_default"])
       worker.send(:refresh_wildcard_queues)
       expect(worker.queues).to eq(%w[default])
@@ -918,7 +927,7 @@ RSpec.describe Pgbus::Process::Worker do
   end
 
   describe "zombie message detection" do
-    let(:wake_signal) { worker.instance_variable_get(:@wake_signal) }
+    let(:wake_signal) { worker.wake_signal }
 
     before do
       allow(wake_signal).to receive(:wait)
@@ -1030,7 +1039,9 @@ RSpec.describe Pgbus::Process::Worker do
       it "is false when config does not respond to worker_notify_wakeup? (old configs)" do
         stripped_config = double("Config")
         allow(stripped_config).to receive(:respond_to?).with(:worker_notify_wakeup?).and_return(false)
-        worker.instance_variable_set(:@config, stripped_config)
+        # Stub the public config reader rather than construct with the stripped
+        # double (which lacks the stats_* methods the constructor calls).
+        allow(worker).to receive(:config).and_return(stripped_config)
         expect(worker.send(:notify_wakeup?)).to be false
       end
     end
@@ -1044,9 +1055,9 @@ RSpec.describe Pgbus::Process::Worker do
           .to eq(["#{prefix}_default", "#{prefix}_low"])
       end
 
-      it "uses the current @queues, not the initial set (post-eviction safe)" do
-        worker.instance_variable_set(:@queues, %w[events])
-        expect(worker.send(:physical_queue_names)).to eq(["#{prefix}_events"])
+      it "uses the current queues, not the initial set (post-eviction safe)" do
+        events_worker = described_class.new(queues: %w[events], threads: 5)
+        expect(events_worker.send(:physical_queue_names)).to eq(["#{prefix}_events"])
       end
     end
 
@@ -1067,7 +1078,7 @@ RSpec.describe Pgbus::Process::Worker do
 
       it "returns effective_polling_interval when wakeup is on but no listener attached yet" do
         allow(worker).to receive(:notify_wakeup?).and_return(true)
-        worker.instance_variable_set(:@notify_listener, nil)
+        worker.notify_listener = nil
         expect(worker.send(:wake_timeout)).to eq(worker.config.polling_interval)
       end
 
@@ -1076,7 +1087,7 @@ RSpec.describe Pgbus::Process::Worker do
         # not the steady-state cadence. The ceiling lets one missed NOTIFY
         # cost bounded latency, never a stuck queue.
         allow(worker).to receive(:notify_wakeup?).and_return(true)
-        worker.instance_variable_set(:@notify_listener, fake_listener)
+        worker.notify_listener = fake_listener
         expect(worker.send(:wake_timeout))
           .to eq(described_class::NOTIFY_FALLBACK_POLL_SECONDS)
       end
@@ -1088,7 +1099,7 @@ RSpec.describe Pgbus::Process::Worker do
         # up. Fall back to the polling interval until it's restarted.
         allow(worker).to receive(:notify_wakeup?).and_return(true)
         allow(fake_listener).to receive(:running?).and_return(false)
-        worker.instance_variable_set(:@notify_listener, fake_listener)
+        worker.notify_listener = fake_listener
         expect(worker.send(:wake_timeout)).to eq(worker.config.polling_interval)
       end
     end
@@ -1111,7 +1122,7 @@ RSpec.describe Pgbus::Process::Worker do
         allow(Pgbus::Process::NotifyListener).to receive(:new)
         worker.send(:start_notify_listener)
         expect(Pgbus::Process::NotifyListener).not_to have_received(:new)
-        expect(worker.instance_variable_get(:@notify_listener)).to be_nil
+        expect(worker.notify_listener).to be_nil
       end
 
       it "constructs and starts a listener for every physical queue when wakeup is on" do
@@ -1131,7 +1142,7 @@ RSpec.describe Pgbus::Process::Worker do
           logger: Pgbus.logger
         )
         expect(fake_listener).to have_received(:start)
-        expect(worker.instance_variable_get(:@notify_listener)).to be(fake_listener)
+        expect(worker.notify_listener).to be(fake_listener)
       end
 
       it "clamps health_check_ms below 250ms up to the floor" do
@@ -1175,7 +1186,7 @@ RSpec.describe Pgbus::Process::Worker do
         allow(Pgbus.logger).to receive(:error)
 
         expect { worker.send(:start_notify_listener) }.not_to raise_error
-        expect(worker.instance_variable_get(:@notify_listener)).to be_nil
+        expect(worker.notify_listener).to be_nil
         expect(Pgbus.logger).to have_received(:error)
       end
     end
@@ -1197,7 +1208,7 @@ RSpec.describe Pgbus::Process::Worker do
       end
 
       it "is a no-op while a healthy listener is running" do
-        worker.instance_variable_set(:@notify_listener, fake_listener)
+        worker.notify_listener = fake_listener
         allow(worker).to receive(:start_notify_listener)
         worker.send(:ensure_notify_listener)
         expect(worker).not_to have_received(:start_notify_listener)
@@ -1205,18 +1216,18 @@ RSpec.describe Pgbus::Process::Worker do
 
       it "does not retry before the backoff window elapses" do
         # Listener is absent and a retry was just scheduled into the future.
-        worker.instance_variable_set(:@notify_listener, nil)
-        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) + base)
+        worker.notify_listener = nil
+        worker.notify_retry_at = worker.send(:monotonic_now) + base
         allow(worker).to receive(:start_notify_listener)
         worker.send(:ensure_notify_listener)
         expect(worker).not_to have_received(:start_notify_listener)
       end
 
       it "retries start once the backoff window has elapsed" do
-        worker.instance_variable_set(:@notify_listener, nil)
-        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        worker.notify_listener = nil
+        worker.notify_retry_at = worker.send(:monotonic_now) - 1
         allow(worker).to receive(:start_notify_listener) do
-          worker.instance_variable_set(:@notify_listener, fake_listener)
+          worker.notify_listener = fake_listener
         end
 
         worker.send(:ensure_notify_listener)
@@ -1224,48 +1235,48 @@ RSpec.describe Pgbus::Process::Worker do
       end
 
       it "doubles the backoff each time the restart fails" do
-        worker.instance_variable_set(:@notify_listener, nil)
-        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        worker.notify_listener = nil
+        worker.notify_retry_at = worker.send(:monotonic_now) - 1
         # start leaves @notify_listener nil (failed to start).
         allow(worker).to receive(:start_notify_listener)
 
         worker.send(:ensure_notify_listener)
-        expect(worker.instance_variable_get(:@notify_retry_backoff)).to eq(base * 2)
+        expect(worker.notify_retry_backoff).to eq(base * 2)
 
         # Second failed attempt (advance clock past the new window) doubles again.
-        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        worker.notify_retry_at = worker.send(:monotonic_now) - 1
         worker.send(:ensure_notify_listener)
-        expect(worker.instance_variable_get(:@notify_retry_backoff)).to eq(base * 4)
+        expect(worker.notify_retry_backoff).to eq(base * 4)
       end
 
       it "caps the backoff at NOTIFY_RETRY_MAX_SECONDS" do
-        worker.instance_variable_set(:@notify_listener, nil)
-        worker.instance_variable_set(:@notify_retry_backoff, described_class::NOTIFY_RETRY_MAX_SECONDS)
-        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        worker.notify_listener = nil
+        worker.notify_retry_backoff = described_class::NOTIFY_RETRY_MAX_SECONDS
+        worker.notify_retry_at = worker.send(:monotonic_now) - 1
         allow(worker).to receive(:start_notify_listener)
 
         worker.send(:ensure_notify_listener)
-        expect(worker.instance_variable_get(:@notify_retry_backoff))
+        expect(worker.notify_retry_backoff)
           .to eq(described_class::NOTIFY_RETRY_MAX_SECONDS)
       end
 
       it "resets the backoff after a successful restart" do
-        worker.instance_variable_set(:@notify_listener, nil)
-        worker.instance_variable_set(:@notify_retry_backoff, base * 8)
-        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        worker.notify_listener = nil
+        worker.notify_retry_backoff = base * 8
+        worker.notify_retry_at = worker.send(:monotonic_now) - 1
         allow(worker).to receive(:start_notify_listener) do
-          worker.instance_variable_set(:@notify_listener, fake_listener)
+          worker.notify_listener = fake_listener
         end
 
         worker.send(:ensure_notify_listener)
-        expect(worker.instance_variable_get(:@notify_retry_backoff)).to eq(base)
+        expect(worker.notify_retry_backoff).to eq(base)
       end
 
       it "stops a dead listener before restarting it" do
         dead = fake_listener
         allow(dead).to receive(:running?).and_return(false)
-        worker.instance_variable_set(:@notify_listener, dead)
-        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        worker.notify_listener = dead
+        worker.notify_retry_at = worker.send(:monotonic_now) - 1
         allow(worker).to receive(:start_notify_listener)
 
         worker.send(:ensure_notify_listener)
@@ -1273,10 +1284,10 @@ RSpec.describe Pgbus::Process::Worker do
       end
 
       it "reconciles queues after a successful restart (wildcard workers)" do
-        worker.instance_variable_set(:@notify_listener, nil)
-        worker.instance_variable_set(:@notify_retry_at, worker.send(:monotonic_now) - 1)
+        worker.notify_listener = nil
+        worker.notify_retry_at = worker.send(:monotonic_now) - 1
         allow(worker).to receive(:start_notify_listener) do
-          worker.instance_variable_set(:@notify_listener, fake_listener)
+          worker.notify_listener = fake_listener
         end
         allow(worker).to receive(:sync_notify_listener_queues)
 
@@ -1289,7 +1300,7 @@ RSpec.describe Pgbus::Process::Worker do
       let(:multi_worker) { described_class.new(queues: %w[default low], threads: 4) }
       let(:queue_prefix) { multi_worker.config.queue_prefix }
 
-      before { multi_worker.instance_variable_set(:@notify_listener, fake_listener) }
+      before { multi_worker.notify_listener = fake_listener }
 
       it "adds new physical queues and removes dropped ones based on the set difference" do
         # Listener currently watches default + statistics; @queues is
@@ -1310,7 +1321,7 @@ RSpec.describe Pgbus::Process::Worker do
       end
 
       it "is a no-op when no listener is attached" do
-        multi_worker.instance_variable_set(:@notify_listener, nil)
+        multi_worker.notify_listener = nil
         expect { multi_worker.send(:sync_notify_listener_queues) }.not_to raise_error
         expect(fake_listener).not_to have_received(:add_queue)
         expect(fake_listener).not_to have_received(:remove_queue)
@@ -1327,13 +1338,13 @@ RSpec.describe Pgbus::Process::Worker do
 
     describe "#shutdown" do
       it "stops the notify listener before draining the pool" do
-        worker.instance_variable_set(:@notify_listener, fake_listener)
+        worker.notify_listener = fake_listener
         worker.send(:shutdown)
         expect(fake_listener).to have_received(:stop)
       end
 
       it "is a no-op for the listener when none was started (default-off path)" do
-        worker.instance_variable_set(:@notify_listener, nil)
+        worker.notify_listener = nil
         expect { worker.send(:shutdown) }.not_to raise_error
       end
     end
@@ -1362,14 +1373,14 @@ RSpec.describe Pgbus::Process::Worker do
 
       w.send(:stamp_loop_tick)
 
-      expect(w.instance_variable_get(:@loop_tick_at).get).to be_a(Float)
+      expect(w.last_loop_tick).to be_a(Float)
     end
 
     it "does not write to a pipe and behaves as today when no liveness_pipe is given" do
       w = described_class.new(queues: %w[default], threads: 5)
 
       expect { w.send(:stamp_loop_tick) }.not_to raise_error
-      expect(w.instance_variable_get(:@loop_tick_at).get).to be_a(Float)
+      expect(w.last_loop_tick).to be_a(Float)
     end
 
     it "does not raise when the pipe is full (write dropped, worker still alive)" do

--- a/spec/pgbus/process/worker_spec.rb
+++ b/spec/pgbus/process/worker_spec.rb
@@ -1056,8 +1056,19 @@ RSpec.describe Pgbus::Process::Worker do
       end
 
       it "uses the current queues, not the initial set (post-eviction safe)" do
-        events_worker = described_class.new(queues: %w[events], threads: 5)
-        expect(events_worker.send(:physical_queue_names)).to eq(["#{prefix}_events"])
+        # Build with two queues so @initial_queues stays %w[default events], then
+        # drive a real eviction of `default` so @queues diverges to %w[events].
+        # physical_queue_names must reflect the CURRENT list, not the frozen
+        # initial set — reading @initial_queues here would wrongly include default.
+        evicting_worker = described_class.new(queues: %w[default events], threads: 5)
+        allow(mock_client).to receive(:read_multi).and_raise(
+          StandardError,
+          "ERROR:  relation \"pgmq.q_#{prefix}_default\" does not exist"
+        )
+        evicting_worker.send(:fetch_messages, 5)
+
+        expect(evicting_worker.queues).to eq(%w[events])
+        expect(evicting_worker.send(:physical_queue_names)).to eq(["#{prefix}_events"])
       end
     end
 

--- a/spec/pgbus/streams/turbo_stream_override_spec.rb
+++ b/spec/pgbus/streams/turbo_stream_override_spec.rb
@@ -35,7 +35,10 @@ RSpec.describe Pgbus::Streams::TurboStreamOverride do
 
   before do
     Pgbus.configuration.streams_signed_name_secret = "a" * 64
-    allow_any_instance_of(Pgbus::Streams::Stream).to receive(:current_msg_id).and_return(42)
+    # Stub the reachable Pgbus.stream factory (the override's turbo_stream_from
+    # → pgbus_stream_from → fetch_watermark path) instead of any_instance.
+    allow(Pgbus).to receive(:stream)
+      .and_return(instance_double(Pgbus::Streams::Stream, current_msg_id: 42))
     Thread.current[:pgbus_streams_watermark_cache] = nil
   end
 

--- a/spec/pgbus/streams_helper_spec.rb
+++ b/spec/pgbus/streams_helper_spec.rb
@@ -16,14 +16,16 @@ RSpec.describe Pgbus::StreamsHelper do
   end
   let(:view) { view_class.new }
 
+  # The helper's watermark lookup goes through Pgbus.stream(name).current_msg_id
+  # (app/helpers/pgbus/streams_helper.rb#fetch_watermark). Stub the reachable
+  # module factory to a verifying instance_double so the helper never reaches the
+  # real Pgbus::Client / database. Pgbus.stream only memoises its *result* in
+  # @stream_cache; stubbing the method bypasses the cache entirely.
+  let(:stream_double) { instance_double(Pgbus::Streams::Stream, current_msg_id: 1247) }
+
   before do
     Pgbus.configuration.streams_signed_name_secret = "a" * 64
-    # Intercept the watermark lookup so the helper doesn't reach the
-    # real Pgbus::Client (which tries to hit the database). Stubbing
-    # at the Stream instance level is more robust than stubbing
-    # Pgbus.stream — the latter is a module method that gets memoised
-    # in surprising ways under Zeitwerk.
-    allow_any_instance_of(Pgbus::Streams::Stream).to receive(:current_msg_id).and_return(1247)
+    allow(Pgbus).to receive(:stream).and_return(stream_double)
     Thread.current[:pgbus_streams_watermark_cache] = nil
   end
 
@@ -77,20 +79,12 @@ RSpec.describe Pgbus::StreamsHelper do
     end
 
     it "caches the watermark per-thread across multiple calls in the same render" do
-      # Count how many times current_msg_id is called. any_instance_of's
-      # have_received doesn't track calls across instances, so we reach
-      # for a side-effect counter instead.
-      call_count = 0
-      allow_any_instance_of(Pgbus::Streams::Stream).to receive(:current_msg_id) do
-        call_count += 1
-        1247
-      end
-
       view.pgbus_stream_from("chat")
       view.pgbus_stream_from("chat")
       view.pgbus_stream_from("chat")
 
-      expect(call_count).to eq(1)
+      # The per-thread cache means current_msg_id is consulted exactly once.
+      expect(stream_double).to have_received(:current_msg_id).once
     end
 
     it "passes through arbitrary HTML attributes" do
@@ -217,7 +211,7 @@ RSpec.describe Pgbus::StreamsHelper do
     end
 
     it "clamps replay: N to 0 when N > current_msg_id (fresh queue with a huge replay)" do
-      allow_any_instance_of(Pgbus::Streams::Stream).to receive(:current_msg_id).and_return(5)
+      allow(stream_double).to receive(:current_msg_id).and_return(5)
       html = view.pgbus_stream_from("chat", replay: 1000)
       expect(html).to include('since-id="0"')
     end
@@ -248,17 +242,13 @@ RSpec.describe Pgbus::StreamsHelper do
     end
 
     it "caches the watermark lookup when used with replay: (avoids double-query)" do
-      call_count = 0
-      allow_any_instance_of(Pgbus::Streams::Stream).to receive(:current_msg_id) do
-        call_count += 1
-        1247
-      end
-
       view.pgbus_stream_from("chat", replay: 10)
       view.pgbus_stream_from("chat", replay: :all)
       view.pgbus_stream_from("chat") # watermark path
 
-      expect(call_count).to eq(1)
+      # replay: :all short-circuits to 0 without touching the watermark, so the
+      # lookup fires exactly once across the replay: 10 and watermark paths.
+      expect(stream_double).to have_received(:current_msg_id).once
     end
   end
 end

--- a/spec/support/real_pgmq_errors.rb
+++ b/spec/support/real_pgmq_errors.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Loads the genuine PGMQ::Errors::* classes from the pgmq-ruby runtime
+# dependency so specs exercising Pgbus's rescue paths match the real error
+# hierarchy — not a fake Class.new(StandardError) stub that would keep passing
+# even if pgmq-ruby restructured its errors and every rescue silently stopped
+# matching.
+module RealPgmqErrors
+  # Ensure PGMQ::Errors::ConnectionError (and its siblings) are the genuine
+  # classes from pgmq-ruby, then return the ConnectionError class.
+  #
+  # pgmq-ruby autoloads PGMQ::Errors via Zeitwerk (see the gem's pgmq.rb). A
+  # plain `require "pgmq"` populates it the first time, but this suite (and
+  # Pgbus::Client#initialize itself) sometimes replaces the ::PGMQ constant with
+  # a bare Module.new so construction works without a live database. On a bare
+  # module the Zeitwerk autoload is gone and `require` is a no-op (the feature is
+  # already in $LOADED_FEATURES), leaving PGMQ::Errors undefined. So `load` the
+  # errors file directly onto whatever ::PGMQ currently is — this re-executes the
+  # source and re-defines the real classes regardless of prior stubbing, and is
+  # cheap (a handful of one-line class definitions).
+  def real_pgmq_connection_error
+    Object.const_set(:PGMQ, Module.new) unless defined?(::PGMQ)
+    load(Gem.find_files("pgmq/errors.rb").first) unless defined?(PGMQ::Errors::ConnectionError)
+    PGMQ::Errors::ConnectionError
+  end
+end
+
+RSpec.configure do |config|
+  config.include RealPgmqErrors
+end


### PR DESCRIPTION
## Summary

De-brittles the process and client specs by removing three patterns that couple tests to private internals and will break on harmless renames or an RSpec 4 upgrade. Nine behavior-preserving commits, one per spec area; each file green before and after.

**1. `instance_variable_get/set` poking — now zero across `spec/pgbus/process/` and `spec/pgbus/client_spec.rb`.** Replaced with:
- **Constructor keyword injection** for seeded state (defaults unchanged, so production behavior is identical): e.g. `Client.new(config, schema_ensured:)`, `Supervisor.new(forks:, shutting_down:, pending_restarts:, last_watchdog_at:)`, `Consumer.new(queue_names:, notify_listener:, notify_retry_at:, notify_retry_backoff:, started_at_monotonic:)`, `Worker.new(rate_counter:, wake_signal:, stat_buffer:, notify_listener:, …, started_at_monotonic:)`.
- **Narrow public readers / predicates** where no observable existed: `Client#shared_connection?` / `#synchronizing?`, `Supervisor#forks` / `#shutting_down?`, `Consumer#shutting_down?` / `#queue_names` / `#jobs_processed`, `Dispatcher#shutting_down?` / `#maintenance_failure_streak` / `#maintenance_backoff_until` / `#last_loop_tick` / `#set_maintenance_timestamp`, `Worker#lifecycle` / `#last_loop_tick`, `SignalHandler#handled_signals`.
- **Observable-behavior assertions** where a public path already existed: e.g. `@queues_created` cache reads → assert re-`create` on the next `ensure_queue` after `drop_queue`; `@loop_tick_at` → the heartbeat's `loop_tick_supplier`; clock-gated ivars → a stubbed `monotonic_now`.

**2. `allow_any_instance_of` — now zero across all of `spec/`** (grep-verified). No production change:
- `require "pgmq"` boot stubs → `allow(Kernel).to receive(:require).and_call_original` + `.with("pgmq")` (fires in `initialize` before the instance exists).
- `Pgbus::Streams::Stream#current_msg_id` → stub the reachable `Pgbus.stream` factory to a verifying `instance_double`.
- `MigrationDetector#missing_migrations` → stub `MigrationDetector.new` to return an `instance_double`.
- `NotifyListener#build_connection` → stub on the reachable `listener` subject (already the idiom on two existing examples).

**3. Fake error classes — now zero.** The 11 `stub_const("PGMQ::Errors::ConnectionError", Class.new(StandardError))` sites created a fake, so every rescue in `lib/` was matched against a spec-invented class. New `spec/support/real_pgmq_errors.rb#real_pgmq_connection_error` loads the genuine class from the `pgmq-ruby` runtime dep (via `load` of the errors source, so it survives the `PGMQ = Module.new` stub the client uses). The executor archive-retry and client stale-retry paths now prove they match the real `PGMQ::Errors::ConnectionError`.

Production changes are limited to injection seams and test-only readers/writers — no refactors, no behavior change. `Metrics` cops are disabled project-wide, so the added constructor keywords trip no `ParameterList` limit.

Closes #229

## Test plan

- [x] `grep -rn "instance_variable_get\|instance_variable_set" spec/pgbus/process/ spec/pgbus/client_spec.rb` → zero
- [x] `grep -rn "allow_any_instance_of\|expect_any_instance_of" spec/` → zero
- [x] `grep -rn 'stub_const.*PGMQ::Errors' spec/` → zero; real-error examples present for executor archive retry and client stale retry
- [x] `bundle exec rubocop` — clean across all 481 files
- [x] Each touched spec green in isolation (worker 112, supervisor 52, consumer 49, dispatcher 69, client 185, notify_listener 23, + the allow_any and additional-process files)
- [x] Full suite compared against `main` at the same seed: **identical** profile — 3334 examples, 187 failures, 145 pending on both, with the same failing-file breakdown. Every failure is a pre-existing environmental flake (streamer/SSE, system/Puma/Capybara, and an i18n/RuboCop `Registry` constant-collision that also fails on `main`). This change introduces zero new failures.
- [x] An adversarial verification pass over the worker_spec rewrite caught one silently-weakened example (`physical_queue_names` post-eviction) — restored to discriminating coverage in the final commit (verified it fails when the implementation regresses).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public indicators for connection usage and synchronization status.
  * Improved process observability with new lifecycle/shutdown and maintenance timing helpers (including worker progress and loop tick visibility).
  * Expanded constructors with optional injection/tuning parameters for better control.
* **Refactor**
  * Updated how pgmq is loaded and enabled skipping one-time schema checks when preconditions are met.
* **Tests**
  * Refreshed specs to use the new public seams and real pgmq error classes for more accurate error handling coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->