### PR TITLE
feat(errors)!: unify the error hierarchy under Pgbus::Error for 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Breaking Changes
+
+- **The error hierarchy is unified under `Pgbus::Error` for the 1.0 API freeze.** Several call sites raised bare stdlib errors that no `rescue Pgbus::Error` could catch, freezing an inconsistent contract into 1.0. Now: **`Configuration#validate!` and every config setter raise `Pgbus::ConfigurationError`** (was `ArgumentError`) — this is the one that can break existing code: a `rescue ArgumentError` around `Pgbus.configure` or a boot-time config read will no longer catch config failures; switch to `rescue Pgbus::Error` (or `rescue Pgbus::ConfigurationError`). The ActiveJob adapter's `perform_all_later` msg_id-count mismatch now raises **`Pgbus::EnqueueError`** (new, was `RuntimeError`); `ExecutionPools::AsyncPool` shutdown/at-capacity raises now use **`Pgbus::ExecutionPoolError`** (new, was `RuntimeError`); `Serializer#locate_global_id` GlobalID rejections raise **`Pgbus::SerializationError`** (was `ArgumentError`). Four error classes that bypassed the base — `PgmqSchema::VersionNotFoundError`, `Streams::SignedName::InvalidSignedName`/`MissingSecret`, and `Generators::ConfigConverter::Error` — are re-parented under `Pgbus::Error`. Three classes that reject a malformed *argument shape* — `Configuration::CapsuleDSL::ParseError`, `Streams::Cursor::InvalidCursor`, `Streams::StreamNameTooLong` — **deliberately stay `ArgumentError` subclasses**; the policy ("argument-shape errors are `ArgumentError`, operational errors are `Pgbus::Error`") is documented in `lib/pgbus.rb` and pinned by `spec/pgbus/error_hierarchy_spec.rb`. Messages are unchanged. Refs #282.
+
 ### Added
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ end
 
 The capsule string DSL is the shortest form for the common case. Use `c.capsule` when you need named capsules with advanced options like `single_active_consumer` or `consumer_priority`. See [Routing and ordering](#routing-and-ordering) for the full set.
 
-Configuration is validated eagerly: `Pgbus.configure` runs `Configuration#validate!` right after your block yields, so an invalid value (`visibility_timeout = 0`, for example) raises `ArgumentError` at boot instead of failing later inside a worker. Set `c.eager_validation = false` for the rare setup that intentionally holds a transiently-invalid config across sequential `configure` calls.
+Configuration is validated eagerly: `Pgbus.configure` runs `Configuration#validate!` right after your block yields, so an invalid value (`visibility_timeout = 0`, for example) raises `Pgbus::ConfigurationError` at boot instead of failing later inside a worker. Set `c.eager_validation = false` for the rare setup that intentionally holds a transiently-invalid config across sequential `configure` calls.
 
 > **Upgrading from an older pgbus?** Run `rails generate pgbus:update`. It does two things in one pass:
 >
@@ -778,6 +778,25 @@ Each reporter receives `(exception, context_hash)`. The context hash includes ke
 Reporters are wired into all critical rescue paths: job execution failures, worker fetch/process errors, dispatcher maintenance, supervisor fork failures, circuit breaker trips, outbox publish errors, and failed event recording. Non-critical paths (dashboard queries, stat recording) remain log-only.
 
 `ErrorReporter.report` is guaranteed to never raise — if a reporter or the logger itself throws, the error is swallowed silently. This preserves fault-tolerance invariants at every rescue site.
+
+### Error hierarchy
+
+Every operational error Pgbus raises descends from `Pgbus::Error`, so a single rescue catches them all:
+
+```ruby
+begin
+  Pgbus.configure { |c| c.visibility_timeout = 0 }
+rescue Pgbus::Error => e
+  # ConfigurationError, EnqueueError, ExecutionPoolError, SerializationError,
+  # QueueNotFoundError, SchemaNotReady, ... all land here
+end
+```
+
+The named subclasses (a partial list): `Pgbus::ConfigurationError` (`validate!` and config setters), `Pgbus::SerializationError` (payload / GlobalID rejection), `Pgbus::EnqueueError` (batch enqueue integrity), `Pgbus::ExecutionPoolError` (pool shutting down / at capacity), `Pgbus::QueueNotFoundError`, `Pgbus::DeadLetterError`, `Pgbus::JobNotUnique`, `Pgbus::SchemaNotReady`, `Pgbus::ReadTimeoutError`, and `Pgbus::ConnectionCircuitOpenError`.
+
+**One deliberate exception to the rule:** errors that reject a malformed *argument shape* stay `ArgumentError` subclasses, because that's what `ArgumentError` means — `Pgbus::Streams::StreamNameTooLong`, `Pgbus::Streams::Cursor::InvalidCursor`, and `Pgbus::Configuration::CapsuleDSL::ParseError`. Rescue those with `ArgumentError` (or the specific class), not `Pgbus::Error`.
+
+If you upgraded from 0.9.x and previously did `rescue ArgumentError` around `Pgbus.configure`, switch it to `rescue Pgbus::Error` — config validation now raises `Pgbus::ConfigurationError`, which is not an `ArgumentError`.
 
 ### AppSignal integration
 
@@ -2033,7 +2052,7 @@ PostgreSQL + PGMQ
 | `statsd_port` | `8125` | StatsD UDP port (used when `metrics_backend = :statsd`) |
 | `health_port` | `nil` | Port for standalone HTTP liveness/readiness probes served by the supervisor; nil disables |
 | `health_bind` | `"127.0.0.1"` | Bind address for the standalone health server |
-| `eager_validation` | `true` | Run `Configuration#validate!` automatically after `Pgbus.configure` / `ConfigLoader.apply`; an invalid value raises `ArgumentError` at boot. Set `false` to suppress and validate manually. |
+| `eager_validation` | `true` | Run `Configuration#validate!` automatically after `Pgbus.configure` / `ConfigLoader.apply`; an invalid value raises `Pgbus::ConfigurationError` at boot. Set `false` to suppress and validate manually. |
 
 ## Development
 

--- a/docs/app/views/docs/pages/upgrading_pgbus.rb
+++ b/docs/app/views/docs/pages/upgrading_pgbus.rb
@@ -172,16 +172,17 @@ class Views::Docs::Pages::UpgradingPgbus < DocsUI::Page
   end
 
   def v100_stub
-    DocsUI::Section("0.9.8 → 1.0.0", description: "Forward-looking — this section is a stub.") do
-      DocsUI::Callout(:warning, title: "Stub section") do
-        plain "1.0.0 hasn't shipped yet. The renames and removals below are "
-        plain "tracked by the two API-freeze issues that own this scope — "
+    DocsUI::Section("0.9.8 → 1.0.0", description: "The error hierarchy has landed; config renames still pending.") do
+      DocsUI::Callout(:warning, title: "Partial — 1.0.0 hasn't shipped yet") do
+        plain "The unified error hierarchy below is "
+        strong { "shipped" }
+        plain " (issue "
         a(href: "https://github.com/mhenrixon/pgbus/issues/282", class: "link") { "#282" }
-        plain " (error hierarchy) and "
+        plain ") and describes real current behavior on the unreleased 1.0 line. "
+        plain "The config renames and dead-surface removal further down are still "
+        plain "tracked by "
         a(href: "https://github.com/mhenrixon/pgbus/issues/283", class: "link") { "#283" }
-        plain " (config renames + dead-surface removal) — and "
-        strong { "must be updated by those issues as they land" }
-        plain ". Treat everything here as a plan, not a shipped behavior."
+        plain " and remain a plan until that issue lands."
       end
       md <<~'MD'
         ### The 1.0.0 commitment
@@ -195,14 +196,14 @@ class Views::Docs::Pages::UpgradingPgbus < DocsUI::Page
         (the error hierarchy) or because it's free to rename now and expensive to
         rename after (config keys, dead code).
 
-        ### Planned: unified error hierarchy (tracked by #282)
+        ### Breaking: unified error hierarchy (#282)
 
-        Today, `Pgbus::Error` exists with well-formed subclasses, but several
-        call sites still raise bare stdlib errors instead of a `Pgbus::Error`
-        descendant. 1.0.0 is expected to close that gap:
+        Every operational error pgbus raises now descends from `Pgbus::Error`, so
+        `rescue Pgbus::Error` catches them all. Four call sites that previously
+        raised bare stdlib errors changed:
       MD
       DocsUI::Table(
-        [ "Raises today", "Becomes in 1.0.0", "Where" ],
+        [ "Raised before", "Raises now", "Where" ],
         [
           [ [ :code, "ArgumentError" ], [ :code, "Pgbus::ConfigurationError" ], "Configuration#validate! and its setters" ],
           [ [ :code, "RuntimeError" ], [ :code, "Pgbus::ExecutionPoolError" ], [ :code, "AsyncPool" ] ],
@@ -211,19 +212,32 @@ class Views::Docs::Pages::UpgradingPgbus < DocsUI::Page
         ]
       )
       md <<~'MD'
-        A handful of error classes that bypass `Pgbus::Error` entirely today
-        (`PgmqSchema::VersionNotFoundError`, `Streams::SignedName::InvalidSignedName`,
-        `Generators::ConfigConverter::Error`, and others) are also expected to be
-        re-parented underneath it. Classes that reject a malformed *argument
+        Four error classes that bypassed `Pgbus::Error` entirely
+        (`PgmqSchema::VersionNotFoundError`, `Streams::SignedName::InvalidSignedName`
+        and `MissingSecret`, `Generators::ConfigConverter::Error`) are now
+        re-parented underneath it. Three classes that reject a malformed *argument
         shape* — `CapsuleDSL::ParseError`, `Streams::Cursor::InvalidCursor`,
-        `Streams::StreamNameTooLong` — are expected to stay `ArgumentError`
-        subclasses by design, since that's what `ArgumentError` means.
+        `Streams::StreamNameTooLong` — deliberately stay `ArgumentError`
+        subclasses, since that's what `ArgumentError` means. The policy
+        ("argument-shape errors are `ArgumentError`, operational errors are
+        `Pgbus::Error`") is documented at the top of `lib/pgbus.rb`.
 
-        **Deprecation path:** if you `rescue ArgumentError` around
-        `Pgbus.configure` or a job's config access today, that rescue will stop
-        catching config errors once this lands — switch to
-        `rescue Pgbus::Error` (which will catch both the old and new shape
-        during any transition window #282 defines).
+        **The one breaking change for existing code:** if you `rescue ArgumentError`
+        around `Pgbus.configure` or a boot-time config read, that rescue no longer
+        catches config errors — `Configuration#validate!` and its setters now raise
+        `Pgbus::ConfigurationError`, which is **not** an `ArgumentError`. Switch to:
+      MD
+      DocsUI::Code(<<~'RUBY', filename: "config/initializers/pgbus.rb")
+        begin
+          Pgbus.configure { |c| c.visibility_timeout = 0 }
+        rescue Pgbus::Error => e   # was: rescue ArgumentError
+          Rails.logger.error("pgbus config invalid: #{e.message}")
+          raise
+        end
+      RUBY
+      md <<~'MD'
+        Error *messages* are unchanged, so any `rescue ... => e` that only reads
+        `e.message` keeps working. Only the rescued *class* changed.
 
         ### Planned: config renames and dead-surface removal (tracked by #283)
 

--- a/lib/pgbus.rb
+++ b/lib/pgbus.rb
@@ -10,6 +10,24 @@ module Pgbus
   # this to be configurable.
   DEAD_LETTER_SUFFIX = "_dlq"
 
+  # Error-hierarchy policy (the 1.0 contract, issue #282):
+  #
+  #   * OPERATIONAL errors — a pgbus subsystem failed to do its job at runtime
+  #     (bad configuration, a pool that's shutting down, a batch enqueue that
+  #     came back short, a rejected GlobalID, a missing PGMQ version) — descend
+  #     from Pgbus::Error. `rescue Pgbus::Error` is meant to catch every one of
+  #     them; that is the whole point of the hierarchy.
+  #
+  #   * ARGUMENT-SHAPE errors — the caller handed a method a malformed argument
+  #     (a stream name too long for the queue-name budget, an unparseable
+  #     cursor, a capsule DSL line that doesn't parse) — stay ArgumentError
+  #     subclasses. That's what ArgumentError means, and rescuing it is the
+  #     caller's responsibility, not an operational concern. These live in
+  #     their own files: Streams::StreamNameTooLong, Streams::Cursor::InvalidCursor,
+  #     Configuration::CapsuleDSL::ParseError.
+  #
+  # When adding a new error class, decide which half it belongs to and parent
+  # it accordingly — do not default to StandardError.
   class Error < StandardError; end
   class ConfigurationError < Error; end
   class SerializationError < Error; end
@@ -19,6 +37,16 @@ module Pgbus
   class JobNotUnique < Error; end
   class SchemaNotReady < Error; end
   class ReadTimeoutError < Error; end
+
+  # Raised by the ActiveJob adapter when a batch enqueue (perform_all_later)
+  # comes back with a msg_id count that doesn't match the number of jobs sent —
+  # a data-integrity signal that some jobs may not have been persisted.
+  class EnqueueError < Error; end
+
+  # Raised by the execution pools when work can't be accepted: the pool is
+  # shutting down, or it's momentarily at capacity. Consumer-reachable during
+  # job submission, so it descends from Pgbus::Error rather than RuntimeError.
+  class ExecutionPoolError < Error; end
 
   # Raised by Client read paths when the in-memory connection-health circuit
   # breaker (Client::ConnectionHealth) is open: the database has failed enough

--- a/lib/pgbus/active_job/adapter.rb
+++ b/lib/pgbus/active_job/adapter.rb
@@ -151,7 +151,7 @@ module Pgbus
         msg_ids = Pgbus.client.send_batch(queue, payloads)
 
         unless msg_ids.is_a?(Array) && msg_ids.size == jobs.size
-          raise "Pgbus batch enqueue failed: expected #{jobs.size} ids, got #{msg_ids&.size || 0}"
+          raise Pgbus::EnqueueError, "Pgbus batch enqueue failed: expected #{jobs.size} ids, got #{msg_ids&.size || 0}"
         end
 
         jobs.zip(msg_ids).each { |job, id| job.provider_job_id = id }

--- a/lib/pgbus/configuration.rb
+++ b/lib/pgbus/configuration.rb
@@ -358,7 +358,7 @@ module Pgbus
     def log_format=(format)
       format = format.to_sym
       unless VALID_LOG_FORMATS.include?(format)
-        raise ArgumentError, "Invalid log_format: #{format}. Must be one of: #{VALID_LOG_FORMATS.join(", ")}"
+        raise Pgbus::ConfigurationError, "Invalid log_format: #{format}. Must be one of: #{VALID_LOG_FORMATS.join(", ")}"
       end
 
       @log_format = format
@@ -373,7 +373,7 @@ module Pgbus
     def streams_default_broadcast_mode=(mode)
       mode = mode.to_sym
       unless VALID_BROADCAST_MODES.include?(mode)
-        raise ArgumentError,
+        raise Pgbus::ConfigurationError,
               "Invalid streams_default_broadcast_mode: #{mode}. Must be one of: #{VALID_BROADCAST_MODES.join(", ")}"
       end
 
@@ -388,11 +388,11 @@ module Pgbus
                 when Symbol then mode
                 when String then mode.to_sym
                 else
-                  raise ArgumentError,
+                  raise Pgbus::ConfigurationError,
                         "Invalid group_mode type: #{mode.class}. Must be nil, String, or Symbol"
                 end
       unless VALID_GROUP_MODES.include?(coerced)
-        raise ArgumentError, "Invalid group_mode: #{coerced.inspect}. Must be nil, :fifo, or :round_robin"
+        raise Pgbus::ConfigurationError, "Invalid group_mode: #{coerced.inspect}. Must be nil, :fifo, or :round_robin"
       end
 
       @group_mode = coerced
@@ -403,7 +403,7 @@ module Pgbus
     def pgmq_schema_mode=(mode)
       mode = mode.to_sym
       unless VALID_PGMQ_SCHEMA_MODES.include?(mode)
-        raise ArgumentError, "Invalid pgmq_schema_mode: #{mode}. Must be one of: #{VALID_PGMQ_SCHEMA_MODES.join(", ")}"
+        raise Pgbus::ConfigurationError, "Invalid pgmq_schema_mode: #{mode}. Must be one of: #{VALID_PGMQ_SCHEMA_MODES.join(", ")}"
       end
 
       @pgmq_schema_mode = mode
@@ -411,65 +411,74 @@ module Pgbus
 
     def validate!
       if pool_size && !(pool_size.is_a?(Numeric) && pool_size.positive?)
-        raise ArgumentError, "pool_size must be a positive number or nil (auto-tune)"
+        raise Pgbus::ConfigurationError, "pool_size must be a positive number or nil (auto-tune)"
       end
 
-      raise ArgumentError, "pool_timeout must be > 0" unless pool_timeout.is_a?(Numeric) && pool_timeout.positive?
-      raise ArgumentError, "polling_interval must be > 0" unless polling_interval.is_a?(Numeric) && polling_interval.positive?
-      raise ArgumentError, "visibility_timeout must be > 0" unless visibility_timeout.is_a?(Numeric) && visibility_timeout.positive?
-      raise ArgumentError, "max_retries must be >= 0" unless max_retries.is_a?(Integer) && max_retries >= 0
-      raise ArgumentError, "retry_backoff must be > 0" unless retry_backoff.is_a?(Numeric) && retry_backoff.positive?
-      raise ArgumentError, "retry_backoff_max must be > 0" unless retry_backoff_max.is_a?(Numeric) && retry_backoff_max.positive?
+      raise Pgbus::ConfigurationError, "pool_timeout must be > 0" unless pool_timeout.is_a?(Numeric) && pool_timeout.positive?
+      raise Pgbus::ConfigurationError, "polling_interval must be > 0" unless polling_interval.is_a?(Numeric) && polling_interval.positive?
+      unless visibility_timeout.is_a?(Numeric) && visibility_timeout.positive?
+        raise Pgbus::ConfigurationError,
+              "visibility_timeout must be > 0"
+      end
+      raise Pgbus::ConfigurationError, "max_retries must be >= 0" unless max_retries.is_a?(Integer) && max_retries >= 0
+      raise Pgbus::ConfigurationError, "retry_backoff must be > 0" unless retry_backoff.is_a?(Numeric) && retry_backoff.positive?
+      unless retry_backoff_max.is_a?(Numeric) && retry_backoff_max.positive?
+        raise Pgbus::ConfigurationError,
+              "retry_backoff_max must be > 0"
+      end
       unless retry_backoff_jitter.is_a?(Numeric) && retry_backoff_jitter >= 0 && retry_backoff_jitter <= 1
-        raise ArgumentError, "retry_backoff_jitter must be between 0 and 1"
+        raise Pgbus::ConfigurationError, "retry_backoff_jitter must be between 0 and 1"
       end
 
       unless stall_threshold.nil? || (stall_threshold.is_a?(Numeric) && stall_threshold.positive?)
-        raise ArgumentError, "stall_threshold must be a positive number or nil to disable"
+        raise Pgbus::ConfigurationError, "stall_threshold must be a positive number or nil to disable"
       end
       unless read_timeout.nil? || (read_timeout.is_a?(Numeric) && read_timeout.positive?)
-        raise ArgumentError, "read_timeout must be a positive number or nil to disable"
+        raise Pgbus::ConfigurationError, "read_timeout must be a positive number or nil to disable"
       end
 
       unless stats_flush_size.is_a?(Integer) && stats_flush_size.positive?
-        raise ArgumentError, "stats_flush_size must be a positive integer"
+        raise Pgbus::ConfigurationError, "stats_flush_size must be a positive integer"
       end
       unless stats_flush_interval.is_a?(Numeric) && stats_flush_interval.positive?
-        raise ArgumentError, "stats_flush_interval must be a positive number"
+        raise Pgbus::ConfigurationError, "stats_flush_interval must be a positive number"
       end
 
       unless health_port.nil? || (health_port.is_a?(Integer) && health_port.between?(1, 65_535))
-        raise ArgumentError, "health_port must be an integer between 1 and 65535 or nil to disable"
+        raise Pgbus::ConfigurationError, "health_port must be an integer between 1 and 65535 or nil to disable"
       end
 
-      raise ArgumentError, "health_bind must be a non-empty String" unless health_bind.is_a?(String) && !health_bind.empty?
+      raise Pgbus::ConfigurationError, "health_bind must be a non-empty String" unless health_bind.is_a?(String) && !health_bind.empty?
 
-      raise ArgumentError, "statsd_host must be a non-empty String" unless statsd_host.is_a?(String) && !statsd_host.empty?
+      raise Pgbus::ConfigurationError, "statsd_host must be a non-empty String" unless statsd_host.is_a?(String) && !statsd_host.empty?
 
       unless statsd_port.is_a?(Integer) && statsd_port.between?(1, 65_535)
-        raise ArgumentError, "statsd_port must be an integer between 1 and 65535"
+        raise Pgbus::ConfigurationError, "statsd_port must be an integer between 1 and 65535"
       end
 
       # Validate global execution_mode
-      ExecutionPools.normalize_mode(execution_mode)
+      validate_execution_mode!(execution_mode)
 
       Array(workers).each do |w|
         threads = w[:threads] || 5
-        raise ArgumentError, "worker threads must be > 0" unless threads.is_a?(Integer) && threads.positive?
+        raise Pgbus::ConfigurationError, "worker threads must be > 0" unless threads.is_a?(Integer) && threads.positive?
 
         # Validate per-worker execution_mode override if present
         mode = w[:execution_mode]
-        ExecutionPools.normalize_mode(mode) if mode
+        validate_execution_mode!(mode) if mode
       end
 
-      raise ArgumentError, "prefetch_limit must be > 0" if prefetch_limit && !(prefetch_limit.is_a?(Integer) && prefetch_limit.positive?)
+      if prefetch_limit && !(prefetch_limit.is_a?(Integer) && prefetch_limit.positive?)
+        raise Pgbus::ConfigurationError,
+              "prefetch_limit must be > 0"
+      end
 
       if priority_levels && !(priority_levels.is_a?(Integer) && priority_levels >= 1 && priority_levels <= 10)
-        raise ArgumentError, "priority_levels must be an integer between 1 and 10"
+        raise Pgbus::ConfigurationError, "priority_levels must be an integer between 1 and 10"
       end
 
       unless insights_default_minutes.is_a?(Integer) && insights_default_minutes.positive?
-        raise ArgumentError, "insights_default_minutes must be a positive integer"
+        raise Pgbus::ConfigurationError, "insights_default_minutes must be a positive integer"
       end
 
       validate_streams!
@@ -480,47 +489,53 @@ module Pgbus
 
     def validate_streams!
       unless streams_default_retention.is_a?(Numeric) && streams_default_retention >= 0
-        raise ArgumentError, "streams_default_retention must be a non-negative number"
+        raise Pgbus::ConfigurationError, "streams_default_retention must be a non-negative number"
       end
 
       unless streams_max_connections.is_a?(Integer) && streams_max_connections.positive?
-        raise ArgumentError, "streams_max_connections must be a positive integer"
+        raise Pgbus::ConfigurationError, "streams_max_connections must be a positive integer"
       end
 
       unless streams_heartbeat_interval.is_a?(Numeric) && streams_heartbeat_interval.positive?
-        raise ArgumentError, "streams_heartbeat_interval must be a positive number"
+        raise Pgbus::ConfigurationError, "streams_heartbeat_interval must be a positive number"
       end
 
       unless streams_idle_timeout.is_a?(Numeric) && streams_idle_timeout.positive?
-        raise ArgumentError, "streams_idle_timeout must be a positive number"
+        raise Pgbus::ConfigurationError, "streams_idle_timeout must be a positive number"
       end
 
       unless streams_listen_health_check_ms.is_a?(Integer) && streams_listen_health_check_ms.positive?
-        raise ArgumentError, "streams_listen_health_check_ms must be a positive integer"
+        raise Pgbus::ConfigurationError, "streams_listen_health_check_ms must be a positive integer"
       end
 
       unless streams_write_deadline_ms.is_a?(Integer) && streams_write_deadline_ms.positive?
-        raise ArgumentError, "streams_write_deadline_ms must be a positive integer"
+        raise Pgbus::ConfigurationError, "streams_write_deadline_ms must be a positive integer"
       end
 
-      raise ArgumentError, "streams_retention must be a Hash" unless streams_retention.is_a?(Hash)
+      raise Pgbus::ConfigurationError, "streams_retention must be a Hash" unless streams_retention.is_a?(Hash)
 
       if streams_orphan_sweep_interval && !(streams_orphan_sweep_interval.is_a?(Numeric) && streams_orphan_sweep_interval.positive?)
-        raise ArgumentError, "streams_orphan_sweep_interval must be a positive number or nil to disable"
+        raise Pgbus::ConfigurationError, "streams_orphan_sweep_interval must be a positive number or nil to disable"
       end
 
-      raise ArgumentError, "streams_durable_patterns must be an Array of strings/regex" unless streams_durable_patterns.is_a?(Array)
+      unless streams_durable_patterns.is_a?(Array)
+        raise Pgbus::ConfigurationError,
+              "streams_durable_patterns must be an Array of strings/regex"
+      end
 
-      raise ArgumentError, "streams_presence_patterns must be an Array of strings/regex" unless streams_presence_patterns.is_a?(Array)
+      unless streams_presence_patterns.is_a?(Array)
+        raise Pgbus::ConfigurationError,
+              "streams_presence_patterns must be an Array of strings/regex"
+      end
 
       if !streams_presence_member.nil? && !streams_presence_member.respond_to?(:call)
-        raise ArgumentError, "streams_presence_member must respond to #call (a Proc/lambda) or be nil"
+        raise Pgbus::ConfigurationError, "streams_presence_member must respond to #call (a Proc/lambda) or be nil"
       end
 
       return if streams_orphan_threshold.nil?
       return if streams_orphan_threshold.is_a?(Numeric) && streams_orphan_threshold.positive?
 
-      raise ArgumentError, "streams_orphan_threshold must be a positive number or nil to disable"
+      raise Pgbus::ConfigurationError, "streams_orphan_threshold must be a positive number or nil to disable"
     end
 
     def validate_metrics_backend!
@@ -529,7 +544,7 @@ module Pgbus
       return if %i[prometheus statsd].include?(value)
       return if defined?(Pgbus::Metrics::Backend) && value.is_a?(Pgbus::Metrics::Backend)
 
-      raise ArgumentError,
+      raise Pgbus::ConfigurationError,
             "metrics_backend must be nil, :prometheus, :statsd, or a " \
             "Pgbus::Metrics::Backend instance (got #{value.inspect})"
     end
@@ -623,7 +638,7 @@ module Pgbus
                  when Array
                    value.map { |entry| normalize_entry(entry, group: "worker") }
                  else
-                   raise ArgumentError,
+                   raise Pgbus::ConfigurationError,
                          "workers must be a String (DSL), Array (legacy form), or nil — got #{value.class}"
                  end
     end
@@ -639,7 +654,7 @@ module Pgbus
         when Array
           value.map { |entry| normalize_entry(entry, group: "event_consumer") }
         else
-          raise ArgumentError,
+          raise Pgbus::ConfigurationError,
                 "event_consumers must be an Array or nil — got #{value.class}"
         end
     end
@@ -654,13 +669,15 @@ module Pgbus
     # +c.workers "..."+ followed by +c.capsule :name, ...+ appends the
     # named capsule to the list parsed from the string.
     def capsule(name, queues:, threads:, **)
-      raise ArgumentError, "capsule queues must be a non-empty Array" unless queues.is_a?(Array) && queues.any?
-      raise ArgumentError, "capsule threads must be a positive Integer" unless threads.is_a?(Integer) && threads.positive?
+      raise Pgbus::ConfigurationError, "capsule queues must be a non-empty Array" unless queues.is_a?(Array) && queues.any?
+      raise Pgbus::ConfigurationError, "capsule threads must be a positive Integer" unless threads.is_a?(Integer) && threads.positive?
 
       normalized_name = name.to_s
       @workers ||= []
 
-      raise ArgumentError, "capsule #{name.inspect} is already defined" if @workers.any? { |c| capsule_name(c) == normalized_name }
+      if @workers.any? { |c| capsule_name(c) == normalized_name }
+        raise Pgbus::ConfigurationError, "capsule #{name.inspect} is already defined"
+      end
 
       validate_no_queue_overlap!(queues)
 
@@ -696,9 +713,9 @@ module Pgbus
     #   Array         — list of roles to boot
     #
     # Each role is normalized to a downcased symbol and validated against
-    # VALID_ROLES. Unknown role names raise ArgumentError immediately so
-    # typos like `[:workres]` fail loud at boot rather than leaving the
-    # supervisor idling with no children.
+    # VALID_ROLES. Unknown role names raise Pgbus::ConfigurationError
+    # immediately so typos like `[:workres]` fail loud at boot rather than
+    # leaving the supervisor idling with no children.
     def roles=(value)
       if value.nil?
         @roles = nil
@@ -708,7 +725,7 @@ module Pgbus
       normalized = Array(value).map { |r| r.to_s.downcase.to_sym }.uniq
       invalid = normalized - VALID_ROLES
       if invalid.any?
-        raise ArgumentError,
+        raise Pgbus::ConfigurationError,
               "invalid role(s) #{invalid.inspect} — valid roles are: #{VALID_ROLES.join(", ")}"
       end
 
@@ -925,14 +942,24 @@ module Pgbus
         return validate_positive_duration!(value, name)
       end
 
-      raise ArgumentError,
+      raise Pgbus::ConfigurationError,
             "#{name} must be a Numeric (seconds), ActiveSupport::Duration, or nil to disable, got #{value.inspect}"
     end
 
     def validate_positive_duration!(numeric, name)
-      raise ArgumentError, "#{name} must be a positive number, got #{numeric}" unless numeric.positive?
+      raise Pgbus::ConfigurationError, "#{name} must be a positive number, got #{numeric}" unless numeric.positive?
 
       numeric
+    end
+
+    # ExecutionPools.normalize_mode raises ArgumentError for an unknown mode —
+    # that's the right shape for the factory's own callers, but a bad
+    # execution_mode reaching here is a configuration failure, so re-raise it
+    # as ConfigurationError to match the rest of validate! (issue #282).
+    def validate_execution_mode!(mode)
+      ExecutionPools.normalize_mode(mode)
+    rescue ArgumentError => e
+      raise Pgbus::ConfigurationError, e.message
     end
 
     # Symbolize the top-level keys of a worker/consumer config entry so every
@@ -940,7 +967,7 @@ module Pgbus
     # yields string keys; the Ruby DSL and +capsule+ builder yield symbols.
     # Entries are flat hashes with array/scalar values — no deep recursion.
     def normalize_entry(entry, group:)
-      raise ArgumentError, "#{group} entry must be a Hash, got #{entry.class}: #{entry.inspect}" unless entry.is_a?(Hash)
+      raise Pgbus::ConfigurationError, "#{group} entry must be a Hash, got #{entry.class}: #{entry.inspect}" unless entry.is_a?(Hash)
 
       entry.transform_keys(&:to_sym)
     end
@@ -985,13 +1012,13 @@ module Pgbus
       return if existing_queues.empty?
 
       if existing_queues.include?(CapsuleDSL::WILDCARD)
-        raise ArgumentError,
+        raise Pgbus::ConfigurationError,
               "an existing named capsule already uses '*' (matches every queue) — " \
               "the new capsule's queues #{new_queues.inspect} would overlap with it"
       end
 
       if new_queues.include?(CapsuleDSL::WILDCARD)
-        raise ArgumentError,
+        raise Pgbus::ConfigurationError,
               "the new capsule uses '*' (matches every queue) but other named capsules " \
               "are already defined with queues #{existing_queues.inspect} — " \
               "the wildcard would overlap with all of them"
@@ -1000,7 +1027,7 @@ module Pgbus
       conflict = new_queues.find { |q| existing_queues.include?(q) }
       return unless conflict
 
-      raise ArgumentError,
+      raise Pgbus::ConfigurationError,
             "queue #{conflict.inspect} is already assigned to another named capsule — " \
             "named capsules cannot share queues"
     end
@@ -1011,7 +1038,7 @@ module Pgbus
       entries.sum do |entry|
         threads = entry[:threads] || default_threads
         unless threads.is_a?(Integer) && threads.positive?
-          raise ArgumentError,
+          raise Pgbus::ConfigurationError,
                 "#{group} threads must be a positive integer, got #{threads.inspect}"
         end
 

--- a/lib/pgbus/execution_pools/async_pool.rb
+++ b/lib/pgbus/execution_pools/async_pool.rb
@@ -25,7 +25,7 @@ module Pgbus
 
       def post(&block)
         raise_if_fatal!
-        raise "Execution pool is shutting down" if shutdown?
+        raise Pgbus::ExecutionPoolError, "Execution pool is shutting down" if shutdown?
 
         reserved = false
         reserve_capacity!
@@ -193,7 +193,7 @@ module Pgbus
 
       def reserve_capacity!
         @mutex.synchronize do
-          raise "Execution pool is at capacity" if @available_capacity <= 0
+          raise Pgbus::ExecutionPoolError, "Execution pool is at capacity" if @available_capacity <= 0
 
           @available_capacity -= 1
         end

--- a/lib/pgbus/generators/config_converter.rb
+++ b/lib/pgbus/generators/config_converter.rb
@@ -30,7 +30,7 @@ module Pgbus
     # generator's CLI wrapper writes the new initializer and tells the
     # user to delete the YAML when ready.
     class ConfigConverter
-      class Error < StandardError; end
+      class Error < Pgbus::Error; end
 
       # Setters that accept ActiveSupport::Duration (PR 5).
       DURATION_SETTINGS = %w[

--- a/lib/pgbus/pgmq_schema.rb
+++ b/lib/pgbus/pgmq_schema.rb
@@ -11,7 +11,7 @@ module Pgbus
   # Vendored SQL files live in lib/pgbus/pgmq_schema/pgmq_v{VERSION}.sql
   # and are exact copies of the upstream pgmq-extension/sql/pgmq.sql at each release.
   module PgmqSchema
-    class VersionNotFoundError < StandardError; end
+    class VersionNotFoundError < Pgbus::Error; end
 
     SCHEMA_DIR = File.expand_path("pgmq_schema", __dir__).freeze
 

--- a/lib/pgbus/serializer.rb
+++ b/lib/pgbus/serializer.rb
@@ -55,21 +55,21 @@ module Pgbus
     # can be resolved — prevents loading arbitrary objects from crafted payloads.
     def locate_global_id(gid_string)
       gid = GlobalID.parse(gid_string)
-      raise ArgumentError, "Invalid GlobalID: #{gid_string.inspect}" unless gid
+      raise Pgbus::SerializationError, "Invalid GlobalID: #{gid_string.inspect}" unless gid
 
       allowed = Pgbus.configuration.allowed_global_id_models
       if allowed && allowed.empty?
-        raise ArgumentError,
+        raise Pgbus::SerializationError,
               "GlobalID deserialization is disabled (allowed_global_id_models is empty). " \
               "Set to nil to allow all models, or add permitted classes."
       end
       if allowed&.any? { |entry| !entry.is_a?(Class) && !entry.is_a?(Module) }
-        raise ArgumentError,
+        raise Pgbus::SerializationError,
               "allowed_global_id_models must contain Class/Module objects, " \
               "got: #{allowed.map(&:class).uniq.join(", ")}"
       end
       if allowed&.none? { |klass| gid.model_class <= klass }
-        raise ArgumentError,
+        raise Pgbus::SerializationError,
               "GlobalID model #{gid.model_class} is not in allowed_global_id_models. " \
               "Add it to Pgbus.configuration.allowed_global_id_models to permit deserialization."
       end

--- a/lib/pgbus/streams/signed_name.rb
+++ b/lib/pgbus/streams/signed_name.rb
@@ -14,10 +14,10 @@ module Pgbus
     # `"gid://app/Order/42:messages"`). Verification returns that string;
     # tampered or unsigned input raises `InvalidSignedName`.
     module SignedName
-      class InvalidSignedName < StandardError
+      class InvalidSignedName < Pgbus::Error
       end
 
-      class MissingSecret < StandardError
+      class MissingSecret < Pgbus::Error
       end
 
       def self.verify!(token)

--- a/spec/pgbus/active_job/adapter_spec.rb
+++ b/spec/pgbus/active_job/adapter_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Pgbus::ActiveJob::Adapter do
       it "raises an error" do
         allow(mock_client).to receive(:send_batch).and_return([1])
 
-        expect { adapter.enqueue_all([job, job2]) }.to raise_error(RuntimeError, /batch enqueue failed/)
+        expect { adapter.enqueue_all([job, job2]) }.to raise_error(Pgbus::EnqueueError, /batch enqueue failed/)
       end
     end
   end

--- a/spec/pgbus/config_loader_spec.rb
+++ b/spec/pgbus/config_loader_spec.rb
@@ -111,14 +111,14 @@ RSpec.describe Pgbus::ConfigLoader do
       expect(entry).to eq(topics: %w[orders.*], threads: 4)
     end
 
-    it "raises ArgumentError naming the offending key for an invalid value" do
+    it "raises Pgbus::ConfigurationError naming the offending key for an invalid value" do
       yaml = <<~YAML
         test:
           visibility_timeout: 0
       YAML
       expect do
         with_yaml(yaml) { |path| described_class.load(path, env: "test") }
-      end.to raise_error(ArgumentError, /visibility_timeout/)
+      end.to raise_error(Pgbus::ConfigurationError, /visibility_timeout/)
     end
 
     it "raises for an invalid value in a flat (un-sectioned) file" do
@@ -127,7 +127,7 @@ RSpec.describe Pgbus::ConfigLoader do
       YAML
       expect do
         with_yaml(yaml) { |path| described_class.load(path, env: "development") }
-      end.to raise_error(ArgumentError, /polling_interval/)
+      end.to raise_error(Pgbus::ConfigurationError, /polling_interval/)
     end
 
     it "loads a valid file without raising" do
@@ -379,7 +379,7 @@ RSpec.describe Pgbus::ConfigLoader do
       Pgbus.reset!
       expect do
         described_class.apply({ "polling_interval" => 0 })
-      end.to raise_error(ArgumentError, /polling_interval/)
+      end.to raise_error(Pgbus::ConfigurationError, /polling_interval/)
     end
 
     it "does not validate when eager_validation is disabled" do

--- a/spec/pgbus/configuration_log_format_spec.rb
+++ b/spec/pgbus/configuration_log_format_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Pgbus::Configuration do
     end
 
     it "raises for invalid formats" do
-      expect { config.log_format = :xml }.to raise_error(ArgumentError, /Invalid log_format/)
+      expect { config.log_format = :xml }.to raise_error(Pgbus::ConfigurationError, /Invalid log_format/)
     end
 
     it "accepts string values" do

--- a/spec/pgbus/configuration_pgmq_mode_spec.rb
+++ b/spec/pgbus/configuration_pgmq_mode_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects invalid modes" do
       expect { config.pgmq_schema_mode = :invalid }
-        .to raise_error(ArgumentError, /invalid/)
+        .to raise_error(Pgbus::ConfigurationError, /invalid/)
     end
   end
 end

--- a/spec/pgbus/configuration_spec.rb
+++ b/spec/pgbus/configuration_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe Pgbus::Configuration do
         config.pool_size = nil
         config.workers = [{ queues: %w[default], threads: "5" }]
         expect { config.resolved_pool_size }.to raise_error(
-          ArgumentError,
+          Pgbus::ConfigurationError,
           /worker.*threads.*positive integer/
         )
       end
@@ -365,7 +365,7 @@ RSpec.describe Pgbus::Configuration do
         config.pool_size = nil
         config.workers = [{ queues: %w[default], threads: 0.5 }]
         expect { config.resolved_pool_size }.to raise_error(
-          ArgumentError,
+          Pgbus::ConfigurationError,
           /worker.*threads.*positive integer/
         )
       end
@@ -374,7 +374,7 @@ RSpec.describe Pgbus::Configuration do
         config.pool_size = nil
         config.workers = [{ queues: %w[default], threads: 0 }]
         expect { config.resolved_pool_size }.to raise_error(
-          ArgumentError,
+          Pgbus::ConfigurationError,
           /worker.*threads.*positive integer/
         )
       end
@@ -383,7 +383,7 @@ RSpec.describe Pgbus::Configuration do
         config.pool_size = nil
         config.workers = [{ queues: %w[default], threads: -1 }]
         expect { config.resolved_pool_size }.to raise_error(
-          ArgumentError,
+          Pgbus::ConfigurationError,
           /worker.*threads.*positive integer/
         )
       end
@@ -393,7 +393,7 @@ RSpec.describe Pgbus::Configuration do
         config.workers = nil
         config.event_consumers = [{ topics: %w[orders.#], threads: "abc" }]
         expect { config.resolved_pool_size }.to raise_error(
-          ArgumentError,
+          Pgbus::ConfigurationError,
           /event_consumer.*threads.*positive integer/
         )
       end
@@ -401,7 +401,7 @@ RSpec.describe Pgbus::Configuration do
       it "includes the offending value in the error message" do
         config.pool_size = nil
         config.workers = [{ queues: %w[default], threads: "abc" }]
-        expect { config.resolved_pool_size }.to raise_error(ArgumentError, /"abc"/)
+        expect { config.resolved_pool_size }.to raise_error(Pgbus::ConfigurationError, /"abc"/)
       end
     end
   end
@@ -467,9 +467,9 @@ RSpec.describe Pgbus::Configuration do
                                      ])
       end
 
-      it "raises ArgumentError when an entry is not a Hash" do
+      it "raises Pgbus::ConfigurationError when an entry is not a Hash" do
         expect { config.workers = [%w[not a hash]] }.to raise_error(
-          ArgumentError, /worker entry must be a Hash/
+          Pgbus::ConfigurationError, /worker entry must be a Hash/
         )
       end
     end
@@ -526,12 +526,12 @@ RSpec.describe Pgbus::Configuration do
     end
 
     context "when given anything else" do
-      it "raises ArgumentError for an Integer" do
-        expect { config.workers = 5 }.to raise_error(ArgumentError, /String.*Array|Array.*String/)
+      it "raises Pgbus::ConfigurationError for an Integer" do
+        expect { config.workers = 5 }.to raise_error(Pgbus::ConfigurationError, /String.*Array|Array.*String/)
       end
 
-      it "raises ArgumentError for a Hash" do
-        expect { config.workers = { queues: %w[default] } }.to raise_error(ArgumentError, /String.*Array|Array.*String/)
+      it "raises Pgbus::ConfigurationError for a Hash" do
+        expect { config.workers = { queues: %w[default] } }.to raise_error(Pgbus::ConfigurationError, /String.*Array|Array.*String/)
       end
     end
   end
@@ -555,9 +555,9 @@ RSpec.describe Pgbus::Configuration do
       expect(config.event_consumers).to be_nil
     end
 
-    it "raises ArgumentError when an entry is not a Hash" do
+    it "raises Pgbus::ConfigurationError when an entry is not a Hash" do
       expect { config.event_consumers = ["not a hash"] }.to raise_error(
-        ArgumentError, /event_consumer entry must be a Hash/
+        Pgbus::ConfigurationError, /event_consumer entry must be a Hash/
       )
     end
   end
@@ -604,25 +604,25 @@ RSpec.describe Pgbus::Configuration do
       config.capsule(:critical, queues: %w[critical], threads: 5)
       expect do
         config.capsule(:critical, queues: %w[urgent], threads: 3)
-      end.to raise_error(ArgumentError, /:critical.*already defined/)
+      end.to raise_error(Pgbus::ConfigurationError, /:critical.*already defined/)
     end
 
     it "rejects nil queues" do
       expect do
         config.capsule(:bad, queues: nil, threads: 5)
-      end.to raise_error(ArgumentError, /queues/)
+      end.to raise_error(Pgbus::ConfigurationError, /queues/)
     end
 
     it "rejects empty queues" do
       expect do
         config.capsule(:bad, queues: [], threads: 5)
-      end.to raise_error(ArgumentError, /queues/)
+      end.to raise_error(Pgbus::ConfigurationError, /queues/)
     end
 
     it "rejects non-positive threads" do
       expect do
         config.capsule(:bad, queues: %w[a], threads: 0)
-      end.to raise_error(ArgumentError, /threads/)
+      end.to raise_error(Pgbus::ConfigurationError, /threads/)
     end
 
     it "raises if a queue overlaps with an already-defined capsule" do
@@ -630,7 +630,7 @@ RSpec.describe Pgbus::Configuration do
       config.capsule(:a, queues: %w[shared], threads: 5)
       expect do
         config.capsule(:b, queues: %w[shared], threads: 5)
-      end.to raise_error(ArgumentError, /shared.*already.*capsule/i)
+      end.to raise_error(Pgbus::ConfigurationError, /shared.*already.*capsule/i)
     end
   end
 
@@ -677,7 +677,7 @@ RSpec.describe Pgbus::Configuration do
       config.capsule(:critical, queues: %w[critical], threads: 5)
       expect do
         config.capsule("critical", queues: %w[urgent], threads: 3)
-      end.to raise_error(ArgumentError, /already defined/)
+      end.to raise_error(Pgbus::ConfigurationError, /already defined/)
     end
 
     it "string DSL stores auto-generated names as strings" do
@@ -710,7 +710,7 @@ RSpec.describe Pgbus::Configuration do
       config.capsule(:critical, queues: %w[critical], threads: 3)
       expect do
         config.capsule(:catch_all, queues: ["*"], threads: 5)
-      end.to raise_error(ArgumentError, /already.*capsule|wildcard/i)
+      end.to raise_error(Pgbus::ConfigurationError, /already.*capsule|wildcard/i)
     end
 
     it "rejects adding a named capsule when an existing NAMED wildcard capsule exists" do
@@ -718,7 +718,7 @@ RSpec.describe Pgbus::Configuration do
       config.capsule(:catch_all, queues: ["*"], threads: 5)
       expect do
         config.capsule(:critical, queues: %w[critical], threads: 3)
-      end.to raise_error(ArgumentError, /already.*capsule|wildcard/i)
+      end.to raise_error(Pgbus::ConfigurationError, /already.*capsule|wildcard/i)
     end
   end
 
@@ -739,7 +739,7 @@ RSpec.describe Pgbus::Configuration do
       config.capsule(:foo, queues: %w[shared], threads: 5)
       expect do
         config.capsule(:bar, queues: %w[shared], threads: 5)
-      end.to raise_error(ArgumentError, /shared.*already.*capsule/i)
+      end.to raise_error(Pgbus::ConfigurationError, /shared.*already.*capsule/i)
     end
   end
 
@@ -805,12 +805,12 @@ RSpec.describe Pgbus::Configuration do
       expect(config.roles).to eq(%i[workers dispatcher])
     end
 
-    it "raises ArgumentError for an unknown role (typo protection)" do
-      expect { config.roles = [:workres] }.to raise_error(ArgumentError, /invalid role.*workres/i)
+    it "raises Pgbus::ConfigurationError for an unknown role (typo protection)" do
+      expect { config.roles = [:workres] }.to raise_error(Pgbus::ConfigurationError, /invalid role.*workres/i)
     end
 
     it "lists valid roles in the error message" do
-      expect { config.roles = [:bogus] }.to raise_error(ArgumentError, /workers.*dispatcher.*scheduler/i)
+      expect { config.roles = [:bogus] }.to raise_error(Pgbus::ConfigurationError, /workers.*dispatcher.*scheduler/i)
     end
 
     it "does not raise for any of the supported roles" do
@@ -911,26 +911,26 @@ RSpec.describe Pgbus::Configuration do
       expect(config.recurring_execution_retention).to eq(7 * 24 * 3600)
     end
 
-    it "raises ArgumentError immediately when assigned a negative number" do
+    it "raises Pgbus::ConfigurationError immediately when assigned a negative number" do
       duration_settings.each do |setting|
         expect { config.public_send("#{setting}=", -1) }.to raise_error(
-          ArgumentError, /#{setting}.*positive/
+          Pgbus::ConfigurationError, /#{setting}.*positive/
         )
       end
     end
 
-    it "raises ArgumentError immediately when assigned zero" do
+    it "raises Pgbus::ConfigurationError immediately when assigned zero" do
       duration_settings.each do |setting|
         expect { config.public_send("#{setting}=", 0) }.to raise_error(
-          ArgumentError, /#{setting}.*positive/
+          Pgbus::ConfigurationError, /#{setting}.*positive/
         )
       end
     end
 
-    it "raises ArgumentError immediately when assigned a non-numeric value" do
+    it "raises Pgbus::ConfigurationError immediately when assigned a non-numeric value" do
       duration_settings.each do |setting|
         expect { config.public_send("#{setting}=", "five seconds") }.to raise_error(
-          ArgumentError, /#{setting}.*Numeric.*Duration/
+          Pgbus::ConfigurationError, /#{setting}.*Numeric.*Duration/
         )
       end
     end
@@ -963,7 +963,7 @@ RSpec.describe Pgbus::Configuration do
   describe "#validate!" do
     it "rejects invalid prefetch_limit" do
       config.prefetch_limit = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /prefetch_limit/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /prefetch_limit/)
     end
 
     it "accepts nil health_port (standalone server disabled)" do
@@ -978,12 +978,12 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects a non-integer health_port" do
       config.health_port = "9394"
-      expect { config.validate! }.to raise_error(ArgumentError, /health_port/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /health_port/)
     end
 
     it "rejects an out-of-range health_port" do
       config.health_port = 70_000
-      expect { config.validate! }.to raise_error(ArgumentError, /health_port/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /health_port/)
     end
 
     it "accepts valid prefetch_limit" do
@@ -993,12 +993,12 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects non-numeric stall_threshold" do
       config.stall_threshold = "90"
-      expect { config.validate! }.to raise_error(ArgumentError, /stall_threshold/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /stall_threshold/)
     end
 
     it "rejects zero stall_threshold" do
       config.stall_threshold = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /stall_threshold/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /stall_threshold/)
     end
 
     it "accepts nil stall_threshold (disabled)" do
@@ -1008,17 +1008,17 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects false stall_threshold" do
       config.stall_threshold = false
-      expect { config.validate! }.to raise_error(ArgumentError, /stall_threshold/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /stall_threshold/)
     end
 
     it "rejects non-numeric read_timeout" do
       config.read_timeout = "30"
-      expect { config.validate! }.to raise_error(ArgumentError, /read_timeout/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /read_timeout/)
     end
 
     it "rejects zero read_timeout" do
       config.read_timeout = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /read_timeout/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /read_timeout/)
     end
 
     it "accepts nil read_timeout (disabled)" do
@@ -1028,22 +1028,22 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects false read_timeout" do
       config.read_timeout = false
-      expect { config.validate! }.to raise_error(ArgumentError, /read_timeout/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /read_timeout/)
     end
 
     it "rejects zero stats_flush_size" do
       config.stats_flush_size = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /stats_flush_size/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /stats_flush_size/)
     end
 
     it "rejects negative stats_flush_size" do
       config.stats_flush_size = -1
-      expect { config.validate! }.to raise_error(ArgumentError, /stats_flush_size/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /stats_flush_size/)
     end
 
     it "rejects non-integer stats_flush_size" do
       config.stats_flush_size = 100.5
-      expect { config.validate! }.to raise_error(ArgumentError, /stats_flush_size/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /stats_flush_size/)
     end
 
     it "accepts a positive stats_flush_size" do
@@ -1053,12 +1053,12 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects zero stats_flush_interval" do
       config.stats_flush_interval = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /stats_flush_interval/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /stats_flush_interval/)
     end
 
     it "rejects negative stats_flush_interval" do
       config.stats_flush_interval = -1
