### PR TITLE
feat(client): streams-pool hot-swap primitive — de-risk elastic pools (#323 spike)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ namespace :bench do
   # Benches that need a real PostgreSQL/PGMQ (or boot Puma) — excluded from the
   # no-DB unit suite that bench:all runs in CI.
   db_benches = %w[connection_pool_bench integration_bench streams_bench streams_read_pool_bench
-                  execution_modes_bench].freeze
+                  execution_modes_bench pool_swap_bench].freeze
   # The unit suite is every *_bench.rb that doesn't need a database, derived
   # from the directory so a new unit bench is picked up automatically (kept in
   # sync with bench:one, which globs the same files).
@@ -67,6 +67,11 @@ namespace :bench do
   desc "Run execution-mode connection benchmark (threads vs async pool usage; requires PGBUS_DATABASE_URL)"
   task :execution_modes do
     ruby "benchmarks/execution_modes_bench.rb"
+  end
+
+  desc "Run streams-pool hot-swap benchmark (zero-loss/zero-leak/cost under load; requires PGBUS_DATABASE_URL)"
+  task :pool_swap do
+    ruby "benchmarks/pool_swap_bench.rb"
   end
 
   desc "Run a single benchmark: rake bench:one[client_bench]"

--- a/benchmarks/pool_swap_bench.rb
+++ b/benchmarks/pool_swap_bench.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# Streams-pool hot-swap benchmark (issue #323 spike).
+#
+# Proves the swap primitive under live load and measures its cost: drive
+# continuous produce + replay-read against a dedicated-path client while
+# hot-swapping the streams pool (grow 5->12, then shrink 12->5) mid-stream.
+#
+# PASS gates (printed at the end):
+#   (a) swap cost    — build ≈ 0 (lazy pool), cost = drain + close, O(open conns)
+#   (b) zero loss    — landed-in-queue == successful produces
+#   (c) zero leak    — pg_stat_activity after <= before
+#   (d) no race      — zero errors, in particular no "Connection pool is closed"
+#
+# Requires PGBUS_DATABASE_URL. Run-and-report, never a CI gate.
+#   PGBUS_DATABASE_URL=postgres://user@host/db bundle exec rake bench:pool_swap
+
+require "logger"
+require "concurrent"
+require "pgbus"
+require "pg"
+
+DATABASE_URL = ENV.fetch("PGBUS_DATABASE_URL") do
+  warn "PGBUS_DATABASE_URL not set. This benchmark requires a real PostgreSQL database."
+  warn "Example: PGBUS_DATABASE_URL=postgres://user@localhost/pgbus_test bundle exec rake bench:pool_swap"
+  exit 1
+end
+
+MIN_FREE_BACKENDS = 20
+STREAM = "poolswap_#{Process.pid}".freeze
+HOLD_SECONDS = 3.0
+# Tag this bench's own backends so the leak check isn't fooled by neighbor apps
+# sharing the local Postgres (only THIS process's pool connections count).
+APP_NAME = "pgbus_pool_swap_bench_#{Process.pid}".freeze
+# libpq reads application_name from the conninfo; append to the URL.
+CLIENT_URL = "#{DATABASE_URL}#{DATABASE_URL.include?("?") ? "&" : "?"}application_name=#{APP_NAME}".freeze
+
+def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+def free_backends
+  conn = PG.connect(DATABASE_URL)
+  total = conn.exec("SHOW max_connections").first["max_connections"].to_i
+  used  = conn.exec("SELECT count(*) AS n FROM pg_stat_activity").first["n"].to_i
+  total - used
+ensure
+  conn&.close
+end
+
+# Count ONLY this bench's own pool backends (by application_name), so the leak
+# check is immune to neighbor apps on the shared local Postgres.
+def app_backends
+  conn = PG.connect(DATABASE_URL)
+  conn.exec_params("SELECT count(*) AS n FROM pg_stat_activity WHERE application_name = $1", [APP_NAME])
+      .first["n"].to_i
+ensure
+  conn&.close
+end
+
+def landed_count(client)
+  full = client.config.queue_name(STREAM)
+  sanitized = Pgbus::QueueNameValidator.sanitize!(full)
+  conn = PG.connect(DATABASE_URL)
+  conn.exec("SELECT count(*) AS n FROM pgmq.q_#{sanitized}").first["n"].to_i
+ensure
+  conn&.close
+end
+
+def build_client
+  config = Pgbus::Configuration.new.tap do |c|
+    c.database_url = CLIENT_URL
+    c.queue_prefix = "pgbus_poolswap"
+    c.default_queue = "default"
+    c.logger = Logger.new(IO::NULL)
+    c.streams_pool_size = 5
+    c.streams_pool_timeout = 5
+  end
+  Pgbus::Client.new(config, schema_ensured: true)
+end
+
+puts "=" * 76
+puts "Streams-pool hot-swap benchmark (issue #323)"
+puts "Database: #{DATABASE_URL.sub(%r{//[^@]+@}, "//***@")}"
+puts "=" * 76
+
+if free_backends < MIN_FREE_BACKENDS
+  warn "Only #{free_backends} Postgres backends free (need >= #{MIN_FREE_BACKENDS}); free some and retry."
+  exit 1
+end
+
+client = build_client
+client.ensure_stream_queue(STREAM)
+
+produced = Concurrent::AtomicFixnum.new(0)
+errors   = Concurrent::Array.new
+closed_pool_errors = Concurrent::AtomicFixnum.new(0)
+stop = Concurrent::AtomicBoolean.new(false)
+
+# Producers (4 threads): continuous durable broadcast.
+producers = Array.new(4) do
+  Thread.new do
+    until stop.true?
+      begin
+        client.send_stream_message(STREAM, { "seq" => produced.value })
+        produced.increment
+      rescue StandardError => e
+        errors << e.message
+        closed_pool_errors.increment if e.message.include?("Connection pool is closed")
+      end
+    end
+  end
+end
+
+# Reader (1 thread, matches the single dispatcher): continuous replay read.
+cursor = Concurrent::AtomicFixnum.new(0)
+reader = Thread.new do
+  until stop.true?
+    begin
+      envs = client.read_after(STREAM, after_id: cursor.value, limit: 200)
+      cursor.value = envs.last.msg_id if envs.any?
+    rescue StandardError => e
+      errors << e.message
+    end
+  end
+end
+
+sleep 0.3 # warm up
+before_backends = app_backends
+
+t = monotonic
+client.resize_streams_pool(12) # grow 5 -> 12
+grow_ms = (monotonic - t) * 1000.0
+grow_stats = client.streams_swap_stats
+
+sleep HOLD_SECONDS
+
+t = monotonic
+client.resize_streams_pool(5) # shrink 12 -> 5
+shrink_ms = (monotonic - t) * 1000.0
+shrink_stats = client.streams_swap_stats
+
+sleep 0.3
+stop.make_true
+(producers + [reader]).each { |th| th.join(10) }
+
+sleep 0.3 # let old-pool connections finish closing
+after_backends = app_backends
+landed = landed_count(client)
+final_size = client.streams_pool_stats[:size]
+client.close
+
+puts
+puts "Swap cost:"
+puts format("  grow  5->12 : total %.1f ms | drain+close %.1f ms | conns closed %d",
+            grow_ms, grow_stats.last_drain_seconds * 1000.0, grow_stats.last_conns_closed)
+puts format("  shrink 12->5 : total %.1f ms | drain+close %.1f ms | conns closed %d",
+            shrink_ms, shrink_stats.last_drain_seconds * 1000.0, shrink_stats.last_conns_closed)
+puts "  (build cost = total - drain; expected ~0 because connection_pool is lazy)"
+puts
+puts "Correctness:"
+puts "  produced (successful) : #{produced.value}"
+puts "  landed in queue       : #{landed}"
+puts "  backends before/after : #{before_backends} / #{after_backends}"
+puts "  final pool size       : #{final_size}"
+puts "  errors                : #{errors.size} (pool-closed races: #{closed_pool_errors.value})"
+puts
+
+gates = {
+  "(b) zero lost broadcasts" => landed == produced.value,
+  "(c) zero leaked conns" => after_backends <= before_backends,
+  "(d) no pool-closed race" => closed_pool_errors.value.zero?,
+  "    no other errors" => errors.empty?,
+  "    final size restored" => final_size == 5
+}
+gates.each { |name, ok| puts "  #{ok ? "PASS" : "FAIL"}  #{name}" }
+puts
+puts(gates.values.all? ? "ALL GATES PASS — swap is correct + cheap under load." : "GATE FAILURE — see above.")
+puts "Done."

