### PR TITLE
chore(claude): add unknowns-discovery phases to /plan and /lfg

### DIFF
--- a/.claude/commands/lfg.md
+++ b/.claude/commands/lfg.md
@@ -86,6 +86,16 @@ Create a TaskCreate todo list with specific implementation steps.
 
 ## Phase 4: Implement (TDD)
 
+### The deviation log (keep it from the first edit)
+
+The plan is the map; the codebase is the territory. The moment reality forces a choice the plan or issue didn't settle, log it in `implementation-notes.md` at the repo root — one line, at the moment it happens, not reconstructed later:
+
+- **Deviations** — the plan said X, you did Y, because Z
+- **Discoveries** — facts about the codebase the plan didn't know
+- **Judgment calls** — choices the user might have made differently (defaults, naming, scope cuts)
+
+Pick the conservative option and keep going. The log is how the user audits your judgment afterwards. Never commit the file: its contents move into the PR body (Phase 7), then the file is deleted.
+
 For each logical unit:
 
 ### 4.1: Write Failing Test First
@@ -268,6 +278,20 @@ rm /tmp/pr-body.md
 
 The `--body-file` path avoids the double-layer of shell interpretation entirely and makes long PR bodies easier to read in the terminal buffer.
 
+The PR body MUST end with a `## Deviations & judgment calls` section copied from
+`implementation-notes.md` (then delete the file). If the plan held completely,
+write "None — the plan held." This section is read FIRST in review — it is the
+audit trail for every decision the plan didn't make.
+
+---
+
+## Phase 8: Comprehension Close-Out
+
+The tests prove the CODE is right; this phase keeps the USER's mental model right. After the PR is up, end your final message with:
+
+1. **The decisions, not the diff** — the 3–5 non-obvious choices in this change someone must understand to maintain it. Lead with anything from the deviation log; the user has never seen those.
+2. **Three merge-gate questions** the user should be able to answer before merging. If any answer isn't obvious to them, offer a walkthrough — an unanswerable question is comprehension debt, and merging anyway is how it compounds.
+
 ---
 
 ## Verification Checklist
@@ -279,6 +303,8 @@ The `--body-file` path avoids the double-layer of shell interpretation entirely 
 - [ ] Backwards compatibility maintained
 - [ ] PGMQ operations go through Client wrapper
 - [ ] PR created with description
+- [ ] PR body ends with `## Deviations & judgment calls` (from implementation-notes.md, since deleted)
+- [ ] Comprehension close-out delivered (decisions + three merge-gate questions)
 
 ---
 

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -2,7 +2,7 @@
 description: "Investigates the codebase, designs a solution, and produces a durable plan artifact — a GitHub issue or a plan markdown under docs/plans/. Read-only: never edits application code. Use before /lfg for anything non-trivial."
 model: fable
 argument-hint: "issue <feature or problem> | md <feature or problem> | <feature or problem>"
-allowed-tools: Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh search:*), Bash(gh label list:*), Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(date:*), Read, Grep, Glob, Write, Agent
+allowed-tools: Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh search:*), Bash(gh label list:*), Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(date:*), Read, Grep, Glob, Write, Agent, AskUserQuestion
 ---
 
 # Plan — design expensive, execute cheap
@@ -32,13 +32,27 @@ Protect this session's context: delegate mechanical exploration to cheaper subag
 3. Check the architecture layers in `CLAUDE.md` and read the matching source files — past decisions and gotchas live there.
 4. Check `git log` for recent related work; the design should extend it, not fight it.
 