-      expect { config.validate! }.to raise_error(ArgumentError, /stats_flush_interval/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /stats_flush_interval/)
     end
 
     it "accepts a positive stats_flush_interval" do
@@ -1068,12 +1068,12 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects invalid priority_levels" do
       config.priority_levels = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /priority_levels/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /priority_levels/)
     end
 
     it "rejects priority_levels > 10" do
       config.priority_levels = 11
-      expect { config.validate! }.to raise_error(ArgumentError, /priority_levels/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /priority_levels/)
     end
 
     it "accepts valid priority_levels" do
@@ -1097,7 +1097,7 @@ RSpec.describe Pgbus::Configuration do
     end
 
     it "rejects invalid group_mode" do
-      expect { config.group_mode = :invalid }.to raise_error(ArgumentError, /group_mode/)
+      expect { config.group_mode = :invalid }.to raise_error(Pgbus::ConfigurationError, /group_mode/)
     end
 
     it "coerces string group_mode to symbol" do
@@ -1105,19 +1105,19 @@ RSpec.describe Pgbus::Configuration do
       expect(config.group_mode).to eq(:fifo)
     end
 
-    it "raises ArgumentError (not NoMethodError) for non-string/symbol types" do
-      expect { config.group_mode = 1 }.to raise_error(ArgumentError, /type/)
-      expect { config.group_mode = true }.to raise_error(ArgumentError, /type/)
+    it "raises Pgbus::ConfigurationError (not NoMethodError) for non-string/symbol types" do
+      expect { config.group_mode = 1 }.to raise_error(Pgbus::ConfigurationError, /type/)
+      expect { config.group_mode = true }.to raise_error(Pgbus::ConfigurationError, /type/)
     end
 
     it "rejects non-positive insights_default_minutes" do
       config.insights_default_minutes = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /insights_default_minutes/)
     end
 
     it "rejects negative insights_default_minutes" do
       config.insights_default_minutes = -1