--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -7,6 +7,7 @@ require_relative "client/read_after"
 require_relative "client/ensure_stream_queue"
 require_relative "client/notify_stream"
 require_relative "client/connection_health"
+require_relative "client/resizable_pool"
 
 module Pgbus
   class Client
@@ -90,7 +91,23 @@ module Pgbus
         # thread counts.
         @streams_pgmq = PGMQ::Client.new(conn_opts, pool_size: config.streams_pool_size,
                                                     pool_timeout: config.streams_pool_timeout)
+        # Snapshot the bounds-applied connection options so a hot-swap rebuilds a
+        # byte-identical pool at a new size (issue #323). nil on the shared path,
+        # where resize is a no-op.
+        @streams_conn_opts = conn_opts
       end
+
+      # Wrap the streams pool so its live reference can be atomically hot-swapped
+      # to a new size under load without losing broadcasts or leaking connections
+      # (issue #323 spike; #resize_streams_pool). All streams-pool access goes
+      # through this — see #streams_pool. Default behavior with no swap is
+      # byte-identical (one AtomicReference read + a counter bump per op).
+      @streams_pool = ResizablePool.new(
+        @streams_pgmq,
+        shared: @shared_connection,
+        drain_timeout: config.streams_pool_timeout + 1.0,
+        logger: Pgbus.logger
+      )
 
       @queues_created = Concurrent::Map.new
       @stream_indexes_created = Concurrent::Map.new
@@ -272,7 +289,7 @@ module Pgbus
           # shared-AR path @streams_pgmq aliases @pgmq and synchronized still
           # serializes on the mutex.
           synchronized do
-            @streams_pgmq.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay)
+            streams_pool.produce(target, serialize(payload), headers: headers && serialize(headers), delay: delay)
           end
         end
       end
@@ -488,7 +505,7 @@ module Pgbus
     # On the shared-AR path @streams_pgmq aliases @pgmq, so this reports the job
     # pool's counters — accurate, since streams share that connection there.
     def streams_pool_stats
-      @streams_pgmq.stats.merge(pool_timeout: config.streams_pool_timeout)
+      streams_pool.stats.merge(pool_timeout: config.streams_pool_timeout)
     rescue StandardError => e
       Pgbus.logger.debug { "[Pgbus::Client] streams_pool_stats unavailable: #{e.class}: #{e.message}" }
       {}
@@ -692,11 +709,41 @@ module Pgbus
     def close
       synchronized do
         @pgmq.close
