### PR TITLE
fix(test): reset config before each ConfigLoader example to kill an ordering flake

### DIFF
--- a/spec/pgbus/config_loader_spec.rb
+++ b/spec/pgbus/config_loader_spec.rb
@@ -5,6 +5,13 @@ require "spec_helper"
 require "tempfile"
 
 RSpec.describe Pgbus::ConfigLoader do
+  # Reset before AND after each example: the `after` alone leaves the first
+  # example run under a random seed exposed to config state another spec file
+  # left dirty (e.g. queue_prefix = "pgbus_test"). Examples here that assert the
+  # pristine default (a sectioned file with no matching env applies nothing) then
+  # fail on the leaked value. The `before` guarantees a clean default regardless
+  # of run order.
+  before { Pgbus.reset! }
   after { Pgbus.reset! }
 
   def with_yaml(content)


### PR DESCRIPTION
## Summary

Kills a random-seed test-ordering flake in `spec/pgbus/config_loader_spec.rb` that can fail CI on **any** PR (it surfaced on the docs-only #296, which changes zero Ruby).

## Root cause

The `describe Pgbus::ConfigLoader` block had only an `after { Pgbus.reset! }` hook. Under a random seed, the first example to run in the file inherits config state that another spec file left dirty — specifically `Pgbus.configuration.queue_prefix = "pgbus_test"`. The example asserting that a sectioned `pgbus.yml` with no matching env **applies nothing** then hardcodes the pristine default:

```ruby
expect(Pgbus.configuration.queue_prefix).to eq("pgbus")   # got "pgbus_test"
```

"Applies nothing" means the prefix stays whatever it already was — so the leaked value fails the assertion. `with_temp_config` (used by these examples) does not pre-reset, unlike the file's other helper `with_yaml`.

## Proof

- Reproduced deterministically on `main` (6666a4d): `bundle exec rspec spec/pgbus/ spec/generators/ --seed 6154` → `3051 examples, 1 failure` at `config_loader_spec.rb:178`.
- The spec **passes in isolation** — confirming ordering pollution, not a real bug in the loader.
- With `before { Pgbus.reset! }` added: same seed 6154, full suite → `3051 examples, 0 failures`.

## Fix

One `before { Pgbus.reset! }` so every example starts from a clean default regardless of run order, with a comment explaining why it's not redundant with the existing `after`.

## Test plan

- [ ] `bundle exec rspec spec/pgbus/ spec/generators/ --seed 6154` is green.
- [ ] `bundle exec rspec spec/pgbus/config_loader_spec.rb` is green.