-      expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /insights_default_minutes/)
     end
 
     it "accepts nil workers (workerless modes like scheduler-only or dispatcher-only)" do
@@ -1127,22 +1127,22 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects fractional insights_default_minutes" do
       config.insights_default_minutes = 90.5
-      expect { config.validate! }.to raise_error(ArgumentError, /insights_default_minutes/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /insights_default_minutes/)
     end
 
     it "rejects negative retry_backoff" do
       config.retry_backoff = -1
-      expect { config.validate! }.to raise_error(ArgumentError, /retry_backoff must be > 0/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /retry_backoff must be > 0/)
     end
 
     it "rejects nil retry_backoff_max" do
       config.retry_backoff_max = nil
-      expect { config.validate! }.to raise_error(ArgumentError, /retry_backoff_max must be > 0/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /retry_backoff_max must be > 0/)
     end
 
     it "rejects jitter > 1" do
       config.retry_backoff_jitter = 1.5
-      expect { config.validate! }.to raise_error(ArgumentError, /retry_backoff_jitter must be between 0 and 1/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /retry_backoff_jitter must be between 0 and 1/)
     end
 
     it "accepts valid backoff settings" do
@@ -1154,7 +1154,7 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects invalid global execution_mode" do
       config.execution_mode = :bogus
