### PR TITLE
fix(release): bump the pgbus pin in place instead of re-locking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -215,33 +215,40 @@ task :release, %i[version force] do |_t, args|
   # leg with exit 16, and docs-CI on any docs change). Regenerating here keeps the
   # version-pin drift out of the release commit instead of surfacing on the next PR.
   header "Frozen lockfiles"
-  # Map each frozen lockfile to the gemfile bundle should resolve. Set
-  # BUNDLE_GEMFILE EXPLICITLY (absolute) for every entry — an inherited
-  # BUNDLE_GEMFILE (present when this runs under `bundle exec rake`) takes
-  # precedence over directory-based Gemfile discovery, so `chdir` alone would
-  # let the docs bundle resolve the ROOT Gemfile instead of docs/Gemfile. An
-  # absolute BUNDLE_GEMFILE removes that ambiguity and needs no chdir.
-  frozen_gemfiles = {
-    "gemfiles/rails_7_1.gemfile.lock" => "gemfiles/rails_7_1.gemfile",
-    "docs/Gemfile.lock" => "docs/Gemfile"
-  }
+  # The ONLY thing a version bump changes in these frozen lockfiles is the pgbus
+  # path-gem pin — so bump exactly that line, in place, with a string edit.
+  #
+  # We deliberately do NOT run `bundle lock` here: a full re-resolve trips over
+  # constraints that have nothing to do with pgbus. Concretely, docs/Gemfile.lock
+  # carries a broad PLATFORMS list (…-gnu / …-musl / arm-linux) for which a
+  # platform gem like `thruster` ships no variant, so `bundle lock` fails with
+  # "Could not find gems matching 'thruster' valid for all resolution platforms"
+  # on any machine whose cache doesn't already hold those exact gems — aborting
+  # the release. `bundle lock --local` was even worse (wrong-file write + no
+  # fetch). A targeted pin edit sidesteps all of it, is deterministic on any
+  # machine, and produces the minimal 2-line diff (the PATH spec + the
+  # DEPENDENCIES pin). See #338/#341 and the surgical-bump fix.
+  frozen_lockfiles = %w[gemfiles/rails_7_1.gemfile.lock docs/Gemfile.lock]
   regenerated_lockfiles = []
-  frozen_gemfiles.each do |lockfile, gemfile|
+  frozen_lockfiles.each do |lockfile|
     unless File.exist?(lockfile)
       skip "#{lockfile} not present"
       next
     end
 
-    # `bundle lock` (NOT `--local`): `--local` forbids remote fetch, so it can't
-    # resolve gems that aren't in the local cache (e.g. the docs bundle's
-    # platform gems) and — worse — it ignores the BUNDLE_GEMFILE-derived lockfile
-    # path and writes the ROOT Gemfile.lock instead. A plain `bundle lock` writes
-    # the correct `<gemfile>.lock` and still produces a minimal diff (only the
-    # pgbus path-gem pin moves; the rest of the lock stays put). See #338 fix.
-    env = { "BUNDLE_FROZEN" => "false", "BUNDLE_GEMFILE" => File.expand_path(gemfile) }
-    sh(env, "bundle lock")
+    content = File.read(lockfile)
+    # Matches both the PATH-source spec ("    pgbus (X.Y.Z)") and the
+    # DEPENDENCIES pin ("  pgbus (X.Y.Z)"), leaving everything else untouched.
+    bumped = content.gsub(/^(\s+pgbus) \([^)]*\)$/, "\\1 (#{new_version})")
+
+    if bumped == content
+      skip "#{lockfile} — no pgbus pin to bump"
+      next
+    end
+
+    File.write(lockfile, bumped)
     regenerated_lockfiles << lockfile
-    success "Regenerated #{lockfile}"
+    success "Bumped pgbus pin in #{lockfile}"
   end
 
   # Step 2: Verify gem builds cleanly

--- a/spec/pgbus/frozen_lockfile_sync_spec.rb
+++ b/spec/pgbus/frozen_lockfile_sync_spec.rb
@@ -25,8 +25,10 @@ RSpec.describe "Frozen lockfile version sync" do
 
         expect(pinned).to eq(Pgbus::VERSION),
                           "#{relative} pins pgbus #{pinned.inspect} but the gemspec is " \
-                          "#{Pgbus::VERSION.inspect} — regenerate it (rake release does this in the " \
-                          "bump commit): BUNDLE_GEMFILE=#{relative.sub(/\.lock$/, "")} bundle lock"
+                          "#{Pgbus::VERSION.inspect}. `rake release` bumps this pin in place; to fix " \
+                          "by hand, replace the `pgbus (...)` pin(s) in #{relative} with " \
+                          "`pgbus (#{Pgbus::VERSION})` (do NOT run `bundle lock` — the docs lock's " \
+                          "PLATFORMS list makes a full re-resolve fail on platform-only gems)."
       end
     end
   end


### PR DESCRIPTION
## Summary

`rake release` still aborted at the docs lockfile step after #341, with:

```
Could not find gems matching 'thruster' valid for all resolution platforms
```

**#341's diagnosis (`--local`) was incomplete.** The real cause: any `bundle lock` re-resolves the **whole** lockfile, and `docs/Gemfile.lock` carries a broad `PLATFORMS` list (`aarch64-linux-gnu`, `arm-linux-musl`, `arm-linux`, …) for which a platform-only gem like `thruster` ships **no variant**. So the re-resolve fails on those platforms — on any machine whose gem cache doesn't already hold the exact platform gems. My local cache held them, which masked the bug in my earlier testing. It has nothing to do with pgbus or `--local`.

**Fix:** a version bump only changes the pgbus **pin**. Bump exactly that line in place with a regex string edit — no `bundle lock`, no re-resolve, no `BUNDLE_GEMFILE`, no cache dependency:

```ruby
content.gsub(/^(\s+pgbus) \([^)]*\)$/, "\\1 (#{new_version})")
```

Deterministic on any machine, minimal (2 lines per lock), and the surgical edit leaves the lock valid.

## Test plan

- [x] Simulated the full release step (bump `version.rb` 0.10.0 → 0.11.0 + surgical lock edit): each lock changes exactly 2 lines, zero lingering old-version pins
- [x] **Both frozen installs succeed with the edited locks** — `BUNDLE_FROZEN=true bundle install` for the 7.1 gemfile ("Bundle complete!") and docs ("complete"); the surgical edit doesn't corrupt the lock
- [x] Confirmed the release task no longer executes `bundle lock` at all (the thruster failure is impossible)
- [x] `bundle exec rspec spec/pgbus spec/generators` — 3365, 0 failures; frozen-lockfile-sync spec still green
- [x] `bundle exec rubocop` — clean

## Deviations & judgment calls

- **This supersedes my #341 fix, which was wrong.** #341 dropped `--local` and I "proved" it worked — but I tested with a warm gem cache that already had thruster's platform gems, so the re-resolve succeeded locally and hid the real failure. On a clean machine (yours) it still aborted. The lesson: the whole `bundle lock` re-resolve approach was flawed; the correct move is to never re-resolve for a pin bump.
- Kept the fix minimal and cache-independent — a string edit is the right tool for "change one pinned version," not a dependency resolver.

Follow-up to #338/#341.