-## Phase 2 — Design
+## Phase 2 — Surface the unknowns (blindspot pass + interview)
+
+Investigation tells you what the codebase says; this phase finds what the REQUEST doesn't say. Run it BEFORE designing — a wrong assumption caught here costs one question; caught in review it costs a rewrite.
+
+1. **Blindspot pass.** Write down the unknowns you are carrying into the design:
+   - decisions the request leaves open (defaults, naming, public API/config surface, rollout & upgrade story)
+   - edge cases the codebase makes possible that the request never mentions
+   - anything with no precedent in this repo — flag it explicitly as unknown-unknown territory
+2. **Interview the user** with AskUserQuestion, one question at a time, prioritized by blast radius: architecture-changing answers first, then public API / config surface, then UX. Rules:
+   - Skip anything the codebase, CLAUDE.md, or an existing issue already answers.
+   - 2–5 questions is the sweet spot; zero is fine when the request is genuinely unambiguous — say so rather than inventing questions.
+   - Every question offers concrete options with a recommended default, never an open-ended essay prompt.
+3. **Record the answers** in the plan's Decision section as `Settled in interview:` bullets — constraints the executor must not re-litigate.
+
+## Phase 3 — Design
 
 - Develop 2-3 candidate approaches with real tradeoffs. Pick one and say why; record why the others lost.
 - The chosen design must respect project invariants: all PGMQ access through `Pgbus::Client`, queue prefixing via `config.queue_name()`, dead letter routing, visibility timeouts, worker recycling, TDD (specs named before implementation steps), no `Marshal.load`, thread-safe shared state.
 - Decide the test strategy per the testing rules: unit specs for config/event/serializer, integration specs for ActiveJob adapter, mocked client for dashboard DataSource.
 
-## Phase 3 — Emit the plan artifact
+## Phase 4 — Emit the plan artifact
 
 Use this structure for the issue body or markdown file. Every section is load-bearing — an executor uses Context to avoid re-discovery, Steps to act, Gates to verify, Boundaries to stop.
 
@@ -52,7 +66,7 @@ Use this structure for the issue body or markdown file. Every section is load-be
 <Bullet list: `path/to/file.rb` — why it matters to this change. Include client, adapter, event bus, process, and web layers as relevant. Self-contained: no references to "as discussed" or this session.>
 
 ## Decision
-<Chosen approach and rationale. Then: alternatives considered and why each was rejected.>
+<Chosen approach and rationale. Then: alternatives considered and why each was rejected. End with `Settled in interview:` bullets for every constraint the user confirmed in the interview phase — the executor must not re-litigate these.>
 
 ## Implementation steps
 <Ordered, small, each mapped to the appropriate architecture layer. Specs come before the code they cover. Name exact files to create or change.>
@@ -73,6 +87,6 @@ For GitHub issues: create with `gh issue create --title "..." --body-file <tmpfi
 
 For markdown files: Write to `docs/plans/YYYY-MM-DD-<slug>.md`. Leave it uncommitted — committing is the user's call.
 
-## Phase 4 — Handoff
+## Phase 5 — Handoff
 
 Report back: link to the issue (or file path), the chosen approach in 2-3 sentences, and the exact execute command. Stop there — do not start implementing.


### PR DESCRIPTION
## Summary
- `/plan` gains a **Phase 2 — Surface the unknowns** step: a blindspot pass over open decisions/edge cases, followed by a one-question-at-a-time `AskUserQuestion` interview (prioritized by blast radius), with answers recorded as `Settled in interview:` bullets in the plan's Decision section. Later phases renumbered (Design → 3, Emit the plan artifact → 4, Handoff → 5). `AskUserQuestion` added to the command's `allowed-tools`.
- `/lfg` gains a **deviation log** (`implementation-notes.md` at the repo root) kept live during Phase 4 implementation — deviations, discoveries, and judgment calls logged as they happen, never committed directly.
- `/lfg` gains a mandatory **`## Deviations & judgment calls` PR-body section** (Phase 7), folded in from `implementation-notes.md` before the file is deleted — "None — the plan held." if nothing deviated.
- `/lfg` gains a new **Phase 8 — Comprehension Close-Out**: the final message must surface the 3-5 non-obvious decisions (leading with the deviation log) and three merge-gate questions the user should be able to answer before merging.

## Why
Catch unknowns before execution (discovery) instead of after (review-fix loops); prose-only change to `.claude/commands/`.