-      expect { config.validate! }.to raise_error(ArgumentError, /execution_mode/i)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /execution_mode/i)
     end
 
     it "accepts valid execution_mode values" do
@@ -1166,7 +1166,7 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects invalid per-worker execution_mode" do
       config.workers = [{ queues: %w[default], threads: 5, execution_mode: :bogus }]
-      expect { config.validate! }.to raise_error(ArgumentError, /execution_mode/i)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /execution_mode/i)
     end
 
     it "accepts per-worker execution_mode override" do
@@ -1196,12 +1196,12 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects an unknown metrics_backend symbol" do
       config.metrics_backend = :bogus
-      expect { config.validate! }.to raise_error(ArgumentError, /metrics_backend/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /metrics_backend/)
     end
 
     it "rejects a non-backend metrics_backend object" do
       config.metrics_backend = "prometheus"
-      expect { config.validate! }.to raise_error(ArgumentError, /metrics_backend/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /metrics_backend/)
     end
 
     it "accepts the default statsd_host, statsd_port, and health_bind" do
@@ -1210,17 +1210,17 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects a non-String statsd_host" do
       config.statsd_host = 123
-      expect { config.validate! }.to raise_error(ArgumentError, /statsd_host/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /statsd_host/)
     end
 
     it "rejects an empty statsd_host" do
       config.statsd_host = ""