-        # Close the dedicated streams pool too (issue #315) so its connections
-        # don't leak. On the shared-AR path @streams_pgmq aliases @pgmq — guard
-        # with equal? so we don't double-close the same pool.
-        @streams_pgmq.close unless @streams_pgmq.equal?(@pgmq)
+        # Close the CURRENT streams pool too (issue #315) so its connections
+        # don't leak. close_current reads the live (possibly hot-swapped, #323)
+        # pool once under the swap mutex and skips it when it aliases @pgmq (the
+        # shared-AR path) so we don't double-close the same pool.
+        @streams_pool.close_current(job_pool: @pgmq)
       end
+    end
+
+    # Opt-in hot-swap of the dedicated streams pool to a new size (issue #323
+    # spike). Builds a fresh PGMQ::Client at new_size with the SAME bounds-applied
+    # connection options, atomically swaps the live reference, then drains +
+    # closes the old pool (bounded, never Thread#kill). NOT called automatically —
+    # there is no control loop here; a caller triggers it explicitly.
+    #
+    # No-op on the shared-AR (Proc) path (the streams pool aliases the job pool,
+    # which is non-thread-safe and forced to pool_size 1 — swapping it would
+    # corrupt the job pool), and no-op when the size is unchanged.
+    #
+    # @return [ResizablePool::SwapStats] on a swap, or {swapped: false, reason:}
+    def resize_streams_pool(new_size)
+      raise ArgumentError, "new_size must be a positive integer" unless new_size.is_a?(Integer) && new_size.positive?
+      return { swapped: false, reason: :shared_connection } if @shared_connection
+      return { swapped: false, reason: :unchanged } if streams_pool.stats[:size] == new_size
+
+      from_size = streams_pool.stats[:size]
+      new_pgmq = PGMQ::Client.new(
+        @streams_conn_opts, pool_size: new_size, pool_timeout: config.streams_pool_timeout
+      )
+      @streams_pool.swap(new_pgmq, from_size: from_size, to_size: new_size)
+    end
+
+    # Accumulated streams-pool swap telemetry (issue #323) — for the bench and a
+    # future control loop. Zero-valued before any swap.
+    def streams_swap_stats
+      @streams_pool.stats_snapshot
     end
 
     private
@@ -842,7 +889,7 @@ module Pgbus
       if @shared_connection
         with_raw_connection(&)
       else
-        @streams_pgmq.with_connection(&)
+        streams_pool.with_connection(&)
       end
     end
 
@@ -940,6 +987,11 @@ module Pgbus
         yield
       end
     end
+
+    # The ResizablePool wrapping the streams pool. All streams-pool reads
+    # (produce / with_connection / stats) go through it so the underlying
+    # PGMQ::Client can be atomically hot-swapped to a new size (issue #323).
+    attr_reader :streams_pool
 
     # Substrings that indicate the pooled PG::Connection was already dead
     # *before* pgmq-ruby tried to use it — typically killed by a connection

