### PR TITLE
fix(mcp): return a clean 401 instead of a frozen response triple (FrozenError → 500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- **`Pgbus::MCP.rack_app` now returns a clean 401 on auth failure instead of a 500.** The `RackApp` auth gate returned a *frozen* `UNAUTHORIZED` response triple; once mounted in Rails, response-mutating middleware downstream (`Rack::TempfileReaper` assigns `response[2]`, `Rack::ETag` adds a header) raised `FrozenError`, so every request with a missing/mismatched `PGBUS_MCP_TOKEN` surfaced as an opaque 500 in the host app's error tracker rather than the intended 401. The gate now builds a fresh, mutable array and headers hash per call (only the JSON body string stays memoized+frozen). A request-level spec drives the app through the real `TempfileReaper`/`ETag` stack to guard against regression. Refs #304.
+
 ### Security
 
 ## [0.9.8.1] - 2026-07-04

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    pgbus (0.9.8.1)
+    pgbus (0.9.9)
       concurrent-ruby (~> 1.2)
       fugit (~> 1.11, >= 1.11.1)
       globalid (~> 1.0)
@@ -537,7 +537,7 @@ CHECKSUMS
   pg (1.6.3-x86_64-darwin) sha256=ee2e04a17c0627225054ffeb43e31a95be9d7e93abda2737ea3ce4a62f2729d6
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
-  pgbus (0.9.8.1)
+  pgbus (0.9.9)
   pgmq-ruby (0.7.0) sha256=018a33e304b0c4513d3dc8cd06322ac767ebc0b475422738a71c198f066f2a76
   playwright-ruby-client (1.61.0) sha256=1f5c5f0307a2f6bd70b4fa797020a30eef5680caf8d5bd9ccc8d3937f6666e08
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570

--- a/lib/pgbus/mcp/rack_app.rb
+++ b/lib/pgbus/mcp/rack_app.rb
@@ -22,11 +22,12 @@ module Pgbus
     # / behind your VPN, never internet-exposed.
     class RackApp
       BEARER_PREFIX = "Bearer "
-      UNAUTHORIZED = [
-        401,
-        { "Content-Type" => "application/json", "WWW-Authenticate" => "Bearer" },
-        [{ jsonrpc: "2.0", id: nil, error: { code: -32_001, message: "Unauthorized" } }.to_json]
-      ].freeze
+      # Only the JSON body string is frozen and reused. The outer response triple
+      # and its headers hash MUST be built fresh per call (#unauthorized) so
+      # downstream Rack middleware can mutate them — Rack::TempfileReaper assigns
+      # response[2] and Rack::ETag adds headers. Returning a frozen array/hash
+      # raised FrozenError → 500 instead of 401 (issue #304).
+      UNAUTHORIZED_BODY = { jsonrpc: "2.0", id: nil, error: { code: -32_001, message: "Unauthorized" } }.to_json.freeze
 
       # @param data_source [Pgbus::Web::DataSource] read layer the tools query.
       #   Built once and shared: DataSource acquires Pgbus::BusRecord.connection
@@ -55,12 +56,21 @@ module Pgbus
       # the gem's transport has no auth of its own.
       def call(env)
         request = Rack::Request.new(env)
-        return UNAUTHORIZED unless authorized?(request)
+        return unauthorized unless authorized?(request)
 
         @transport.handle_request(request)
       end
 
       private
+
+      # A fresh, mutable 401 response triple each call. See UNAUTHORIZED_BODY.
+      def unauthorized
+        [
+          401,
+          { "Content-Type" => "application/json", "WWW-Authenticate" => "Bearer" },
+          [UNAUTHORIZED_BODY]
+        ]
+      end
 
       # An explicit auth callable wins; otherwise fall back to the bearer token;
       # otherwise (neither configured) allow — the constructor already warned.

--- a/lib/pgbus/mcp/rack_app.rb
+++ b/lib/pgbus/mcp/rack_app.rb
@@ -64,10 +64,12 @@ module Pgbus
       private
 
       # A fresh, mutable 401 response triple each call. See UNAUTHORIZED_BODY.
+      # Header keys are lowercase per the Rack 3 SPEC (matches stream_app.rb and
+      # prometheus_exporter.rb); Rack::Headers looks them up case-insensitively.
       def unauthorized
         [
           401,
-          { "Content-Type" => "application/json", "WWW-Authenticate" => "Bearer" },
+          { "content-type" => "application/json", "www-authenticate" => "Bearer" },
           [UNAUTHORIZED_BODY]
         ]
       end

--- a/spec/pgbus/mcp/rack_app_spec.rb
+++ b/spec/pgbus/mcp/rack_app_spec.rb
@@ -88,6 +88,33 @@ RSpec.describe Pgbus::MCP::RackApp do
 
       expect(response.headers["WWW-Authenticate"]).to eq("Bearer")
     end
+
+    it "returns a fresh, mutable response array on each auth failure" do
+      app = described_class.new(data_source: data_source, token: "s3cret")
+      env = Rack::MockRequest.env_for("/", input: health_call, **json_headers)
+
+      first = app.call(env)
+      second = app.call(Rack::MockRequest.env_for("/", input: health_call, **json_headers))
+
+      expect(first).not_to be_frozen
+      expect(first[1]).not_to be_frozen
+      expect(first).not_to equal(second)
+    end
+
+    # Regression for #304: the frozen UNAUTHORIZED triple raised FrozenError once
+    # a downstream, response-mutating middleware ran — turning 401 into 500. Drive
+    # the app through the real Rack::TempfileReaper (assigns response[2]) and
+    # Rack::ETag (adds a header) to catch it the way Rails does.
+    it "answers 401 through response-mutating middleware without a FrozenError" do
+      require "rack/tempfile_reaper"
+      require "rack/etag"
+      stack = Rack::TempfileReaper.new(Rack::ETag.new(described_class.new(data_source: data_source, token: "s3cret")))
+
+      response = Rack::MockRequest.new(stack).post("/", input: health_call, **json_headers)
+
+      expect(response.status).to eq(401)
+      expect(JSON.parse(response.body).dig("error", "message")).to eq("Unauthorized")
+    end
   end
 
   describe "custom auth callable" do


### PR DESCRIPTION
## Summary

`Pgbus::MCP::RackApp` returned a **frozen** `UNAUTHORIZED` response triple on every auth failure. Mounted in a Rails app, downstream response-mutating middleware raises `FrozenError`:

- `Rack::TempfileReaper#call` assigns `response[2] = BodyProxy.new(...)` → `can't modify frozen Array`
- `Rack::ETag#call` adds a header to the frozen hash

So a missing/mismatched `PGBUS_MCP_TOKEN` surfaced as an opaque **HTTP 500** in the host app's error tracker instead of the intended **401**. Calling the app in isolation (`app.call(env)`) returned 401 correctly — which is exactly why the existing unit tests missed it.

Closes #304

## Fix

Build a fresh, mutable array + headers hash per call in a private `#unauthorized`. Only the JSON body *string* stays memoized and frozen (`UNAUTHORIZED_BODY`) — the frozen string is fine; the frozen outer array and headers hash were the problem.

```ruby
UNAUTHORIZED_BODY = { jsonrpc: "2.0", id: nil, error: { code: -32_001, message: "Unauthorized" } }.to_json.freeze

def unauthorized
  [401, { "Content-Type" => "application/json", "WWW-Authenticate" => "Bearer" }, [UNAUTHORIZED_BODY]]
end
```

Same 401 status, same headers, same JSON body — only object identity/mutability changed. Fully backwards compatible.

## Test plan

- [x] New regression spec drives the app through the **real** `Rack::TempfileReaper` + `Rack::ETag` stack (the exact middleware from the stack trace) and asserts a clean 401 — this failed with `FrozenError` before the fix
- [x] New spec asserts each auth failure yields a fresh, non-frozen array + headers hash
- [x] All 5 existing token-gate specs still green
- [x] `bundle exec rspec spec/pgbus/mcp` → 94 examples, 0 failures
- [x] `bundle exec rubocop` clean on changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthorized token-gate requests now correctly return **401 Unauthorized** instead of failing with **500**.
  * Unauthorized responses were adjusted to prevent middleware from encountering immutability issues, improving reliability across the full request pipeline.

* **Tests**
  * Added regression coverage to confirm each unauthorized response is freshly generated and mutable per request.
  * Added a middleware-stack check to ensure the **401** behavior remains stable and avoids recurrence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->