-      expect { config.validate! }.to raise_error(ArgumentError, /statsd_host/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /statsd_host/)
     end
 
     it "rejects a nil statsd_host" do
       config.statsd_host = nil
-      expect { config.validate! }.to raise_error(ArgumentError, /statsd_host/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /statsd_host/)
     end
 
     it "accepts a valid statsd_host" do
@@ -1230,27 +1230,27 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects a non-Integer statsd_port" do
       config.statsd_port = "8125"
-      expect { config.validate! }.to raise_error(ArgumentError, /statsd_port/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /statsd_port/)
     end
 
     it "rejects a zero statsd_port" do
       config.statsd_port = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /statsd_port/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /statsd_port/)
     end
 
     it "rejects a negative statsd_port" do
       config.statsd_port = -1
-      expect { config.validate! }.to raise_error(ArgumentError, /statsd_port/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /statsd_port/)
     end
 
     it "rejects an out-of-range statsd_port" do
       config.statsd_port = 70_000
-      expect { config.validate! }.to raise_error(ArgumentError, /statsd_port/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /statsd_port/)
     end
 
     it "rejects a nil statsd_port" do
       config.statsd_port = nil
-      expect { config.validate! }.to raise_error(ArgumentError, /statsd_port/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /statsd_port/)
     end
 
     it "accepts a valid statsd_port" do