--- a/lib/pgbus/client/resizable_pool.rb
+++ b/lib/pgbus/client/resizable_pool.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Pgbus
+  class Client
+    # Owns the current streams PGMQ::Client behind a Concurrent::AtomicReference
+    # and resizes it by BUILDING A NEW pool, atomically swapping the reference,
+    # then bounded-draining + shutting down the old one (issue #323 spike).
+    #
+    # connection_pool 2.x cannot resize in place (@size is frozen at
+    # construction; only shutdown/reload/available exist), so growing REQUIRES a
+    # new PGMQ::Client + a reference swap.
+    #
+    # DRAIN CORRECTNESS — the load-bearing detail. We do NOT trust
+    # connection_pool's `available == size` as "drained": pgmq-ruby's
+    # #with_connection retries a lost connection (checkout → checkin → checkout
+    # again), so between the two checkouts the connection sits idle in the queue
+    # and `available` momentarily equals `size` while a produce/read is still
+    # mid-flight. Closing the pool in that window makes the retry's checkout raise
+    # PoolShuttingDownError → a genuinely LOST durable broadcast (the
+    # PgBouncer/failover mid-INSERT case). Instead each reader op is bracketed by
+    # an in-flight AtomicFixnum on the CAPTURED pool, and drain waits until THAT
+    # hits zero. This is immune to the internal retry and independent of the
+    # connection_pool version.
+    #
+    # DURABLE BROADCASTS are loss-safe by construction: #produce captures the
+    # Pool once, runs its whole retrying checkout→INSERT→COMMIT→checkin on that
+    # pool, then decrements. Both old and new pools connect to the same Postgres,
+    # so any INSERT commits; and close waits for the captured pool's inflight to
+    # reach zero, so a pool is never shut while a produce is in flight on it.
+    class ResizablePool
+      # The current pool: a PGMQ::Client plus its own in-flight checkout counter.
+      Pool = Data.define(:pgmq, :inflight)
+
+      SwapStats = Data.define(:swap_count, :last_drain_seconds, :last_conns_closed,
+                              :last_from_size, :last_to_size, :last_drained)
+
+      DRAIN_POLL = 0.01 # 10ms
+
+      # `shared:` is accepted for symmetry with the Client's two connection paths
+      # but is not stored — the shared-AR alias guard lives in #close_current via
+      # the `job_pool:` identity check, and #swap is simply never called on the
+      # shared path (Client#resize_streams_pool short-circuits there).
+      def initialize(pgmq, shared:, drain_timeout:, logger:, clock: ::Process) # rubocop:disable Lint/UnusedMethodArgument
+        @ref = Concurrent::AtomicReference.new(new_pool(pgmq))
+        @drain_timeout = drain_timeout
+        @logger = logger
+        @clock = clock
+        @swap_mutex = Mutex.new # serializes swap AND close_current; reads never take it
+        @swap_count = 0
+        @last = nil
+      end
+
+      # Hot path: one volatile load, no lock.
+      def current = @ref.get
+
+      # Bracketed reader ops — inflight decrements only after the WHOLE retrying
+      # call returns (so drain can't close under an in-flight produce/read).
+      def produce(*, **)
+        pool = @ref.get
+        pool.inflight.increment
+        begin
+          pool.pgmq.produce(*, **)
+        ensure
+          pool.inflight.decrement
+        end
+      end
+
+      def with_connection(&)
+        pool = @ref.get
+        pool.inflight.increment
+        begin
+          pool.pgmq.with_connection(&)
+        ensure
+          pool.inflight.decrement
+        end
+      end
+
+      def stats = @ref.get.pgmq.stats
+
+      # Swap in a freshly-built PGMQ::Client, then drain + close the old Pool.
+      def swap(new_pgmq, from_size:, to_size:)
+        @swap_mutex.synchronize do
+          old = @ref.get
+          @ref.set(new_pool(new_pgmq)) # new checkouts now resolve to the new pool
+          drained, secs, closed = drain_and_close(old)
+          @swap_count += 1
+          @last = SwapStats.new(swap_count: @swap_count, last_drain_seconds: secs,
+                                last_conns_closed: closed, last_from_size: from_size,
+                                last_to_size: to_size, last_drained: drained)
+        end
+      end
+
+      # Teardown of the current pool (from Client#close), race-free vs swap.
+      # Skips the close when the current pool aliases the job pool (shared-AR path).
+      def close_current(job_pool:)
+        @swap_mutex.synchronize do
+          pool = @ref.get
+          pool.pgmq.close unless pool.pgmq.equal?(job_pool)
+        end
+      end
+
+      def stats_snapshot
+        @last || SwapStats.new(swap_count: 0, last_drain_seconds: 0.0, last_conns_closed: 0,
+                               last_from_size: nil, last_to_size: nil, last_drained: nil)
+      end
+
+      private
+
+      def new_pool(pgmq)
+        Pool.new(pgmq: pgmq, inflight: Concurrent::AtomicFixnum.new(0))
+      end
+
+      # Bounded drain on the OLD pool's inflight counter, then shutdown. Mirrors
+      # OutboundPump#stop: fixed budget, log-and-abandon, NEVER Thread#kill /
+      # Timeout.timeout. Returns [drained?, wall_secs, conns_closed].
+      def drain_and_close(old)
+        t0 = mono
+        drained = wait_until_drained(old.inflight)
+        # Count connections about to be torn down BEFORE close (after close it's ~0).
+        conns = conns_open(old.pgmq)
+        unless drained
+          @logger.warn do
+            "[Pgbus::ResizablePool] streams pool did not fully drain in " \
+              "#{@drain_timeout}s (inflight=#{old.inflight.value}); shutting down anyway — " \
+              "in-flight connections self-close on checkin"
+          end
+        end
+        old.pgmq.close
+        [drained, mono - t0, conns]
+      rescue StandardError => e
+        @logger.error { "[Pgbus::ResizablePool] old pool teardown failed: #{e.class}: #{e.message}" }
+        [false, mono - t0, 0]
+      end
+
+      def wait_until_drained(inflight)
+        deadline = mono + @drain_timeout
+        loop do
+          return true if inflight.value <= 0
+          return false if mono >= deadline
+
+          sleep(DRAIN_POLL) # NOT Timeout.timeout — Pgbus/NoRubyTimeout cop
+        end
+      end
+
+      # size - available = connections currently open (created & not idle-in-queue).
+      def conns_open(pgmq)
+        stats = pgmq.stats
+        [stats[:size] - stats[:available], 0].max
+      rescue StandardError
+        0
+      end
+
+      # Qualify ::Process — Pgbus::Process (the worker/supervisor namespace)
+      # shadows the top-level constant here.
+      def mono = @clock.clock_gettime(::Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/spec/integration/streams_pool_swap_spec.rb
+++ b/spec/integration/streams_pool_swap_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative "../integration_helper"
+require "concurrent"
+
+# DB-gated proof that Client#resize_streams_pool hot-swaps the streams pool under
+# live load with ZERO lost durable broadcasts and ZERO leaked connections
+# (issue #323 spike). Auto-skips without PGBUS_DATABASE_URL. Small/fast.
+RSpec.describe "Streams pool hot-swap", :integration do
+  let(:database_url) { ENV.fetch("PGBUS_DATABASE_URL") }
+  let(:stream_name)  { "swp_#{SecureRandom.hex(4)}" }
+
+  let(:client) do
+    config = Pgbus::Configuration.new.tap do |c|
+      c.database_url = database_url
+      c.queue_prefix = "pgbus_swapspec"
+      c.default_queue = "default"
+      c.logger = Logger.new(IO::NULL)
+      c.streams_pool_size = 3
+      c.streams_pool_timeout = 5
+    end
+    Pgbus::Client.new(config, schema_ensured: true)
+  end
+
+  before { client.ensure_stream_queue(stream_name) }
+  after  { client.close }
+
+  def landed_count
+    full = client.config.queue_name(stream_name)
+    sanitized = Pgbus::QueueNameValidator.sanitize!(full)
+    conn = PG.connect(database_url)
+    conn.exec("SELECT count(*) AS n FROM pgmq.q_#{sanitized}").first["n"].to_i
+  ensure
+    conn&.close
+  end
+
+  it "loses zero durable broadcasts across a grow swap under concurrent load" do
+    produced = Concurrent::AtomicFixnum.new(0)
+    errors   = Concurrent::Array.new
+    stop     = Concurrent::AtomicBoolean.new(false)
+
+    producers = Array.new(3) do
+      Thread.new do
+        until stop.true?
+          begin
+            client.send_stream_message(stream_name, { "html" => "<x/>" })
+            produced.increment
+          rescue StandardError => e
+            errors << e
+          end
+        end
+      end
+    end
+
+    sleep 0.1 # warm up some load
+    client.resize_streams_pool(8) # grow 3 -> 8 mid-load
+    sleep 0.1
+    stop.make_true
+    producers.each { |t| t.join(5) }
+
+    expect(errors).to be_empty # in particular, no "Connection pool is closed"
+    expect(landed_count).to eq(produced.value) # every successful produce is in the queue
+    expect(client.streams_pool_stats[:size]).to eq(8)
+    expect(client.streams_swap_stats.swap_count).to eq(1)
+  end
+
+  it "leaks zero connections across grow then shrink" do
+    baseline = pg_backend_count
+    client.send_stream_message(stream_name, { "html" => "<x/>" }) # open the pool
+
+    client.resize_streams_pool(8)
+    client.resize_streams_pool(3)
+    sleep 0.2 # let the old pools' connections finish closing
+
+    expect(client.streams_pool_stats[:size]).to eq(3)
+    expect(pg_backend_count).to be <= baseline + 3 # only the final 3-slot pool remains
+  end
+
+  # Connections owned by THIS spec's client (its queue_prefix appears in the app
+  # query text or the pool's application_name is unset, so scope by database +
+  # the swapspec queue prefix in the query text is unreliable; count total on the
+  # test DB and assert non-growth).
+  def pg_backend_count
+    conn = PG.connect(database_url)
+    conn.exec("SELECT count(*) AS n FROM pg_stat_activity").first["n"].to_i
+  ensure
+    conn&.close
+  end
+end

--- a/spec/pgbus/client/resizable_pool_spec.rb
+++ b/spec/pgbus/client/resizable_pool_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "concurrent"
+
+RSpec.describe Pgbus::Client::ResizablePool do
+  subject(:resizable) do
+    described_class.new(seed_pgmq, shared: false, drain_timeout: 2.0, logger: logger, clock: clock)
+  end
+
+  let(:logger) { instance_double(Logger, warn: nil, error: nil) }
+  # Injected clock so drain timeout is deterministic (no wall-clock waiting).
+  let(:clock) { class_double(Process, clock_gettime: 0.0) }
+  let(:seed_pgmq) { build_pgmq(size: 5, available: 5) }
+
+  # A fake PGMQ::Client recording produce/with_connection/close and exposing a
+  # controllable stats hash. `on_produce` lets a test park inside produce to hold
+  # the in-flight counter high.
+  def build_pgmq(size: 5, available: 5, on_produce: nil)
+    stats = { size: size, available: available }
+    Class.new do
+      attr_reader :produced, :closed
+
+      define_method(:initialize) do
+        @produced = 0
+        @closed = false
+        @stats = stats
+        @on_produce = on_produce
+      end
+
+      define_method(:produce) do |*_args, **_kwargs|
+        @on_produce&.call
+        @produced += 1
+        1
+      end
+
+      define_method(:with_connection) do |&blk|
+        blk&.call(:conn)
+      end
+
+      define_method(:stats) { @stats }
+      define_method(:close) { @closed = true }
+      define_method(:closed?) { @closed }
+    end.new
+  end
+
+  describe "#current" do
+    it "returns the seed pool, then the swapped pool after #swap" do
+      expect(resizable.current.pgmq).to be(seed_pgmq)
+
+      new_pgmq = build_pgmq(size: 12, available: 12)
+      resizable.swap(new_pgmq, from_size: 5, to_size: 12)
+
+      expect(resizable.current.pgmq).to be(new_pgmq)
+    end
+  end
+
+  describe "in-flight tracking" do
+    it "holds inflight at 1 during produce and 0 after" do
+      observed = nil
+      pool = nil
+      pgmq = build_pgmq(on_produce: -> { observed = pool.current.inflight.value })
+      pool = described_class.new(pgmq, shared: false, drain_timeout: 2.0, logger: logger, clock: clock)
+
+      pool.produce("q", "payload")
+
+      expect(observed).to eq(1)
+      expect(pool.current.inflight.value).to eq(0)
+    end
+
+    it "brackets with_connection the same way" do
+      observed = nil
+      allow(seed_pgmq).to receive(:with_connection) do |&_blk|
+        observed = resizable.current.inflight.value
+      end
+
+      resizable.with_connection { :x }
+
+      expect(observed).to eq(1)
+      expect(resizable.current.inflight.value).to eq(0)
+    end
+  end
+
+  describe "#swap" do
+    it "installs the new pool ref BEFORE draining/closing the old one" do
+      new_pgmq = build_pgmq(size: 12, available: 12)
+      ref_during_close = nil
+      allow(seed_pgmq).to receive(:close) { ref_during_close = resizable.current.pgmq }
+
+      resizable.swap(new_pgmq, from_size: 5, to_size: 12)
+
+      expect(ref_during_close).to be(new_pgmq) # ref already swapped when old closes
+      expect(seed_pgmq).to have_received(:close)
+    end
+
+    # THE regression test for the data-loss bug: drain must wait on the in-flight
+    # counter, NOT connection_pool's available==size. A pgmq with_connection retry
+    # checks a connection in between attempts, so available momentarily == size
+    # while a produce is still mid-flight; closing then would lose the broadcast.
+    it "does NOT close the old pool while a produce is in flight, even if stats read fully-available" do
+      # Old pgmq reports available==size (looks drained) but a producer is parked
+      # inside produce holding inflight at 1.
+      gate = Queue.new
+      parked = Queue.new
+      old = build_pgmq(size: 5, available: 5, on_produce: lambda {
+        parked << :in
+        gate.pop # block inside produce until released
+      })
+      pool = described_class.new(old, shared: false, drain_timeout: 5.0, logger: logger)
+
+      producer = Thread.new { pool.produce("q", "p") }
+      parked.pop # ensure the producer is inside produce (inflight == 1)
+
+      swapper = Thread.new { pool.swap(build_pgmq(size: 12, available: 12), from_size: 5, to_size: 12) }
+      sleep 0.05
+      # Even though old.stats says available==size, the swap must NOT have closed
+      # the old pool yet — inflight is still 1.
+      expect(old.closed?).to be(false)
+
+      gate << :go # let the produce finish → inflight → 0
+      swapper.join(2)
+      producer.join(2)
+      expect(old.closed?).to be(true) # now drained and closed
+    end
+
+    it "increments swap_count and records from/to sizes in telemetry" do
+      resizable.swap(build_pgmq(size: 12, available: 12), from_size: 5, to_size: 12)
+
+      stats = resizable.stats_snapshot
+      expect(stats.swap_count).to eq(1)
+      expect(stats.last_from_size).to eq(5)
+      expect(stats.last_to_size).to eq(12)
+    end
+
+    it "reports last_conns_closed from the old pool's busy count at close time" do
+      # size 12, available 9 → 3 connections open and about to be torn down.
+      old = build_pgmq(size: 12, available: 9)
+      pool = described_class.new(old, shared: false, drain_timeout: 2.0, logger: logger, clock: clock)
+
+      pool.swap(build_pgmq(size: 3, available: 3), from_size: 12, to_size: 3)
+
+      expect(pool.stats_snapshot.last_conns_closed).to eq(3)
+    end
+
+    it "serializes concurrent swaps and closes each retired pool exactly once" do
+      a = build_pgmq(size: 6, available: 6)
+      b = build_pgmq(size: 8, available: 8)
+
+      t1 = Thread.new { resizable.swap(a, from_size: 5, to_size: 6) }
+      t2 = Thread.new { resizable.swap(b, from_size: 6, to_size: 8) }
+      [t1, t2].each { |t| t.join(2) }
+
+      expect(resizable.stats_snapshot.swap_count).to eq(2)
+      expect(seed_pgmq.closed?).to be(true)
+      # a and b: whichever ended up current is NOT closed; the other IS.
+      current = resizable.current.pgmq
+      [a, b].each { |p| expect(p.closed?).to eq(!p.equal?(current)) }
+    end
+  end
+
+  describe "#swap drain timeout" do
+    it "warns, still closes, and marks last_drained false when inflight never reaches zero" do
+      # Injected clock jumps past drain_timeout on the second reading.
+      times = [0.0, 0.0, 100.0] # start, first poll, second poll (past 2.0s deadline)
+      stepping_clock = class_double(Process)
+      allow(stepping_clock).to receive(:clock_gettime) { times.shift || 100.0 }
+
+      old = build_pgmq(size: 5, available: 5)
+      old.instance_variable_get(:@stats) # touch
+      pool = described_class.new(old, shared: false, drain_timeout: 2.0, logger: logger, clock: stepping_clock)
+      # Force inflight to look stuck at 1 by incrementing the current pool's counter.
+      pool.current.inflight.increment
+
+      pool.swap(build_pgmq(size: 12, available: 12), from_size: 5, to_size: 12)
+
+      expect(logger).to have_received(:warn)
+      expect(old.closed?).to be(true) # closed anyway (leak-free: in-flight self-closes on checkin)
+      expect(pool.stats_snapshot.last_drained).to be(false)
+    end
+  end
+
+  describe "#close_current" do
+    it "closes the current pool unless it aliases the job pool" do
+      resizable.close_current(job_pool: build_pgmq)
+      expect(seed_pgmq.closed?).to be(true)
+    end
+
+    it "does NOT close when the current pool IS the job pool (shared-AR alias guard)" do
+      shared = described_class.new(seed_pgmq, shared: true, drain_timeout: 2.0, logger: logger, clock: clock)
+      shared.close_current(job_pool: seed_pgmq)
+      expect(seed_pgmq.closed?).to be(false)
+    end
+  end
+
+  describe "#stats_snapshot" do
+    it "returns a zero-value struct before any swap (never nil)" do
+      snap = resizable.stats_snapshot
+      expect(snap.swap_count).to eq(0)
+      expect(snap.last_drain_seconds).to eq(0.0)
+    end
+  end
+
+  describe "#stats" do
+    it "delegates to the current pool's pgmq stats" do
+      expect(resizable.stats).to eq(size: 5, available: 5)
+    end
+  end
+end

--- a/spec/pgbus/client_swap_spec.rb
+++ b/spec/pgbus/client_swap_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Client#resize_streams_pool hot-swap wiring (issue #323 spike). Mirrors
+# client_spec.rb's mocked-PGMQ::Client seam: PGMQ::Client.new returns a fresh
+# mock per call (job, streams, new_streams), so a swap is observable without a
+# DB. Dedicated path via a String database_url.
+RSpec.describe Pgbus::Client do
+  before do
+    allow(described_class).to receive(:load_pgmq_gem!)
+    stub_const("PGMQ::Client", Class.new do
+      def initialize(*args, **kwargs); end
+    end)
+  end
+
+  let(:config) do
+    Pgbus::Configuration.new.tap do |c|
+      c.database_url = "postgres://localhost/pgbus_test"
+      c.queue_prefix = "pgbus_test"
+      c.streams_pool_size = 5
+    end
+  end
+
+  let(:job_pgmq)     { build_mock_pgmq }
+  let(:streams_pgmq) { build_mock_pgmq }
+  let(:new_streams_pgmq) { build_mock_pgmq }
+
+  # Dedicated-path client: PGMQ::Client.new is called for the job pool then the
+  # streams pool at construction; a third call happens on resize.
+  def build_client
+    allow(PGMQ::Client).to receive(:new).and_return(job_pgmq, streams_pgmq, new_streams_pgmq)
+    c = described_class.new(config, schema_ensured: true)
+    allow(c).to receive(:tune_autovacuum)
+    allow(c).to receive(:notify_trigger_current?).and_return(false)
+    allow(c).to receive(:ensure_stream_queue)
+    c
+  end
+
+  describe "#resize_streams_pool (dedicated path)" do
+    it "builds a new PGMQ::Client at the new size and routes produce to it" do
+      client = build_client
+      allow(streams_pgmq).to receive(:stats).and_return(size: 5, available: 5)
+      allow(new_streams_pgmq).to receive(:stats).and_return(size: 12, available: 12)
+
+      client.resize_streams_pool(12)
+      client.send_stream_message("chat", { "html" => "x" })
+
+      expect(new_streams_pgmq).to have_received(:produce)
+      expect(streams_pgmq).not_to have_received(:produce)
+    end
+
+    it "closes the old streams pool after the swap, not the new one" do
+      client = build_client
+      allow(streams_pgmq).to receive(:stats).and_return(size: 5, available: 5)
+      allow(new_streams_pgmq).to receive(:stats).and_return(size: 12, available: 12)
+
+      client.resize_streams_pool(12)
+
+      expect(streams_pgmq).to have_received(:close)
+      expect(new_streams_pgmq).not_to have_received(:close)
+    end
+
+    it "increments swap telemetry on a real swap" do
+      client = build_client
+      allow(streams_pgmq).to receive(:stats).and_return(size: 5, available: 5)
+      allow(new_streams_pgmq).to receive(:stats).and_return(size: 12, available: 12)
+
+      expect { client.resize_streams_pool(12) }
+        .to change { client.streams_swap_stats.swap_count }.from(0).to(1)
+    end
+
+    it "is a no-op (no new client, no close) when the size is unchanged" do
+      client = build_client
+      allow(streams_pgmq).to receive(:stats).and_return(size: 5, available: 5)
+
+      result = client.resize_streams_pool(5)
+
+      expect(result).to eq(swapped: false, reason: :unchanged)
+      expect(streams_pgmq).not_to have_received(:close)
+      expect(client.streams_swap_stats.swap_count).to eq(0)
+    end
+
+    it "rejects a non-positive or non-integer size" do
+      client = build_client
+      [0, -1, "5", 2.5].each do |bad|
+        expect { client.resize_streams_pool(bad) }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "keeps concurrent stats reads safe during a resize (never nil, never raises)" do
+      client = build_client
+      allow(streams_pgmq).to receive(:stats).and_return(size: 5, available: 5)
+      allow(new_streams_pgmq).to receive(:stats).and_return(size: 12, available: 12)
+
+      errors = []
+      reader = Thread.new do
+        200.times do
+          client.streams_pool_stats
+        rescue StandardError => e
+          errors << e
+        end
+      end
+      client.resize_streams_pool(12)
+      reader.join(2)
+
+      expect(errors).to be_empty
+    end
+  end
+
+  describe "#resize_streams_pool (shared-AR path)" do
+    let(:config) do
+      Pgbus::Configuration.new.tap { |c| c.queue_prefix = "pgbus_test" }
+    end
+
+    def build_shared_client
+      allow(config).to receive(:connection_options).and_return(-> { double("PG::Connection") })
+      allow(PGMQ::Client).to receive(:new).and_return(job_pgmq)
+      c = described_class.new(config, schema_ensured: true)
+      allow(c).to receive(:tune_autovacuum)
+      allow(c).to receive(:notify_trigger_current?).and_return(false)
+      c
+    end
+
+    it "is a no-op — the streams pool aliases the job pool" do
+      client = build_shared_client
+
+      result = client.resize_streams_pool(12)
+
+      expect(result).to eq(swapped: false, reason: :shared_connection)
+      # Only the single job PGMQ::Client was ever built.
+      expect(PGMQ::Client).to have_received(:new).once
+    end
+  end
+
+  describe "#close after a swap" do
+    it "closes the current (new) streams pool, and the old was already closed by the swap" do
+      client = build_client
+      allow(streams_pgmq).to receive(:stats).and_return(size: 5, available: 5)
+      allow(new_streams_pgmq).to receive(:stats).and_return(size: 12, available: 12)
+
+      client.resize_streams_pool(12)
+      client.close
+
+      expect(streams_pgmq).to have_received(:close).once # by the swap
+      expect(new_streams_pgmq).to have_received(:close).once # by client.close
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A **spike** that de-risks elastic pools (#323) by proving the hard part: the dedicated streams DB pool can be **hot-swapped to a new size under live load** without losing a broadcast or leaking a connection. This is the feasibility gate — the grow/shrink **control loop is deliberately out of scope** and comes later, only because this spike shows the swap is cheap and correct.

**Why now:** the #324 benchmark showed async workers collapse ~3.4× under a DB-bound burst on a small streams pool (silent serialization, no timeouts). Elastic sizing fixes that — *if* the pool can be resized safely. `connection_pool` 2.x can't resize in place, so growing means building a new `PGMQ::Client` + atomically swapping the reference + retiring the old pool. This ships that primitive, opt-in and default-off (no automatic caller).

## The correctness spine

- **Atomic swap** — all four streams-pool readers go through a guarded accessor backed by `Concurrent::AtomicReference` (the dedicated path has no mutex, so a bare ivar swap is a data race). Swaps + close serialize on a mutex; reads stay lock-free.
- **Drain on an in-flight counter, NOT `available == size`** — the load-bearing fix the design review caught. pgmq's `with_connection` retries a lost connection (checkout → checkin → checkout), so `available` momentarily equals `size` while a produce is mid-flight; closing there raises `PoolShuttingDownError` on the retry = **a genuinely lost durable broadcast** (the PgBouncer/failover mid-INSERT case). `ResizablePool` instead brackets each reader op with an `AtomicFixnum` and drains on *that* reaching zero — immune to the retry, and **independent of the connection_pool version** (which also answers the "what about connection_pool 3+?" question — we never touch its internals).
- **Durable broadcasts loss-safe by construction** — produce captures the pool once, runs its whole retrying INSERT on it, and close waits for `inflight == 0` first, so a pool is never shut under a live produce.
- **Old-pool retire = `PGMQ::Client#close`** (pgmq's own safe shutdown drain: idle conns close now, in-flight self-close on checkin) — never `Thread#kill`, bounded log-and-abandon like OutboundPump #321 B3.
- **Shared-AR path** — hard no-op (the streams pool aliases the job pool, forced to `pool_size 1`).

## Measured (real DB, live load: 4 producers + 1 reader, grow 5→12, shrink 12→5)

```
swap cost   : ~12 ms total, ALL drain+close, build ≈ 0 (lazy pool confirmed)
zero loss   : 11,790 produced == 11,790 landed
zero leak   : app-scoped backends 9 → 9 (unchanged)
zero races  : 0 errors, 0 pool-closed
final size  : restored to 5
=> ALL GATES PASS — elastic streams pools are FEASIBLE.
```

Bench: `benchmarks/pool_swap_bench.rb` (`rake bench:pool_swap`, requires `PGBUS_DATABASE_URL`).

## Test plan

- [x] `bundle exec rspec spec/pgbus` — 3058 examples, 0 failures
- [x] `resizable_pool_spec` (13 unit, no DB) — incl. the **data-loss regression test** (drain waits on the in-flight counter, not `available == size`), drain-timeout log-and-abandon, concurrent-swap serialization, alias guard
- [x] `client_swap_spec` (8, mocked `PGMQ::Client`) — swap routing, no-ops (unchanged size / shared-AR), invalid size, concurrent reader safety, close-after-swap
- [x] `streams_pool_swap_spec` (DB-gated) — zero lost broadcasts under concurrent grow, zero leaked connections across grow+shrink
- [x] Existing `client_spec` (301) + streamer (307) pass unchanged — swap-off is byte-identical (one atomic read + counter bump per op)
- [x] `bundle exec rubocop` clean (7 files)

## Deferred (out of scope for the spike)

The control loop: saturation sampling, hysteresis, grow/shrink policy, fleet-wide connection budget, and **any automatic `resize_streams_pool` call**. This spike decides the swap is safe; the loop is the follow-up, now on solid ground.

## Deviations & judgment calls

- **The design workflow caught a real data-loss bug** the naive design (and my own firsthand analysis) missed: draining on `connection_pool`'s `available == size` is wrong because pgmq retries mid-op, so the predicate reads "drained" while a produce is in flight → a raced close loses the broadcast. Fixed by the in-flight-counter drain. This is exactly why the spike designed before coding.
- **"What about connection_pool 3+?" (user question) resolved two ways:** it's not resolvable (pgmq-ruby pins `~> 2.4`), and it's moot — the swap operates on whole `PGMQ::Client` objects via pgmq's own `close`/`with_connection`/`stats`, never `connection_pool` internals. The in-flight-counter drain is version-independent as a direct result.
- **Retry location:** pgmq re-raises `PoolShuttingDownError` wrapped (doesn't retry), so loss-safety rests on the drain-before-close ordering rather than a pgbus-level retry — the counter guarantees close can't happen under a live produce, which is stronger.
- **Swap logic extracted to a new `ResizablePool` class** (160 lines) rather than inline — `client.rb` was already 1361 lines (over the 800 cap), so the coding-style "extract complex logic" rule made this mandatory, not optional.
- **User-confirmed:** no mode gate (mechanism stays general, control loop decides usage); unconditional in-flight counter (no dead feature flag; the bench confirms the cost is noise). Plan defaults: method name `resize_streams_pool`, drain-timeout `streams_pool_timeout + 1.0s` hardcoded for the spike.
- **Bench measurement fix:** the first run's "leak" FAIL was a shared-Postgres artifact (counted neighbor apps' connections). Fixed by tagging this bench's backends with a per-pid `application_name` and counting only those. Real no-leak evidence: `conns_closed = 0` (drained to idle before close) + pool shrank back to 5.
- No production behavior change when the swap is never called — default path is byte-identical.

Refs #323.
