### PR TITLE
fix(release): drop --local from frozen-lockfile regen (it broke rake release)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -232,8 +232,14 @@ task :release, %i[version force] do |_t, args|
       next
     end
 
+    # `bundle lock` (NOT `--local`): `--local` forbids remote fetch, so it can't
+    # resolve gems that aren't in the local cache (e.g. the docs bundle's
+    # platform gems) and — worse — it ignores the BUNDLE_GEMFILE-derived lockfile
+    # path and writes the ROOT Gemfile.lock instead. A plain `bundle lock` writes
+    # the correct `<gemfile>.lock` and still produces a minimal diff (only the
+    # pgbus path-gem pin moves; the rest of the lock stays put). See #338 fix.
     env = { "BUNDLE_FROZEN" => "false", "BUNDLE_GEMFILE" => File.expand_path(gemfile) }
-    sh(env, "bundle lock --local")
+    sh(env, "bundle lock")
     regenerated_lockfiles << lockfile
     success "Regenerated #{lockfile}"
   end

--- a/spec/pgbus/frozen_lockfile_sync_spec.rb
+++ b/spec/pgbus/frozen_lockfile_sync_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The checked-in frozen lockfiles pin the pgbus path gem and are installed with
+# `--frozen`/deployment in CI, so they MUST name the current gemspec version or
+# the frozen install instant-fails (the Rails 7.1 leg with exit 16; docs-CI on
+# any docs change). `rake release` regenerates them in the bump commit, but this
+# spec catches the drift directly — and in the normal rspec run, not just when a
+# frozen CI leg happens to fail. See #338 (the release-task sync) and its fix.
+#
+# rubocop:disable RSpec/DescribeClass -- a repo-hygiene guard, not a class under test
+RSpec.describe "Frozen lockfile version sync" do
+  %w[gemfiles/rails_7_1.gemfile.lock docs/Gemfile.lock].each do |relative|
+    describe relative do
+      let(:path) { File.expand_path(File.join("../..", relative), __dir__) }
+
+      it "exists (it is a tracked, checked-in lockfile)" do
+        expect(File).to exist(path)
+      end
+
+      it "pins the pgbus path gem at the current gemspec version" do
+        # Matches the PATH-source stanza line: `    pgbus (X.Y.Z)`.
+        pinned = File.read(path)[/^\s+pgbus \((\d+\.\d+\.\d+[^)]*)\)/, 1]
+
+        expect(pinned).to eq(Pgbus::VERSION),
+                          "#{relative} pins pgbus #{pinned.inspect} but the gemspec is " \
+                          "#{Pgbus::VERSION.inspect} — regenerate it (rake release does this in the " \
+                          "bump commit): BUNDLE_GEMFILE=#{relative.sub(/\.lock$/, "")} bundle lock"
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## Summary

`rake release` aborted at the frozen-lockfile step. Both failures trace to `bundle lock --local` (introduced in #338):

- **Silent wrong-file write:** for `gemfiles/rails_7_1.gemfile`, `--local` ignored the `BUNDLE_GEMFILE`-derived lockfile path and wrote the **root** `Gemfile.lock` instead of `gemfiles/rails_7_1.gemfile.lock`. The "✓ Regenerated gemfiles/rails_7_1.gemfile.lock" message was a lie — the 7.1 lock was never updated.
- **Fatal resolution failure:** for `docs/Gemfile`, `--local` forbids remote fetch and couldn't resolve platform gems missing from the local cache (`Could not find gems matching 'thruster'`), aborting the whole release with exit 7.

**Fix:** drop `--local`. A plain `bundle lock` writes the correct `<gemfile>.lock`, resolves authoritatively, and still produces a **minimal diff** (only the pgbus path-gem pin moves — verified). No stray root-`Gemfile.lock` write.

Also adds **`spec/pgbus/frozen_lockfile_sync_spec.rb`**: asserts each tracked frozen lockfile pins the current `Pgbus::VERSION`, so this drift fails in the normal `rspec` run instead of only when a frozen CI leg happens to fail. It carries an actionable message naming the exact `bundle lock` command to fix it.

## Test plan

- [x] Simulated the fixed Rakefile loop: both lockfiles write to their correct paths; root `Gemfile.lock` untouched (mtime unchanged)
- [x] Confirmed dropping `--local` keeps the diff minimal (only the pgbus pin moves)
- [x] New spec proven RED against a 0.10.0-pinned lock / 0.10.1 gemspec, GREEN when synced
- [x] `bundle exec rspec spec/pgbus spec/generators` — 3365 examples, 0 failures
- [x] `bundle exec rubocop` — 519 files, no offenses

## Deviations & judgment calls

- Triggered as `/lfg 336`, but #336 is a merged PR — the actual task was the broken `rake release` the user hit. Treated it as the bug fix.
- The regression guard is a **spec asserting lockfile-pin == gemspec version**, not a mock of `rake release` (which commits/tags/pushes and isn't unit-testable). This catches the exact drift class the release step exists to prevent, regardless of cause — a more robust guard than testing the shell command.
- Reverted the in-progress `version.rb` bump + lockfile changes from `main`; those are the release's job and will be regenerated by `rake release` after this fix merges.