@@ -1260,17 +1260,17 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects a non-String health_bind" do
       config.health_bind = 123
-      expect { config.validate! }.to raise_error(ArgumentError, /health_bind/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /health_bind/)
     end
 
     it "rejects an empty health_bind" do
       config.health_bind = ""
-      expect { config.validate! }.to raise_error(ArgumentError, /health_bind/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /health_bind/)
     end
 
     it "rejects a nil health_bind" do
       config.health_bind = nil
-      expect { config.validate! }.to raise_error(ArgumentError, /health_bind/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /health_bind/)
     end
 
     it "accepts a valid health_bind" do
@@ -1538,37 +1538,37 @@ RSpec.describe Pgbus::Configuration do
   describe "#validate! with streams settings" do
     it "rejects negative streams_default_retention" do
       config.streams_default_retention = -1
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_default_retention/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_default_retention/)
     end
 
     it "rejects non-positive streams_max_connections" do
       config.streams_max_connections = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_max_connections/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_max_connections/)
     end
 
     it "rejects non-positive streams_heartbeat_interval" do
       config.streams_heartbeat_interval = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_heartbeat_interval/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_heartbeat_interval/)
     end
 
     it "rejects non-Hash streams_retention" do
       config.streams_retention = "nope"
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_retention/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_retention/)
     end
 
     it "rejects non-positive streams_idle_timeout" do
       config.streams_idle_timeout = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_idle_timeout/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_idle_timeout/)
     end
 
     it "rejects non-positive streams_listen_health_check_ms" do
       config.streams_listen_health_check_ms = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_listen_health_check_ms/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_listen_health_check_ms/)
     end
 
     it "rejects non-positive streams_write_deadline_ms" do
       config.streams_write_deadline_ms = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_write_deadline_ms/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_write_deadline_ms/)
     end
 
     it "accepts a valid streams config" do
@@ -1682,16 +1682,16 @@ RSpec.describe Pgbus::Configuration do
   describe "Pgbus.configure eager validation" do
     after { Pgbus.reset! }
 
-    it "raises ArgumentError when an invalid value is set in the block" do
+    it "raises Pgbus::ConfigurationError when an invalid value is set in the block" do
       expect do
         Pgbus.configure { |c| c.visibility_timeout = 0 }
-      end.to raise_error(ArgumentError, /visibility_timeout/)
+      end.to raise_error(Pgbus::ConfigurationError, /visibility_timeout/)
     end
 
     it "raises for a value that only validate! catches (not caught by the setter)" do
       expect do
         Pgbus.configure { |c| c.polling_interval = 0 }
-      end.to raise_error(ArgumentError, /polling_interval/)
+      end.to raise_error(Pgbus::ConfigurationError, /polling_interval/)
     end
 
     it "passes for a valid configure block" do
@@ -1729,7 +1729,7 @@ RSpec.describe Pgbus::Configuration do
     it "still allows explicit validate! after opting out" do
       Pgbus.configuration.eager_validation = false
       Pgbus.configure { |c| c.polling_interval = 0 }
-      expect { Pgbus.configuration.validate! }.to raise_error(ArgumentError, /polling_interval/)
+      expect { Pgbus.configuration.validate! }.to raise_error(Pgbus::ConfigurationError, /polling_interval/)
     end
   end
 end

--- a/spec/pgbus/error_hierarchy_spec.rb
+++ b/spec/pgbus/error_hierarchy_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Pins the 1.0 error-hierarchy contract (issue #282). Two policies:
+#   1. Operational errors descend from Pgbus::Error so `rescue Pgbus::Error`
+#      catches every pgbus-raised operational failure.
+#   2. Argument-shape errors (malformed caller input) stay ArgumentError
+#      subclasses by design — that's what ArgumentError means.
+RSpec.describe Pgbus::Error do
+  # Generators live outside Zeitwerk (lib/pgbus.rb ignores lib/pgbus/generators),
+  # so ConfigConverter isn't autoloaded — require it so its Error is defined.
+  # The rest resolve lazily via const_get below.
+  before { require "pgbus/generators/config_converter" }
+
+  describe "operational errors descend from Pgbus::Error" do
+    [
+      "Pgbus::ConfigurationError",
+      "Pgbus::SerializationError",
+      "Pgbus::QueueNotFoundError",
+      "Pgbus::DeadLetterError",
+      "Pgbus::ConcurrencyLimitExceeded",
+      "Pgbus::JobNotUnique",
+      "Pgbus::SchemaNotReady",
+      "Pgbus::ReadTimeoutError",
+      "Pgbus::ConnectionCircuitOpenError",
+      "Pgbus::EnqueueError",
+      "Pgbus::ExecutionPoolError",
+      "Pgbus::Process::ReplicaConnectionError",
+      "Pgbus::PgmqSchema::VersionNotFoundError",
+      "Pgbus::Streams::SignedName::InvalidSignedName",
+      "Pgbus::Streams::SignedName::MissingSecret",
+      "Pgbus::Generators::ConfigConverter::Error"
+    ].each do |const_name|
+      it "#{const_name} < Pgbus::Error" do
+        klass = Object.const_get(const_name)
+        expect(klass).to be < described_class
+      end
+    end
+  end
+
+  describe "argument-shape errors stay ArgumentError subclasses (policy pin)" do
+    [
+      "Pgbus::Configuration::CapsuleDSL::ParseError",
+      "Pgbus::Streams::Cursor::InvalidCursor",
+      "Pgbus::Streams::StreamNameTooLong"
+    ].each do |const_name|
+      it "#{const_name} < ArgumentError and NOT < Pgbus::Error" do
+        klass = Object.const_get(const_name)
+        expect(klass).to be < ArgumentError
+        expect(klass).not_to be < described_class
+      end
+    end
+  end
+
+  it "Pgbus::Error is a StandardError (rescuable by bare rescue)" do
+    expect(described_class).to be < StandardError
+  end
+end

--- a/spec/pgbus/execution_pools/async_pool_spec.rb
+++ b/spec/pgbus/execution_pools/async_pool_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Pgbus::ExecutionPools::AsyncPool do
     it "raises when pool is shutting down" do
       pool.shutdown
       sleep 0.05
-      expect { pool.post { nil } }.to raise_error(RuntimeError, /shutting down/)
+      expect { pool.post { nil } }.to raise_error(Pgbus::ExecutionPoolError, /shutting down/)
     end
 
     it "raises when pool is at capacity" do
@@ -64,7 +64,7 @@ RSpec.describe Pgbus::ExecutionPools::AsyncPool do
       capacity.times { pool.post { barrier.wait(5) } }
       sleep 0.05
 
-      expect { pool.post { nil } }.to raise_error(RuntimeError, /at capacity/)
+      expect { pool.post { nil } }.to raise_error(Pgbus::ExecutionPoolError, /at capacity/)
       barrier.set
     end
   end

--- a/spec/pgbus/security_spec.rb
+++ b/spec/pgbus/security_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Security" do
 
         expect do
           Pgbus::Serializer.locate_global_id("gid://pgbus-test/Secret/1")
-        end.to raise_error(ArgumentError, /not in allowed_global_id_models/)
+        end.to raise_error(Pgbus::SerializationError, /not in allowed_global_id_models/)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe "Security" do
       it "rejects all GlobalID models with a clear message" do
         expect do
           Pgbus::Serializer.locate_global_id(gid_uri)
-        end.to raise_error(ArgumentError, /deserialization is disabled/)
+        end.to raise_error(Pgbus::SerializationError, /deserialization is disabled/)
       end
     end
 
@@ -63,14 +63,14 @@ RSpec.describe "Security" do
       it "raises with a clear type error" do
         expect do
           Pgbus::Serializer.locate_global_id(gid_uri)
-        end.to raise_error(ArgumentError, %r{must contain Class/Module objects})
+        end.to raise_error(Pgbus::SerializationError, %r{must contain Class/Module objects})
       end
     end
 
     it "raises on invalid GlobalID strings" do
       expect do
         Pgbus::Serializer.locate_global_id("not-a-gid")
-      end.to raise_error(ArgumentError, /Invalid GlobalID/)
+      end.to raise_error(Pgbus::SerializationError, /Invalid GlobalID/)
     end
   end
 

--- a/spec/pgbus/streams/broadcast_mode_config_spec.rb
+++ b/spec/pgbus/streams/broadcast_mode_config_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects invalid values" do
       expect { config.streams_default_broadcast_mode = :bogus }
-        .to raise_error(ArgumentError, /streams_default_broadcast_mode/)
+        .to raise_error(Pgbus::ConfigurationError, /streams_default_broadcast_mode/)
     end
   end
 
@@ -49,12 +49,12 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects non-positive streams_orphan_sweep_interval" do
       config.streams_orphan_sweep_interval = 0
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_orphan_sweep_interval/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_orphan_sweep_interval/)
     end
 
     it "rejects non-positive streams_orphan_threshold" do
       config.streams_orphan_threshold = -1
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_orphan_threshold/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_orphan_threshold/)
     end
 
     it "accepts nil streams_orphan_sweep_interval (disables sweeper)" do

--- a/spec/pgbus/streams/durable_patterns_spec.rb
+++ b/spec/pgbus/streams/durable_patterns_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects non-Array values" do
       config.streams_durable_patterns = "chat"
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_durable_patterns/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_durable_patterns/)
     end
 
     it "accepts an array of strings and regex" do

--- a/spec/pgbus/streams/presence_patterns_spec.rb
+++ b/spec/pgbus/streams/presence_patterns_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects non-Array values" do
       config.streams_presence_patterns = "chat"
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_presence_patterns/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_presence_patterns/)
     end
 
     it "accepts an array of strings and regex" do
@@ -36,7 +36,7 @@ RSpec.describe Pgbus::Configuration do
 
     it "rejects a non-callable value at boot (fail fast)" do
       config.streams_presence_member = "not callable"
-      expect { config.validate! }.to raise_error(ArgumentError, /streams_presence_member must respond to #call/)
+      expect { config.validate! }.to raise_error(Pgbus::ConfigurationError, /streams_presence_member must respond to #call/)
     end
   end
 


### PR DESCRIPTION
## Summary

At 1.0 the error hierarchy becomes a public contract. `Pgbus::Error` already existed with well-formed subclasses, but several call sites raised bare stdlib errors that no `rescue Pgbus::Error` could catch — freezing an inconsistent contract into the 1.0 API. This unifies **operational** errors under `Pgbus::Error` while deliberately keeping **argument-shape** errors as `ArgumentError` subclasses, and documents the split as an intentional policy at the top of `lib/pgbus.rb`.

Closes #282 · Part of epic #273.

## What changed

**New / changed raise classes (messages unchanged — only the class changed):**

| Raised before | Raises now | Where |
|---|---|---|
| `ArgumentError` | `Pgbus::ConfigurationError` | `Configuration#validate!` + all setters (51 sites + the `execution_mode` path) |
| `RuntimeError` (bare string) | `Pgbus::ExecutionPoolError` (new) | `ExecutionPools::AsyncPool` shutdown / at-capacity |
| `RuntimeError` (bare string) | `Pgbus::EnqueueError` (new) | `ActiveJob` adapter `perform_all_later` msg_id-count mismatch |
| `ArgumentError` | `Pgbus::SerializationError` | `Serializer#locate_global_id` GlobalID rejection |

**Re-parented under `Pgbus::Error`** (were `< StandardError`): `PgmqSchema::VersionNotFoundError`, `Streams::SignedName::InvalidSignedName`, `Streams::SignedName::MissingSecret`, `Generators::ConfigConverter::Error`.

**Kept as `ArgumentError` by design** (argument-shape errors): `Configuration::CapsuleDSL::ParseError`, `Streams::Cursor::InvalidCursor`, `Streams::StreamNameTooLong`. The `StreamNameTooLong` comment already documented this choice; the policy now lives in `lib/pgbus.rb` and is pinned by `spec/pgbus/error_hierarchy_spec.rb`.

The `execution_mode` validation delegates to `ExecutionPools.normalize_mode`, which raises `ArgumentError` for its own factory callers (`ExecutionPools.build`). Rather than change that shared contract, `validate!` translates it to `ConfigurationError` at the config boundary via a small `validate_execution_mode!` helper.

## ⚠️ Breaking change

`Configuration#validate!` and its setters now raise `Pgbus::ConfigurationError` (which is **not** an `ArgumentError`). If you `rescue ArgumentError` around `Pgbus.configure` or a boot-time config read, it will stop catching config failures — switch to `rescue Pgbus::Error`. Documented in the upgrade guide's 1.0 section, the README error-handling section, and the CHANGELOG under `[Unreleased]` → Breaking Changes.

## Test plan

- [x] `spec/pgbus/error_hierarchy_spec.rb` (new) — every operational error asserts `< Pgbus::Error`; the three argument-shape classes assert `< ArgumentError` **and** `not < Pgbus::Error`, pinning the policy.
- [x] 89 assertions across 10 spec files updated from `ArgumentError`/`RuntimeError` to the new classes on the touched call sites only (out-of-scope `ArgumentError` sites — `Filters#register`, `QueueNameValidator`, `Metrics.resolve_backend`, `Worker`/`CLI` inline validation, cursor/key/envelope — left unchanged).
- [x] `bundle exec rspec spec/pgbus/ spec/generators/` → **3085 examples, 0 failures, 1 pending** (pre-existing platform skip); line coverage 90.37% / branch 75.93% (above gates).
- [x] `bundle exec rubocop` → clean on all 19 changed Ruby files (the 5 remaining offenses are pre-existing in `spec/integration/batch_flow_spec.rb`, untouched here).
- [x] `grep -rn 'raise "' lib/ | grep -v generators/` → zero bare-string raises.
- [x] `cd docs && bundle exec rspec` → **69 examples, 0 failures**.

https://claude.ai/code/session_019UyWsPP7veHzzB8Z1zGr6W
